### PR TITLE
[AVC] Refactor metrics

### DIFF
--- a/packages/python-packages/apiview-copilot/cli.py
+++ b/packages/python-packages/apiview-copilot/cli.py
@@ -615,12 +615,12 @@ def db_purge(containers: Optional[list[str]] = None, run_indexer: bool = False):
             print(f"Error purging container: {e}")
 
 
-def get_apiview_comments(review_id: str, environment: str = "production", use_api: bool = False) -> dict:
+def get_apiview_comments(review_id: str, environment: str = "production") -> dict:
     """
     Retrieves comments for a specific APIView review and returns them grouped by element ID and
     sorted by CreatedOn time. Omits resolved and deleted comments, and removes unnecessary fields.
     """
-    return _get_apiview_comments(review_id, environment, use_api)
+    return _get_apiview_comments(review_id, environment)
 
 
 def get_active_reviews(start_date: str, end_date: str, language: str, environment: str = "production") -> list:
@@ -912,11 +912,6 @@ class CliCommandsLoader(CLICommandsLoader):
                 options_list=["--environment"],
                 default="production",
                 choices=["production", "staging"],
-            )
-            ac.argument(
-                "use_api",
-                action="store_true",
-                help="Use the APIView API to retrieve comments instead of Cosmos DB.",
             )
         with ArgumentsContext(self, "metrics report") as ac:
             ac.argument("start_date", help="The start date for the metrics report (YYYY-MM-DD).")

--- a/packages/python-packages/apiview-copilot/cli.py
+++ b/packages/python-packages/apiview-copilot/cli.py
@@ -17,28 +17,24 @@ import pathlib
 import sys
 import time
 from collections import OrderedDict
-from datetime import datetime
 from typing import Optional
 
 import colorama
-import prompty
-import prompty.azure
 import requests
-from azure.cosmos import CosmosClient
-from azure.cosmos.exceptions import CosmosHttpResponseError
 from colorama import Fore, Style
 from knack import CLI, ArgumentsContext, CLICommandsLoader
 from knack.commands import CommandGroup
 from knack.help_files import helps
+from src._apiview import get_active_reviews as _get_active_reviews
+from src._apiview import get_apiview_comments as _get_apiview_comments
 from src._apiview_reviewer import SUPPORTED_LANGUAGES, ApiViewReview
-from src._credential import get_credential
 from src._database_manager import ContainerNames, get_database_manager
 from src._garbage_collector import GarbageCollector
 from src._mention import handle_mention_request
-from src._models import APIViewComment
+from src._metrics import get_metrics_report
 from src._search_manager import SearchManager
 from src._settings import SettingsManager
-from src._utils import get_language_pretty_name, get_prompt_path
+from src._utils import get_language_pretty_name
 from src.agent._agent import get_main_agent, invoke_agent
 
 colorama.init(autoreset=True)
@@ -619,313 +615,24 @@ def db_purge(containers: Optional[list[str]] = None, run_indexer: bool = False):
             print(f"Error purging container: {e}")
 
 
-def _get_apiview_cosmos_client(container_name: str, environment: str = "production"):
-    """
-    Returns the Cosmos DB container client for the specified container and environment.
-    """
-    apiview_account_names = {
-        "production": "apiview-cosmos",
-        "staging": "apiviewstaging",
-    }
-    try:
-        cosmos_acc = apiview_account_names.get(environment)
-        cosmos_db = "APIViewV2"
-        if not cosmos_acc:
-            raise ValueError(
-                # pylint: disable=line-too-long
-                f"Unrecognized environment: {environment}. Valid options are: {', '.join(apiview_account_names.keys())}."
-            )
-        cosmos_url = f"https://{cosmos_acc}.documents.azure.com:443/"
-        client = CosmosClient(url=cosmos_url, credential=get_credential())
-        database = client.get_database_client(cosmos_db)
-        container = database.get_container_client(container_name)
-        return container
-    except CosmosHttpResponseError as e:
-        if e.status_code == 403:
-            print(
-                # pylint: disable=line-too-long
-                "Error: You do not have permission to access Cosmos DB.\nTo grant yourself access, run: python scripts\\apiview_permissions.py"
-            )
-        sys.exit(1)
-
-
-_APIVIEW_COMMENT_SELECT_FIELDS = [
-    "id",
-    "CreatedOn",
-    "CreatedBy",
-    "CommentText",
-    "IsResolved",
-    "IsDeleted",
-    "ElementId",
-    "ReviewId",
-    "APIRevisionId",
-    "Upvotes",
-    "Downvotes",
-    "CommentType",
-]
-APIVIEW_COMMENT_SELECT_FIELDS = [f"c.{field}" for field in _APIVIEW_COMMENT_SELECT_FIELDS]
-
-
 def get_apiview_comments(review_id: str, environment: str = "production", use_api: bool = False) -> dict:
     """
     Retrieves comments for a specific APIView review and returns them grouped by element ID and
     sorted by CreatedOn time. Omits resolved and deleted comments, and removes unnecessary fields.
     """
