### PR TITLE
Use logger factory instead of console for codeowners library logging

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/CodeownersToolsTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/CodeownersToolsTests.cs
@@ -31,11 +31,11 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             _mockLogger = new Mock<ILogger<CodeownersTools>>();
             _mockCodeownersValidator = new Mock<ICodeownersValidatorHelper>();
 
-
             _tool = new CodeownersTools(
                 _mockGithub,
                 _mockOutput.Object,
                 _mockLogger.Object,
+                null,
                 _mockCodeownersValidator.Object);
         }
 
@@ -63,7 +63,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             gh.Setup(s => s.GetContentsSingleAsync(Constants.AZURE_OWNER_PATH, "repo", Constants.AZURE_CODEOWNERS_PATH, It.IsAny<string>()))
                 .ReturnsAsync(new RepositoryContent("CODEOWNERS", ".github/CODEOWNERS", "shaCode", 0, ContentType.File, null, null, null, null, "utf-8", Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("")), null, null));
 
-            var tool = new CodeownersTools(gh.Object, _mockOutput.Object, _mockLogger.Object, _mockCodeownersValidator.Object);
+            var tool = new CodeownersTools(gh.Object, _mockOutput.Object, _mockLogger.Object, null, _mockCodeownersValidator.Object);
 
             var result = await tool.UpdateCodeowners("repo", false, "", "NonExistService", new List<string>(), new List<string>(), true);
 
