### PR TITLE
Fix language name issue when generating SDK from copilot

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/SpecWorkFlowToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/SpecWorkFlowToolTests.cs
@@ -21,6 +21,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
         private Mock<ITypeSpecHelper> mockTypeSpecHelper;
         private ILogger<SpecWorkflowTool> logger;
         private SpecWorkflowTool specWorkflowTool;
+        private IInputSanitizer inputSanitizer;
 
         [SetUp]
         public void Setup()
@@ -31,6 +32,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             mockGitHelper = new Mock<IGitHelper>();
             mockTypeSpecHelper = new Mock<ITypeSpecHelper>();
             logger = new TestLogger<SpecWorkflowTool>();
+            inputSanitizer = new InputSanitizer();
 
             mockOutputService.Setup(x => x.Format(It.IsAny<GenericResponse>()))
                            .Returns((GenericResponse r) => string.Join(", ", r.Details));
@@ -47,7 +49,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
                 mockGitHelper.Object,
                 mockTypeSpecHelper.Object,
                 mockOutputService.Object,
-                logger
+                logger,
+                inputSanitizer
             );
         }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/InputSanitizer.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/InputSanitizer.cs
@@ -11,6 +11,11 @@ namespace Azure.Sdk.Tools.Cli.Helpers
     {
         public string SanitizeName(string languageId)
         {
+            if (string.IsNullOrEmpty(languageId))
+            {
+                return string.Empty;
+            }
+
             var lang = languageId.ToLower();
             return lang switch
             {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/InputSanitizer.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/InputSanitizer.cs
@@ -1,16 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-
-using Octokit;
-
 namespace Azure.Sdk.Tools.Cli.Helpers
 {
-    public interface IReleasePlanHelper
+    public interface IInputSanitizer
     {
         public string SanitizeName(string languageId);
     }
-    public class ReleasePlanHelper : IReleasePlanHelper
+    public class InputSanitizer : IInputSanitizer
     {
         public string SanitizeName(string languageId)
         {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/ReleasePlanHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/ReleasePlanHelper.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+
+using Octokit;
+
+namespace Azure.Sdk.Tools.Cli.Helpers
+{
+    public interface IReleasePlanHelper
+    {
+        public string SanitizeName(string languageId);
+    }
+    public class ReleasePlanHelper : IReleasePlanHelper
+    {
+        public string SanitizeName(string languageId)
+        {
+            var lang = languageId.ToLower();
+            return lang switch
+            {
+                "dotnet" => ".NET",
+                "csharp" => ".NET",
+                ".net" => ".NET",
+                "typescript" => "JavaScript",
+                "python" => "Python",
+                "javascript" => "JavaScript",
+                "java" => "Java",
+                "go" => "Go",
+                _ => languageId
+            };
+        }
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
@@ -48,6 +48,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             services.AddSingleton<ICodeownersHelper, CodeownersHelper>();
             services.AddSingleton<ICodeownersValidatorHelper, CodeownersValidatorHelper>();
             services.AddSingleton<IEnvironmentHelper, EnvironmentHelper>();
+            services.AddSingleton<IReleasePlanHelper, ReleasePlanHelper>();
 
             // Process Helper Classes
             services.AddSingleton<INpxHelper, NpxHelper>();

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
@@ -48,7 +48,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             services.AddSingleton<ICodeownersHelper, CodeownersHelper>();
             services.AddSingleton<ICodeownersValidatorHelper, CodeownersValidatorHelper>();
             services.AddSingleton<IEnvironmentHelper, EnvironmentHelper>();
-            services.AddSingleton<IReleasePlanHelper, ReleasePlanHelper>();
+            services.AddSingleton<IInputSanitizer, InputSanitizer>();
 
             // Process Helper Classes
             services.AddSingleton<INpxHelper, NpxHelper>();

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/SpecWorkFlowTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/SpecWorkFlowTool.cs
@@ -21,7 +21,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
         ITypeSpecHelper typespecHelper,
         IOutputHelper output,
         ILogger<SpecWorkflowTool> logger,
-        IReleasePlanHelper releasePlanHelper) : MCPTool
+        IInputSanitizer inputSanitizer) : MCPTool
     {
         private static readonly string PUBLIC_SPECS_REPO = "azure-rest-api-specs";
         private static readonly string REPO_OWNER = "Azure";
@@ -233,7 +233,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 {
                     Status = "Success"
                 };
-                language = releasePlanHelper.SanitizeName(language);
+                language = inputSanitizer.SanitizeName(language);
                 logger.LogInformation($"Generating SDK for TypeSpec project: {typespecProjectRoot}, API Version: {apiVersion}, SDK Release Type: {sdkReleaseType}, Language: {language}, Pull Request Number: {pullRequestNumber}, Work Item ID: {workItemId}");
                 // Is language supported for SDK generation
                 if (!DevOpsService.IsSDKGenerationSupported(language))

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/SpecWorkFlowTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/SpecWorkFlowTool.cs
@@ -20,7 +20,8 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
         IGitHelper gitHelper,
         ITypeSpecHelper typespecHelper,
         IOutputHelper output,
-        ILogger<SpecWorkflowTool> logger) : MCPTool
+        ILogger<SpecWorkflowTool> logger,
+        IReleasePlanHelper releasePlanHelper) : MCPTool
     {
         private static readonly string PUBLIC_SPECS_REPO = "azure-rest-api-specs";
         private static readonly string REPO_OWNER = "Azure";
@@ -232,6 +233,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 {
                     Status = "Success"
                 };
+                language = releasePlanHelper.SanitizeName(language);
                 logger.LogInformation($"Generating SDK for TypeSpec project: {typespecProjectRoot}, API Version: {apiVersion}, SDK Release Type: {sdkReleaseType}, Language: {language}, Pull Request Number: {pullRequestNumber}, Work Item ID: {workItemId}");
                 // Is language supported for SDK generation
                 if (!DevOpsService.IsSDKGenerationSupported(language))


### PR DESCRIPTION
Add a sanitizer helper class to sanitize language name. I have found an issue when agent says generate SDK for `csharp` and three is no pipeline to support it or sometimes it says language is Dotnet