### PR TITLE
[azsdk-cli] Use scoped tools and helpers, add micro agent example

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Contract/MCPTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Contract/MCPTool.cs
@@ -3,32 +3,31 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
 
-namespace Azure.Sdk.Tools.Cli.Contract
+namespace Azure.Sdk.Tools.Cli.Contract;
+
+/// <summary>
+/// This is the base class defining how an MCP enabled tool will interface with the server.
+///
+/// This covers:
+///     - route registration/disambiguation
+///     - compilation trim avoidance for reflection-included MCP tools
+/// </summary>
+public abstract class MCPTool
 {
-    /// <summary>
-    /// This is the base class defining how an MCP enabled tool will interface with the server.
-    ///
-    /// This covers:
-    ///     - route registration/disambiguation
-    ///     - compilation trim avoidance for reflection-included MCP tools
-    /// </summary>
-    public abstract class MCPTool
+    public MCPTool() { }
+
+    public Command? Command;
+
+    public int ExitCode { get; set; } = 0;
+
+    public void SetFailure(int exitCode = 1)
     {
-        public MCPTool() { }
-
-        public Command? Command;
-
-        public int ExitCode { get; set; } = 0;
-
-        public void SetFailure(int exitCode = 1)
-        {
-            ExitCode = exitCode;
-        }
-
-        public CommandGroup[] CommandHierarchy { get; set; } = [];
-
-        public abstract Command GetCommand();
-
-        public abstract Task HandleCommand(InvocationContext ctx, CancellationToken ct);
+        ExitCode = exitCode;
     }
+
+    public CommandGroup[] CommandHierarchy { get; set; } = [];
+
+    public abstract Command GetCommand();
+
+    public abstract Task HandleCommand(InvocationContext ctx, CancellationToken ct);
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Microagents/MicroagentHostServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Microagents/MicroagentHostServiceTests.cs
@@ -3,6 +3,8 @@ using System.ClientModel.Primitives;
 using Azure.AI.OpenAI;
 using Azure.Sdk.Tools.Cli.Microagents;
 using Azure.Sdk.Tools.Cli.Microagents.Tools;
+using Azure.Sdk.Tools.Cli.Helpers;
+using NUnit.Framework;
 using Moq;
 using OpenAI.Chat;
 
@@ -23,7 +25,8 @@ internal class MicroagentHostServiceTests
         chatClientMock = new Mock<ChatClient>();
         openAIClientMock.Setup(client => client.GetChatClient(It.IsAny<string>()))
             .Returns(chatClientMock.Object);
-        microagentHostService = new MicroagentHostService(openAIClientMock.Object, loggerMock.Object);
+        var tokenUsageHelper = new TokenUsageHelper(Mock.Of<Azure.Sdk.Tools.Cli.Helpers.IOutputHelper>());
+        microagentHostService = new MicroagentHostService(openAIClientMock.Object, loggerMock.Object, tokenUsageHelper);
     }
 
     [Test]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ExampleToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ExampleToolTests.cs
@@ -58,6 +58,7 @@ internal class ExampleToolTests
             mockGitHubService,
             mockProcessHelper.Object,
             mockPowershellHelper.Object,
+            tokenUsageHelper: new TokenUsageHelper(mockOutput.Object),
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             null
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TokenUsageHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TokenUsageHelper.cs
@@ -2,24 +2,8 @@ namespace Azure.Sdk.Tools.Cli.Helpers;
 
 public class TokenUsageHelper(IOutputHelper outputHelper)
 {
-    private static Dictionary<string, (double inputPrice, double outputPrice)> modelPrices = new()
-    {
-        // Global pricing via https://platform.openai.com/docs/pricing
-        { "gpt-5", (1.25, 10) },
-        { "gpt-5-mini", (0.25, 2) },
-        { "gpt-4.1", (2, 8) },
-        { "gpt-4.1-mini", (0.40, 1.60) },
-        { "gpt-4.1-nano", (0.10, 0.40) },
-        { "gpt-4o", (2.50, 10) },
-        { "gpt-4o-mini", (0.15, 0.60) },
-        { "o3-mini", (1.10, 4.40) },
-    };
-
     protected double PromptTokens { get; set; } = 0;
     protected double CompletionTokens { get; set; } = 0;
-    protected double InputCost { get; set; } = 0;
-    protected double OutputCost { get; set; } = 0;
-    protected double TotalCost { get; set; } = 0;
     protected IEnumerable<string> ModelsUsed { get; set; } = [];
 
     public void Add(string model, long inputTokens, long outputTokens)
@@ -27,32 +11,14 @@ public class TokenUsageHelper(IOutputHelper outputHelper)
         ModelsUsed = ModelsUsed.Union([model]);
         PromptTokens += inputTokens;
         CompletionTokens += outputTokens;
-        SetCost(model);
     }
 
