### PR TITLE
improved exception and logging

### DIFF
--- a/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/Agent/AgentFileManager.cs
+++ b/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/Agent/AgentFileManager.cs
@@ -9,7 +9,7 @@ namespace Azure.Tools.GeneratorAgent.Agent
     {
         private const string UnknownStatus = "Unknown";
         private const string ProcessedStatus = "Processed";
-        
+
         private readonly PersistentAgentsClient Client;
         private readonly ILogger<AgentFileManager> Logger;
         private readonly AppSettings AppSettings;
@@ -19,7 +19,7 @@ namespace Azure.Tools.GeneratorAgent.Agent
             ArgumentNullException.ThrowIfNull(client);
             ArgumentNullException.ThrowIfNull(logger);
             ArgumentNullException.ThrowIfNull(appSettings);
-            
+
             Client = client;
             Logger = logger;
             AppSettings = appSettings;
@@ -33,48 +33,48 @@ namespace Azure.Tools.GeneratorAgent.Agent
 
             var results = await Task.WhenAll(uploadTasks).ConfigureAwait(false);
 
-            var uploadedFileIds = results
-                .Where(id => !string.IsNullOrEmpty(id))
-                .Select(id => id!);
+            var failures = results.Where(r => r.IsFailure).ToList();
+            if (failures.Any())
+            {
+                var firstFailure = failures.First();
+                throw new InvalidOperationException($"Failed to upload files: {firstFailure.Exception?.Message}", firstFailure.Exception);
+            }
+
+            var uploadedFileIds = results.Select(result => result.Value!);
 
             await WaitForIndexingAsync(uploadedFileIds, cancellationToken).ConfigureAwait(false);
 
             var vectorStoreId = await CreateVectorStoreAsync(uploadedFileIds, cancellationToken).ConfigureAwait(false);
 
-                        Logger.LogDebug("Files added to vector store successfully: {VectorStoreId}", vectorStoreId);
             return vectorStoreId;
         }
 
-        protected virtual async Task<string?> UploadSingleFileAsync(string fileName, string content, CancellationToken cancellationToken)
+        protected virtual async Task<Result<string>> UploadSingleFileAsync(string fileName, string content, CancellationToken cancellationToken)
         {
-            try
+            var txtFileName = Path.ChangeExtension(fileName, "txt");
+
+            using var contentStream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+
+            var uploaded = await Client.Files.UploadFileAsync(
+                contentStream,
+                PersistentAgentFilePurpose.Agents,
+                txtFileName,
+                cancellationToken: cancellationToken
+            ).ConfigureAwait(false);
+
+            if (uploaded?.Value?.Id != null)
             {
-                var txtFileName = Path.ChangeExtension(fileName, "txt");
-
-                using var contentStream = new MemoryStream(Encoding.UTF8.GetBytes(content));
-
-                var uploaded = await Client.Files.UploadFileAsync(
-                    contentStream,
-                    PersistentAgentFilePurpose.Agents,
-                    txtFileName,
-                    cancellationToken: cancellationToken
-                ).ConfigureAwait(false);
-
-                if (uploaded?.Value?.Id != null)
+                if (Logger.IsEnabled(LogLevel.Debug))
                 {
                     Logger.LogDebug("Uploaded file: {FileName} -> {FileId}", fileName, uploaded.Value.Id);
-                    return uploaded.Value.Id;
                 }
-                else
-                {
-                    Logger.LogWarning("Failed to upload file: {FileName}", fileName);
-                    return null;
-                }
+                return Result<string>.Success(uploaded.Value.Id);
             }
-            catch (Exception ex)
+            else
             {
-                Logger.LogError(ex, "Error uploading file: {FileName}", fileName);
-                return null;
+                var errorMsg = $"Failed to upload file: {fileName}";
+                Logger.LogWarning(errorMsg);
+                return Result<string>.Failure(new InvalidOperationException(errorMsg));
             }
         }
 
@@ -84,7 +84,7 @@ namespace Azure.Tools.GeneratorAgent.Agent
             var pollingInterval = AppSettings.IndexingPollingInterval;
             var stopwatch = System.Diagnostics.Stopwatch.StartNew();
 
