### PR TITLE
[tsp-client] Make emitter-output-dir support less breaking

### DIFF
--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## UNRELEASED - 0.28.2
+
+- If `package-dir` and `emitter-output-dir` are both specified in a given tspconfig.yaml give preference to `package-dir` until the legacy behavior is officially deprecated.
+
 ## 2025-08-15 - 0.28.1
 
 - Fix bug when using `emitter-output-dir` in tspconfig.yaml, always pass the repo root path for the `{output-dir}` variable.

--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release
 
-## UNRELEASED - 0.28.2
+## 2025-09-16 - 0.28.2
 
 - If `package-dir` and `emitter-output-dir` are both specified in a given tspconfig.yaml give preference to `package-dir` until the legacy behavior is officially deprecated.
 

--- a/tools/tsp-client/package-lock.json
+++ b/tools/tsp-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/typespec-client-generator-cli",
-      "version": "0.28.1",
+      "version": "0.28.2",
       "license": "MIT",
       "dependencies": {
         "@autorest/core": "^3.10.2",

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "description": "A tool to generate Azure SDKs from TypeSpec",
   "main": "dist/index.js",
   "homepage": "https://github.com/Azure/azure-sdk-tools/tree/main/tools/tsp-client#readme",

--- a/tools/tsp-client/src/commands.ts
+++ b/tools/tsp-client/src/commands.ts
@@ -97,10 +97,10 @@ async function initProcessDataAndWriteTspLocation(
   }
 
   // Check for relevant package path variables and resolve
-  let emitterOutputDir = tspConfigData?.options?.[emitterData.emitter]?.["emitter-output-dir"];
+  let emitterOutputDir = tspConfigData?.options?.[emitterData.emitter]?.["package-dir"];
   const packageDir = tspConfigData?.options?.[emitterData.emitter]?.["package-dir"];
   let newPackageDir;
-  if (emitterOutputDir) {
+  if (!packageDir && emitterOutputDir) {
     const [options, _] = await resolveCompilerOptions(NodeHost, {
       cwd: process.cwd(),
       entrypoint: "main.tsp",
@@ -415,7 +415,9 @@ export async function generateCommand(argv: any) {
     );
   }
 
-  const legacyPathResolution = !tspConfigData?.options?.[emitter]?.["emitter-output-dir"];
+  // Give preference to package-dir if both are specified
+  // This is to avoid breaking existing behavior
+  const legacyPathResolution = tspConfigData?.options?.[emitter]?.["package-dir"];
 
   if (skipInstall) {
     Logger.info("Skipping installation of dependencies");

--- a/tools/tsp-client/test/commands.spec.ts
+++ b/tools/tsp-client/test/commands.spec.ts
@@ -360,6 +360,18 @@ describe.sequential("Verify commands", () => {
           joinPaths(cwd(), "./test/examples/init/", "sdk/legacypath", "contosowidgetmanager-rest"),
         ),
       );
+      // Make sure that the emitter-output-dir value is ignored
+      try {
+        await stat(
+          joinPaths(
+            cwd(),
+            "./test/examples/specification/contosowidgetmanager-legacy-package-dir/nonexistent",
+          ),
+        );
+        assert.fail("The emitter-output-dir path should not exist");
+      } catch (error: any) {
+        assert.match(error.message, /ENOENT: no such file or directory/);
+      }
       await removeDirectory(joinPaths(cwd(), "./test/examples/init/sdk"));
     } catch (error: any) {
       assert.fail("Failed to init. Error: " + error);

--- a/tools/tsp-client/test/examples/specification/contosowidgetmanager-legacy-package-dir/Contoso.WidgetManager/tspconfig.yaml
+++ b/tools/tsp-client/test/examples/specification/contosowidgetmanager-legacy-package-dir/Contoso.WidgetManager/tspconfig.yaml
@@ -26,6 +26,7 @@ options:
     flavor: azure
   "@azure-tools/typespec-ts":
     package-dir: "contosowidgetmanager-rest"
+    emitter-output-dir: "{project-root}/../nonexistent" # This path is intentionally invalid to ensure package-dir is used instead
     package-details:
       name: "@azure-rest/contoso-widgetmanager-rest"
     flavor: azure


### PR DESCRIPTION
Go and Rust have historically recommended folks add an emitter-output-dir variable in their tspconfig.yaml files for their libraries, but relied on tsp-client ignoring emitter-output-dir when generating client libraries. The 0.28.0 version of tsp-client which added support for emitter-output-dir broke these languages because we give preference to emitter-output-dir over package-dir in tspconfig.yaml. Having both `package-dir` and `emitter-output-dir` should be an error going forward (tracking issue TBD), we have also merged updates to the tspconfig.yaml files for Go and Rust libraries so the latest versions of all tsp projects are clean and indeed only have emitter-output-dir. However, since Go has many libraries that will eventually need to be updated to the latest commit in the specs repo, tsp-client is switching the order in which it checks for package-dir or emitter-output-dir for folks referencing older commits of a given tspconfig.yaml. 
 