### PR TITLE
Add custom instructions to fetch TypeSpec docs

### DIFF
--- a/eng/common/instructions/azsdk-tools/typespec-docs.instructions.md
+++ b/eng/common/instructions/azsdk-tools/typespec-docs.instructions.md
@@ -1,0 +1,11 @@
+Your goal is to provide the most up-to-date documentation on the TypeSpec language, core libraries, and writing Azure services and clients in TypeSpec. Whenever a user asks a question about how something should be written in TypeSpec, you should use the documentation links below to pinpoint the most relevant and accurate information.
+
+## TypeSpec Azure
+
+- https://azure.github.io/typespec-azure/docs/llms.txt contains an index of up-to-date documentation for TypeSpec Azure libraries, including how to write service specifications for Azure Resource Manager (ARM) and Azure Data Plane services, as well as how to customize generated clients.
+- Always refer to https://azure.github.io/typespec-azure/docs/llms.txt when a user asks TypeSpec related questions in case there is existing documentation that can help answer them. This also applies when a user asks to make changes to TypeSpec specifications.
+
+## TypeSpec documentation
+
+- https://typespec.io/docs/llms.txt contains an index of up-to-date documentation for TypeSpec language basics and core libraries, including how concepts like visibility and versioning work.
+- Always refer to https://typespec.io/docs/llms.txt when a user asks TypeSpec related questions that aren't covered by the TypeSpec Azure topics.


### PR DESCRIPTION
We're now generating llms.txt files for TypeSpec/TypeSpec Azure doc sites which gives more "AI-friendly" versions of our docs in markdown format vs the HTML pages for the rest of us :smile:

I originally planned to add MCP tools to surface these docs (https://github.com/Azure/azure-sdk-tools/pull/12007), but found that using these instructions - and referencing them from copilot-instructions, will follow up in azure-rest-api-specs - worked at least as well as the MCP tools for getting the correct docs into the LLM context. Since `llms.txt` is more granular than the llms-full.txt files, in testing I saw copilot be much more surgical in which docs it fetched - resulting in fewer tokens required to get relevant typespec docs. You also get the benefit of seeing exactly which doc pages the agent fetches.

I'll also add the following markdown to the azure-rest-api-specs copilot-instructions.md to make sure these instructions are pulled in - this has worked well in testing:

```md
## Up-to-date TypeSpec documentation

Follow [typespec docs](../eng/common/instructions/azsdk-tools/typespec-docs.instructions.md) to get the most up-to-date documentation for TypeSpec, including best practices for writing TypeSpec for Azure.
```
---

Some of the sample prompts I tested with and verified:

_Opened an existing TypeSpec file that wasn't using the `@previewVersion` decorator_
> Does this follow the guidelines for defining a preview version?

_highlighting a data-plane operation_
> Explain what the highlighted template is doing

_Have an existing TypeSpec file open__
> How do I add a custom action for Trinkets - I want to have a "buy" action that will place an order for some quantity of trinkets

_Highlighting a data plane operation__
> I need to add a custom header to that operation - "X-Foo"

### Interesting findings

I tested all my prompts in both a copy of the specs repo with these instructions, and one without. For __most__ of the prompts, the  AI-generated TypeSpec code ended up being nearly the same. However the explanations for the version using these instructions (and pulling down llms.txt) were much more accurate. In all the explanations of what an HTTP request/response would actually look like from the version _without_ these instructions, the AI was confident, but verifiably wrong. These errors were subtle because they sounded reasonable: names of LRO headers, 202 vs 201 status codes, action paths that were off by a character - all wrong if you looked at the emitted swagger files. The llms.txt-backed AI got them right.
The llms.txt-backed agent also did better for newer, less-frequently used features. For example, it was able to look up documentation on the `@previewVersion` decorator whereas the non-llms.txt-backed agent did not know about it.