-            Logger.LogDebug("Waiting for {Count} files to be indexed... (timeout: {Timeout}s)", 
+            Logger.LogDebug("Waiting for {Count} files to be indexed... (timeout: {Timeout}s)",
                 uploadedFilesIds.Count(), maxWaitTime.TotalSeconds);
 
             const int batchSize = 10;
@@ -92,13 +92,13 @@ namespace Azure.Tools.GeneratorAgent.Agent
             {
                 var results = new List<(string FileId, PersistentAgentFileInfo? File)>();
                 var totalCount = 0;
-                
+
                 var batch = new List<string>(batchSize);
                 foreach (var fileId in uploadedFilesIds)
                 {
                     batch.Add(fileId);
                     totalCount++;
-                    
+
                     if (batch.Count == batchSize)
                     {
                         var checkTasks = batch.Select(id => CheckFileStatusAsync(id, ct));
@@ -107,19 +107,18 @@ namespace Azure.Tools.GeneratorAgent.Agent
                         batch.Clear();
                     }
                 }
-                
-                // Process remaining items in the last batch
+
                 if (batch.Count > 0)
                 {
                     var checkTasks = batch.Select(id => CheckFileStatusAsync(id, ct));
                     var batchResults = await Task.WhenAll(checkTasks).ConfigureAwait(false);
                     results.AddRange(batchResults);
                 }
-                
+
                 var allIndexed = true;
                 var pendingFiles = Logger.IsEnabled(LogLevel.Debug) ? new List<string>() : null;
                 var currentStatusCounts = Logger.IsEnabled(LogLevel.Information) ? new Dictionary<string, int>() : null;
-                
+
                 foreach ((string FileId, PersistentAgentFileInfo? File) result in results)
                 {
                     if (result.File == null)
@@ -139,9 +138,6 @@ namespace Azure.Tools.GeneratorAgent.Agent
                         {
                             currentStatusCounts[status] = currentStatusCounts.GetValueOrDefault(status) + 1;
                         }
-                        
-                        Logger.LogDebug("File {Filename} (ID: {FileId}) status: {Status}", 
-                            result.File?.Filename, result.FileId, status);
 
                         if (!status.Equals(ProcessedStatus, StringComparison.OrdinalIgnoreCase))
                         {
@@ -157,14 +153,17 @@ namespace Azure.Tools.GeneratorAgent.Agent
                 if (Logger.IsEnabled(LogLevel.Debug) && currentStatusCounts != null)
                 {
                     var statusSummary = string.Join(", ", currentStatusCounts.Select(kvp => $"{kvp.Key}: {kvp.Value}"));
-                    Logger.LogDebug("Indexing status: {StatusSummary} | Elapsed: {Elapsed:F1}s", 
+                    Logger.LogDebug("Indexing status: {StatusSummary} | Elapsed: {Elapsed:F1}s",
                         statusSummary, stopwatch.Elapsed.TotalSeconds);
                 }
 
                 if (allIndexed)
                 {
-                    Logger.LogDebug("All {Count} files indexed successfully in {Duration:F1}s", 
-                        totalCount, stopwatch.Elapsed.TotalSeconds);
+                    if (Logger.IsEnabled(LogLevel.Debug))
+                    {
+                        Logger.LogDebug("All {Count} files indexed successfully in {Duration:F1}s",
+                            totalCount, stopwatch.Elapsed.TotalSeconds);
+                    }
                     return;
                 }
 
@@ -177,11 +176,12 @@ namespace Azure.Tools.GeneratorAgent.Agent
             }
 
             var finalResults = await Task.WhenAll(uploadedFilesIds.Select(id => CheckFileStatusAsync(id, ct))).ConfigureAwait(false);
-            
+
             var allProcessed = !finalResults.Any(r => r.File?.Status.ToString()?.Equals(ProcessedStatus, StringComparison.OrdinalIgnoreCase) != true);
             if (allProcessed)
             {
-                Logger.LogInformation("All files indexed successfully in {Duration:F1}s (completed during final check)",
+
+                Logger.LogDebug("All files indexed successfully in {Duration:F1}s (completed during final check)",
                     stopwatch.Elapsed.TotalSeconds);
                 return;
             }
@@ -190,15 +190,15 @@ namespace Azure.Tools.GeneratorAgent.Agent
                 .Where(r => r.File != null)
                 .GroupBy(r => r.File!.Status.ToString() ?? UnknownStatus)
                 .ToDictionary(g => g.Key, g => g.Count());
-            
+
             var finalStatusSummary = string.Join(", ", finalSummary.Select(kvp => $"{kvp.Key}: {kvp.Value}"));
-            
+
             throw new TimeoutException(
                 $"Timeout after {maxWaitTime.TotalSeconds}s while waiting for file indexing to complete. " +
                 $"Final status: {finalStatusSummary}. " +
                 $"This may indicate the Azure AI service is experiencing delays or the files require more processing time.");
         }
-        
+
         private async Task<(string FileId, PersistentAgentFileInfo? File)> CheckFileStatusAsync(string fileId, CancellationToken ct)
         {
             try
@@ -206,24 +206,7 @@ namespace Azure.Tools.GeneratorAgent.Agent
                 var file = await Client.Files.GetFileAsync(fileId, cancellationToken: ct).ConfigureAwait(false);
                 return (fileId, file);
             }
-            catch (Azure.RequestFailedException ex) when (ex.Status == 404)
-            {
-                Logger.LogWarning("File not found (404): {FileId} - it may have been deleted or not yet available", fileId);
-                return (fileId, null);
-            }
-            catch (Azure.RequestFailedException ex) when (ex.Status >= 400 && ex.Status < 500)
-            {
-                Logger.LogWarning("Client error ({StatusCode}) checking file {FileId}: {Message}",
-                    ex.Status, fileId, ex.Message);
-                return (fileId, null);
-            }
-            catch (Azure.RequestFailedException ex) when (ex.Status >= 500)
-            {
-                Logger.LogWarning("Server error ({StatusCode}) checking file {FileId}: {Message} - will retry",
-                    ex.Status, fileId, ex.Message);
-                return (fileId, null);
-            }
-            catch (Exception ex)
+            catch (Exception ex) when (!(ex is Azure.RequestFailedException))
             {
                 Logger.LogWarning(ex, "Unexpected error checking status for file: {FileId}", fileId);
                 return (fileId, null);
@@ -243,12 +226,54 @@ namespace Azure.Tools.GeneratorAgent.Agent
                 cancellationToken: ct
             ).ConfigureAwait(false);
 
-            Logger.LogInformation("Created vector store: {Name} ({Id})", store.Value.Name, store.Value.Id);
+            Logger.LogDebug("Vector store created with ID: {VectorStoreId}", store.Value.Id);
 
-            Logger.LogDebug("Waiting {WaitTime}ms for vector store to be ready...", AppSettings.VectorStoreReadyWaitTime);
             await Task.Delay(AppSettings.VectorStoreReadyWaitTime, ct).ConfigureAwait(false);
 
             return store.Value.Id;
+        }
+
+        public virtual async Task UpdateFileInVectorStoreAsync(string vectorStoreId, string fileName, string content, CancellationToken cancellationToken = default)
+        {
+            var uploadResult = await UploadSingleFileAsync(fileName, content, cancellationToken).ConfigureAwait(false);
+            if (uploadResult.IsFailure)
+            {
+                throw new InvalidOperationException($"Failed to upload updated file: {fileName}", uploadResult.Exception);
+            }
+
+            var newFileId = uploadResult.Value!;
+
+            // Step 1: Find and remove the old version from vector store
+            await foreach (var existingFile in Client.VectorStores.GetVectorStoreFilesAsync(vectorStoreId, cancellationToken: cancellationToken))
+            {
+                // Get file details to check the name
+                var fileDetails = await Client.Files.GetFileAsync(existingFile.Id, cancellationToken).ConfigureAwait(false);
+
+                // Compare with the expected filename (with .txt extension)
+                var expectedFileName = Path.ChangeExtension(fileName, "txt");
+
+                if (fileDetails.Value.Filename == expectedFileName)
+                {
+                    // Remove old file from vector store
+                    await Client.VectorStores.DeleteVectorStoreFileAsync(vectorStoreId, existingFile.Id, cancellationToken).ConfigureAwait(false);
+                    Logger.LogDebug("Removed old version of {FileName} from vector store", fileName);
+
+                    // Delete the old file
+                    await Client.Files.DeleteFileAsync(existingFile.Id, cancellationToken).ConfigureAwait(false);
+                    Logger.LogDebug("Deleted old file with ID: {FileId}", existingFile.Id);
+                    break;
+                }
+            }
+            // Step 2: Add the new file to vector store
+            await Client.VectorStores.CreateVectorStoreFileAsync(
+                vectorStoreId: vectorStoreId,
+                fileId: newFileId,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            // Step 3: Wait for the new file to be indexed
+            await WaitForIndexingAsync(new[] { newFileId }, cancellationToken).ConfigureAwait(false);
+            
+            Logger.LogDebug("Successfully updated {FileName} in vector store {VectorStoreId}", fileName, vectorStoreId);
         }
     }
 }

--- a/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/Agent/AgentResponseParser.cs
+++ b/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/Agent/AgentResponseParser.cs
@@ -20,10 +20,7 @@ namespace Azure.Tools.GeneratorAgent.Agent
         /// </summary>
         public static AgentTypeSpecResponse ParseResponse(string rawResponse)
         {
-            if (rawResponse == null)
-            {
-                throw new ArgumentException("Agent response is null", nameof(rawResponse));
-            }
+            ArgumentNullException.ThrowIfNull(rawResponse);
 
             try
             {
@@ -60,10 +57,7 @@ namespace Azure.Tools.GeneratorAgent.Agent
         /// </summary>
         public static IEnumerable<RuleError> ParseErrors(string rawResponse)
         {
-            if (rawResponse == null)
-            {
-                throw new ArgumentException("Agent response is null", nameof(rawResponse));
-            }
+            ArgumentNullException.ThrowIfNull(rawResponse);
 
             try
             {

--- a/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/Configuration/AppSettings.cs
+++ b/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/Configuration/AppSettings.cs
@@ -22,6 +22,7 @@ namespace Azure.Tools.GeneratorAgent.Configuration
         public string ProjectEndpoint => GetRequiredSetting("AzureSettings:ProjectEndpoint");
         public string Model => Configuration.GetSection("AzureSettings:Model").Value ?? "gpt-4o";
         public string AgentName => Configuration.GetSection("AzureSettings:AgentName").Value ?? "AZC Fixer";
+        public int MaxIterations => Configuration.GetSection("AzureSettings:maxIterations").Get<int>();
         public string AgentInstructions => Configuration.GetSection("AzureSettings:AgentInstructions").Value ?? "";
         public string FixPromptTemplate => Configuration.GetSection("AzureSettings:FixPromptTemplate").Value ?? "";
         public string ErrorAnalysisPromptTemplate => Configuration.GetSection("AzureSettings:ErrorAnalysisPromptTemplate").Value ?? "";

--- a/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/Configuration/ValidationContext.cs
+++ b/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/Configuration/ValidationContext.cs
@@ -41,30 +41,27 @@ namespace Azure.Tools.GeneratorAgent.Configuration
         public static Result<ValidationContext> TryValidateAndCreate(
             string? typespecPath, 
             string? commitId, 
-            string sdkOutputPath, 
-            ILogger logger)
+            string sdkOutputPath)
         {
             bool isLocalPath = string.IsNullOrWhiteSpace(commitId);
 
             Result<string> typespecValidation = InputValidator.ValidateTypeSpecDir(typespecPath, isLocalPath);
             if (typespecValidation.IsFailure)
             {
-                return Result<ValidationContext>.Failure(new ArgumentException($"TypeSpec path validation failed: {typespecValidation.Exception?.Message}"));
+                return Result<ValidationContext>.Failure(typespecValidation.Exception!);
             }
 
             Result<string> commitValidation = InputValidator.ValidateCommitId(commitId);
             if (commitValidation.IsFailure)
             {
-                return Result<ValidationContext>.Failure(new ArgumentException($"Commit ID validation failed: {commitValidation.Exception?.Message}"));
+                return Result<ValidationContext>.Failure(commitValidation.Exception!);
             }
 
             Result<string> outputValidation = InputValidator.ValidateOutputDirectory(sdkOutputPath);
             if (outputValidation.IsFailure)
             {
-                return Result<ValidationContext>.Failure(new ArgumentException($"SDK output path validation failed: {outputValidation.Exception?.Message}"));
+                return Result<ValidationContext>.Failure(outputValidation.Exception!);
             }
-
-            logger.LogInformation("All input validation completed successfully");
 
             return Result<ValidationContext>.Success(new ValidationContext(
                 typespecValidation.Value!,

--- a/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/ErrorParsingService.cs
+++ b/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/ErrorParsingService.cs
@@ -19,28 +19,34 @@ namespace Azure.Tools.GeneratorAgent
             Logger = logger;
         }
 
-        public virtual async Task<IEnumerable<Fix>> AnalyzeErrorsAsync(Result<object> result, CancellationToken cancellationToken)
+        public virtual async Task<Result<IEnumerable<Fix>>> AnalyzeErrorsAsync(Result<object> result, CancellationToken cancellationToken)
         {
-            Logger.LogInformation("Analyzing errors...");
-
             if (result.ProcessException?.Output == null)
             {
                 Logger.LogWarning("No fixable error, skipping error analysis.");
-                return Enumerable.Empty<Fix>();
+                return Result<IEnumerable<Fix>>.Success(Enumerable.Empty<Fix>());
             }
+
+            Logger.LogDebug("Build error output:\n{ErrorOutput}", result.ProcessException.Output);
 
             var errors = ParseWithRegex(result.ProcessException.Output);
 
             if (!errors.Any())
             {
-                Logger.LogInformation("No errors found with regex. Falling back to AI-based parsing.");
+                Logger.LogDebug("No errors found with regex. Falling back to AI-based parsing.");
                 if (ErrorFixerAgent != null)
                 {
-                    errors = await ErrorFixerAgent.AnalyzeErrorsAsync(result.ProcessException.Output, cancellationToken).ConfigureAwait(false);
+                    var aiAnalysisResult = await ErrorFixerAgent.AnalyzeErrorsAsync(result.ProcessException.Output, cancellationToken).ConfigureAwait(false);
+                    if (aiAnalysisResult.IsFailure)
+                    {
+                        return Result<IEnumerable<Fix>>.Failure(aiAnalysisResult.Exception ?? new InvalidOperationException("AI analysis failed"));
+                    }
+                    errors = aiAnalysisResult.Value!;
                 }
             }
 
-            return GenerateFixes(errors);
+            var fixesResult = GenerateFixes(errors);
+            return fixesResult;
         }
 
         private IEnumerable<RuleError> ParseWithRegex(string output)
@@ -52,10 +58,10 @@ namespace Azure.Tools.GeneratorAgent
             }
 
             MatchCollection matches = ErrorRegex.Matches(output);
-            Logger.LogDebug("Found {MatchCount} potential error matches using regex.", matches.Count);
 
+            // Use HashSet to deduplicate exact (type, message) combinations
             HashSet<(string type, string message)> seenErrors = new();
-            List<RuleError> errors = new(matches.Count);
+            List<RuleError> errors = new();
 
             foreach (Match match in matches)
             {
@@ -64,40 +70,51 @@ namespace Azure.Tools.GeneratorAgent
                     string errorType = match.Groups[1].Value.Trim();
                     string errorMessage = match.Groups[2].Value.Trim();
 
+                    if (Logger.IsEnabled(LogLevel.Debug))
+                    { 
+                    Logger.LogDebug("Raw regex match: Type='{ErrorType}', Message='{ErrorMessage}'", errorType, errorMessage);
+                    }
+
                     if (string.IsNullOrWhiteSpace(errorType) || string.IsNullOrWhiteSpace(errorMessage))
                     {
+                        Logger.LogDebug("Skipping empty error type or message");
                         continue;
                     }
 
-                    if (!seenErrors.Add((errorType, errorMessage)))
+                    // Deduplicate exact (type, message) combinations
+                    if (seenErrors.Add((errorType, errorMessage)))
                     {
-                        continue;
+                        errors.Add(new RuleError(errorType, errorMessage));
                     }
-
-                    errors.Add(new RuleError(errorType, errorMessage));
-                    Logger.LogDebug("Extracted error: {ErrorType} - {ErrorMessage}", errorType, errorMessage);
                 }
             }
 
+            if (Logger.IsEnabled(LogLevel.Debug))
+            {
+                Logger.LogDebug("Parsed {UniqueErrorCount} unique errors from {TotalMatches} regex matches", errors.Count, matches.Count);
+            }
             return errors;
         }
 
-        private IEnumerable<Fix> GenerateFixes(IEnumerable<RuleError> errors)
+        private Result<IEnumerable<Fix>> GenerateFixes(IEnumerable<RuleError> errors)
         {
             ArgumentNullException.ThrowIfNull(errors);
 
-            try
+            var errorList = errors.ToList();
+
+            var fixes = ErrorAnalyzerService.GetFixes(errorList);
+            var materializedFixes = fixes.ToList();
+            
+            if (Logger.IsEnabled(LogLevel.Debug))
             {
-                var fixes = ErrorAnalyzerService.GetFixes(errors);
-                var materializedFixes = fixes.ToList();
-                Logger.LogInformation("Generated {FixCount} fixes for errors.", materializedFixes.Count);
-                return materializedFixes;
+                Logger.LogDebug("Generated {FixCount} fixes:", materializedFixes.Count);
+                foreach (var fix in materializedFixes)
+                {
+                    Logger.LogDebug("  - {FixType}: {Action}", fix.GetType().Name, fix.Action);
+                }
             }
-            catch (Exception ex)
-            {
-                Logger.LogError(ex, "Failed to generate fixes for errors.");
-                return Enumerable.Empty<Fix>();
-            }
+            
+            return Result<IEnumerable<Fix>>.Success(materializedFixes);
         }
     }
 }

--- a/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/FixGeneratorService.cs
+++ b/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/FixGeneratorService.cs
@@ -20,10 +20,9 @@ namespace Azure.Tools.GeneratorAgent
         /// <summary>
         /// Analyzes both compile and build results to generate a unified list of fixes.
         /// </summary>
-        public async Task<List<Fix>> AnalyzeAndGetFixesAsync(Result<object>? compileResult, Result<object>? buildResult, CancellationToken cancellationToken)
+        public async Task<Result<List<Fix>>> AnalyzeAndGetFixesAsync(Result<object>? compileResult, Result<object>? buildResult, CancellationToken cancellationToken)
         {
-            // Build enumerable chain without intermediate collections - optimized approach
-            var fixTasks = new List<Task<IEnumerable<Fix>>>();
+            var fixTasks = new List<Task<Result<IEnumerable<Fix>>>>();
 
             if (compileResult?.IsFailure == true)
             {
@@ -35,14 +34,32 @@ namespace Azure.Tools.GeneratorAgent
                 fixTasks.Add(ErrorParsingService.AnalyzeErrorsAsync(buildResult, cancellationToken));
             }
 
-            // Process all tasks and flatten results efficiently
+            if (fixTasks.Count == 0)
+            {
+                Logger.LogDebug("No errors to analyze");
+
+                return Result<List<Fix>>.Success(new List<Fix>());
+            }
+
+            // Process all tasks and handle failures
             var allFixResults = await Task.WhenAll(fixTasks).ConfigureAwait(false);
+            
+            // Check for any failures
+            var failures = allFixResults.Where(r => r.IsFailure).ToList();
+            if (failures.Any())
+            {
+                var firstFailure = failures.First();
+                return Result<List<Fix>>.Failure(firstFailure.Exception ?? new InvalidOperationException("Error analysis failed"));
+            }
+
             var finalFixes = allFixResults
-                .SelectMany(fixes => fixes)  // Flatten enumerable chain
+                .Where(r => r.IsSuccess)
+                .SelectMany(r => r.Value!)
                 .ToList();
             
-            Logger.LogInformation("Total fixes generated: {TotalFixCount}", finalFixes.Count);
-            return finalFixes;
+            Logger.LogDebug("Total fixes generated: {TotalFixCount}", finalFixes.Count);
+
+            return Result<List<Fix>>.Success(finalFixes);
         }
     }
 }