-    comments = []
-    try:
-        if use_api:
-            if not review_id:
-                raise ValueError("When using the API, `--review-id` must be provided.")
-            apiview_endpoints = {
-                "production": "https://apiview.dev",
-                "staging": "https://apiviewstagingtest.com",
-            }
-            endpoint_root = apiview_endpoints.get(environment)
-            endpoint = f"{endpoint_root}/api/Comments/{review_id}?commentType=APIRevision&isDeleted=false"
-            apiview_scopes = {
-                "production": "api://apiview/.default",
-                "staging": "api://apiviewstaging/.default",
-            }
-            credential = get_credential()
-            scope = apiview_scopes.get(environment)
-            token = credential.get_token(scope)
-            response = requests.get(
-                endpoint,
-                headers={"Content-Type": "application/json", "Authorization": f"Bearer {token.token}"},
-                timeout=30,
-            )
-
-            if response.status_code != 200:
-                print(f"Error retrieving comments: {response.status_code} - {response.text}")
-                return {}
-            try:
-                comments = response.json()
-            except Exception as json_exc:
-                content = response.content.decode("utf-8")
-                if "Please login using your GitHub account" in content:
-                    print("Error: API is still requesting authentication via Github.")
-                    return {}
-                else:
-                    print(f"Error parsing comments JSON: {json_exc}")
-                    return {}
-        else:
-            container = _get_apiview_cosmos_client(container_name="Comments", environment=environment)
-            result = container.query_items(
-                # pylint: disable=line-too-long
-                query=f"SELECT {', '.join(APIVIEW_COMMENT_SELECT_FIELDS)} FROM c WHERE c.ReviewId = @review_id AND c.IsResolved = false AND c.IsDeleted = false",
-                parameters=[{"name": "@review_id", "value": review_id}],
-            )
-            comments = list(result)
-    except Exception as e:
-        print(f"Error retrieving comments for review {review_id}: {e}")
-        return {}
-
-    conversations = {}
-    if comments:
-        for comment in comments:
-            element_id = comment.get("ElementId")
-            if element_id in conversations:
-                conversations[element_id].append(comment)
-            else:
-                conversations[element_id] = [comment]
-    for element_id, comments in conversations.items():
-        # sort comments by created_on time
-        comments.sort(key=lambda x: x.get("CreatedOn", 0))
-    return conversations
+    return _get_apiview_comments(review_id, environment, use_api)
 
 
-def _calculate_ai_vs_manual_comment_ratio(comments: list[APIViewComment]) -> float:
+def get_active_reviews(start_date: str, end_date: str, language: str, environment: str = "production") -> list:
     """
-    Calculates the ratio of AI-generated comments to manual comments.
+    Retrieves active APIView reviews in the specified environment during the specified period.
     """
