### PR TITLE
Create shared helper module for tsp-client commands

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/TspConvertToolTest.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/TspConvertToolTest.cs
@@ -16,7 +16,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             var npxHelper = new Mock<INpxHelper>().Object;
             var logger = new Mock<ILogger<TypeSpecConvertTool>>().Object;
             var outputService = new Mock<IOutputHelper>().Object;
-            var tool = new TypeSpecConvertTool(npxHelper, logger, outputService);
+            var tspHelper = new Mock<ITspClientHelper>().Object;
+            var tool = new TypeSpecConvertTool(npxHelper, logger, outputService, tspHelper);
 
             // Act
             var command = tool.GetCommand();
@@ -35,7 +36,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             var npxHelper = new Mock<INpxHelper>().Object;
             var logger = new Mock<ILogger<TypeSpecConvertTool>>().Object;
             var outputService = new Mock<IOutputHelper>().Object;
-            var tool = new TypeSpecConvertTool(npxHelper, logger, outputService);
+            var tspHelper = new Mock<ITspClientHelper>().Object;
+            var tool = new TypeSpecConvertTool(npxHelper, logger, outputService, tspHelper);
 
             // Act
             var result = await tool.ConvertSwaggerAsync("swagger.json", @"C:\temp", false, false, false, CancellationToken.None);
@@ -52,7 +54,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             var npxHelper = new Mock<INpxHelper>().Object;
             var logger = new Mock<ILogger<TypeSpecConvertTool>>().Object;
             var outputService = new Mock<IOutputHelper>().Object;
-            var tool = new TypeSpecConvertTool(npxHelper, logger, outputService);
+            var tspHelper = new Mock<ITspClientHelper>().Object;
+            var tool = new TypeSpecConvertTool(npxHelper, logger, outputService, tspHelper);
 
             // Act
             var result = await tool.ConvertSwaggerAsync(@"C:\nonexistent\readme.md", @"C:\temp", false, false, false, CancellationToken.None);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/ITspClientHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/ITspClientHelper.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Azure.Sdk.Tools.Cli.Models.Responses;