--- a/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/FixPromptService.cs
+++ b/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/FixPromptService.cs
@@ -20,6 +20,61 @@ namespace Azure.Tools.GeneratorAgent
             AppSettings = appSettings;
         }
 
+        public string ConvertFixesToBatchPrompt(List<Fix> fixes)
+        {
+            ArgumentNullException.ThrowIfNull(fixes);
+
+            if (fixes.Count == 0)
+            {
+                throw new ArgumentException("Fixes list cannot be empty", nameof(fixes));
+            }
+
+            Logger.LogDebug("Creating batch prompt for {FixCount} fixes", fixes.Count);
+
+            // Build combined fix instructions
+            var combinedFixInstructions = new List<string>();
+            var combinedContexts = new List<string>();
+
+            for (int i = 0; i < fixes.Count; i++)
+            {
+                var fix = fixes[i];
+                
+                if (fix is AgentPromptFix promptFix)
+                {
+                    combinedFixInstructions.Add($"Fix {i + 1}: {promptFix.Prompt}");
+                    
+                    if (!string.IsNullOrEmpty(promptFix.Context))
+                    {
+                        combinedContexts.Add($"Context for Fix {i + 1}: {promptFix.Context}");
+                    }
+                }
+                else
+                {
+                    string fixTypeName = fix.GetType().Name;
+                    combinedFixInstructions.Add($"Fix {i + 1}: Fix Type: {fixTypeName}\nAction Required: {fix.Action}");
+                    combinedContexts.Add($"Context for Fix {i + 1}: Generic fix - apply appropriate changes to resolve the compilation error.");
+                }
+            }
+
+            // Combine all fix instructions
+            string allFixInstructions = string.Join("\n\n", combinedFixInstructions);
+            
+            // Combine all contexts
+            string allContexts = combinedContexts.Count > 0 
+                ? string.Join("\n\n", combinedContexts)
+                : "No additional context provided.";
+
+            // Format using the template with combined instructions and contexts
+            return AppSettings.AgentInstructions + string.Format(AppSettings.FixPromptTemplate, allFixInstructions, allContexts);
+        }
+
+
+
+
+
+
+
+
         /// <summary>
         /// Converts a single Fix into a formatted prompt for the AI agent
         /// </summary>