-    private void SetCost(string model)
+    public void LogUsage()
     {
-        var oneMillion = 1_000_000;
-        if (!modelPrices.TryGetValue(model, out (double inputPrice, double outputPrice) value))
-        {
-            throw new ArgumentException($"No pricing information found for model '{model}'.");
-        }
-
-        InputCost = PromptTokens / oneMillion * value.inputPrice;
-        OutputCost = CompletionTokens / oneMillion * value.outputPrice;
-    }
-
-    public void LogCost()
-    {
-        var _inputCost = InputCost == 0 ? "?" : InputCost.ToString("F3");
-        var _outputCost = OutputCost == 0 ? "?" : OutputCost.ToString("F3");
-        var _totalCost = (InputCost + OutputCost) == 0 ? "?" : (InputCost + OutputCost).ToString("F3");
         var models = string.Join(", ", ModelsUsed);
 
-        outputHelper.OutputConsole($"[{models}] Usage (cost / tokens):");
-        outputHelper.OutputConsole($"  Input:  ${_inputCost} / {PromptTokens}");
-        outputHelper.OutputConsole($"  Output: ${_outputCost} / {CompletionTokens}");
-        outputHelper.OutputConsole($"  Total:  ${_totalCost} / {PromptTokens + CompletionTokens}");
+        outputHelper.OutputConsole("--------------------------------------------------------------------------------");
+        outputHelper.OutputConsole($"[token usage][{models}] input: {PromptTokens}, output: {CompletionTokens}, total: {PromptTokens + CompletionTokens}");
         outputHelper.OutputConsole("--------------------------------------------------------------------------------");
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TokenUsageHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TokenUsageHelper.cs
@@ -1,58 +1,45 @@
 namespace Azure.Sdk.Tools.Cli.Helpers;
 
-public class TokenUsageHelper
+public class TokenUsageHelper(IOutputHelper outputHelper)
 {
-    protected double PromptTokens { get; set; }
-    protected double CompletionTokens { get; set; }
-    protected double InputCost { get; set; }
-    protected double OutputCost { get; set; }
-    protected double TotalCost { get; set; }
-    public List<string> Models { get; set; } = [];
-
-    public TokenUsageHelper(string model, long inputTokens, long outputTokens)
+    private static Dictionary<string, (double inputPrice, double outputPrice)> modelPrices = new()
     {
-        PromptTokens = inputTokens;
-        CompletionTokens = outputTokens;
-        Models = [model];
+        // Global pricing via https://platform.openai.com/docs/pricing
+        { "gpt-5", (1.25, 10) },
+        { "gpt-5-mini", (0.25, 2) },
+        { "gpt-4.1", (2, 8) },
+        { "gpt-4.1-mini", (0.40, 1.60) },
+        { "gpt-4.1-nano", (0.10, 0.40) },
+        { "gpt-4o", (2.50, 10) },
+        { "gpt-4o-mini", (0.15, 0.60) },
+        { "o3-mini", (1.10, 4.40) },
+    };
+
+    protected double PromptTokens { get; set; } = 0;
+    protected double CompletionTokens { get; set; } = 0;
+    protected double InputCost { get; set; } = 0;
+    protected double OutputCost { get; set; } = 0;
+    protected double TotalCost { get; set; } = 0;
+    protected IEnumerable<string> ModelsUsed { get; set; } = [];
+
+    public void Add(string model, long inputTokens, long outputTokens)
+    {
+        ModelsUsed = ModelsUsed.Union([model]);
+        PromptTokens += inputTokens;
+        CompletionTokens += outputTokens;
         SetCost(model);
     }
 
-    protected TokenUsageHelper() { }
-
     private void SetCost(string model)
     {
-        var oneMillion = 1000000;
-        double inputPrice, outputPrice;
-
-        // Prices assume the slightly more expensive regional model pricing
-        if (model == "gpt-4o")
+        var oneMillion = 1_000_000;
+        if (!modelPrices.TryGetValue(model, out (double inputPrice, double outputPrice) value))
         {
-            (inputPrice, outputPrice) = (2.75, 11);
-        }
-        else if (model == "gpt-4o-mini")
-        {
-            (inputPrice, outputPrice) = (0.165, 0.66);
-        }
-        if (model == "gpt-4.1")
-        {
-            (inputPrice, outputPrice) = (2, 8);
-        }
-        else if (model == "gpt-4.1-mini")
-        {
-            (inputPrice, outputPrice) = (0.4, 1.60);
-        }
-        else if (model == "o3-mini")
-        {
-            (inputPrice, outputPrice) = (1.21, 4.84);
-        }
-        else
-        {
-            return;
+            throw new ArgumentException($"No pricing information found for model '{model}'.");
         }
 
-
-        InputCost = PromptTokens / oneMillion * inputPrice;
-        OutputCost = CompletionTokens / oneMillion * outputPrice;
+        InputCost = PromptTokens / oneMillion * value.inputPrice;
+        OutputCost = CompletionTokens / oneMillion * value.outputPrice;
     }
 
     public void LogCost()
@@ -60,21 +47,12 @@ public class TokenUsageHelper
         var _inputCost = InputCost == 0 ? "?" : InputCost.ToString("F3");
         var _outputCost = OutputCost == 0 ? "?" : OutputCost.ToString("F3");
         var _totalCost = (InputCost + OutputCost) == 0 ? "?" : (InputCost + OutputCost).ToString("F3");
-        var models = string.Join(", ", Models);
-        Console.WriteLine("--------------------------------------------------------------------------------");
-        Console.WriteLine($"[{models}] Usage (cost / tokens):");
-        Console.WriteLine($"  Input:  ${_inputCost} / {PromptTokens}");
-        Console.WriteLine($"  Output: ${_outputCost} / {CompletionTokens}");
-        Console.WriteLine($"  Total:  ${_totalCost} / {PromptTokens + CompletionTokens}");
-        Console.WriteLine("--------------------------------------------------------------------------------");
-    }
+        var models = string.Join(", ", ModelsUsed);
 
-    public static TokenUsageHelper operator +(TokenUsageHelper a, TokenUsageHelper? b) => new()
-    {
-        Models = a.Models.Union(b?.Models ?? []).ToList(),
-        PromptTokens = a.PromptTokens + (b?.PromptTokens ?? 0),
-        CompletionTokens = a.CompletionTokens + (b?.CompletionTokens ?? 0),
-        InputCost = a.InputCost + (b?.InputCost ?? 0),
-        OutputCost = a.OutputCost + (b?.OutputCost ?? 0),
-    };
+        outputHelper.OutputConsole($"[{models}] Usage (cost / tokens):");
+        outputHelper.OutputConsole($"  Input:  ${_inputCost} / {PromptTokens}");
+        outputHelper.OutputConsole($"  Output: ${_outputCost} / {CompletionTokens}");
+        outputHelper.OutputConsole($"  Total:  ${_totalCost} / {PromptTokens + CompletionTokens}");
+        outputHelper.OutputConsole("--------------------------------------------------------------------------------");
+    }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Microagents/MicroagentHostService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Microagents/MicroagentHostService.cs
@@ -1,10 +1,11 @@
 using System.ComponentModel;
 using Azure.AI.OpenAI;
