### PR TITLE
Support single line of command config

### DIFF
--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2025-09-09 - 0.9.2
+
+- Updated SwaggerToSdkConfigSchema by introducing 'command' to 'RunOptions' type. This is to support running single command for build SDK process
+
 ## 2025-08-05 - 0.9.1
 
 - Support SDK breaking change flagging for V2 folder structure by detecting management plane TypeSpec projects containing 'resource-manager' in the path

--- a/tools/spec-gen-sdk/package-lock.json
+++ b/tools/spec-gen-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/spec-gen-sdk",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/spec-gen-sdk",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/tools/spec-gen-sdk/package.json
+++ b/tools/spec-gen-sdk/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-tools"
   },
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "A TypeScript implementation of the API specification to SDK tool",
   "tags": [
     "spec-gen-sdk"

--- a/tools/spec-gen-sdk/src/types/SwaggerToSdkConfig.ts
+++ b/tools/spec-gen-sdk/src/types/SwaggerToSdkConfig.ts
@@ -12,7 +12,8 @@ export type RunLogOptions = {
 };
 
 export type RunOptions = {
-  path: string;
+  path?: string;
+  command?: string;
   envs?: string[];
   logPrefix?: string;
   stdout?: RunLogOptions;

--- a/tools/spec-gen-sdk/src/types/SwaggerToSdkConfigSchema.json
+++ b/tools/spec-gen-sdk/src/types/SwaggerToSdkConfigSchema.json
@@ -202,6 +202,10 @@
           // Script path related to repo root
           "type": "string"
         },
+        "command": {
+          // Command to run, it only allows single line of command.
+          "type": "string"
+        },
         "envs": {
           // Extra environment variable to be passed to the script.
           // By default the following envs will be passed:
@@ -255,8 +259,7 @@
             "result": "error"
           }
         }
-      },
-      "required": ["path"]
+      }
     },
     "RunLogOptions": {
       // How should SDK Automation handle the log stream.

--- a/tools/spec-gen-sdk/src/utils/runScript.ts
+++ b/tools/spec-gen-sdk/src/utils/runScript.ts
@@ -40,6 +40,9 @@ export const runSdkAutoCustomScript = async (
     continueOnFailed?: boolean;
   }
 ): Promise<SDKAutomationState> => {
+  if (!runOptions.path) {
+    throw new Error('Script path is not provided in run options.');
+  }
   const scriptPath = runOptions.path;
   const cwdAbsolutePath = path.resolve(options.cwd);
   const vsoLogErrorsArray: string[] = [];

--- a/tools/spec-gen-sdk/test/utils/runScript.test.ts
+++ b/tools/spec-gen-sdk/test/utils/runScript.test.ts
@@ -209,5 +209,16 @@ describe('runScript utils', () => {
 
       expect(result).toBe('succeeded');
     });
+
+    it('should throw exception when path is not provided in RunOptions', async () => {
+      const mockRunOptions = {
+        command: 'some command',
+        envs: ['TEST_VAR'],
+      };
+
+      await expect(runSdkAutoCustomScript(mockContext, mockRunOptions, baseOptions))
+        .rejects
+        .toThrow('Script path is not provided in run options.');
+    });
   });
 });


### PR DESCRIPTION
- made `path` as optional config
- added `command` to `RunOptions` type

This is to support defining single line of command inline of the config file for build SDK process.

Two related PRs:
https://github.com/Azure/azure-sdk-for-java/pull/46647
https://github.com/Azure/azure-sdk-for-net/pull/52546