--- a/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/Models/ErrorDetail.cs
+++ b/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/Models/ErrorDetail.cs
@@ -4,7 +4,5 @@ namespace Azure.Tools.GeneratorAgent.Models
     {
         public string Type { get; set; } = string.Empty;
         public string Message { get; set; } = string.Empty;
-        public string? File { get; set; }
-        public int? Line { get; set; }
     }
 }

--- a/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/ProcessExecutionService.cs
+++ b/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/ProcessExecutionService.cs
@@ -61,7 +61,7 @@ namespace Azure.Tools.GeneratorAgent
                 string error = await errorTask.ConfigureAwait(false);
                 bool success = process.ExitCode == 0;
 
-                LogExecutionResult(success, process.ExitCode, command, error);
+                LogExecutionResult(success, process.ExitCode, command, error, output);
 
                 if (!success)
                 {
@@ -182,16 +182,19 @@ namespace Azure.Tools.GeneratorAgent
             return Result<object>.Failure(new TimeoutException(timeoutMessage));
         }
 
-        private void LogExecutionResult(bool success, int exitCode, string command, string error)
+        private void LogExecutionResult(bool success, int exitCode, string command, string error, string output = "")
         {
             if (success)
             {
-                Logger.LogDebug("Command {Command} succeeded", command);
+                if (Logger.IsEnabled(LogLevel.Debug))
+                {
+                    Logger.LogDebug("Command {Command} succeeded", command);
+                }
             }
             else
             {
-                Logger.LogError("Command {Command} failed with exit code {ExitCode}",
-                    command, exitCode);
+                Logger.LogError("Command {Command} failed with exit code {ExitCode}. Error output: {ErrorOutput}",
+                    command, exitCode, error);
             }
         }
     }