-    ai_count = 0
-    manual_count = 0
-    for comment in comments:
-        if comment.created_by == "azure-sdk":
-            ai_count += 1
-        else:
-            manual_count += 1
-    return ai_count / manual_count if manual_count > 0 else float("inf") if ai_count > 0 else 0.0
-
-
-def _calculate_good_vs_bad_comment_ratio(comments: list[APIViewComment]) -> float:
-    """
-    Calculates the ratio of AI-generated comments with a thumbs-up compared to comments with a thumbs-down.
-    """
-    good_count = 0
-    neutral_count = 0
-    bad_count = 0
-    ai_comments = [c for c in comments if c.created_by == "azure-sdk"]
-    for comment in ai_comments:
-        good_count += len(comment.upvotes)
-        bad_count += len(comment.downvotes)
-        if not comment.upvotes and not comment.downvotes:
-            neutral_count += 1
-    return good_count / bad_count if bad_count > 0 else float("inf") if good_count > 0 else 0.0
-
-
-def _calculate_language_adoption(start_date: str, end_date: str, environment: str = "production") -> dict:
-    """
-    Calculates the adoption rate of AI review comments by language.
-    Looks at distinct ReviewIds that had new revisions created during the time period
-    and calculates what percentage of those ReviewIds have AI comments.
-    Returns a dictionary with languages as keys and adoption percentages as values.
-    """
-    # Get comments container client
-    comments_client = _get_apiview_cosmos_client(container_name="Comments", environment=environment)
-    reviews_client = _get_apiview_cosmos_client(container_name="Reviews", environment=environment)
-
-    iso_start = datetime.strptime(start_date, "%Y-%m-%d").strftime("%Y-%m-%dT00:00:00Z")
-    iso_end = datetime.strptime(end_date, "%Y-%m-%d").strftime("%Y-%m-%dT23:59:59.999999Z")
-
-    # Query all comments in the date range to get active ReviewIds
-    comments_query = """
-    SELECT c.ReviewId, c.CreatedBy FROM c 
-    WHERE c.CreatedOn >= @start_date AND c.CreatedOn <= @end_date
-    """
-
-    raw_comments = list(
-        comments_client.query_items(
-            query=comments_query,
-            parameters=[{"name": "@start_date", "value": iso_start}, {"name": "@end_date", "value": iso_end}],
-            enable_cross_partition_query=True,
-        )
-    )
-
-    # Build set of active ReviewIds from comments
-    active_reviews = set()
-    for comment in raw_comments:
-        review_id = comment.get("ReviewId")
-        if review_id:
-            active_reviews.add(review_id)
-
-    # Find ReviewIds with AI comments
-    ai_reviews = {
-        comment["ReviewId"]
-        for comment in raw_comments
-        if comment.get("CreatedBy") == "azure-sdk" and comment.get("ReviewId")
-    }
-
-    # If no comments, try to get all reviews in the date range
-    if not active_reviews:
-        # Query all reviews in the date range
-        reviews_query = """
-        SELECT r.id, r.Language FROM r WHERE r.CreatedOn >= @start_date AND r.CreatedOn <= @end_date
-        """
-        batch_reviews = list(
-            reviews_client.query_items(
-                query=reviews_query,
-                parameters=[{"name": "@start_date", "value": iso_start}, {"name": "@end_date", "value": iso_end}],
-                enable_cross_partition_query=True,
-            )
-        )
-        review_to_language = {}
-        language_reviews = {}
-        for review in batch_reviews:
-            review_id = review.get("id")
-            language = review.get("Language", "").lower()
-            if language and review_id:
-                review_to_language[review_id] = language
-                if language not in language_reviews:
-                    language_reviews[language] = set()
-                language_reviews[language].add(review_id)
-    else:
-        # Query all reviews for active ReviewIds and get their languages
-        review_to_language = {}
-        language_reviews = {}
-        batch_size = 100
-        review_ids = list(active_reviews)
-        for i in range(0, len(review_ids), batch_size):
-            batch_ids = review_ids[i : i + batch_size]
-            reviews_query = """
-            SELECT r.id, r.Language FROM r WHERE ARRAY_CONTAINS(@review_ids, r.id)
-            """
-            batch_reviews = list(
-                reviews_client.query_items(
-                    query=reviews_query,
-                    parameters=[{"name": "@review_ids", "value": batch_ids}],
-                    enable_cross_partition_query=True,
-                )
-            )
-            for review in batch_reviews:
-                review_id = review.get("id")
-                language = review.get("Language", "").lower()
-                if language and review_id:
-                    review_to_language[review_id] = language
-                    if language not in language_reviews:
-                        language_reviews[language] = set()
-                    language_reviews[language].add(review_id)
-
-    # Calculate adoption rate and counts per language
-    adoption_stats = {}
-    for language, review_ids in language_reviews.items():
-        total_reviews = len(review_ids)
-        reviews_with_ai_comments = sum(1 for review_id in review_ids if review_id in ai_reviews)
-        adoption_rate = reviews_with_ai_comments / total_reviews if total_reviews > 0 else 0.0
-        adoption_stats[language] = {
-            "adoption_rate": f"{adoption_rate:.2f}",
-            "active_reviews": total_reviews,
-            "active_copilot_reviews": reviews_with_ai_comments,
-        }
-
-    return adoption_stats
+    return _get_active_reviews(start_date, end_date, language, environment)
 
 
 def report_metrics(start_date: str, end_date: str, environment: str = "production", markdown: bool = False) -> dict:
     """Generate a report of APIView metrics between two dates."""
