### PR TITLE
[AVC] Filter out comments that don't identify a problem

### DIFF
--- a/packages/python-packages/apiview-copilot/metadata/android/filter.yaml
+++ b/packages/python-packages/apiview-copilot/metadata/android/filter.yaml
@@ -1,2 +1,3 @@
 exceptions: |
-  1. Comment on lack of documentation comments
+  1. DO NOT make comments that don't actually identify a problem
+  2. DO NOT comment on lack of documentation comments

--- a/packages/python-packages/apiview-copilot/metadata/dotnet/filter.yaml
+++ b/packages/python-packages/apiview-copilot/metadata/dotnet/filter.yaml
@@ -1,4 +1,5 @@
 exceptions: |
-  1. DO NOT comment on lack of XML documentation comments
-  2. DO NOT comment on the following method on any types 'JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)'
-  3. DO NOT comment about Output-only model properties missing an internal setter to allow for proper deserialization.
+  1. DO NOT make comments that don't actually identify a problem.
+  2. DO NOT comment on lack of XML documentation comments
+  3. DO NOT comment on the following method on any types 'JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)'
+  4. DO NOT comment about Output-only model properties missing an internal setter to allow for proper deserialization.

--- a/packages/python-packages/apiview-copilot/metadata/golang/filter.yaml
+++ b/packages/python-packages/apiview-copilot/metadata/golang/filter.yaml
@@ -1,2 +1,3 @@
 exceptions: |
-  1. Comment on lack of documentation comments
+  1. DO NOT make comments that don't actually identify a problem.
+  2. DO NOT comment on lack of documentation comments

--- a/packages/python-packages/apiview-copilot/metadata/ios/filter.yaml
+++ b/packages/python-packages/apiview-copilot/metadata/ios/filter.yaml
@@ -1,2 +1,3 @@
 exceptions: |
-  1. Comment on lack of documentation comments
+  1. DO NOT make comments that don't actually identify a problem.
+  2. DO NOT comment on lack of documentation comments

--- a/packages/python-packages/apiview-copilot/metadata/java/filter.yaml
+++ b/packages/python-packages/apiview-copilot/metadata/java/filter.yaml
@@ -1,4 +1,5 @@
 exceptions: |
-  1. Do not comment on lack of documentation comments
-  2. Do not suggest enforcing consistency in naming conventions for enums.
-  3. Do not comment on enum naming conventions.
+  1. DO NOT make comments that don't actually identify a problem
+  2. DO NOT comment on lack of documentation comments
+  3. DO NOT suggest enforcing consistency in naming conventions for enums
+  4. DO NOT comment on enum naming conventions

--- a/packages/python-packages/apiview-copilot/metadata/python/filter.yaml
+++ b/packages/python-packages/apiview-copilot/metadata/python/filter.yaml
@@ -1,20 +1,21 @@
 exceptions: |
-  1. DO NOT comment on the `send_request` method
-  2. DO NOT suggest changes to class inheritance patterns (i.e. base‑class relationships only)
-  3. DO NOT suggest removing non-standard `implements` pseudocode
-  4. DO NOT comment on removing ellipsis (...) usage in optional parameters
-  5. DO NOT comment on __init__ overloads in model classes
-  6. DO NOT suggest adding docstrings
-  7. DO NOT suggest using pydantic or dataclasses for models
-  8. DO NOT comment on indentation
-  9. DO NOT suggest consolidating multiple overloads
-  10. DO NOT suggest providing convenience methods directly on the client
-  11. DO NOT comment on non-standard use of TypedDict syntax
-  12. DO NOT comment about using non-standard ivar syntax
-  13. DO NOT comment about using standard attribute annotations (or @property decorators) rather than a custom 'property' syntax.
-  14. DO NOT comment about methods ending with : (colon)
-  15. DO NOT comment on namespaces unless they are violating guidelines
-  16. DO NOT comment about removing the non-standard 'namespace' declaration
-  17. DO NOT suggest removing the full package prefix from class names.
-  18. DO NOT comment on the overuse of **kwargs
-  19. DO NOT comment that the *syntax* of including a module path in the *definition* is wrong (e.g. flagging `class azure.foo.FooClient:` itself as illegal)
+  1. DO NOT make comments that don't actually identify a problem
+  2. DO NOT comment on the `send_request` method
+  3. DO NOT suggest changes to class inheritance patterns (i.e. base‑class relationships only)
+  4. DO NOT suggest removing non-standard `implements` pseudocode
+  5. DO NOT comment on removing ellipsis (...) usage in optional parameters
+  6. DO NOT comment on __init__ overloads in model classes
+  7. DO NOT suggest adding docstrings
+  8. DO NOT suggest using pydantic or dataclasses for models
+  9. DO NOT comment on indentation
+  10. DO NOT suggest consolidating multiple overloads
+  11. DO NOT suggest providing convenience methods directly on the client
+  12. DO NOT comment on non-standard use of TypedDict syntax
+  13. DO NOT comment about using non-standard ivar syntax
+  14. DO NOT comment about using standard attribute annotations (or @property decorators) rather than a custom 'property' syntax.
+  15. DO NOT comment about methods ending with : (colon)
+  16. DO NOT comment on namespaces unless they are violating guidelines
+  17. DO NOT comment about removing the non-standard 'namespace' declaration
+  18. DO NOT suggest removing the full package prefix from class names.
+  19. DO NOT comment on the overuse of **kwargs
+  20. DO NOT comment that the *syntax* of including a module path in the *definition* is wrong (e.g. flagging `class azure.foo.FooClient:` itself as illegal)