--- a/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/Program.cs
+++ b/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/Program.cs
@@ -20,7 +20,7 @@ namespace Azure.Tools.GeneratorAgent
         internal Program(IServiceProvider serviceProvider)
         {
             ArgumentNullException.ThrowIfNull(serviceProvider);
-            
+
             ServiceProvider = serviceProvider;
             Logger = ServiceProvider.GetRequiredService<ILogger<Program>>();
             CommandLineConfig = new CommandLineConfiguration(ServiceProvider.GetRequiredService<ILogger<CommandLineConfiguration>>());
@@ -28,38 +28,38 @@ namespace Azure.Tools.GeneratorAgent
 
         public static async Task<int> Main(string[] args)
         {
-            ToolConfiguration toolConfig = new ToolConfiguration();
-            using ILoggerFactory loggerFactory = toolConfig.CreateLoggerFactory();
+            var toolConfig = new ToolConfiguration();
+            using var loggerFactory = toolConfig.CreateLoggerFactory();
 
-            ServiceCollection services = new ServiceCollection();
+            var services = new ServiceCollection();
             services.AddSingleton(loggerFactory);
             services.AddLogging();
             services.AddGeneratorAgentServices(toolConfig);
 
-            await using ServiceProvider serviceProvider = services.BuildServiceProvider();
-            
-            Program program = new Program(serviceProvider);
+            await using var serviceProvider = services.BuildServiceProvider();
+
+            var program = new Program(serviceProvider);
             return await program.RunAsync(args).ConfigureAwait(false);
         }
 
         internal async Task<int> RunAsync(string[] args)
         {
-            RootCommand rootCommand = CommandLineConfig.CreateRootCommand(HandleCommandAsync);
+            var rootCommand = CommandLineConfig.CreateRootCommand(HandleCommandAsync);
             return await rootCommand.InvokeAsync(args).ConfigureAwait(false);
         }
 
         internal async Task<int> HandleCommandAsync(string? typespecPath, string? commitId, string sdkPath)
         {
-            int validationResult = CommandLineConfig.ValidateInput(typespecPath, commitId, sdkPath);
+            var validationResult = CommandLineConfig.ValidateInput(typespecPath, commitId, sdkPath);
             if (validationResult != ExitCodeSuccess)
             {
                 return validationResult;
             }
 
-            ValidationContext validationContext = ValidationContext.CreateFromValidatedInputs(
+            var validationContext = ValidationContext.CreateFromValidatedInputs(
                 typespecPath!, commitId!, sdkPath);
 
-            using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            using var cancellationTokenSource = new CancellationTokenSource();
             Console.CancelKeyPress += (_, eventArgs) =>
             {
                 Logger.LogInformation("Cancellation requested by user");
@@ -73,101 +73,159 @@ namespace Azure.Tools.GeneratorAgent
             }
             catch (OperationCanceledException)
             {
-                Logger.LogInformation("Operation was cancelled. Shutting down gracefully");
+                Logger.LogInformation("Operation was cancelled");
                 return ExitCodeSuccess;
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError(ex, "Unexpected error occurred during command execution");
-                return ExitCodeFailure;
-            }
-        }
-
-        private async Task<int> ExecuteGenerationAsync(ValidationContext validationContext, CancellationToken cancellationToken)
-        {
-            try
-            {
-                // Step 1: Get services from DI container
-                AppSettings appSettings = ServiceProvider.GetRequiredService<AppSettings>();
-                
-                // Step 2: Get TypeSpec files (from local or GitHub)
-                Func<ValidationContext, TypeSpecFileService> fileServiceFactory = ServiceProvider.GetRequiredService<Func<ValidationContext, TypeSpecFileService>>();
-                TypeSpecFileService fileService = fileServiceFactory(validationContext);
-
-                Dictionary<string, string> typeSpecFiles = await fileService.GetTypeSpecFilesAsync(cancellationToken).ConfigureAwait(false);
-
-                // Step 3: Initialize ErrorFixer Agent with files in memory
-                ErrorFixerAgent errorFixerAgent = ServiceProvider.GetRequiredService<ErrorFixerAgent>();
-                await errorFixerAgent.InitializeAgentEnvironmentAsync(typeSpecFiles, cancellationToken).ConfigureAwait(false);
-
-                // Step 4: Compile Typespec 
-                Func<ValidationContext, LocalLibraryGenerationService> sdkServiceFactory = ServiceProvider.GetRequiredService<Func<ValidationContext, LocalLibraryGenerationService>>();
-                LocalLibraryGenerationService sdkGenerationService = sdkServiceFactory(validationContext);
-                Result<object> compileResult = await sdkGenerationService.CompileTypeSpecAsync(cancellationToken).ConfigureAwait(false);
-
-                // Step 5: Compile Generated SDK
-                Func<ValidationContext, LibraryBuildService> libraryBuildServiceFactory = ServiceProvider.GetRequiredService<Func<ValidationContext, LibraryBuildService>>();
-                LibraryBuildService libraryBuildService = libraryBuildServiceFactory(validationContext);
-                Result<object> buildResult = await libraryBuildService.BuildSdkAsync(cancellationToken).ConfigureAwait(false);
-
-                // Step 6: Analyze all errors and get fixes (singleton)
-                if (compileResult?.IsFailure != true && buildResult?.IsFailure != true)
-                {
-                    Logger.LogInformation("No errors found. Compilation and build successful!");
-                    return ExitCodeSuccess;
-                }
-
-                FixGeneratorService analyzer = ServiceProvider.GetRequiredService<FixGeneratorService>();
-                List<Fix> allFixes = await analyzer.AnalyzeAndGetFixesAsync(compileResult, buildResult, cancellationToken).ConfigureAwait(false);
-            
-                // Step 7: Send fixes to AgentProcessor if List<Fix> is not empty
-                string updatedClientTspContent = await errorFixerAgent.FixCodeAsync(allFixes, cancellationToken).ConfigureAwait(false);
-                if (string.IsNullOrWhiteSpace(updatedClientTspContent))
-                {
-                    Logger.LogWarning("Agent returned empty content for client.tsp");
-                    return ExitCodeFailure;
-                }
-
-                //Step 8: Update Client.tsp
-                await fileService.UpdateTypeSpecFileAsync("client.tsp", updatedClientTspContent, cancellationToken).ConfigureAwait(false);
-                
-                return ExitCodeSuccess;
-            }
-            catch (OperationCanceledException)
-            {
-                Logger.LogInformation("SDK generation was cancelled");
-                return ExitCodeSuccess;
-            }
-            catch (InvalidOperationException ex)
-            {
-                Logger.LogError("Operation failed: {Error}", ex.Message);
-                return ExitCodeFailure;
             }
             catch (ArgumentException ex)
             {
                 Logger.LogError("Invalid configuration: {Error}", ex.Message);
                 return ExitCodeFailure;
             }
-            catch (RequestFailedException ex) when (ex.Status == 401)
+            catch (HttpRequestException ex)
             {
-                Logger.LogError("Authentication failed for Azure AI service. Please check your credentials.");
+                Logger.LogError("GitHub API request failed: {Error}", ex.Message);
                 return ExitCodeFailure;
             }
-            catch (RequestFailedException ex) when (ex.Status >= 500)
+            catch (InvalidOperationException ex) when (ex.Message.Contains("GitHub") || ex.Message.Contains("deserialize"))
             {
-                Logger.LogError("Azure AI service is temporarily unavailable: {Error}", ex.Message);
+                Logger.LogError("GitHub API response error: {Error}", ex.Message);
                 return ExitCodeFailure;
             }
-            catch (RequestFailedException ex)
+            catch (UnauthorizedAccessException)
+            {
+                Logger.LogError("Authentication failed for Azure AI service");
+                return ExitCodeFailure;
+            }
+            catch (Azure.RequestFailedException ex) when (ex.Status >= 400 && ex.Status < 500)
+            {
+                Logger.LogError("Azure AI service client error ({StatusCode}): {Error}", ex.Status, ex.Message);
+                return ExitCodeFailure;
+            }
+            catch (Azure.RequestFailedException ex)
             {
                 Logger.LogError("Azure AI service error: {Error}", ex.Message);
                 return ExitCodeFailure;
             }
             catch (Exception ex)
             {
-                Logger.LogError(ex, "Error occurred during SDK generation");
+                Logger.LogError(ex, "Unexpected error occurred during SDK generation");
                 return ExitCodeFailure;
             }
         }
-    }
+
+        private async Task<int> ExecuteGenerationAsync(ValidationContext validationContext, CancellationToken cancellationToken)
+        {
+            Logger.LogInformation("Starting library generation process");
+
+            var appSettings = ServiceProvider.GetRequiredService<AppSettings>();
+            var maxIterations = appSettings.MaxIterations;
+
+            // Step 1: Get TypeSpec files (from local or GitHub)
+            var fileServiceFactory = ServiceProvider.GetRequiredService<Func<ValidationContext, TypeSpecFileService>>();
+            var fileService = fileServiceFactory(validationContext);
+
+            var typeSpecFilesResult = await fileService.GetTypeSpecFilesAsync(cancellationToken).ConfigureAwait(false);
+            if (typeSpecFilesResult.IsFailure)
+            {
+                typeSpecFilesResult.ThrowIfFailure();
+            }
+
+            var typeSpecFiles = typeSpecFilesResult.Value!;   
+
+            Logger.LogInformation("Successfully loaded {Count} TypeSpec files", typeSpecFiles.Count);
+
+            // Step 2: Initialize ErrorFixer Agent with files in memory
+            var errorFixerAgent = ServiceProvider.GetRequiredService<ErrorFixerAgent>();
+            await errorFixerAgent.InitializeAgentEnvironmentAsync(typeSpecFiles, cancellationToken).ConfigureAwait(false);
+            Logger.LogInformation("Agent environment initialized successfully");
+
+            //Iteratively: Compile -> generate library -> build library -> capture and fix error
+            var currentIteration = 0;
+
+            while (currentIteration < maxIterations)
+            {
+                // Step 4: Compile Typespec 
+                var sdkServiceFactory = ServiceProvider.GetRequiredService<Func<ValidationContext, LocalLibraryGenerationService>>();
+                var sdkGenerationService = sdkServiceFactory(validationContext);
+                var compileResult = await sdkGenerationService.CompileTypeSpecAsync(cancellationToken).ConfigureAwait(false);
+                
+                // Step 5: Compile Generated SDK (only if TypeSpec compilation succeeded)
+                Result<object>? buildResult = null;
+                if (compileResult.IsSuccess)
+                {
+                    Logger.LogInformation("Step 4: TypeSpec compilation completed successfully. Building Library...");
+
+                    var libraryBuildServiceFactory = ServiceProvider.GetRequiredService<Func<ValidationContext, LibraryBuildService>>();
+                    var libraryBuildService = libraryBuildServiceFactory(validationContext);
+                    buildResult = await libraryBuildService.BuildSdkAsync(cancellationToken).ConfigureAwait(false);
+                    
+                    if (buildResult.IsSuccess)
+                    {
+                        Logger.LogInformation("Build completed successfully");
+                    }
+                }
+
+                // Step 6: Check if compile and build are successful
+                if (compileResult.IsSuccess && (buildResult?.IsSuccess ?? true))
+                {
+                    Logger.LogInformation("Generation process completed successfully - no errors found");
+                    break;
+                }
+
+                // Step 7: Analyze errors and get fixes
+                var analyzer = ServiceProvider.GetRequiredService<FixGeneratorService>();
+                var analysisResult = await analyzer.AnalyzeAndGetFixesAsync(compileResult, buildResult, cancellationToken).ConfigureAwait(false);
+                if (analysisResult.IsFailure)
+                {
+                    Logger.LogError("Failed to analyze errors: {Error}", analysisResult.Exception?.Message);
+                    analysisResult.ThrowIfFailure();
+                }
+
+                var allFixes = analysisResult.Value!;
+                Logger.LogInformation("Error analysis completed successfully - generated {FixCount} fixes", allFixes.Count);
+
+                //No point continuing if no fixes were generated
+                if (allFixes.Count == 0)
+                {
+                    Logger.LogInformation("No fixes generated - compilation errors may not be addressable by this agent");
+                    break;
+                }
+
+                // Step 8: Apply fixes - handle Result<T>
+                var fixResult = await errorFixerAgent.FixCodeAsync(allFixes, cancellationToken).ConfigureAwait(false);
+                if (fixResult.IsFailure)
+                {
+                    Logger.LogError("Agent failed to fix code: {Error}", fixResult.Exception?.Message);
+                    fixResult.ThrowIfFailure();
+                }
+                
+                var updatedClientTspContent = fixResult.Value!;
+                if (string.IsNullOrWhiteSpace(updatedClientTspContent))
+                {
+                    throw new InvalidOperationException("Agent returned empty content for client.tsp");
+                }
+
+                Logger.LogInformation("Agent successfully generated fixes for {FixCount} issues", allFixes.Count);
+
+                // Step 9: Update client.tsp files
+                var updateResult = await fileService.UpdateTypeSpecFileAsync("client.tsp", updatedClientTspContent, cancellationToken).ConfigureAwait(false);
+                if (updateResult.IsFailure)
+                {
+                    Logger.LogError("Failed to update TypeSpec file: {Error}", updateResult.Exception?.Message);
+                    updateResult.ThrowIfFailure();
+                }
+
+                await errorFixerAgent.UpdateFileAsync("client.tsp", updatedClientTspContent, cancellationToken);
+                
+                Logger.LogInformation("Successfully updated client.tsp with generated fixes");
+
+                currentIteration++;
+            }
+                
+            Logger.LogInformation("Library generation completed successfully");
+            return ExitCodeSuccess;
+        }
+    } 
 }