-    # validate that start_date and end_date are in YYYY-MM-DD format
-    bad_dates = []
-    iso_start = None
-    iso_end = None
-    for date_str, label in zip([start_date, end_date], ["start_date", "end_date"]):
-        try:
-            dt = datetime.strptime(date_str, "%Y-%m-%d")
-            if label == "start_date":
-                # Start of day
-                iso_start = dt.strftime("%Y-%m-%dT00:00:00Z")
-            else:
-                # End of day (max time)
-                iso_end = dt.strftime("%Y-%m-%dT23:59:59.999999Z")
-        except ValueError:
-            bad_dates.append(date_str)
-    if bad_dates:
-        print(f"ValueError: Dates must be in YYYY-MM-DD format. Invalid date(s) found: {', '.join(bad_dates)}")
-        return
-
-    comments_client = _get_apiview_cosmos_client(container_name="Comments", environment=environment)
-    query = f"""
-    SELECT {', '.join(APIVIEW_COMMENT_SELECT_FIELDS)} FROM c
-    WHERE c.CreatedOn >= @start_date AND c.CreatedOn <= @end_date
-    """
-    # retrieve comments created between start_date and end_date (ISO 8601)
-    raw_comments = list(
-        comments_client.query_items(
-            query=query,
-            parameters=[{"name": "@start_date", "value": iso_start}, {"name": "@end_date", "value": iso_end}],
-            enable_cross_partition_query=True,
-        )
-    )
-    comments = [APIViewComment(**d) for d in raw_comments]
-
-    # Calculate language adoption
-    language_adoption = _calculate_language_adoption(start_date, end_date, environment=environment)
-
-    report = {
-        "start_date": start_date,
-        "end_date": end_date,
-        "metrics": {
-            "ai_vs_manual_comment_ratio": _calculate_ai_vs_manual_comment_ratio(comments),
-            "good_vs_bad_comment_ratio": _calculate_good_vs_bad_comment_ratio(comments),
-            "language_adoption": language_adoption,
-        },
-    }
-    if markdown:
-        prompt_path = get_prompt_path(folder="other", filename="summarize_metrics")
-        inputs = {"data": report}
-        summary = prompty.execute(prompt_path, inputs=inputs)
-        print(summary)
-    else:
-        return report
+    return get_metrics_report(start_date, end_date, environment, markdown)
 
 
 class CliCommandsLoader(CLICommandsLoader):
@@ -936,6 +643,7 @@ class CliCommandsLoader(CLICommandsLoader):
     def load_command_table(self, args):
         with CommandGroup(self, "apiview", "__main__#{}") as g:
             g.command("get-comments", "get_apiview_comments")
+            g.command("get-active-reviews", "get_active_reviews")
         with CommandGroup(self, "review", "__main__#{}") as g:
             g.command("generate", "generate_review")
             g.command("start-job", "review_job_start")
@@ -975,6 +683,26 @@ class CliCommandsLoader(CLICommandsLoader):
                 "remote",
                 action="store_true",
                 help="Use the remote API review service instead of local processing.",
+            )
+            ac.argument(
+                "start_date",
+                type=str,
+                help="The start date (YYYY-MM-DD).",
+                options_list=["--start-date", "-s"],
+            )
+            ac.argument(
+                "end_date",
+                type=str,
+                help="The end date (YYYY-MM-DD).",
+                options_list=["--end-date", "-e"],
+            )
+            ac.argument(
+                "environment",
+                type=str,
+                help="The APIView environment. Defaults to 'production'.",
+                options_list=["--environment"],
+                default="production",
+                choices=["production", "staging"],
             )
         with ArgumentsContext(self, "review") as ac:
             ac.argument("path", type=str, help="The path to the APIView file")
@@ -1191,25 +919,11 @@ class CliCommandsLoader(CLICommandsLoader):
                 help="Use the APIView API to retrieve comments instead of Cosmos DB.",
             )
         with ArgumentsContext(self, "metrics report") as ac:
-            ac.argument(
-                "start_date",
-                type=str,
-                help="The start date for the metrics report (YYYY-MM-DD).",
-                options_list=["--start-date", "-s"],
-            )
-            ac.argument(
-                "end_date",
-                type=str,
-                help="The end date for the metrics report (YYYY-MM-DD).",
-                options_list=["--end-date", "-e"],
-            )
+            ac.argument("start_date", help="The start date for the metrics report (YYYY-MM-DD).")
+            ac.argument("end_date", help="The end date for the metrics report (YYYY-MM-DD).")
             ac.argument(
                 "environment",
-                type=str,
                 help="The APIView environment from which to calculate the metrics report. Defaults to 'production'.",
-                options_list=["--environment"],
-                default="production",
-                choices=["production", "staging"],
             )
         super(CliCommandsLoader, self).load_arguments(command)
 