@@ -92,7 +92,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             var validator = new Mock<ICodeownersValidatorHelper>();
             validator.Setup(v => v.ValidateCodeOwnerAsync(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(new CodeownersValidationResult { Username = "user", IsValidCodeOwner = true });
 
-            var tool = new CodeownersTools(gh.Object, _mockOutput.Object, _mockLogger.Object, validator.Object);
+            var tool = new CodeownersTools(gh.Object, _mockOutput.Object, _mockLogger.Object, null, validator.Object);
             var result = await tool.UpdateCodeowners("repoName", false, "/sdk/myservice/", "MyService", new List<string> { "@oldowner", "@newowner" }, new List<string>() { "@newowner", "@newowner2" }, true);
             Assert.IsNotNull(result);
             Assert.IsTrue(result.Contains("URL:") || result.Contains("Created"));
@@ -119,7 +119,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             var validator = new Mock<ICodeownersValidatorHelper>();
             validator.Setup(v => v.ValidateCodeOwnerAsync(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(new CodeownersValidationResult { Username = "user", IsValidCodeOwner = true });
 
-            var tool = new CodeownersTools(gh.Object, _mockOutput.Object, _mockLogger.Object, validator.Object);
+            var tool = new CodeownersTools(gh.Object, _mockOutput.Object, _mockLogger.Object, null, validator.Object);
             // Remove @removeowner, keep @oldowner
             var result = await tool.UpdateCodeowners("repoName", false, "/sdk/myservice/", "MyService", new List<string> { "@oldowner" }, new List<string>(), false);
             Assert.IsNotNull(result);
@@ -160,7 +160,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             validator.Setup(v => v.ValidateCodeOwnerAsync(It.IsAny<string>(), It.IsAny<bool>()))
                 .ReturnsAsync(new CodeownersValidationResult { Username = "user", IsValidCodeOwner = true });
 
-            var tool = new CodeownersTools(gh.Object, _mockOutput.Object, _mockLogger.Object, validator.Object);
+            var tool = new CodeownersTools(gh.Object, _mockOutput.Object, _mockLogger.Object, null, validator.Object);
 
             var result = await tool.UpdateCodeowners("repoName", false, "/sdk/newsvc/", "NewSvc", new List<string> { "@a", "@b" }, new List<string> { "@s1", "@s2" }, true);
             Assert.IsNotNull(result);
@@ -196,7 +196,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             validator.Setup(v => v.ValidateCodeOwnerAsync(It.IsAny<string>(), It.IsAny<bool>()))
                 .ReturnsAsync(new CodeownersValidationResult { Username = "user", IsValidCodeOwner = true });
 
-            var tool = new CodeownersTools(gh.Object, _mockOutput.Object, _mockLogger.Object, validator.Object);
+            var tool = new CodeownersTools(gh.Object, _mockOutput.Object, _mockLogger.Object, null, validator.Object);
 
             var result = await tool.UpdateCodeowners("repoName", false, "/sdk/newsvc/", "NewSvc", new List<string> { "@a", "@b" }, new List<string> { "@s1", "@s2" }, true);
             Assert.IsNotNull(result);
@@ -239,7 +239,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             var output = new Mock<IOutputHelper>();
             var validator = new Mock<ICodeownersValidatorHelper>();
 
-            var tool = new CodeownersTools(gh.Object, output.Object, _mockLogger.Object, validator.Object);
+            var tool = new CodeownersTools(gh.Object, output.Object, _mockLogger.Object, null, validator.Object);
 
             var result = await tool.ValidateCodeownersEntryForService("test-repo", "Any", null);
             Assert.IsNotNull(result);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/EngSys/CodeownersTools/CodeownersTools.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/EngSys/CodeownersTools/CodeownersTools.cs
@@ -9,8 +9,8 @@ using Octokit;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Services;
 using Azure.Sdk.Tools.Cli.Contract;
-using Azure.Sdk.Tools.CodeownersUtils.Parsing;
 using Azure.Sdk.Tools.CodeownersUtils.Editing;
+using Azure.Sdk.Tools.CodeownersUtils.Parsing;
 using Azure.Sdk.Tools.Cli.Configuration;
 using Azure.Sdk.Tools.Cli.Models.Responses;
 using Azure.Sdk.Tools.Cli.Commands;
@@ -47,12 +47,15 @@ namespace Azure.Sdk.Tools.Cli.Tools.EngSys
             IGitHubService githubService,
             IOutputHelper output,
             ILogger<CodeownersTools> logger,
+            ILoggerFactory? loggerFactory,
             ICodeownersValidatorHelper codeownersValidator) : base()
         {
             this.githubService = githubService;
             this.output = output;
             this.logger = logger;
             this.codeownersValidator = codeownersValidator;
+
+            CodeownersUtils.Utils.Log.Configure(loggerFactory);
 
             CommandHierarchy =
             [

--- a/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersLinter.Tests/TestHelpers.cs
+++ b/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersLinter.Tests/TestHelpers.cs
@@ -8,6 +8,7 @@ using Azure.Sdk.Tools.CodeownersUtils.Errors;
 using Azure.Sdk.Tools.CodeownersUtils.Caches;
 using Azure.Sdk.Tools.CodeownersUtils.Parsing;
 using Azure.Sdk.Tools.CodeownersUtils.Utils;
+using Microsoft.Extensions.Logging;
 
 namespace Azure.Sdk.Tools.CodeownersUtils.Tests
 {
@@ -26,7 +27,7 @@ namespace Azure.Sdk.Tools.CodeownersUtils.Tests
         /// The user/org visibility data will consist of 5 users, TestOwner0..TestOwner4, with only even users
         /// being visible.
         /// The team/user data will consist of 5 teams with the number of users in each team equal to the
-        /// team number, TestTeam0...TestTeam4.The users in each team will consist of the same users in 
+        /// team number, TestTeam0...TestTeam4.The users in each team will consist of the same users in
         /// the user/org data.
         /// </summary>
         /// <returns>Populated OwnerDataUtils</returns>
@@ -38,7 +39,7 @@ namespace Azure.Sdk.Tools.CodeownersUtils.Tests
             Dictionary<string, List<string>> teamUserDict = new Dictionary<string, List<string>>(StringComparer.InvariantCultureIgnoreCase);
 
             // Create 5 teams
-            for (int i = 0;i < _maxItems; i++)
+            for (int i = 0; i < _maxItems; i++)
             {
                 string team = $"{TestTeamNamePartial}{i}";
                 List<string> users = new List<string>();
@@ -58,7 +59,7 @@ namespace Azure.Sdk.Tools.CodeownersUtils.Tests
             UserOrgVisibilityCache userOrgVisibilityCache = new UserOrgVisibilityCache(null);
             Dictionary<string, bool> userOrgVisDict = new Dictionary<string, bool>(StringComparer.InvariantCultureIgnoreCase);
             // Make every even user visible
-            for (int i = 0;i < 5;i++)
+            for (int i = 0; i < 5; i++)
             {
                 string user = $"{TestOwnerNamePartial}{i}";
                 if (i % 2 == 0)
@@ -82,7 +83,7 @@ namespace Azure.Sdk.Tools.CodeownersUtils.Tests
         {
             Dictionary<string, HashSet<string>> repoLabelDict = new Dictionary<string, HashSet<string>>(StringComparer.InvariantCultureIgnoreCase);
             HashSet<string> repoLabels = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
-            for (int i = 0;i < 5;i++)
+            for (int i = 0; i < 5; i++)
             {
                 string label = $"{TestLabelNamePartial}{i}";
                 repoLabels.Add(label);
@@ -112,7 +113,7 @@ namespace Azure.Sdk.Tools.CodeownersUtils.Tests
         /// <param name="actualCodeownerEntries">The actual, or parsed, list of Codeowners entries.</param>
         /// <param name="expectedCodeownerEntries">The expected list of Codeowners entries</param>
         /// <returns>True if they're equal, false otherwise</returns>
-        public static bool CodeownersEntryListsAreEqual(List<CodeownersEntry> actualCodeownerEntries, 
+        public static bool CodeownersEntryListsAreEqual(List<CodeownersEntry> actualCodeownerEntries,
                                                         List<CodeownersEntry> expectedCodeownerEntries)
         {
             // SequenceEqual determines whether two sequences are equal by comparing the length and
@@ -190,8 +191,8 @@ namespace Azure.Sdk.Tools.CodeownersUtils.Tests
                 WriteIndented = true
             };
             string jsonString = JsonSerializer.Serialize(codeownersEntries, jsonSerializerOptions);
-            Console.WriteLine(jsonString);
-            Console.WriteLine("something to break on");
+            Log.Logger.LogInformation("{Json}", jsonString);
+            Log.Logger.LogInformation("something to break on");
         }
     }
 }

--- a/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersLinter.Tests/Utils/BaselineUtilsTests.cs
+++ b/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersLinter.Tests/Utils/BaselineUtilsTests.cs
@@ -9,6 +9,7 @@ using Azure.Sdk.Tools.CodeownersUtils.Tests.Mocks;
 using Azure.Sdk.Tools.CodeownersUtils.Utils;
 using Azure.Sdk.Tools.CodeownersUtils.Verification;
 using NUnit.Framework;
+using Microsoft.Extensions.Logging;
 
 namespace Azure.Sdk.Tools.CodeownersUtils.Tests.Utils
 {
@@ -43,7 +44,7 @@ namespace Azure.Sdk.Tools.CodeownersUtils.Tests.Utils
             // Cleanup any temporary files created by the tests
             if (_tempFiles.Count > 0)
             {
-                foreach(string tempFile  in _tempFiles)
+                foreach (string tempFile in _tempFiles)
                 {
                     int tryNumber = 0;
                     while (tryNumber < maxTries)
@@ -55,7 +56,7 @@ namespace Azure.Sdk.Tools.CodeownersUtils.Tests.Utils
                         }
                         catch (Exception ex)
                         {
-                            Console.WriteLine($"Exception trying to delete {tempFile}. Ex={ex}");
+                            Log.Logger.LogError(ex, "Exception trying to delete {TempFile}.", tempFile);
                             // sleep 100ms and try again
                             System.Threading.Thread.Sleep(100);
                         }
@@ -64,7 +65,7 @@ namespace Azure.Sdk.Tools.CodeownersUtils.Tests.Utils
                     // Report that the test wasn't able to delete the file after successive tries
                     if (tryNumber == maxTries)
                     {
-                        Console.WriteLine($"Unable to delete {tempFile} after {maxTries}, see above for exception details.");
+                        Log.Logger.LogWarning("Unable to delete {TempFile} after {MaxTries}, see above for exception details.", tempFile, maxTries);
                     }
                 }
             }
@@ -89,7 +90,7 @@ namespace Azure.Sdk.Tools.CodeownersUtils.Tests.Utils
             // Load the expected baseline file and, for sanity's sake, ensure that all errors are filtered
             BaselineUtils expectedBaselineUtils = new BaselineUtils(expectedBaselineFile);
             var filteredWithExpected = expectedBaselineUtils.FilterErrorsUsingBaseline(actualErrors);
-            
+
             // This piece is for sanity, to verify that the the filter only filters out SingleLineErrors and leaves
             // the BlockFormattingErrors.
             if (expectedNumberOfBlockErrors > 0)

--- a/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersLinter/Azure.Sdk.Tools.CodeownersLinter.csproj
+++ b/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersLinter/Azure.Sdk.Tools.CodeownersLinter.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils/Azure.Sdk.Tools.CodeownersUtils.csproj
+++ b/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils/Azure.Sdk.Tools.CodeownersUtils.csproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -9,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils/Caches/TeamUserCache.cs
+++ b/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils/Caches/TeamUserCache.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Azure.Sdk.Tools.CodeownersUtils.Constants;
 using Azure.Sdk.Tools.CodeownersUtils.Utils;
+using Microsoft.Extensions.Logging;
 
 namespace Azure.Sdk.Tools.CodeownersUtils.Caches
 {
@@ -55,7 +56,7 @@ namespace Azure.Sdk.Tools.CodeownersUtils.Caches
                     // succeed regardless of casing.
                     return list.ToDictionary((keyItem) => keyItem.Key, (valueItem) => valueItem.Value, StringComparer.InvariantCultureIgnoreCase);
                 }
-                Console.WriteLine($"Error! Unable to deserialize json team/user data from {TeamUserStorageURI}. rawJson={rawJson}");
+                Log.Logger.LogError("Error! Unable to deserialize json team/user data from {StorageUri}. rawJson={RawJson}", TeamUserStorageURI, rawJson);
                 return new Dictionary<string, List<string>>();
             }
             return _teamUserDict;
@@ -78,7 +79,7 @@ namespace Azure.Sdk.Tools.CodeownersUtils.Caches
                 {
                     return TeamUserDict[teamWithoutOrg];
                 }
-                Console.WriteLine($"Warning: TeamUserDictionary did not contain a team entry for {teamWithoutOrg}");
+                Log.Logger.LogWarning("Warning: TeamUserDictionary did not contain a team entry for {Team}", teamWithoutOrg);
             }
             return new List<string>();
         }

--- a/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils/Utils/FileHelpers.cs
+++ b/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils/Utils/FileHelpers.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace Azure.Sdk.Tools.CodeownersUtils.Utils
 {
@@ -29,7 +30,7 @@ namespace Azure.Sdk.Tools.CodeownersUtils.Utils
         }
 
         /// <summary>
-        /// Load a file from the repository into an List&lt;string&gt;. 
+        /// Load a file from the repository into an List&lt;string&gt;.
         /// Q) Why is this necessary?
         /// A) There are some pieces of metadata that require looking forward to ensure correctness.
         /// </summary>
@@ -64,19 +65,19 @@ namespace Azure.Sdk.Tools.CodeownersUtils.Utils
                     if (response.StatusCode == HttpStatusCode.OK)
                     {
                         // This writeline is probably unnecessary but good to have if there are previous attempts that failed
-                        Console.WriteLine($"GetUrlContents for {url} attempt number {attempts} succeeded.");
+                        Log.Logger.LogInformation("GetUrlContents for {Url} attempt number {Attempts} succeeded.", url, attempts);
                         return response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
                     }
                     else
                     {
-                        Console.WriteLine($"GetUrlContents attempt number {attempts}. Non-{HttpStatusCode.OK} status code trying to fetch {url}. Status Code = {response.StatusCode}");
+                        Log.Logger.LogWarning("GetUrlContents attempt number {Attempts}. Non-{StatusCode} status code trying to fetch {Url}. Status Code = {ResponseStatus}", attempts, HttpStatusCode.OK, url, response.StatusCode);
                     }
                 }
                 catch (HttpRequestException httpReqEx)
                 {
                     // HttpRequestException means the request failed due to an underlying issue such as network connectivity,
                     // DNS failure, server certificate validation or timeout.
-                    Console.WriteLine($"GetUrlContents attempt number {attempts}. HttpRequestException trying to fetch {url}. Exception message = {httpReqEx.Message}");
+                    Log.Logger.LogWarning("GetUrlContents attempt number {Attempts}. HttpRequestException trying to fetch {Url}. Exception message = {Message}", attempts, url, httpReqEx.Message);
                 }
 
                 // Skip retries on a NotFound response

--- a/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils/Utils/Log.cs
+++ b/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils/Utils/Log.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Azure.Sdk.Tools.CodeownersUtils.Utils
+{
+    /// <summary>
+    /// Lightweight logging helper for the library.
+    /// By default this uses a NullLogger so consumers don't have to configure logging.
+    /// Consumers (apps/tests) can call Log.Configure(...) with an ILogger to
+    /// enable logging to their preferred sink.
+    /// </summary>
+    public static class Log
+    {
+        private static ILogger logger = NullLogger.Instance;
+
+        public static ILogger Logger => logger;
+
+        public static void Configure(ILogger logger)
+        {
+            Log.logger = logger ?? NullLogger.Instance;
+        }
+
+        public static void Configure(ILoggerFactory loggerFactory)
+        {
+            Log.logger = loggerFactory?.CreateLogger(typeof(Log).Assembly.GetName().Name)?? NullLogger.Instance;
+        }
+    }
+}


### PR DESCRIPTION
The codeowners tests were adding a bunch of logging that was coming out of the codeowners utils library, which was annoying me. As a library it should not be using `Console.WriteLine` so this refactors it to follow the guidance at https://learn.microsoft.com/en-us/dotnet/core/extensions/logging-library-authors