+using Azure.Sdk.Tools.Cli.Helpers;
 using OpenAI.Chat;
 
 namespace Azure.Sdk.Tools.Cli.Microagents;
 
-public class MicroagentHostService(AzureOpenAIClient openAI, ILogger<MicroagentHostService> logger) : IMicroagentHostService
+public class MicroagentHostService(AzureOpenAIClient openAI, ILogger<MicroagentHostService> logger, TokenUsageHelper tokenUsageHelper) : IMicroagentHostService
 {
     private const string ExitToolName = "Exit";
 
@@ -60,6 +61,7 @@ public class MicroagentHostService(AzureOpenAIClient openAI, ILogger<MicroagentH
             // Request the chat completion
             logger.LogDebug("Sending conversation history with {MessageCount} messages to model '{Model}'", conversationHistory.Count, agentDefinition.Model);
             var response = await chatClient.CompleteChatAsync(conversationHistory, chatCompletionOptions, ct);
+            tokenUsageHelper.Add(agentDefinition.Model, response.Value.Usage.InputTokenCount, response.Value.Usage.OutputTokenCount);
 
             var toolCall = response.Value.ToolCalls.Single();
             logger.LogInformation("Model called tool '{ToolName}'", toolCall.FunctionName);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Program.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Program.cs
@@ -46,7 +46,8 @@ public class Program
         WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
         builder.Services.AddOpenTelemetry()
-            .WithTracing(b => {
+            .WithTracing(b =>
+            {
                 b.AddSource(Constants.TOOLS_ACTIVITY_SOURCE)
                     .AddAspNetCoreInstrumentation()
                     .AddHttpClientInstrumentation()
@@ -63,15 +64,13 @@ public class Program
             consoleLogOptions.LogToStandardErrorThreshold = logErrorThreshold;
         });
 
-        // Skip verbose azure client logging
+        // Skip azure client logging noise
         builder.Logging.AddFilter((category, level) =>
         {
-            var isAzureClient = category!.StartsWith("Azure.", StringComparison.Ordinal);
-            var isToolsClient = category!.StartsWith("Azure.Sdk.Tools.", StringComparison.Ordinal);
-            if (isAzureClient && !isToolsClient)
-            {
-                return level >= LogLevel.Warning;
-            }
+            if (null == category) { return level >= logErrorThreshold; }
+            var isAzureClient = category.StartsWith("Azure.", StringComparison.Ordinal);
+            var isToolsClient = category.StartsWith("Azure.Sdk.Tools.", StringComparison.Ordinal);
+            if (isAzureClient && !isToolsClient) { return level >= LogLevel.Error; }
             return level >= logErrorThreshold;
         });
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Program.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Program.cs
@@ -66,7 +66,7 @@ public class Program
         // Skip azure client logging noise
         builder.Logging.AddFilter((category, level) =>
         {
-            if (null == category) { return level >= logLevel; }
+            if (debug || null == category) { return level >= logLevel; }
             var isAzureClient = category.StartsWith("Azure.", StringComparison.Ordinal);
             var isToolsClient = category.StartsWith("Azure.Sdk.Tools.", StringComparison.Ordinal);
             if (isAzureClient && !isToolsClient) { return level >= LogLevel.Error; }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Program.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Program.cs
@@ -56,22 +56,21 @@ public class Program
             })
             .UseOtlpExporter();
 
-        // Log everything to stderr in mcp mode so the client doesn't try to interpret stdout messages that aren't json rpc
-        var logErrorThreshold = isCLI ? LogLevel.Error : LogLevel.Debug;
-
         builder.Logging.AddConsole(consoleLogOptions =>
         {
+            // Log everything to stderr in mcp mode so the client doesn't try to interpret stdout messages that aren't json rpc
+            var logErrorThreshold = isCLI ? LogLevel.Error : LogLevel.Debug;
             consoleLogOptions.LogToStandardErrorThreshold = logErrorThreshold;
         });
 
         // Skip azure client logging noise
         builder.Logging.AddFilter((category, level) =>
         {
-            if (null == category) { return level >= logErrorThreshold; }
+            if (null == category) { return level >= logLevel; }
             var isAzureClient = category.StartsWith("Azure.", StringComparison.Ordinal);
             var isToolsClient = category.StartsWith("Azure.Sdk.Tools.", StringComparison.Ordinal);
             if (isAzureClient && !isToolsClient) { return level >= LogLevel.Error; }
-            return level >= logErrorThreshold;
+            return level >= logLevel;
         });
 
         // add the console logger

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Azure/Agent/AzureAgentService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Azure/Agent/AzureAgentService.cs
@@ -20,8 +20,8 @@ public class AzureAgentService(
 ) : IAzureAgentService
 {
     public string ProjectEndpoint { get; } = _projectEndpoint ?? defaultProjectEndpoint;
-    private static readonly string defaultProjectEndpoint = "https://azsdk-engsys-ai.services.ai.azure.com/api/projects/azsdk-engsys-ai";
-    private readonly string model = _model ?? "gpt-4.1-mini";
+    private static readonly string defaultProjectEndpoint = "https://azsdk-engsys-openai.services.ai.azure.com/api/projects/azsdk-engsys-openai-foundry";
+    private readonly string model = _model ?? "o3-mini";
 
     private readonly PersistentAgentsClient client = new(_projectEndpoint ?? defaultProjectEndpoint, azureService.GetCredential());
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Azure/Agent/AzureAgentService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Azure/Agent/AzureAgentService.cs
@@ -44,32 +44,32 @@ Again, the entire response **MUST BE VALID JSON**";
 
     public async Task DeleteAgents(CancellationToken ct = default)
     {
-        logger.LogInformation("Deleting agents in project '{ProjectEndpoint}'", ProjectEndpoint);
+        logger.LogDebug("Deleting agents in project '{ProjectEndpoint}'", ProjectEndpoint);
         AsyncPageable<PersistentAgent> agents = client.Administration.GetAgentsAsync(cancellationToken: ct);
         await foreach (var agent in agents)
         {
-            logger.LogInformation("Deleting agent {AgentId} ({AgentName})", agent.Id, agent.Name);
+            logger.LogDebug("Deleting agent {AgentId} ({AgentName})", agent.Id, agent.Name);
             await client.Administration.DeleteAgentAsync(agent.Id, ct);
         }
 
         AsyncPageable<PersistentAgentThread> threads = client.Threads.GetThreadsAsync(cancellationToken: ct);
         await foreach (var thread in threads)
         {
-            logger.LogInformation("Deleting thread {ThreadId}", thread.Id);
+            logger.LogDebug("Deleting thread {ThreadId}", thread.Id);
             await client.Threads.DeleteThreadAsync(thread.Id, ct);
         }
 
         AsyncPageable<PersistentAgentsVectorStore> vectorStores = client.VectorStores.GetVectorStoresAsync(cancellationToken: ct);
         await foreach (var vectorStore in vectorStores)
         {
-            logger.LogInformation("Deleting vector store {VectorStoreId} ({VectorStoreName})", vectorStore.Id, vectorStore.Name);
+            logger.LogDebug("Deleting vector store {VectorStoreId} ({VectorStoreName})", vectorStore.Id, vectorStore.Name);
             await client.VectorStores.DeleteVectorStoreAsync(vectorStore.Id, ct);
         }
 
         var files = await client.Files.GetFilesAsync(cancellationToken: ct);
         foreach (var file in files.Value)
         {
-            logger.LogInformation("Deleting file {FileId} ({FileName})", file.Id, file.Filename);
+            logger.LogDebug("Deleting file {FileId} ({FileName})", file.Id, file.Filename);
             await client.Files.DeleteFileAsync(file.Id, ct);
         }
     }
@@ -144,7 +144,7 @@ Again, the entire response **MUST BE VALID JSON**";
         tokenUsageHelper.Add(model, run.Usage.PromptTokens, run.Usage.CompletionTokens);
 
         // NOTE: in the future we will want to keep these around if the user wants to keep querying the file in a session
-        logger.LogDebug("Deleting temporary resources: agent {AgentId}, vector store {VectorStoreId}, {fileCount} files", agent.Id, vectorStore.Id, uploaded.Count);
+        logger.LogInformation("Deleting temporary resources: agent {AgentId}, vector store {VectorStoreId}, {fileCount} files", agent.Id, vectorStore.Id, uploaded.Count);
         await DeleteAgents(ct);
 
         return string.Join("\n", response);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Azure/Agent/AzureAgentServiceFactory.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Azure/Agent/AzureAgentServiceFactory.cs
@@ -1,3 +1,5 @@
+using Azure.Sdk.Tools.Cli.Helpers;
+
 namespace Azure.Sdk.Tools.Cli.Services;
 
 public interface IAzureAgentServiceFactory
@@ -5,10 +7,10 @@ public interface IAzureAgentServiceFactory
     IAzureAgentService Create(string? projectEndpoint = null, string? model = null);
 }
 
-public class AzureAgentServiceFactory(IAzureService azureService, ILogger<AzureAgentService> logger) : IAzureAgentServiceFactory
+public class AzureAgentServiceFactory(IAzureService azureService, ILogger<AzureAgentService> logger, TokenUsageHelper tokenUsageHelper) : IAzureAgentServiceFactory
 {
     public IAzureAgentService Create(string? projectEndpoint = null, string? model = null)
     {
-        return new AzureAgentService(azureService, logger, projectEndpoint, model);
+        return new AzureAgentService(azureService, logger, tokenUsageHelper, projectEndpoint, model);
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
@@ -27,10 +27,10 @@ namespace Azure.Sdk.Tools.Cli.Services
         {
             // Services
             services.AddSingleton<IAzureService, AzureService>();
-            services.AddSingleton<IAzureAgentServiceFactory, AzureAgentServiceFactory>();
             services.AddSingleton<IDevOpsConnection, DevOpsConnection>();
             services.AddSingleton<IDevOpsService, DevOpsService>();
             services.AddSingleton<IGitHubService, GitHubService>();
+            services.AddScoped<IAzureAgentServiceFactory, AzureAgentServiceFactory>();
 
             // Language Check Services (Composition-based)
             services.AddSingleton<ILanguageChecks, LanguageChecks>();
@@ -58,6 +58,8 @@ namespace Azure.Sdk.Tools.Cli.Services
             services.AddSingleton<ISpecGenSdkConfigHelper, SpecGenSdkConfigHelper>();
             services.AddSingleton<IInputSanitizer, InputSanitizer>();
             services.AddSingleton<ITspClientHelper, TspClientHelper>();
+            // Add as scoped so we can track/update usage across tools and services per request for logging/telemetry
+            services.AddScoped<TokenUsageHelper>();
 
             // Process Helper Classes
             services.AddSingleton<INpxHelper, NpxHelper>();
@@ -107,7 +109,7 @@ namespace Azure.Sdk.Tools.Cli.Services
                 {
                     if (toolMethod.GetCustomAttribute<McpServerToolAttribute>() is not null)
                     {
-                        services.AddSingleton((Func<IServiceProvider, McpServerTool>)(services =>
+                        services.AddScoped((Func<IServiceProvider, McpServerTool>)(services =>
                         {
                             var options = new McpServerToolCreateOptions { Services = services, SerializerOptions = serializerOptions };
                             var innerTool = toolMethod.IsStatic

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Example/ExampleTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Example/ExampleTool.cs
@@ -315,7 +315,7 @@ public class ExampleTool : MCPTool
 
             var response = await chatClient.CompleteChatAsync(messages, cancellationToken: ct);
             tokenUsageHelper.Add(model, response.Value.Usage.InputTokenCount, response.Value.Usage.OutputTokenCount);
-            tokenUsageHelper.LogCost();
+            tokenUsageHelper.LogUsage();
 
             return new ExampleServiceResponse
             {
@@ -519,7 +519,7 @@ public class ExampleTool : MCPTool
             if (n < 2)
             {
                 SetFailure();
-                return new DefaultCommandResponse { ResponseError = "--fibonacci must be >= 2 to exercise the micro-agent (trivial cases are disallowed)" };
+                return new DefaultCommandResponse { ResponseError = "--fibonacci must be >= 2 to run the micro-agent" };
             }
 
             var advanceTool = AgentTool<Fibonacci, Fibonacci>.FromFunc(
@@ -551,12 +551,12 @@ public class ExampleTool : MCPTool
 
             var resultValue = await microagentHostService.RunAgentToCompletion(agent, ct);
 
-            tokenUsageHelper.LogCost();
+            tokenUsageHelper.LogUsage();
             return new DefaultCommandResponse { Result = $"Fibonacci({n}) = {resultValue}" };
         }
         catch (Exception ex)
         {
-            tokenUsageHelper.LogCost();
+            tokenUsageHelper.LogUsage();
             logger.LogError(ex, "Error demonstrating micro-agent Fibonacci for n={n}", n);
             SetFailure();
             return new DefaultCommandResponse { ResponseError = $"Failed to compute Fibonacci({n}): {ex.Message}" };

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Example/ExampleTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Example/ExampleTool.cs
@@ -36,6 +36,7 @@ public class ExampleTool : MCPTool
     private readonly AzureOpenAIClient openAIClient;
     private readonly IProcessHelper processHelper;
     private readonly IPowershellHelper powershellHelper;
+    private readonly TokenUsageHelper tokenUsageHelper;
 
     // CLI Options and Arguments
     private readonly Argument<string> aiInputArg = new(
@@ -81,6 +82,7 @@ public class ExampleTool : MCPTool
         IGitHubService gitHubService,
         IProcessHelper processHelper,
         IPowershellHelper powershellHelper,
+        TokenUsageHelper tokenUsageHelper,
         AzureOpenAIClient openAIClient
     ) : base()
     {
@@ -92,6 +94,7 @@ public class ExampleTool : MCPTool
         this.openAIClient = openAIClient;
         this.processHelper = processHelper;
         this.powershellHelper = powershellHelper;
+        this.tokenUsageHelper = tokenUsageHelper;
 
         // Set command hierarchy - results in: azsdk example
         CommandHierarchy = [
@@ -294,6 +297,8 @@ public class ExampleTool : MCPTool
             };
 
             var response = await chatClient.CompleteChatAsync(messages, cancellationToken: ct);
+            tokenUsageHelper.Add(model, response.Value.Usage.InputTokenCount, response.Value.Usage.OutputTokenCount);
+            tokenUsageHelper.LogCost();
 
             return new ExampleServiceResponse
             {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineAnalysisTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineAnalysisTool.cs
@@ -118,14 +118,14 @@ public class PipelineAnalysisTool : MCPTool
         {
             var result = await AnalyzePipelineFailureLogs(project ?? projectFromLink, buildId, [logId], analyzeWithAgent, ct);
             ctx.ExitCode = ExitCode;
-            tokenUsageHelper.LogCost();
+            tokenUsageHelper.LogUsage();
             output.Output(result);
         }
         else
         {
             var result = await AnalyzePipeline(project ?? projectFromLink, buildId, analyzeWithAgent, ct);
             ctx.ExitCode = ExitCode;
-            tokenUsageHelper.LogCost();
+            tokenUsageHelper.LogUsage();
             output.Output(result);
         }
     }


### PR DESCRIPTION
Making all the MCP tools injected via `AddScoped` instead of as singletons. This will allow us to inject other classes that can manage state for the request scope. In this PR the token usage helper is made scoped so that we can track agent token usage across the code for an entire request, and then later consume it from multiple places like our telemetry service (FYI @praveenkuttappan).

Also updating the backend foundry project endpoint for the agent service, since the legacy project has started breaking for API calls.

To play around with the scoped token usage helper, I added an example tool/cli command for the micro agent service which computes fibonacci.

Finally, this fixes an issue from last month where logs coming out of any `Azure.Sdk.Tools.*` namespace were not printed to console.