--- a/packages/python-packages/apiview-copilot/src/_apiview.py
+++ b/packages/python-packages/apiview-copilot/src/_apiview.py
@@ -1,0 +1,143 @@
+import sys
+
+import requests
+from azure.cosmos import CosmosClient
+from azure.cosmos.exceptions import CosmosHttpResponseError
+from src._credential import get_credential
+
+_APIVIEW_COMMENT_SELECT_FIELDS = [
+    "id",
+    "CreatedOn",
+    "CreatedBy",
+    "CommentText",
+    "IsResolved",
+    "IsDeleted",
+    "ElementId",
+    "ReviewId",
+    "APIRevisionId",
+    "Upvotes",
+    "Downvotes",
+    "CommentType",
+]
+APIVIEW_COMMENT_SELECT_FIELDS = [f"c.{field}" for field in _APIVIEW_COMMENT_SELECT_FIELDS]
+
+
+def get_apiview_cosmos_client(container_name: str, environment: str = "production"):
+    """
+    Returns the Cosmos DB container client for the specified container and environment.
+    """
+    apiview_account_names = {
+        "production": "apiview-cosmos",
+        "staging": "apiviewstaging",
+    }
+    try:
+        cosmos_acc = apiview_account_names.get(environment)
+        cosmos_db = "APIViewV2"
+        if not cosmos_acc:
+            raise ValueError(
+                # pylint: disable=line-too-long
+                f"Unrecognized environment: {environment}. Valid options are: {', '.join(apiview_account_names.keys())}."
+            )
+        cosmos_url = f"https://{cosmos_acc}.documents.azure.com:443/"
+        client = CosmosClient(url=cosmos_url, credential=get_credential())
+        database = client.get_database_client(cosmos_db)
+        container = database.get_container_client(container_name)
+        return container
+    except CosmosHttpResponseError as e:
+        if e.status_code == 403:
+            print(
+                # pylint: disable=line-too-long
+                "Error: You do not have permission to access Cosmos DB.\nTo grant yourself access, run: python scripts\\apiview_permissions.py"
+            )
+        sys.exit(1)
+
+
+def get_apiview_comments(review_id: str, environment: str = "production", use_api: bool = False) -> dict:
+    """
+    Retrieves comments for a specific APIView review and returns them grouped by element ID and
+    sorted by CreatedOn time. Omits resolved and deleted comments, and removes unnecessary fields.
+    """
+    comments = []
+    try:
+        if use_api:
+            if not review_id:
+                raise ValueError("When using the API, `--review-id` must be provided.")
+            apiview_endpoints = {
+                "production": "https://apiview.dev",
+                "staging": "https://apiviewstagingtest.com",
+            }
+            endpoint_root = apiview_endpoints.get(environment)
+            endpoint = f"{endpoint_root}/api/Comments/{review_id}?commentType=APIRevision&isDeleted=false"
+            apiview_scopes = {
+                "production": "api://apiview/.default",
+                "staging": "api://apiviewstaging/.default",
+            }
+            credential = get_credential()
+            scope = apiview_scopes.get(environment)
+            token = credential.get_token(scope)
+            response = requests.get(
+                endpoint,
+                headers={"Content-Type": "application/json", "Authorization": f"Bearer {token.token}"},
+                timeout=30,
+            )
+
+            if response.status_code != 200:
+                print(f"Error retrieving comments: {response.status_code} - {response.text}")
+                return {}
+            try:
+                comments = response.json()
+            except Exception as json_exc:
+                content = response.content.decode("utf-8")
+                if "Please login using your GitHub account" in content:
+                    print("Error: API is still requesting authentication via Github.")
+                    return {}
+                else:
+                    print(f"Error parsing comments JSON: {json_exc}")
+                    return {}
+        else:
+            container = get_apiview_cosmos_client(container_name="Comments", environment=environment)
+            result = container.query_items(
+                # pylint: disable=line-too-long
+                query=f"SELECT {', '.join(APIVIEW_COMMENT_SELECT_FIELDS)} FROM c WHERE c.ReviewId = @review_id AND c.IsResolved = false AND c.IsDeleted = false",
+                parameters=[{"name": "@review_id", "value": review_id}],
+            )
+            comments = list(result)
+    except Exception as e:
+        print(f"Error retrieving comments for review {review_id}: {e}")
+        return {}
+
+    conversations = {}
+    if comments:
+        for comment in comments:
+            element_id = comment.get("ElementId")
+            if element_id in conversations:
+                conversations[element_id].append(comment)
+            else:
+                conversations[element_id] = [comment]
+    for element_id, comments in conversations.items():
+        # sort comments by created_on time
+        comments.sort(key=lambda x: x.get("CreatedOn", 0))
+    return conversations
+
+
+def get_active_reviews(start_date: str, end_date: str, language: str, environment: str = "production") -> list:
+    """
+    Lists active APIView reviews in the specified environment during the specified period.
+    """
+    reviews = []
+    try:
+        container = get_apiview_cosmos_client(container_name="Reviews", environment=environment)
+        result = container.query_items(
+            query=f"SELECT {APIVIEW_COMMENT_SELECT_FIELDS} FROM c WHERE c.IsClosed = false AND c.CreatedOn >= @start_date AND c.CreatedOn <= @end_date AND c.Language = @language",
+            parameters=[
+                {"name": "@start_date", "value": start_date},
+                {"name": "@end_date", "value": end_date},
+                {"name": "@language", "value": language},
+            ],
+            enable_cross_partition_query=True,
+        )
+        reviews = list(result)
+    except Exception as e:
+        print(f"Error retrieving active reviews: {e}")
+        return []
+    return reviews