+
+namespace Azure.Sdk.Tools.Cli.Helpers;
+
+/// <summary>
+/// Abstraction for running common tsp-client commands (convert, update, diff, map, etc.).
+/// This centralizes npx invocation logic so multiple tools (Generate, Build, Update workflows)
+/// can share a single implementation without instantiating each other.
+/// </summary>
+public interface ITspClientHelper
+{
+    /// <summary>
+    /// Runs `tsp-client convert --swagger-readme <readme> --output-dir <out>` with optional flags.
+    /// </summary>
+    Task<TspToolResponse> ConvertSwaggerAsync(string swaggerReadmePath, string outputDirectory, bool isArm, bool fullyCompatible, bool isCli, CancellationToken ct);
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TspClientHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TspClientHelper.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Azure.Sdk.Tools.Cli.Models.Responses;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Sdk.Tools.Cli.Helpers;
+
+/// <inheritdoc />
+public class TspClientHelper : ITspClientHelper
+{
+    private readonly INpxHelper npxHelper;
+    private readonly ILogger<TspClientHelper> logger;
+
+    public TspClientHelper(INpxHelper npxHelper, ILogger<TspClientHelper> logger)
+    {
+        this.npxHelper = npxHelper;
+        this.logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<TspToolResponse> ConvertSwaggerAsync(string swaggerReadmePath, string outputDirectory, bool isArm, bool fullyCompatible, bool isCli, CancellationToken ct)
+    {
+        logger.LogInformation("tsp-client convert: {readme} -> {out} (arm={arm}, fullyCompatible={fc})", swaggerReadmePath, outputDirectory, isArm, fullyCompatible);
+        var npxOptions = new NpxOptions(
+            "@azure-tools/typespec-client-generator-cli",
+            ["tsp-client", "convert", "--swagger-readme", swaggerReadmePath, "--output-dir", outputDirectory],
+            logOutputStream: true
+        );
+
+        if (isArm)
+        {
+            npxOptions.AddArgs("--arm");
+        }
+        if (fullyCompatible)
+        {
+            npxOptions.AddArgs("--fully-compatible");
+        }
+
+        var result = await npxHelper.Run(npxOptions, ct);
+        if (result.ExitCode != 0)
+        {
+            // Returning failure; omit verbose output in CLI mode since stream already logged.
+            return new TspToolResponse
+            {
+                ResponseError = isCli
+                    ? "Failed to convert swagger to TypeSpec project, see details in the above logs."
+                    : "Failed to convert swagger to TypeSpec project, see generator output below" + Environment.NewLine + result.Output
+            };
+        }
+
+        return new TspToolResponse
+        {
+            IsSuccessful = true,
+            TypeSpecProjectPath = outputDirectory
+        };
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
@@ -54,6 +54,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             services.AddSingleton<ICodeownersValidatorHelper, CodeownersValidatorHelper>();
             services.AddSingleton<IEnvironmentHelper, EnvironmentHelper>();
             services.AddSingleton<IInputSanitizer, InputSanitizer>();
+            services.AddSingleton<ITspClientHelper, TspClientHelper>();
 
             // Process Helper Classes
             services.AddSingleton<INpxHelper, NpxHelper>();

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/TspConvertTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/TspConvertTool.cs
@@ -22,12 +22,14 @@ namespace Azure.Sdk.Tools.Cli.Tools.TypeSpec
         private readonly INpxHelper npxHelper;
         private readonly ILogger<TypeSpecConvertTool> logger;
         private readonly IOutputHelper output;
+        private readonly ITspClientHelper tspClientHelper;
 
-        public TypeSpecConvertTool(INpxHelper npxHelper, ILogger<TypeSpecConvertTool> logger, IOutputHelper output)
+        public TypeSpecConvertTool(INpxHelper npxHelper, ILogger<TypeSpecConvertTool> logger, IOutputHelper output, ITspClientHelper tspClientHelper)
         {
             this.npxHelper = npxHelper;
             this.logger = logger;
             this.output = output;
+            this.tspClientHelper = tspClientHelper;
             CommandHierarchy = [SharedCommandGroups.TypeSpec];
         }
 
@@ -123,7 +125,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.TypeSpec
                 }
 
                 var fullOutputDir = Path.GetFullPath(outputDirectory.Trim());
-                return await RunTspClientAsync(fullPathToSwaggerReadme, fullOutputDir, isAzureResourceManagement, fullyCompatible, isCli, ct);
+                return await tspClientHelper.ConvertSwaggerAsync(fullPathToSwaggerReadme, fullOutputDir, isAzureResourceManagement, fullyCompatible, isCli, ct);
             }
             catch (Exception ex)
             {
@@ -158,56 +160,5 @@ namespace Azure.Sdk.Tools.Cli.Tools.TypeSpec
             return null; // Validation passed
         }
 
-        private async Task<TspToolResponse> RunTspClientAsync(
-            string pathToSwaggerReadme,
-            string outputDirectory,
-            bool isAzureResourceManagement,
-            bool fullyCompatible,
-            bool isCli,
-            CancellationToken ct
-        )
-        {
-            var npxOptions = new NpxOptions(
-                "@azure-tools/typespec-client-generator-cli",
-                ["tsp-client", "convert", "--swagger-readme", pathToSwaggerReadme, "--output-dir", outputDirectory],
-                logOutputStream: true
-            );
-
-            if (isAzureResourceManagement)
-            {
-                npxOptions.AddArgs("--arm");
-            }
-
-            if (fullyCompatible)
-            {
-                npxOptions.AddArgs("--fully-compatible");
-            }
-
-            var result = await npxHelper.Run(npxOptions, ct);
-            if (result.ExitCode != 0)
-            {
-                SetFailure();
-                // Omit printing details in CLI mode since we already stream the generator cli output
-                if (isCli)
-                {
-                    return new TspToolResponse
-                    {
-                        ResponseError = $"Failed to convert swagger to TypeSpec project, see details in the above logs."
-                    };
-                }
-                return new TspToolResponse
-                {
-                    ResponseError = $"Failed to convert swagger to TypeSpec project, see generator output below" +
-                                    Environment.NewLine +
-                                    result.Output
-                };
-            }
-
-            return new TspToolResponse
-            {
-                IsSuccessful = true,
-                TypeSpecProjectPath = outputDirectory
-            };
-        }
     }
 }


### PR DESCRIPTION
Created shared helpers for tsp-client commands  (common utility class used by multiple tools) so they provide single implementation of core logic 
- Looser coupling (for multiple tool calls to use) 
- Clear separation of “UI” (CLI command) vs logic 

> Will add update workflow in a follow-up PR, which will include details with the TspClientUpdate Tooling (it was increasing the size of PR)
