### PR TITLE
Make Prepare-Release.ps1 executable

### DIFF
--- a/eng/common/scripts/Prepare-Release.ps1
+++ b/eng/common/scripts/Prepare-Release.ps1
@@ -1,3 +1,5 @@
+#!/usr/bin/env pwsh
+
 #Requires -Version 6.0
 
 <#


### PR DESCRIPTION
I could make all the non-include PS1 scripts executable, but beyond TestResources - which I already updated - this is the only one I call frequently from within bash.