--- a/packages/python-packages/apiview-copilot/src/_metrics.py
+++ b/packages/python-packages/apiview-copilot/src/_metrics.py
@@ -1,0 +1,202 @@
+from datetime import datetime
+from typing import Optional
+
+import prompty
+import prompty.azure
+from src._apiview import APIVIEW_COMMENT_SELECT_FIELDS, get_apiview_cosmos_client
+from src._models import APIViewComment
+from src._utils import get_prompt_path
+
+
+def _calculate_language_adoption(start_date: str, end_date: str, environment: str = "production") -> dict:
+    """
+    Calculates the adoption rate of AI review comments by language.
+    Looks at distinct ReviewIds that had new revisions created during the time period
+    and calculates what percentage of those ReviewIds have AI comments.
+    Returns a dictionary with languages as keys and adoption percentages as values.
+    """
+    # Get comments container client
+    comments_client = get_apiview_cosmos_client(container_name="Comments", environment=environment)
+    reviews_client = get_apiview_cosmos_client(container_name="Reviews", environment=environment)
+
+    iso_start = datetime.strptime(start_date, "%Y-%m-%d").strftime("%Y-%m-%dT00:00:00Z")
+    iso_end = datetime.strptime(end_date, "%Y-%m-%d").strftime("%Y-%m-%dT23:59:59.999999Z")
+
+    # Query all comments in the date range to get active ReviewIds
+    comments_query = """
+    SELECT c.ReviewId, c.CreatedBy FROM c 
+    WHERE c.CreatedOn >= @start_date AND c.CreatedOn <= @end_date
+    """
+
+    raw_comments = list(
+        comments_client.query_items(
+            query=comments_query,
+            parameters=[{"name": "@start_date", "value": iso_start}, {"name": "@end_date", "value": iso_end}],
+            enable_cross_partition_query=True,
+        )
+    )
+
+    # Build set of active ReviewIds from comments
+    active_reviews = set()
+    for comment in raw_comments:
+        review_id = comment.get("ReviewId")
+        if review_id:
+            active_reviews.add(review_id)
+
+    # Find ReviewIds with AI comments
+    ai_reviews = {
+        comment["ReviewId"]
+        for comment in raw_comments
+        if comment.get("CreatedBy") == "azure-sdk" and comment.get("ReviewId")
+    }
+
+    # If no comments, try to get all reviews in the date range
+    if not active_reviews:
+        # Query all reviews in the date range
+        reviews_query = """
+        SELECT r.id, r.Language FROM r WHERE r.CreatedOn >= @start_date AND r.CreatedOn <= @end_date
+        """
+        batch_reviews = list(
+            reviews_client.query_items(
+                query=reviews_query,
+                parameters=[{"name": "@start_date", "value": iso_start}, {"name": "@end_date", "value": iso_end}],
+                enable_cross_partition_query=True,
+            )
+        )
+        review_to_language = {}
+        language_reviews = {}
+        for review in batch_reviews:
+            review_id = review.get("id")
+            language = review.get("Language", "").lower()
+            if language and review_id:
+                review_to_language[review_id] = language
+                if language not in language_reviews:
+                    language_reviews[language] = set()
+                language_reviews[language].add(review_id)
+    else:
+        # Query all reviews for active ReviewIds and get their languages
+        review_to_language = {}
+        language_reviews = {}
+        batch_size = 100
+        review_ids = list(active_reviews)
+        for i in range(0, len(review_ids), batch_size):
+            batch_ids = review_ids[i : i + batch_size]
+            reviews_query = """
+            SELECT r.id, r.Language FROM r WHERE ARRAY_CONTAINS(@review_ids, r.id)
+            """
+            batch_reviews = list(
+                reviews_client.query_items(
+                    query=reviews_query,
+                    parameters=[{"name": "@review_ids", "value": batch_ids}],
+                    enable_cross_partition_query=True,
+                )
+            )
+            for review in batch_reviews:
+                review_id = review.get("id")
+                language = review.get("Language", "").lower()
+                if language and review_id:
+                    review_to_language[review_id] = language
+                    if language not in language_reviews:
+                        language_reviews[language] = set()
+                    language_reviews[language].add(review_id)
+
+    # Calculate adoption rate and counts per language
+    adoption_stats = {}
+    for language, review_ids in language_reviews.items():
+        total_reviews = len(review_ids)
+        reviews_with_ai_comments = sum(1 for review_id in review_ids if review_id in ai_reviews)
+        adoption_rate = reviews_with_ai_comments / total_reviews if total_reviews > 0 else 0.0
+        adoption_stats[language] = {
+            "adoption_rate": f"{adoption_rate:.2f}",
+            "active_reviews": total_reviews,
+            "active_copilot_reviews": reviews_with_ai_comments,
+        }
+
+    return adoption_stats
+
+
+def _calculate_ai_vs_manual_comment_ratio(comments: list[APIViewComment]) -> float:
+    """
+    Calculates the ratio of AI-generated comments to manual comments.
+    """
+    ai_count = 0
+    manual_count = 0
+    for comment in comments:
+        if comment.created_by == "azure-sdk":
+            ai_count += 1
+        else:
+            manual_count += 1
+    return ai_count / manual_count if manual_count > 0 else float("inf") if ai_count > 0 else 0.0
+
+
+def _calculate_good_vs_bad_comment_ratio(comments: list[APIViewComment]) -> float:
+    """
+    Calculates the ratio of AI-generated comments with a thumbs-up compared to comments with a thumbs-down.
+    """
+    good_count = 0
+    neutral_count = 0
+    bad_count = 0
+    ai_comments = [c for c in comments if c.created_by == "azure-sdk"]
+    for comment in ai_comments:
+        good_count += len(comment.upvotes)
+        bad_count += len(comment.downvotes)
+        if not comment.upvotes and not comment.downvotes:
+            neutral_count += 1
+    return good_count / bad_count if bad_count > 0 else float("inf") if good_count > 0 else 0.0
+
+
+def get_metrics_report(start_date: str, end_date: str, environment: str, markdown: bool = False) -> Optional[dict]:
+    """Generate a metrics report for a date range."""
+    # validate that start_date and end_date are in YYYY-MM-DD format
+    bad_dates = []
+    iso_start = None
+    iso_end = None
+    for date_str, label in zip([start_date, end_date], ["start_date", "end_date"]):
+        try:
+            dt = datetime.strptime(date_str, "%Y-%m-%d")
+            if label == "start_date":
+                # Start of day
+                iso_start = dt.strftime("%Y-%m-%dT00:00:00Z")
+            else:
+                # End of day (max time)
+                iso_end = dt.strftime("%Y-%m-%dT23:59:59.999999Z")
+        except ValueError:
+            bad_dates.append(date_str)
+    if bad_dates:
+        print(f"ValueError: Dates must be in YYYY-MM-DD format. Invalid date(s) found: {', '.join(bad_dates)}")
+        return
+
+    comments_client = get_apiview_cosmos_client(container_name="Comments", environment=environment)
+    query = f"""
+    SELECT {', '.join(APIVIEW_COMMENT_SELECT_FIELDS)} FROM c
+    WHERE c.CreatedOn >= @start_date AND c.CreatedOn <= @end_date
+    """
+    # retrieve comments created between start_date and end_date (ISO 8601)
+    raw_comments = list(
+        comments_client.query_items(
+            query=query,
+            parameters=[{"name": "@start_date", "value": iso_start}, {"name": "@end_date", "value": iso_end}],
+            enable_cross_partition_query=True,
+        )
+    )
+    comments = [APIViewComment(**d) for d in raw_comments]
+
+    # Calculate language adoption
+    language_adoption = _calculate_language_adoption(start_date, end_date, environment=environment)
+
+    report = {
+        "start_date": start_date,
+        "end_date": end_date,
+        "metrics": {
+            "ai_vs_manual_comment_ratio": _calculate_ai_vs_manual_comment_ratio(comments),
+            "good_vs_bad_comment_ratio": _calculate_good_vs_bad_comment_ratio(comments),
+            "language_adoption": language_adoption,
+        },
+    }
+    if markdown:
+        prompt_path = get_prompt_path(folder="other", filename="summarize_metrics")
+        inputs = {"data": report}
+        summary = prompty.execute(prompt_path, inputs=inputs)
+        print(summary)
+    else:
+        return report