--- a/packages/python-packages/apiview-copilot/metadata/rust/filter.yaml
+++ b/packages/python-packages/apiview-copilot/metadata/rust/filter.yaml
@@ -1,2 +1,3 @@
 exceptions: |
-  1. Comment on lack of documentation comments
+  1. DO NOT make comments that don't actually identify a problem.
+  2. DO NOT comment on lack of documentation comments

--- a/packages/python-packages/apiview-copilot/metadata/typescript/filter.yaml
+++ b/packages/python-packages/apiview-copilot/metadata/typescript/filter.yaml
@@ -1,13 +1,14 @@
 exceptions: |
-  1. DO NOT comment on lack of documentation comments
-  2. DO NOT comment on the use of "."
-  3. DO NOT comment on syntax errors
-  4. DO NOT suggest renaming overload methods to distinguish one from another
-  5. DO NOT suggest consolidating overloads into a single declaration
-  6. DO NOT suggest consolidating the similar Options interfaces into one
-  7. DO NOT suggest providing an explicit default value to constant variables
-  8. DO NOT suggest narrowing aliased type of string to an enum or a union of known literal values
-  9. DO NOT suggest including namespace prefix
-  10. DO NOT suggest using namespaces or modules
-  11. DO NOT suggest grouping related interfaces into separate modules
-  12. DO NOT suggest a type alias over an empty interface extension
+  1. DO NOT make comments that don't actually identify a problem.
+  2. DO NOT comment on lack of documentation comments
+  3. DO NOT comment on the use of "."
+  4. DO NOT comment on syntax errors
+  5. DO NOT suggest renaming overload methods to distinguish one from another
+  6. DO NOT suggest consolidating overloads into a single declaration
+  7. DO NOT suggest consolidating the similar Options interfaces into one
+  8. DO NOT suggest providing an explicit default value to constant variables
+  9. DO NOT suggest narrowing aliased type of string to an enum or a union of known literal values
+  10. DO NOT suggest including namespace prefix
+  11. DO NOT suggest using namespaces or modules
+  12. DO NOT suggest grouping related interfaces into separate modules
+  13. DO NOT suggest a type alias over an empty interface extension

--- a/packages/python-packages/apiview-copilot/prompts/api_review/comment_filter.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/api_review/comment_filter.prompty
@@ -21,24 +21,26 @@ model:
 sample:
   language: Python
   exceptions: |
-    1. Comment on the `send_request` method
-    2. Suggest changes to class inheritance patterns (i.e. base‑class relationships only)
-    3. Comment on `implements ContextManager` pseudocode
-    4. Comment on ellipsis (...) usage in optional parameters
-    5. Comment on __init__ overloads in model classes or MutableMapping inheritance
-    6. Suggest adding docstrings
-    7. Suggest using pydantic or dataclasses for models
-    8. Comment on async list method naming
-    9. Comment on indentation
-    10. Suggest consolidating multiple overloads
-    11. Suggest providing convenience methods directly on the client
-    12. Comment on non-standard use of TypedDict syntax
-    13. Comment about ivar being non-standard in docstrings
-    14. Comment about use of distributed_trace/async decorators
-    15. Comment about methods ending with :
-    16. Comments about not using the non-standard namespace declaration
-    17. Comment on the overuse of **kwargs
-    18. Comment that the *syntax* of including a module path in the *definition* is wrong (e.g. flagging `class azure.foo.FooClient:` itself as illegal)
+    1. DO NOT make comments that don't actually identify a problem
+    2. DO NOT comment on the `send_request` method
+    3. DO NOT suggest changes to class inheritance patterns (i.e. base‑class relationships only)
+    4. DO NOT suggest removing non-standard `implements` pseudocode
+    5. DO NOT comment on removing ellipsis (...) usage in optional parameters
+    6. DO NOT comment on __init__ overloads in model classes
+    7. DO NOT suggest adding docstrings
+    8. DO NOT suggest using pydantic or dataclasses for models
+    9. DO NOT comment on indentation
+    10. DO NOT suggest consolidating multiple overloads
+    11. DO NOT suggest providing convenience methods directly on the client
+    12. DO NOT comment on non-standard use of TypedDict syntax
+    13. DO NOT comment about using non-standard ivar syntax
+    14. DO NOT comment about using standard attribute annotations (or @property decorators) rather than a custom 'property' syntax.
+    15. DO NOT comment about methods ending with : (colon)
+    16. DO NOT comment on namespaces unless they are violating guidelines
+    17. DO NOT comment about removing the non-standard 'namespace' declaration
+    18. DO NOT suggest removing the full package prefix from class names.
+    19. DO NOT comment on the overuse of **kwargs
+    20. DO NOT comment that the *syntax* of including a module path in the *definition* is wrong (e.g. flagging `class azure.foo.FooClient:` itself as illegal)
   outline: |
     ## namespace azure.widget
     - WidgetClient


### PR DESCRIPTION
Fixes #11732.

Adds a line to every language's filter to remove comments that don't identify a problem. 