### PR TITLE
[AVC] Revert non-reasoning prompt to GPT-4.1

### DIFF
--- a/packages/python-packages/apiview-copilot/prompts/api_review/comment_filter.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/api_review/comment_filter.prompty
@@ -10,13 +10,13 @@ model:
   configuration:
     type: azure_openai
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: gpt-5
+    azure_deployment: gpt-4.1
     api_version: 2025-03-01-preview
   parameters:
-    frequency_penalty: 0
-    presence_penalty: 0
-    max_completion_tokens: 80000
-    reasoning_effort: "minimal"
+    temperature: 0.0
+    top_p: 1.0
+    stop: []
+    max_tokens: 16384
     response_format: ${file:filtered_result_schema.json}
 sample:
   language: Python

--- a/packages/python-packages/apiview-copilot/prompts/api_review/existing_comment_filter.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/api_review/existing_comment_filter.prompty
@@ -9,13 +9,13 @@ model:
   configuration:
     type: azure_openai
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: gpt-5
+    azure_deployment: gpt-4.1
     api_version: 2025-03-01-preview
   parameters:
-    frequency_penalty: 0
-    presence_penalty: 0
-    max_completion_tokens: 80000
-    reasoning_effort: "minimal"
+    temperature: 0.0
+    top_p: 1.0
+    stop: []
+    max_tokens: 16384
     response_format: ${file:existing_comparison_result_schema.json}
 sample:
   language: Python

--- a/packages/python-packages/apiview-copilot/prompts/api_review/generic_comment_judge.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/api_review/generic_comment_judge.prompty
@@ -9,13 +9,13 @@ model:
   configuration:
     type: azure_openai
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: gpt-5
+    azure_deployment: gpt-4.1
     api_version: 2025-03-01-preview
   parameters:
-    frequency_penalty: 0
-    presence_penalty: 0
-    max_completion_tokens: 80000
-    reasoning_effort: "minimal"
+    temperature: 0.0
+    top_p: 1.0
+    stop: []
+    max_tokens: 16384
 sample:
   language: Python
   content: |

--- a/packages/python-packages/apiview-copilot/prompts/api_review/merge_comments.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/api_review/merge_comments.prompty
@@ -9,13 +9,13 @@ model:
   configuration:
     type: azure_openai
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: gpt-5
+    azure_deployment: gpt-4.1
     api_version: 2025-03-01-preview
   parameters:
-    frequency_penalty: 0
-    presence_penalty: 0
-    max_completion_tokens: 80000
-    reasoning_effort: "minimal"
+    temperature: 0.0
+    top_p: 1.0
+    stop: []
+    max_tokens: 16384
     response_format: ${file:guideline_result_schema.json}
 sample:
   comments: |

--- a/packages/python-packages/apiview-copilot/prompts/evals/eval_judge_prompt.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/evals/eval_judge_prompt.prompty
@@ -8,14 +8,14 @@ model:
   api: chat
   configuration:
     type: azure_openai
-    api_version: 2025-03-01-preview
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: gpt-5
+    azure_deployment: gpt-4.1
+    api_version: 2025-03-01-preview
   parameters:
-    frequency_penalty: 0
-    presence_penalty: 0
-    max_completion_tokens: 80000
-    reasoning_effort: "minimal"
+    temperature: 0.0
+    top_p: 1.0
+    stop: []
+    max_tokens: 16384
 sample:
   language: python
   code: |

--- a/packages/python-packages/apiview-copilot/prompts/mention/parse_conversation_action.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/mention/parse_conversation_action.prompty
@@ -8,14 +8,14 @@ model:
   api: chat
   configuration:
     type: azure_openai
-    api_version: 2025-03-01-preview
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: gpt-5
+    azure_deployment: gpt-4.1
+    api_version: 2025-03-01-preview
   parameters:
-    frequency_penalty: 0
-    presence_penalty: 0
-    max_completion_tokens: 80000
-    reasoning_effort: "minimal"
+    temperature: 0.0
+    top_p: 1.0
+    stop: []
+    max_tokens: 16384
 sample:
   language: python
   package_name: azure.widget

