### PR TITLE
[azsdk-cli] Change boolean? to boolean for convert swagger/tsp tool

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/TspConvertTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/TspConvertTool.cs
@@ -80,18 +80,15 @@ namespace Azure.Sdk.Tools.Cli.Tools.TypeSpec
             string pathToSwaggerReadme,
             [Description("The output directory for the generated TypeSpec project. This must be an existing empty directory.")]
             string outputDirectory,
-            [Description(@"
-                Indicates whether the swagger is for an Azure Resource Management (ARM) API.
-                Should be true if the swagger's path contains `resource-manager`.
-                ")
+            [Description("Indicates whether the swagger is for an Azure Resource Management (ARM) API. " +
+                         "Should be true if the swagger's path contains `resource-manager`.")
             ]
-            bool? isAzureResourceManagement,
-            [Description(@"
-                Indicates whether the generated TypeSpec project should be fully compatible with the swagger.
-                It is recommended to set this to `false` so that the generated project leverages TypeSpec built-in libraries with standard patterns and templates.
-                ")
+            bool isAzureResourceManagement,
+            [Description("Indicates whether the generated TypeSpec project should be fully compatible with the swagger. " +
+                         "It is recommended to set this to `false` so that the generated project leverages " +
+                         "TypeSpec built-in libraries with standard patterns and templates.")
             ]
-            bool? fullyCompatible,
+            bool fullyCompatible,
             bool isCli,
             CancellationToken ct
         )
@@ -126,7 +123,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.TypeSpec
                 }
 
                 var fullOutputDir = Path.GetFullPath(outputDirectory.Trim());
-                return await RunTspClientAsync(fullPathToSwaggerReadme, fullOutputDir, isAzureResourceManagement ?? false, fullyCompatible ?? false, isCli, ct);
+                return await RunTspClientAsync(fullPathToSwaggerReadme, fullOutputDir, isAzureResourceManagement, fullyCompatible, isCli, ct);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Using the `boolean?` nullable type results in a tools/list object that has an array type for the `type` property of the parameter (see below) instead of string. This breaks the IntelliJ copilot chat plugin when loading the MCP server tools (found by adding `com.github.copilot:trace` to the intellij debug log configuration):

> 2025-09-11 15:37:46,006 [ 439679]   WARN - #com.github.copilot.mcp.agent.lsp.LspGetToolsNotificationListener - failed to handle MCP tools notification
> com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: **Expected STRING but was BEGIN_ARRAY** at path $.servers[0].tools[31].inputSchema.properties..type


The MCP schema appears to support any object type for the whole parameter property (https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-06-18/schema.json#L2373-L2377), so my guess is this is an implementation issue with the plugin. Other mcp clients like vscode load the tools list just fine.

Below is an example of tool parameter properties returned from the `tools/list` call that reproduces the issue. Using `"type": "boolean"` works but `"type": ["boolean","null"]` will crash the plugin.

```
"fullyCompatible": {
  "description": "Indicates whether the generated TypeSpec project should be fully compatible with the swagger. It is recommended to set this to `false` so that the generated project leverages TypeSpec built-in libraries with standard patterns and templates.",
  "type": [
    "boolean",
    "null"
  ]
}
```

As a follow-up I am going to add an analyzer to prevent nullable parameter types for MCP tools, unless we can confirm this is an issue with the copilot plugin or the MCP C# sdk and get it fixed upstream.