+
+

--- a/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/TypeSpecFileService.cs
+++ b/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/TypeSpecFileService.cs
@@ -36,126 +36,133 @@ namespace Azure.Tools.GeneratorAgent
 
         /// <summary>
         /// Gets TypeSpec files from either local directory or GitHub repository.
-        /// Returns a dictionary where key is filename and value is file content.
+        /// Returns a Result containing dictionary where key is filename and value is file content.
         /// </summary>
-        public async Task<Dictionary<string, string>> GetTypeSpecFilesAsync(
+        public async Task<Result<Dictionary<string, string>>> GetTypeSpecFilesAsync(
             CancellationToken cancellationToken = default)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
 
+            Result<Dictionary<string, string>> result;
+
             if (string.IsNullOrWhiteSpace(ValidationContext.ValidatedCommitId))
             {
                 // Local case
-                return await GetLocalTypeSpecFilesAsync(ValidationContext.ValidatedTypeSpecDir, cancellationToken).ConfigureAwait(false);
+                result = await GetLocalTypeSpecFilesAsync(ValidationContext.ValidatedTypeSpecDir, cancellationToken).ConfigureAwait(false);
             }
             else
             {
                 // GitHub case
-                return await GetGitHubTypeSpecFilesAsync(cancellationToken).ConfigureAwait(false);
+                result = await GetGitHubTypeSpecFilesAsync(cancellationToken).ConfigureAwait(false);
             }
+
+            // Handle result and log appropriately
+            if (result.IsFailure)
+            {
+                Logger.LogError("Failed to load TypeSpec files: {Error}", result.Exception?.Message);
+                return result;
+            }
+            
+            var typeSpecFiles = result.Value!;
+            if (typeSpecFiles.Count == 0)
+            {
+                Logger.LogWarning("No TypeSpec files found");
+            }
+
+            return result;
         }
 
-        private async Task<Dictionary<string, string>> GetLocalTypeSpecFilesAsync(
+        private async Task<Result<Dictionary<string, string>>> GetLocalTypeSpecFilesAsync(
             string typeSpecDir, 
             CancellationToken cancellationToken)
         {
-            Logger.LogInformation("Reading TypeSpec files from local directory: {TypeSpecDir}", typeSpecDir);
-
-            try
+            // Fail fast validation - check directory exists
+            if (!Directory.Exists(typeSpecDir))
             {
-                Dictionary<string, string> typeSpecFiles = new Dictionary<string, string>();
+                return Result<Dictionary<string, string>>.Failure(
+                    new DirectoryNotFoundException($"TypeSpec directory not found: {typeSpecDir}"));
+            }
+
+            var typeSpecFiles = new Dictionary<string, string>();
+            string[] allFiles = Directory.GetFiles(typeSpecDir, "*.tsp", SearchOption.AllDirectories);
+
+            foreach (string filePath in allFiles)
+            {
+                string fileName = Path.GetFileName(filePath);
+                string content = await File.ReadAllTextAsync(filePath, Encoding.UTF8, cancellationToken).ConfigureAwait(false);
+                typeSpecFiles[fileName] = content;
                 
-                string[] allFiles = Directory.GetFiles(typeSpecDir, "*.tsp", SearchOption.AllDirectories);
-
-                foreach (string filePath in allFiles)
+                if (Logger.IsEnabled(LogLevel.Debug))
                 {
-                    string fileName = Path.GetFileName(filePath);
-                    string content = await File.ReadAllTextAsync(filePath, Encoding.UTF8, cancellationToken).ConfigureAwait(false);
-                    typeSpecFiles[fileName] = content;
+                    Logger.LogDebug("Loaded file: {FileName} ({Size} characters)", fileName, content.Length);
                 }
-
-                Logger.LogInformation("Successfully read {Count} TypeSpec files from local directory\n", typeSpecFiles.Count);
-                return typeSpecFiles;
             }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                Logger.LogCritical(ex, "Error reading TypeSpec files from local directory: {TypeSpecDir}", typeSpecDir);
-                throw;
-            }
+            
+            return Result<Dictionary<string, string>>.Success(typeSpecFiles);
         }
 
