### PR TITLE
`test-proxy` supports `multipart/*`

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ContentTypeUtilities.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ContentTypeUtilities.cs
@@ -30,7 +30,13 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 return false;
 
             var ct = values[0];
-            if (!ct.StartsWith("multipart/mixed", StringComparison.OrdinalIgnoreCase))
+            /*
+             * For the most part, the multipart serialization/deserialization code should be universal across
+             * all the various types of multipart/* payloads.
+             * 
+             * Until we discover otherwise, we'll treat them the same.
+             */
+            if (!ct.StartsWith("multipart/", StringComparison.OrdinalIgnoreCase))
                 return false;
 
             const string key = "boundary=";


### PR DESCRIPTION
At least as far as treat them the same for serialization/deserialization/sanitization.

Lack of handling Content-Disposition may cause us to overaggressively base64 encode (due to presence of Content-Disposition but no Content-Type header part), but that's not the worst outcome.

[Previous PR for updating multipart storage at rest](https://github.com/Azure/azure-sdk-tools/pull/10381/files)

Todo:
- [ ] Intercept body matching logic [here](https://github.com/Azure/azure-sdk-tools/blob/466644bdb50b21506851b2c1b91e810b677816a8/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs#L161) Add a special case for multipart form data that uses `GetMultipartBodyBytes`
- [ ] Add `GetMultipartBodyBytes` that extracts _just_ body bytes from a multipart payload to [https://github.com/Azure/azure-sdk-tools/blob/466644bdb50b21506851b2c1b91e810b677816a8/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/MultipartUtilities.cs#L16C39-L16C40) OR use a body reader that relies on ASP.NET implementation of multipart bodies as we do in [RecordedTestSanitizer](https://github.com/Azure/azure-sdk-tools/blob/466644bdb50b21506851b2c1b91e810b677816a8/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordedTestSanitizer.cs#L114)
- [ ] Utilize the `GetMultipartBodyBytes` on request and response bodies, then compare ONLY the body bytes
- [ ] Return the payload if it matches bare body bytes
- [ ] Tests for form-data payload
- [ ] Match ignoring boundary values