--- a/packages/python-packages/apiview-copilot/tests/metrics_test.py
+++ b/packages/python-packages/apiview-copilot/tests/metrics_test.py
@@ -10,13 +10,13 @@ Test for metrics functionality.
 
 from unittest.mock import Mock, patch
 
-import cli
+import src._metrics as metrics
 
 
 class TestMetrics:
     """Test class for metrics functions."""
 
-    @patch("cli._get_apiview_cosmos_client")
+    @patch("src._metrics.get_apiview_cosmos_client")
     def test_calculate_language_adoption_basic(self, mock_cosmos_client):
         """Test basic language adoption calculation."""
         # Mock reviews data (should use 'id' not 'ReviewId')
@@ -41,7 +41,7 @@ class TestMetrics:
         mock_reviews = Mock()
         mock_reviews.query_items.return_value = iter(mock_reviews_data)
         mock_cosmos_client.side_effect = [mock_comments, mock_reviews]
-        result = cli._calculate_language_adoption("2024-01-01", "2024-01-31")  # pylint: disable=protected-access
+        result = metrics._calculate_language_adoption("2024-01-01", "2024-01-31")  # pylint: disable=protected-access
         expected = {
             "python": {
                 "adoption_rate": "0.50",
@@ -61,7 +61,7 @@ class TestMetrics:
         }
         assert result == expected
 
-    @patch("cli._get_apiview_cosmos_client")
+    @patch("src._metrics.get_apiview_cosmos_client")
     def test_calculate_language_adoption_empty(self, mock_cosmos_client):
         """Test language adoption calculation with no data."""
         mock_comments = Mock()
@@ -69,10 +69,10 @@ class TestMetrics:
         mock_reviews = Mock()
         mock_reviews.query_items.return_value = iter([])
         mock_cosmos_client.side_effect = [mock_comments, mock_reviews]
-        result = cli._calculate_language_adoption("2024-01-01", "2024-01-31")  # pylint: disable=protected-access
+        result = metrics._calculate_language_adoption("2024-01-01", "2024-01-31")  # pylint: disable=protected-access
         assert not result
 
-    @patch("cli._get_apiview_cosmos_client")
+    @patch("src._metrics.get_apiview_cosmos_client")
     def test_calculate_language_adoption_no_ai_comments(self, mock_cosmos_client):
         """Test language adoption with revisions but no AI comments."""
         mock_reviews = [
@@ -88,7 +88,7 @@ class TestMetrics:
         mock_reviews = Mock()
         mock_reviews.query_items.return_value = iter(mock_reviews_data)
         mock_cosmos_client.side_effect = [mock_comments, mock_reviews]
-        result = cli._calculate_language_adoption("2024-01-01", "2024-01-31")  # pylint: disable=protected-access
+        result = metrics._calculate_language_adoption("2024-01-01", "2024-01-31")  # pylint: disable=protected-access
         expected = {
             "python": {
                 "adoption_rate": "0.00",
@@ -98,7 +98,7 @@ class TestMetrics:
         }
         assert result == expected
 
-    @patch("cli._get_apiview_cosmos_client")
+    @patch("src._metrics.get_apiview_cosmos_client")
     def test_calculate_language_adoption_multiple_revisions_per_review(self, mock_cosmos_client):
         """Test language adoption with multiple revisions per review."""
         mock_reviews = [
@@ -120,7 +120,7 @@ class TestMetrics:
         mock_reviews = Mock()
         mock_reviews.query_items.return_value = iter(mock_reviews_data)
         mock_cosmos_client.side_effect = [mock_comments, mock_reviews]
-        result = cli._calculate_language_adoption("2024-01-01", "2024-01-31")  # pylint: disable=protected-access
+        result = metrics._calculate_language_adoption("2024-01-01", "2024-01-31")  # pylint: disable=protected-access
         expected = {
             "python": {
                 "adoption_rate": "0.50",
@@ -135,7 +135,7 @@ class TestMetrics:
         }
         assert result == expected
 
-    @patch("cli._get_apiview_cosmos_client")
+    @patch("src._metrics.get_apiview_cosmos_client")
     def test_datetime_parsing_in_language_adoption(self, mock_cosmos_client):
         """Test that datetime parsing works correctly in language adoption."""
         mock_comments = Mock()
@@ -143,11 +143,11 @@ class TestMetrics:
         mock_reviews = Mock()
         mock_reviews.query_items.return_value = iter([])
         mock_cosmos_client.side_effect = [mock_comments, mock_reviews]
-        result = cli._calculate_language_adoption("2024-01-01", "2024-12-31")  # pylint: disable=protected-access
+        result = metrics._calculate_language_adoption("2024-01-01", "2024-12-31")  # pylint: disable=protected-access
         assert not result
 
-    @patch("cli._calculate_language_adoption")
-    @patch("cli._get_apiview_cosmos_client")
+    @patch("src._metrics._calculate_language_adoption")
+    @patch("src._metrics.get_apiview_cosmos_client")
     def test_report_metrics_includes_language_adoption(self, mock_cosmos_client, mock_language_adoption):
         """Test that report_metrics includes language adoption in output."""
 
@@ -169,7 +169,7 @@ class TestMetrics:
         }
 
         # Call report_metrics and capture the return value
-        result = cli.report_metrics("2024-01-01", "2024-01-31")
+        result = metrics.get_metrics_report("2024-01-01", "2024-01-31", environment="test")
 
         # Verify language_adoption is in the metrics
         assert "language_adoption" in result["metrics"]


### PR DESCRIPTION
- Refactors APIView functionality and metrics into dedicated files. 
- Remove `--use-api` from `avc apiview get-comments`. You can only query the API and can no longer query the CosmosDB directly.
- Adds an `avc apiview get-active-reviews` command to list which reviews were considered "active" for the metrics period.

Example usage:
```bash
avc apiview get-active-reviews -l python -s 2025-08-01 -e 2025-08-31
[
  {
    "PackageName": "azure-identity",
    "id": "f020a2e326444ae2acc406846e39dc48"
  },
  {
    "PackageName": "azure-storage-blob",
    "id": "0bc7af0b718b4db19ba1875758aa5d9a"
  },
  {
    "PackageName": "azure-storage-file-datalake",
    "id": "44182315aa5f4b0fbd91945ac955eb22"
  }
]
```