-        private async Task<Dictionary<string, string>> GetGitHubTypeSpecFilesAsync(
+        private async Task<Result<Dictionary<string, string>>> GetGitHubTypeSpecFilesAsync(
             CancellationToken cancellationToken)
         {
-            Logger.LogInformation("Fetching TypeSpec files from GitHub: {TypeSpecDir} at commit {CommitId}", 
-                ValidationContext.ValidatedTypeSpecDir, ValidationContext.ValidatedCommitId);
+            GitHubFileService = GitHubServiceFactory(ValidationContext);
 
-            try
+            var githubResult = await GitHubFileService.GetTypeSpecFilesAsync(cancellationToken).ConfigureAwait(false);
+            
+            if (githubResult.IsFailure)
             {
-                GitHubFileService = GitHubServiceFactory(ValidationContext);
+                return Result<Dictionary<string, string>>.Failure(githubResult.Exception!);
+            }
 
-                // Get files from GitHub
-                Dictionary<string, string> result = await GitHubFileService.GetTypeSpecFilesAsync(cancellationToken).ConfigureAwait(false);
+            var result = githubResult.Value ?? new Dictionary<string, string>();
 
-                // Create secure temporary directory for compilation
-                if (result.Count > 0)
+            if (result.Count > 0)
+            {
+                var tempDirResult = await CreateSecureTempDirectoryFromGitHubFiles(result, cancellationToken).ConfigureAwait(false);
+                if (tempDirResult.IsFailure)
                 {
-                    string tempDirectory = await CreateSecureTempDirectoryFromGitHubFiles(result, cancellationToken).ConfigureAwait(false);
-                    ValidationContext.CurrentTypeSpecDirForCompilation = tempDirectory;
-
-                    Logger.LogInformation("Successfully read {Count} TypeSpec files from Github Repository\n", result.Count);
+                    return Result<Dictionary<string, string>>.Failure(tempDirResult.Exception!);
                 }
+                
+                ValidationContext.CurrentTypeSpecDirForCompilation = tempDirResult.Value!;
+            }
 
-                return result;
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                Logger.LogCritical(ex, "Unexpected error fetching TypeSpec files from GitHub: {TypeSpecDir} at commit {CommitId}", 
-                    ValidationContext.ValidatedTypeSpecDir, ValidationContext.ValidatedCommitId);
-                throw;
-            }
+            return Result<Dictionary<string, string>>.Success(result);
         }
 
         /// <summary>
         /// Creates a secure temporary directory and writes GitHub files to it.
         /// Implements essential security measures for production use.
         /// </summary>
