### PR TITLE
Add outputDir override to resolveOptions for current directory usage

### DIFF
--- a/tools/js-sdk-release-tools/package-lock.json
+++ b/tools/js-sdk-release-tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/js-sdk-release-tools",
-  "version": "2.14.6",
+  "version": "2.14.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/js-sdk-release-tools",
-      "version": "2.14.6",
+      "version": "2.14.7",
       "license": "MIT",
       "dependencies": {
         "@azure-tools/openapi-tools-common": "^1.2.2",

--- a/tools/js-sdk-release-tools/package.json
+++ b/tools/js-sdk-release-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/js-sdk-release-tools",
-  "version": "2.14.6",
+  "version": "2.14.7",
   "description": "",
   "files": [
     "dist"

--- a/tools/js-sdk-release-tools/src/common/utils.ts
+++ b/tools/js-sdk-release-tools/src/common/utils.ts
@@ -329,6 +329,9 @@ export async function resolveOptions(typeSpecDirectory: string): Promise<Exclude
             cwd: process.cwd(),
             entrypoint: typeSpecDirectory, // not really used here
             configPath: typeSpecDirectory,
+            overrides: {
+                outputDir: process.cwd() // This will make outputDir just the current directory without adding 'tsp-output'
+            }
         });
     return options
 }

--- a/tools/js-sdk-release-tools/src/common/utils.ts
+++ b/tools/js-sdk-release-tools/src/common/utils.ts
@@ -211,10 +211,8 @@ export async function getGeneratedPackageDirectory(typeSpecDirectory: string, sd
     // Try to get package directory from emitter-output-dir first    
     const emitterOutputDir = emitterOptions?.['emitter-output-dir'];
     if (emitterOutputDir) {
-        // emitterOutputDir from resolved options should already be an absolute path
-        // Convert to relative path from sdkRepoRoot for consistency
-        const relativePath = path.relative(sdkRepoRoot, emitterOutputDir);
-        return posix.normalize(relativePath);
+        // emitter-output-dir is an absolute path, return it directly
+        return emitterOutputDir;
     }
 
     let packageDir = tspConfig.configFile.parameters?.["package-dir"]?.default;

--- a/tools/js-sdk-release-tools/src/common/utils.ts
+++ b/tools/js-sdk-release-tools/src/common/utils.ts
@@ -206,7 +206,7 @@ export async function loadTspConfig(typeSpecDirectory: string): Promise<Exclude<
 // generated path is in posix format
 // e.g. sdk/mongocluster/arm-mongocluster
 export async function getGeneratedPackageDirectory(typeSpecDirectory: string, sdkRepoRoot: string): Promise<string> {
-    const tspConfig = await resolveOptions(typeSpecDirectory);
+    const tspConfig = await resolveOptions(typeSpecDirectory, sdkRepoRoot);
     const emitterOptions = tspConfig.options?.[emitterName];
     // Try to get package directory from emitter-output-dir first    
     const emitterOutputDir = emitterOptions?.['emitter-output-dir'];
@@ -322,7 +322,7 @@ export async function existsAsync(path: string): Promise<boolean> {
     }
 }
 
-export async function resolveOptions(typeSpecDirectory: string): Promise<Exclude<any, null | undefined>> {
+export async function resolveOptions(typeSpecDirectory: string, sdkRepoRoot?: string): Promise<Exclude<any, null | undefined>> {
     const [{ config, ...options }, diagnostics] = await compiler.resolveCompilerOptions(
         compiler.NodeHost,
         {
@@ -330,7 +330,7 @@ export async function resolveOptions(typeSpecDirectory: string): Promise<Exclude
             entrypoint: typeSpecDirectory, // not really used here
             configPath: typeSpecDirectory,
             overrides: {
-                outputDir: process.cwd() // This will make outputDir just the current directory without adding 'tsp-output'
+                outputDir: sdkRepoRoot || process.cwd() // Use sdkRepoRoot if provided, otherwise use current directory
             }
         });
     return options


### PR DESCRIPTION
emitter-output-dir: "{output-dir}/{service-dir}/{your-package-dir-name} "

test pipeline:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5338718&view=logs&j=83516c17-6666-5250-abde-63983ce72a49&t=00be4b52-4a63-5865-8e02-c61723ad0692&l=158

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5342996&view=logs&j=83516c17-6666-5250-abde-63983ce72a49&t=00be4b52-4a63-5865-8e02-c61723ad0692
