### PR TITLE
[azsdk-cli] Fixing minor issue where we don't propagate the cancellation token for validating readme files

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Generators/ReadMeGeneratorToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Generators/ReadMeGeneratorToolTests.cs
@@ -90,7 +90,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.Generators
         /// </summary>
         /// <returns></returns>
         [TestCase(
-            "Bad link, still has locale in it: https://learn.microsoft.com/fr-fr/blahblah", 
+            "Bad link, still has locale in it: https://learn.microsoft.com/fr-fr/blahblah",
             "The readme contains links with locales. Keep the link, but remove these locales from links: (fr-fr).", TestName = "Links with locales in them")]
         [TestCase(
             "Still referencing aztemplate and (package path)",
@@ -138,9 +138,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.Generators
             var serviceCollection = new ServiceCollection();
             var OutputHelper = new MockOutputHelper();
 
-
             serviceCollection.AddLogging();     // so our ILogger<T>'s will be available.
-
 
             ServiceRegistrations.RegisterCommonServices(serviceCollection);
             serviceCollection.AddSingleton<IOutputHelper>(OutputHelper);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/PackageCheckTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/PackageCheckTool.cs
@@ -35,30 +35,30 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
         public override Command GetCommand()
         {
             var parentCommand = new Command("run-checks", "Run validation checks for SDK packages");
-            
+
             // Add the package path option to the parent command so it can be used without subcommands
             parentCommand.AddOption(SharedOptions.PackagePath);
-            
+
             // Set handler for the parent command to default to All checks
             parentCommand.SetHandler(async (InvocationContext ctx) =>
             {
                 var packagePath = ctx.ParseResult.GetValueForOption(SharedOptions.PackagePath);
                 await HandleCommandWithOptions(packagePath, PackageCheckType.All, ctx.GetCancellationToken());
             });
-            
+
             // Create sub-commands for each check type
             var checkTypeValues = Enum.GetValues<PackageCheckType>();
             foreach (var checkType in checkTypeValues)
             {
                 var subCommand = new Command(checkType.ToString().ToLowerInvariant(), $"Run {checkType} validation check");
                 subCommand.AddOption(SharedOptions.PackagePath);
-                
+
                 subCommand.SetHandler(async (InvocationContext ctx) =>
                 {
                     var packagePath = ctx.ParseResult.GetValueForOption(SharedOptions.PackagePath);
-                    await HandleCommandWithOptions(packagePath, checkType, ctx.GetCancellationToken()); 
+                    await HandleCommandWithOptions(packagePath, checkType, ctx.GetCancellationToken());
                 });
-                
+
                 parentCommand.AddCommand(subCommand);
             }
 
@@ -69,7 +69,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
         {
             // Get the command name which corresponds to the check type
             var commandName = ctx.ParseResult.CommandResult.Command.Name;
-            
+
             // If this is the parent command (run-checks), default to All
             if (commandName == "run-checks")
             {
@@ -77,7 +77,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
                 await HandleCommandWithOptions(packagePath, PackageCheckType.All, ct);
                 return;
             }
-            
+
             // Parse the command name back to enum for subcommands
             if (Enum.TryParse<PackageCheckType>(commandName, true, out var checkType))
             {
@@ -91,7 +91,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
         }
 
         private async Task HandleCommandWithOptions(string packagePath, PackageCheckType checkType, CancellationToken ct)
-        {          
+        {
             var result = await RunPackageCheck(packagePath, checkType, ct);
             ExitCode = result.ExitCode;
             output.Output(result);
@@ -114,7 +114,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
                     PackageCheckType.All => await RunAllChecks(packagePath, ct),
                     PackageCheckType.Changelog => await RunChangelogValidation(packagePath, ct),
                     PackageCheckType.Dependency => await RunDependencyCheck(packagePath, ct),
-                    PackageCheckType.Readme => await RunReadmeValidation(packagePath),
+                    PackageCheckType.Readme => await RunReadmeValidation(packagePath, ct),
                     PackageCheckType.Cspell => await RunSpellingValidation(packagePath),
                     _ => throw new ArgumentOutOfRangeException(
                         nameof(checkType),
@@ -154,7 +154,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
             }
 
             // Run README validation
-            var readmeValidationResult = await languageChecks.ValidateReadmeAsync(packagePath);
+            var readmeValidationResult = await languageChecks.ValidateReadmeAsync(packagePath, ct);
             results.Add(readmeValidationResult);
             if (readmeValidationResult.ExitCode != 0)
             {
@@ -169,9 +169,9 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
                 overallSuccess = false;
             }
 
-            if (!overallSuccess) 
-            { 
-                SetFailure(1); 
+            if (!overallSuccess)
+            {
+                SetFailure(1);
             }
 
             var message = overallSuccess ? "All checks completed successfully" : "Some checks failed";
@@ -205,18 +205,18 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
             return result;
         }
 
-        private async Task<CLICheckResponse> RunReadmeValidation(string packagePath)
+        private async Task<CLICheckResponse> RunReadmeValidation(string packagePath, CancellationToken ct = default)
         {
             logger.LogInformation("Running README validation");
-            
-            var result = await languageChecks.ValidateReadmeAsync(packagePath);
+
+            var result = await languageChecks.ValidateReadmeAsync(packagePath, ct);
             return result;
         }
 
         private async Task<CLICheckResponse> RunSpellingValidation(string packagePath)
         {
             logger.LogInformation("Running spelling validation");
-            
+
             var result = await languageChecks.CheckSpellingAsync(packagePath);
             return result;
         }


### PR DESCRIPTION
That validation can be slow since it has to install some packages. 