--- a/packages/python-packages/apiview-copilot/prompts/mention/parse_conversation_to_memory.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/mention/parse_conversation_to_memory.prompty
@@ -8,14 +8,14 @@ model:
   api: chat
   configuration:
     type: azure_openai
-    api_version: 2025-03-01-preview
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: gpt-5
+    azure_deployment: gpt-4.1
+    api_version: 2025-03-01-preview
   parameters:
-    frequency_penalty: 0
-    presence_penalty: 0
-    max_completion_tokens: 80000
-    reasoning_effort: "minimal"
+    temperature: 0.0
+    top_p: 1.0
+    stop: []
+    max_tokens: 16384
     response_format: ${file:conversation_parsing_result_schema.json}
 sample:
   language: dotnet

--- a/packages/python-packages/apiview-copilot/prompts/mention/summarize_actions.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/mention/summarize_actions.prompty
@@ -12,14 +12,14 @@ model:
   api: chat
   configuration:
     type: azure_openai
-    api_version: 2025-03-01-preview
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: gpt-5
+    azure_deployment: gpt-4.1
+    api_version: 2025-03-01-preview
   parameters:
-    frequency_penalty: 0
-    presence_penalty: 0
-    max_completion_tokens: 80000
-    reasoning_effort: "minimal"
+    temperature: 0.0
+    top_p: 1.0
+    stop: []
+    max_tokens: 16384
 sample:
   results: | 
     {

--- a/packages/python-packages/apiview-copilot/prompts/thread_resolution/parse_thread_resolution_action.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/thread_resolution/parse_thread_resolution_action.prompty
@@ -8,14 +8,14 @@ model:
   api: chat
   configuration:
     type: azure_openai
-    api_version: 2025-03-01-preview
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: gpt-5
+    azure_deployment: gpt-4.1
+    api_version: 2025-03-01-preview
   parameters:
-    frequency_penalty: 0
-    presence_penalty: 0
-    max_completion_tokens: 80000
-    reasoning_effort: "minimal"
+    temperature: 0.0
+    top_p: 1.0
+    stop: []
+    max_tokens: 16384
 sample:
   language: python
   package_name: azure.widget

--- a/packages/python-packages/apiview-copilot/prompts/thread_resolution/parse_thread_resolution_to_memory.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/thread_resolution/parse_thread_resolution_to_memory.prompty
@@ -8,14 +8,14 @@ model:
   api: chat
   configuration:
     type: azure_openai
-    api_version: 2025-03-01-preview
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: gpt-5
+    azure_deployment: gpt-4.1
+    api_version: 2025-03-01-preview
   parameters:
-    frequency_penalty: 0
-    presence_penalty: 0
-    max_completion_tokens: 80000
-    reasoning_effort: "minimal"
+    temperature: 0.0
+    top_p: 1.0
+    stop: []
+    max_tokens: 16384
     response_format: ${file:conversation_parsing_result_schema.json}
 sample:
   language: python

--- a/packages/python-packages/apiview-copilot/prompts/thread_resolution/summarize_actions.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/thread_resolution/summarize_actions.prompty
@@ -12,14 +12,14 @@ model:
   api: chat
   configuration:
     type: azure_openai
-    api_version: 2025-03-01-preview
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: gpt-5
+    azure_deployment: gpt-4.1
+    api_version: 2025-03-01-preview
   parameters:
-    frequency_penalty: 0
-    presence_penalty: 0
-    max_completion_tokens: 80000
-    reasoning_effort: "minimal"
+    temperature: 0.0
+    top_p: 1.0
+    stop: []
+    max_tokens: 16384
 sample:
   results: | 
     {


### PR DESCRIPTION
We migrated all non-reasoning prompts from GPT-4.1 to GPT-5 with "minimal" reasoning. However, we have observed that these migrated prompts have run into rate limits and can take much longer to complete than their GPT-4.1 equivalent, and the results cannot be made deterministic through parameter tuning.

Since the goal of these prompts is to be fast (and deterministic) this PR reverts back to the earlier model.