-        private async Task<string> CreateSecureTempDirectoryFromGitHubFiles(
+        private async Task<Result<string>> CreateSecureTempDirectoryFromGitHubFiles(
             Dictionary<string, string> githubFiles, 
             CancellationToken cancellationToken)
         {
             string tempPath = string.Empty;
 
-            try
+            // Create validated temp path
+            tempPath = CreateSecureTempPath();
+
+            // Validate the constructed path
+            Result<string> pathValidation = InputValidator.ValidateDirTraversal(tempPath, "temporary TypeSpec directory");
+            if (pathValidation.IsFailure)
             {
-                // Security: Create validated temp path
-                tempPath = CreateSecureTempPath();
-
-                // Security: Validate the constructed path
-                Result<string> pathValidation = InputValidator.ValidateDirTraversal(tempPath, "temporary TypeSpec directory");
-                if (pathValidation.IsFailure)
-                {
-                    throw new SecurityException($"Temporary directory path validation failed: {pathValidation.Exception?.Message}");
-                }
-
-                // Create directory
-                Directory.CreateDirectory(tempPath);
-                TempDirectories.Add(tempPath);
-
-                // Security: Write files with validation
-                await WriteFilesSecurely(tempPath, githubFiles, cancellationToken).ConfigureAwait(false);
-
-                Logger.LogInformation("Created secure temp directory: {TempPath} with {FileCount} files", tempPath, githubFiles.Count);
-                return tempPath;
+                return Result<string>.Failure(new SecurityException($"Temporary directory path validation failed: {pathValidation.Exception?.Message}"));
             }
-            catch (Exception ex) when (ex is not OperationCanceledException)
+
+            // Create directory
+            Directory.CreateDirectory(tempPath);
+            TempDirectories.Add(tempPath);
+
+            // Write files with validation
+            var writeResult = await WriteFilesSecurely(tempPath, githubFiles, cancellationToken).ConfigureAwait(false);
+            if (writeResult.IsFailure)
             {
-                // Security: Always cleanup on failure
                 await CleanupTempDirectorySecurely(tempPath).ConfigureAwait(false);
-                
-                Logger.LogError(ex, "Failed to create secure temp directory: {TempPath}", tempPath);
-                throw new InvalidOperationException($"Failed to create secure temporary TypeSpec directory: {ex.Message}", ex);
+                return Result<string>.Failure(writeResult.Exception!);
             }
+
+            Logger.LogDebug("Created secure temp directory: {TempPath} with {FileCount} files", tempPath, githubFiles.Count);
+            return Result<string>.Success(tempPath);
         }
 
         /// <summary>
@@ -164,10 +171,10 @@ namespace Azure.Tools.GeneratorAgent
         /// </summary>
         private string CreateSecureTempPath()
         {
-            // Security: Sanitize the TypeSpec directory name
+            // Sanitize the TypeSpec directory name
             string sanitizedSpecDir = SanitizeDirectoryNameSecurely(ValidationContext.ValidatedTypeSpecDir);
             
-            // Security: Create unique timestamp + random identifier
+            // Create unique timestamp + random identifier
             string timestamp = DateTimeOffset.UtcNow.ToString("yyyyMMdd_HHmmss_fff");
             string uniqueId = Path.GetRandomFileName()[..8]; // First 8 chars for uniqueness
             
@@ -184,7 +191,7 @@ namespace Azure.Tools.GeneratorAgent
         /// <summary>
         /// Writes files securely with proper validation and error handling.
         /// </summary>
-        private async Task WriteFilesSecurely(
+        private async Task<Result<bool>> WriteFilesSecurely(
             string tempPath, 
             Dictionary<string, string> githubFiles, 
             CancellationToken cancellationToken)
@@ -193,7 +200,7 @@ namespace Azure.Tools.GeneratorAgent
 
             foreach (var kvp in githubFiles)
             {
-                // Security: Validate each filename
+                // Validate each filename
                 Result<string> fileValidation = InputValidator.ValidateDirTraversal(kvp.Key, "TypeSpec filename");
                 if (fileValidation.IsFailure)
                 {
@@ -203,7 +210,7 @@ namespace Azure.Tools.GeneratorAgent
 
                 string filePath = Path.Combine(tempPath, kvp.Key);
                 
-                // Security: Ensure file path is within temp directory (prevent directory traversal)
+                // Ensure file path is within temp directory (prevent directory traversal)
                 string fullFilePath = Path.GetFullPath(filePath);
                 if (!fullFilePath.StartsWith(fullTempPath, StringComparison.OrdinalIgnoreCase))
                 {
@@ -211,7 +218,7 @@ namespace Azure.Tools.GeneratorAgent
                     continue;
                 }
 
-                // Security: Create subdirectories safely
+                // Create subdirectories safely
                 string? directoryPath = Path.GetDirectoryName(filePath);
                 if (!string.IsNullOrEmpty(directoryPath) && !Directory.Exists(directoryPath))
                 {
@@ -220,8 +227,14 @@ namespace Azure.Tools.GeneratorAgent
 
                 // Write file with proper encoding
                 await File.WriteAllTextAsync(filePath, kvp.Value, Encoding.UTF8, cancellationToken).ConfigureAwait(false);
-                Logger.LogDebug("Securely wrote file: {FilePath} ({Size} characters)", filePath, kvp.Value.Length);
+                
+                if (Logger.IsEnabled(LogLevel.Debug))
+                {
+                    Logger.LogDebug("Securely wrote file: {FilePath} ({Size} characters)", filePath, kvp.Value.Length);
+                }
             }
+
+            return Result<bool>.Success(true);
         }
 
         /// <summary>
@@ -232,7 +245,7 @@ namespace Azure.Tools.GeneratorAgent
             if (string.IsNullOrWhiteSpace(directoryName))
                 return "default";
 
-            // Security: Replace all invalid and potentially dangerous characters
+            // Replace all invalid and potentially dangerous characters
             char[] invalidChars = Path.GetInvalidFileNameChars();
             var sanitized = new StringBuilder(directoryName.Length);
 
@@ -250,14 +263,14 @@ namespace Azure.Tools.GeneratorAgent
 
             string result = sanitized.ToString();
             
-            // Security: Limit length for filesystem compatibility
+            // Limit length for filesystem compatibility
             const int maxLength = 50; // Conservative length for cross-platform compatibility
             if (result.Length > maxLength)
             {
                 result = result[..maxLength];
             }
 
-            // Security: Ensure not empty after sanitization
+            // Ensure not empty after sanitization
             return string.IsNullOrEmpty(result) ? "default" : result.TrimEnd('_');
         }
 
@@ -265,40 +278,35 @@ namespace Azure.Tools.GeneratorAgent
         /// Updates a TypeSpec file in the current working directory with security validation.
         /// Used for iterative error fixing.
         /// </summary>
-        public async Task UpdateTypeSpecFileAsync(string fileName, string content, CancellationToken cancellationToken = default)
+        public async Task<Result<bool>> UpdateTypeSpecFileAsync(string fileName, string content, CancellationToken cancellationToken = default)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
             ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
             ArgumentNullException.ThrowIfNull(content);
 
-            // Security: Validate filename
+            // Validate filename
             Result<string> fileValidation = InputValidator.ValidateDirTraversal(fileName, "TypeSpec filename");
             if (fileValidation.IsFailure)
             {
-                throw new SecurityException($"TypeSpec filename validation failed: {fileName}");
+                return Result<bool>.Failure(new SecurityException($"TypeSpec filename validation failed: {fileName}"));
             }
 
             string currentDir = ValidationContext.CurrentTypeSpecDir;
             string filePath = Path.Combine(currentDir, fileName);
             
-            // Security: Ensure file is within current directory
+            // Ensure file is within current directory
             string fullCurrentDir = Path.GetFullPath(currentDir);
             string fullFilePath = Path.GetFullPath(filePath);
             if (!fullFilePath.StartsWith(fullCurrentDir, StringComparison.OrdinalIgnoreCase))
             {
-                throw new SecurityException($"File '{fileName}' attempts to write outside current directory");
+                return Result<bool>.Failure(new SecurityException($"File '{fileName}' attempts to write outside current directory"));
             }
 
-            try
-            {
-                await File.WriteAllTextAsync(filePath, content, Encoding.UTF8, cancellationToken).ConfigureAwait(false);
-                Logger.LogInformation("Securely updated TypeSpec file: {FilePath} ({Size} characters)", filePath, content.Length);
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException and not SecurityException)
-            {
-                Logger.LogError(ex, "Failed to update TypeSpec file: {FilePath}", filePath);
-                throw new InvalidOperationException($"Failed to update TypeSpec file: {fileName}", ex);
-            }
+            await File.WriteAllTextAsync(filePath, content, Encoding.UTF8, cancellationToken).ConfigureAwait(false);
+
+            Logger.LogDebug("Updated TypeSpec file: {FileName} ({Size} characters)", Path.GetFileName(filePath), content.Length);
+    
+            return Result<bool>.Success(true);
         }
 
         /// <summary>
@@ -311,7 +319,6 @@ namespace Azure.Tools.GeneratorAgent
 
             try
             {
-                // Security: Use Task.Run for potentially blocking I/O operation
                 await Task.Run(() =>
                 {
                     Directory.Delete(tempDirectory, recursive: true);
@@ -333,7 +340,7 @@ namespace Azure.Tools.GeneratorAgent
 
             try
             {
-                // Security: Clean up all tracked temp directories
+                // Clean up all tracked temp directories
                 foreach (string tempDir in TempDirectories)
                 {
                     try
@@ -341,7 +348,10 @@ namespace Azure.Tools.GeneratorAgent
                         if (Directory.Exists(tempDir))
                         {
                             Directory.Delete(tempDir, recursive: true);
-                            Logger.LogDebug("Disposed temp directory: {TempDir}", tempDir);
+                            if (Logger.IsEnabled(LogLevel.Debug))
+                            {
+                                Logger.LogDebug("Disposed temp directory: {TempDir}", tempDir);
+                            }
                         }
                     }
                     catch (Exception ex)


### PR DESCRIPTION
## PR Summary & Focus

This PR introduces a loop over the process: Compile TypeSpec, Generate Library,  Capture errors , Find fixes ,  Apply fixes , Repeat  

While testing, I found that applying fixes one-at-a-time causes confusion about which version of `client.tsp` the agent should be working with.  Two approaches were considered:

1. Repeatedly upload the updated `client.tsp` after each fix (which requires additional API calls)  
2. Use a **single prompt** where the agent applies all necessary fixes in one go

I’ve implemented the second approach in this PR, as it appears more effective so far.

---

## Additional Improvements: Logging, Exception Handling & Performance

While doing this work I also applied some learnings around logging, exception handling, and performance:

1. **Avoiding unnecessary cost from logs**  
   Logs can impose overhead even when the level is off, since formatting or argument evaluation may still execute. To reduce that cost, I added `logger.IsEnabled(...)` checks around expensive operations.

2. **Using `Result<T>` vs exceptions**  
   - For *expected failures* (e.g. validation errors), `Result<T>` is faster and cleaner, since using exceptions incurs stack unwinding cost. :contentReference[oaicite:0]{index=0}  
   - For *unexpected failures* (e.g. network timeouts, service errors), exceptions still make sense, since their overhead is small relative to the underlying I/O and their semantics are clearer in those cases.  

3. **Single‐boundary exception handling**  
   I’ve tried to push exception handling up to a single boundary (e.g. in `Program.cs`), so that business logic isn’t littered with try/catch and we have a clear place for logging and translating exceptions.

---

## Feedback Needed

There are still areas I believe can be improved. I’m particularly uncertain about:

- Whether I’ve **differentiated correctly** between when to use `Result<T>` vs when to use exceptions  
- If any exception handling is redundant, misplaced, or overly broad  
- Whether there are places where logging is duplicated, too verbose, or missing needed context  

@jsquire @m-redding I’d appreciate your thoughts especially on the `Result<T>` vs exception usage. Any suggestions for refactoring or optimizing the flow would be great.  
