### PR TITLE
Expose APIView functionality to tools/mcp agents

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/LeanControllers/APIRevisionsTokenAuthController.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanControllers/APIRevisionsTokenAuthController.cs
@@ -134,4 +134,37 @@ public class APIRevisionsTokenAuthController : ControllerBase
             return StatusCode(StatusCodes.Status500InternalServerError, "Failed to generate review text");
         }
     }
+
+
+    [HttpGet("{reviewId}/getReviewVersions", Name = "GetReviewVersions")]
+    public async Task<ActionResult<string>> GetReviewVersions(string reviewId)
+    {
+        try
+        {
+            IEnumerable<APIRevisionListItemModel> revisions = await _apiRevisionsManager.GetAPIRevisionsAsync(reviewId);
+            List<RevisionResponseModel> results = revisions
+                .Where(r => !r.IsDeleted && r.PackageVersion != null)
+                .GroupBy(r => r.PackageVersion)
+                .Select(g => g.OrderByDescending(r => r.CreatedOn).First())
+                .Select(revision => new RevisionResponseModel()
+                {
+                    RevisionId = revision.Id,
+                    PackageVersion = revision.PackageVersion,
+                    CreatedOn = revision.CreatedOn,
+                    LastUpdatedOn = revision.LastUpdatedOn,
+                    IsDeleted = revision.IsDeleted,
+                    IsReleased = revision.IsReleased,
+                    ReleasedOn = revision.ReleasedOn
+                })
+                .OrderByDescending(r => r.CreatedOn)
+                .ToList();
+
+            return new LeanJsonResult(results, StatusCodes.Status200OK);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting review versions for review {ReviewId}", reviewId);
+            return StatusCode(StatusCodes.Status500InternalServerError, "Failed to get review versions");
+        }
+    }
 }

--- a/src/dotnet/APIView/APIViewWeb/LeanControllers/ReviewsHybridAuthController.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanControllers/ReviewsHybridAuthController.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using APIViewWeb.Helpers;
+using APIViewWeb.LeanModels;
+using APIViewWeb.Managers;
+using APIViewWeb.Managers.Interfaces;
+using APIViewWeb.Repositories;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace APIViewWeb.LeanControllers;
+
+[ApiController]
+[Authorize("RequireTokenOrCookieAuthentication")]
+[Route("api/reviews")]
+public class ReviewsHybridAuthController : ControllerBase
+{
+    private readonly ICommentsManager _commentsManager;
+    private readonly IAPIRevisionsManager _apiRevisionsManager;
+    private readonly IBlobCodeFileRepository _codeFileRepository;
+    private readonly IEnumerable<LanguageService> _languageServices;
+
+    public ReviewsHybridAuthController(ICommentsManager commentsManager,
+        IBlobCodeFileRepository codeFileRepository,
+        IAPIRevisionsManager reviewRevisionsManager,
+        IEnumerable<LanguageService> languageServices)
+    {
+        _apiRevisionsManager = reviewRevisionsManager;
+        _codeFileRepository = codeFileRepository;
+        _commentsManager = commentsManager;
+        _languageServices = languageServices;
+    }
+
+    ///<summary>
+    ///Retrieve the Content (codeLines and Navigation) of a review
+    ///</summary>
+    ///<param name="reviewId"></param>
+    ///<param name="activeApiRevisionId"></param>
+    /// <param name="diffApiRevisionId"></param>
+    ///<returns></returns>
+    [Route("{reviewId}/content")]
+    [HttpGet]
+    public async Task<ActionResult<CodePanelData>> GetReviewContentAsync(string reviewId, [FromQuery] string activeApiRevisionId,
+        [FromQuery] string diffApiRevisionId = null)
+    {
+        var activeAPIRevision = await _apiRevisionsManager.GetAPIRevisionAsync(User, activeApiRevisionId);
+        APIRevisionListItemModel diffAPIRevision = null;
+
+        if (activeAPIRevision.IsDeleted)
+        {
+            return new LeanJsonResult(null, StatusCodes.Status204NoContent);
+        }
+
+        if (!string.IsNullOrEmpty(diffApiRevisionId))
+        {
+            diffAPIRevision = await _apiRevisionsManager.GetAPIRevisionAsync(User, diffApiRevisionId);
+
+            if (diffAPIRevision.IsDeleted)
+            {
+                return new LeanJsonResult(null, StatusCodes.Status204NoContent);
+            }
+        }
+
+        if (activeAPIRevision.Files[0].ParserStyle == ParserStyle.Tree)
+        {
+            var comments = await _commentsManager.GetCommentsAsync(reviewId, commentType: CommentType.APIRevision);
+            var activeRevisionReviewCodeFile = await _codeFileRepository.GetCodeFileFromStorageAsync(revisionId: activeAPIRevision.Id, codeFileId: activeAPIRevision.Files[0].FileId);
+
+            if (activeRevisionReviewCodeFile.ContentGenerationInProgress)
+            {
+                var languageServices = LanguageServiceHelpers.GetLanguageService(activeAPIRevision.Language, _languageServices);
+                return new LeanJsonResult("Content generation in progress", StatusCodes.Status202Accepted, languageServices.ReviewGenerationPipelineUrl);
+            }
+
+            var codePanelRawData = new CodePanelRawData()
+            {
+                activeRevisionCodeFile = activeRevisionReviewCodeFile,
+                Comments = comments
+            };
+
+            if (diffAPIRevision != null)
+            {
+                codePanelRawData.diffRevisionCodeFile = await _codeFileRepository.GetCodeFileFromStorageAsync(revisionId: diffAPIRevision.Id, codeFileId: diffAPIRevision.Files[0].FileId);
+            }
+
+            // Render the code files to generate UI token tree
+            var result = await CodeFileHelpers.GenerateCodePanelDataAsync(codePanelRawData);
+            return new LeanJsonResult(result, StatusCodes.Status200OK);
+        }
+
+        return new LeanJsonResult("Invalid APIRevision", StatusCodes.Status500InternalServerError);
+    }
+
+}

--- a/src/dotnet/APIView/APIViewWeb/LeanModels/ReviewListModels.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanModels/ReviewListModels.cs
@@ -157,4 +157,16 @@ namespace APIViewWeb.LeanModels
         public string Title { get; set; }
         public bool IsDeleted { get; set; }
     }
+
+
+    public class RevisionResponseModel
+    {
+        public string RevisionId { get; set; }
+        public string PackageVersion { get; set; }
+        public DateTime CreatedOn { get; set; }
+        public DateTime LastUpdatedOn { get; set; }
+        public bool IsDeleted { get; set; }
+        public bool IsReleased { get; set; }
+        public DateTime ReleasedOn { get; set; }
+    }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedCommandGroups.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedCommandGroups.cs
@@ -53,6 +53,12 @@ namespace Azure.Sdk.Tools.Cli.Commands
             Options: []
         );
 
+        public static readonly CommandGroup APIView = new(
+            Verb: "apiview",
+            Description: "Commands for interacting with APIView services and functionality",
+            Options: []
+        );
+
 #if DEBUG
         public static readonly CommandGroup Example = new(
             Verb: "example",

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedOptions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedOptions.cs
@@ -10,6 +10,7 @@ using Azure.Sdk.Tools.Cli.Tools.Pipeline;
 using Azure.Sdk.Tools.Cli.Tools.ReleasePlan;
 using Azure.Sdk.Tools.Cli.Tools.Example;
 using Azure.Sdk.Tools.Cli.Tools.TypeSpec;
+using Azure.Sdk.Tools.Cli.Tools.APIView;
 
 namespace Azure.Sdk.Tools.Cli.Commands
 {
@@ -41,6 +42,7 @@ namespace Azure.Sdk.Tools.Cli.Commands
             typeof(TypeSpecInitTool),
             typeof(TspClientUpdateTool),
             typeof(TypeSpecPublicRepoValidationTool),
+            typeof(APIViewTool),
 
             #if DEBUG
             // only add these tools in debug mode

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/APIViewResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/APIViewResponse.cs
@@ -1,0 +1,30 @@
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace Azure.Sdk.Tools.Cli.Models.Responses;
+
+public class APIViewResponse : Response
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; } = false;
+
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
+
+    [JsonPropertyName("data")]
+    public object? Data { get; set; }
+
+    public override string ToString()
+    {
+        var output = new StringBuilder();
+
+        output.AppendLine(Success ? "Operation completed successfully" : "Operation failed");
+
+        if (!string.IsNullOrEmpty(Message))
+        {
+            output.AppendLine(Message);
+        }
+
+        return ToString(output.ToString());
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/APIView/APIViewAuthenticationService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/APIView/APIViewAuthenticationService.cs
@@ -1,0 +1,263 @@
+using System.Diagnostics;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Azure.Core;
+using Azure.Identity;
+
+namespace Azure.Sdk.Tools.Cli.Services.APIView;
+
+public interface IAPIViewAuthenticationService
+{
+    Task<string?> GetAuthenticationTokenAsync(string? providedToken = null, string environment = "production");
+    Task ConfigureAuthenticationAsync(HttpClient httpClient, string environment = "production", string? providedToken = null);
+    Task<string> CheckAuthenticationStatusAsync(string? endpoint = null);
+    string GetAuthenticationGuidance();
+    string GetTokenSource(string? token);
+    bool IsAuthenticationFailure(string content);
+    string CreateAuthenticationErrorResponse(string message, string revisionId = null, string activeRevisionId = null,
+        string diffRevisionId = null, string baseUrl = null);
+}
+
+public class APIViewAuthenticationService : IAPIViewAuthenticationService
+{
+    private readonly ILogger<APIViewAuthenticationService> _logger;
+
+    public APIViewAuthenticationService(ILogger<APIViewAuthenticationService> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<string?> GetAuthenticationTokenAsync(string? providedToken = null,
+        string environment = "production")
+    {
+        if (!string.IsNullOrEmpty(providedToken))
+        {
+            return providedToken;
+        }
+
+        string? githubToken = GetGitHubToken();
+        if (!string.IsNullOrEmpty(githubToken))
+        {
+            _logger.LogDebug("Using GitHub token for authentication");
+            return githubToken;
+        }
+
+        try
+        {
+            DefaultAzureCredential credential = new();
+            string scope = APIViewConfiguration.ApiViewScopes[environment];
+            
+            if (string.IsNullOrEmpty(scope))
+            {
+                _logger.LogWarning("Environment not valid.");
+                return null;
+            }
+
+            try
+            {
+                TokenRequestContext tokenRequest = new([scope]);
+                AccessToken tokenResponse = await credential.GetTokenAsync(tokenRequest);
+
+                _logger.LogInformation("Successfully obtained Azure token with scope {Scope}", scope);
+                return tokenResponse.Token;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to get Azure token with scope {Scope}: {Message}", scope, ex.Message);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to get any Azure token, no authentication available");
+        }
+
+        _logger.LogWarning(
+            "No authentication token available. APIView requests may fail if authentication is required.");
+        return null;
+    }
+
+    public async Task ConfigureAuthenticationAsync(HttpClient httpClient, string environment = "production",
+        string? providedToken = null)
+    {
+        string? token = await GetAuthenticationTokenAsync(providedToken, environment);
+        if (!string.IsNullOrEmpty(token))
+        {
+            httpClient.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", token);
+
+            httpClient.DefaultRequestHeaders.Add("X-API-Key", token);
+        }
+
+        httpClient.DefaultRequestHeaders.Add("User-Agent", APIViewConfiguration.UserAgent);
+        httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+
+        _logger.LogDebug("Request headers configured - Authorization: {HasAuth}, User-Agent: {UserAgent}",
+            !string.IsNullOrEmpty(token) ? "Bearer [TOKEN]" : "None", APIViewConfiguration.UserAgent);
+    }
+
+    public string GetAuthenticationGuidance()
+    {
+        return @"Authentication is required to access APIView data. Please choose one of these options:
+
+1. **GitHub Token**:
+   - Set environment variable: GITHUB_TOKEN=your_token_here
+   - Or run: gh auth login
+
+2. **Azure CLI**:
+   - Run: az login
+   - Ensure you have access to APIView resources
+
+3. **Provide token directly**:
+   - Pass authToken parameter to the MCP tool
+
+To get a GitHub token:
+1. Go to https://github.com/settings/tokens
+2. Generate a new token with 'repo' and 'read:org' scopes
+3. Set it as GITHUB_TOKEN environment variable";
+    }
+
+    public string GetTokenSource(string? token)
+    {
+        if (string.IsNullOrEmpty(token))
+        {
+            return "none";
+        }
+
+        string? githubToken = Environment.GetEnvironmentVariable(APIViewConfiguration.GitHubTokenEnvironmentVariable);
+        if (!string.IsNullOrEmpty(githubToken) && githubToken == token)
+        {
+            return "environment-variable";
+        }
+
+        try
+        {
+            DefaultAzureCredential credential = new();
+            return "azure-managed-identity";
+        }
+        catch
+        {
+            return "github-cli-or-provided";
+        }
+    }
+
+
+    public bool IsAuthenticationFailure(string content)
+    {
+        return content.Contains("Account/Login") ||
+               (content.Contains("login") && content.Contains("<html")) ||
+               content.Contains("authentication required", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public string CreateAuthenticationErrorResponse(string message, string revisionId = null,
+        string activeRevisionId = null, string diffRevisionId = null, string baseUrl = null)
+    {
+        string guidance = GetAuthenticationGuidance();
+
+        var errorResponse = new
+        {
+            error = "Authentication Required",
+            message,
+            guidance,
+            revisionId,
+            activeRevisionId,
+            diffRevisionId,
+            loginUrl = !string.IsNullOrEmpty(baseUrl) ? $"{baseUrl}/Account/Login" : null
+        };
+
+        return JsonSerializer.Serialize(errorResponse, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    public async Task<string> CheckAuthenticationStatusAsync(string? environmentOption = null)
+    {
+        string environment = environmentOption ?? "production";
+        string baseUrl = APIViewConfiguration.BaseUrlEndpoints[environment];
+        string? token = await GetAuthenticationTokenAsync(null, environment);
+        
+        bool hasToken = !string.IsNullOrEmpty(token);
+        bool isAuthenticationWorking = false;
+        string? authenticationError = null;
+
+        if (hasToken)
+        {
+            try
+            {
+                using var httpClient = new HttpClient();
+                await ConfigureAuthenticationAsync(httpClient, environment, token);
+                
+                string testUrl = $"{baseUrl}/api/authtest/status";
+                using var response = await httpClient.GetAsync(testUrl);
+                
+                if (response.IsSuccessStatusCode)
+                {
+                    string responseContent = await response.Content.ReadAsStringAsync();
+                    isAuthenticationWorking = responseContent.Contains("\"IsAuthenticated\":true", StringComparison.OrdinalIgnoreCase);
+                    
+                    if (!isAuthenticationWorking)
+                    {
+                        authenticationError = "Token exists but authentication failed - token may be invalid or expired";
+                    }
+                }
+                else
+                {
+                    authenticationError = $"Authentication test failed with status {response.StatusCode}";
+                }
+            }
+            catch (Exception ex)
+            {
+                authenticationError = $"Authentication test failed: {ex.Message}";
+            }
+        }
+
+        var status = new
+        {
+            hasToken,
+            isAuthenticationWorking,
+            tokenSource = GetTokenSource(token),
+            endpoint = baseUrl,
+            authenticationError,
+            guidance = isAuthenticationWorking ? "Authentication working successfully" : GetAuthenticationGuidance()
+        };
+
+        return JsonSerializer.Serialize(status, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+
+    private string? GetGitHubToken()
+    {
+        string? githubToken = Environment.GetEnvironmentVariable(APIViewConfiguration.GitHubTokenEnvironmentVariable);
+        if (!string.IsNullOrEmpty(githubToken))
+        {
+            return githubToken;
+        }
+
+        try
+        {
+            Process process = new();
+            process.StartInfo.FileName = "gh";
+            process.StartInfo.Arguments = "auth status --show-token";
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
+
+            process.Start();
+            string output = process.StandardError.ReadToEnd().Trim();
+            process.WaitForExit();
+
+            if (process.ExitCode == 0 && !string.IsNullOrEmpty(output))
+            {
+                Match match = Regex.Match(output, APIViewConfiguration.GitHubTokenRegex);
+                if (match.Success)
+                {
+                    return match.Groups["token"]?.Value.Trim();
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to get GitHub token from gh CLI");
+        }
+
+        return null;
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/APIView/APIViewConfiguration.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/APIView/APIViewConfiguration.cs
@@ -1,0 +1,23 @@
+namespace Azure.Sdk.Tools.Cli.Services.APIView;
+
+public static class APIViewConfiguration
+{
+    public const string UserAgent = "Azure-SDK-Tools-MCP";
+    public const string GitHubTokenEnvironmentVariable = "GITHUB_TOKEN";
+    public const string GitHubCliCommand = "gh auth status --show-token";
+    public const string GitHubTokenRegex = @"Token:\s(?<token>[_a-zA-Z0-9]+)";
+
+    public static readonly Dictionary<string, string> BaseUrlEndpoints = new()
+    {
+        { "production", "https://apiview.dev" },
+        { "staging", "https://apiviewstagingtest.com" },
+        { "local", "http://localhost:5000" }
+    };
+
+    public static readonly Dictionary<string, string> ApiViewScopes = new()
+    {
+        { "production", "api://apiview/.default" },
+        { "staging", "api://apiviewstaging/.default" },
+        { "local", "api://apiviewstaging/.default" }
+    };
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/APIView/APIViewHttpService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/APIView/APIViewHttpService.cs
@@ -1,0 +1,87 @@
+using System.Net;
+
+namespace Azure.Sdk.Tools.Cli.Services.APIView;
+
+public interface IAPIViewHttpService
+{
+    Task<string?> GetAsync(string endpoint, string operation, string environment = "production", string? authToken = null);
+}
+
+public class APIViewHttpService : IAPIViewHttpService
+{
+    private readonly IAPIViewAuthenticationService _authService;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<APIViewHttpService> _logger;
+
+    public APIViewHttpService(
+        IHttpClientFactory httpClientFactory,
+        IAPIViewAuthenticationService authService,
+        ILogger<APIViewHttpService> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _authService = authService;
+        _logger = logger;
+    }
+
+    public async Task<string?> GetAsync(string endpoint, string operation, string environment = "production",
+        string? authToken = null)
+    {
+        try
+        {
+            string baseUrl = APIViewConfiguration.BaseUrlEndpoints[environment];
+            HttpClient httpClient = _httpClientFactory.CreateClient();
+
+            await _authService.ConfigureAuthenticationAsync(httpClient, environment, authToken);
+
+            string requestUrl = $"{baseUrl}{endpoint}";
+            using HttpResponseMessage response = await httpClient.GetAsync(requestUrl);
+            if (response.StatusCode == HttpStatusCode.Found || response.StatusCode == HttpStatusCode.Redirect)
+            {
+                string? location = response.Headers.Location?.ToString();
+                if (!string.IsNullOrEmpty(location) && (location.Contains("Login") || location.Contains("login")))
+                {
+                    _logger.LogError("Authentication required: Redirected to login page at {Location}", location);
+                    return _authService.CreateAuthenticationErrorResponse(
+                        $"APIView requires authentication to access {operation}",
+                        baseUrl: baseUrl);
+                }
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError("API call failed during {Operation} with status code {StatusCode}: {ReasonPhrase}",
+                    operation, response.StatusCode, response.ReasonPhrase);
+
+                if (response.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    _logger.LogError(
+                        "Authentication failed. Ensure you have a valid GitHub token or Azure credentials.");
+                }
+
+                return null;
+            }
+
+            string content = await response.Content.ReadAsStringAsync();
+
+            if (_authService.IsAuthenticationFailure(content))
+            {
+                _logger.LogError("Authentication required: Received login page instead of {Operation} data", operation);
+                return _authService.CreateAuthenticationErrorResponse(
+                    $"APIView requires authentication to access {operation}",
+                    baseUrl: baseUrl);
+            }
+
+            return content;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "HTTP request failed during {Operation}", operation);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error occurred during {Operation}", operation);
+            return null;
+        }
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/APIViewService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/APIViewService.cs
@@ -1,0 +1,142 @@
+using System.Text.Json;
+using Azure.Sdk.Tools.Cli.Services.APIView;
+
+namespace Azure.Sdk.Tools.Cli.Services;
+
+public interface IAPIViewService
+{
+    Task<string?> GetCommentByRevisionAsync(string revisionId, string environment = "production", string? authToken = null);
+    Task<string?> GetRevisionContent(string reviewId, string activeRevisionId, string? diffRevisionId, string environment = "production", string? authToken = null);
+    Task<string?> ListReviewVersions(string reviewId, string environment = "production", string? authToken = null);
+    Task<string?> GetLatestRevisionAsync(string reviewId, string environment = "production", string? authToken = null);
+    Task<string> CheckAuthenticationStatusAsync(string environment = "production");
+    Task<string> GetAuthenticationGuidanceAsync();
+}
+
+public class APIViewService : IAPIViewService
+{
+    private readonly IAPIViewAuthenticationService _authService;
+    private readonly IAPIViewHttpService _httpService;
+    private readonly ILogger<APIViewService> _logger;
+
+    public APIViewService(
+        IAPIViewHttpService httpService,
+        IAPIViewAuthenticationService authService,
+        ILogger<APIViewService> logger)
+    {
+        _httpService = httpService;
+        _authService = authService;
+        _logger = logger;
+    }
+
+    public async Task<string?> GetCommentByRevisionAsync(string revisionId, string environment = "production", string? authToken = null)
+    {
+        try
+        {
+            string endpoint = $"/api/Comments/getRevisionComments?apiRevisionId={revisionId}";
+            string? result = await _httpService.GetAsync(endpoint, "comments", environment, authToken);
+
+            if (result == null)
+            {
+                _logger.LogWarning("No comments found for revision {RevisionId}", revisionId);
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get comments for revision {RevisionId}", revisionId);
+            return null;
+        }
+    }
+
+    public async Task<string?> GetRevisionContent(string reviewId, string activeRevisionId, string? diffRevisionId, string environment = "production", string? authToken = null)
+    {
+        try
+        {
+            string endpoint = $"/api/reviews/{reviewId}/content?activeApiRevisionId={activeRevisionId}&diffApiRevisionId={diffRevisionId}";
+            string? result = await _httpService.GetAsync(endpoint, "get revision content", environment, authToken);
+
+            if (string.IsNullOrWhiteSpace(result))
+            {
+                _logger.LogWarning("Received empty response for revisions {ActiveRevisionId} - {DiffRevisionId}",
+                    activeRevisionId, diffRevisionId);
+                return null;
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get diff between revisions: {ActiveRevisionId} - {DiffRevisionId}",
+                activeRevisionId, diffRevisionId);
+            return null;
+        }
+    }
+
+    public async Task<string?> ListReviewVersions(string reviewId, string environment = "production", string? authToken = null)
+    {
+        try
+        {
+            string endpoint = $"/api/apirevisions/{reviewId}/getReviewVersions";
+            string? result = await _httpService.GetAsync(endpoint, "review revisions", environment, authToken);
+
+            if (result == null)
+            {
+                _logger.LogWarning("No revisions found for review {ReviewId}", reviewId);
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get revisions for review {ReviewId}", reviewId);
+            return null;
+        }
+    }
+
+    public async Task<string?> GetLatestRevisionAsync(string reviewId, string environment = "production", string? authToken = null)
+    {
+        try
+        {
+            string endpoint = $"/api/apirevisions/getRevisionText?reviewId={reviewId}&selectionType=Latest";
+            string? result = await _httpService.GetAsync(endpoint, "latest revision", environment, authToken);
+
+            if (result == null)
+            {
+                _logger.LogWarning("No latest revision found for review {ReviewId}", reviewId);
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get latest revision for review {ReviewId}", reviewId);
+            return null;
+        }
+    }
+
+    public async Task<string> CheckAuthenticationStatusAsync(string environment = "production")
+    {
+        return await _authService.CheckAuthenticationStatusAsync(environment);
+    }
+
+    public async Task<string> GetAuthenticationGuidanceAsync()
+    {
+        string? token = await _authService.GetAuthenticationTokenAsync();
+        var guidance = new
+        {
+            isAuthenticated = !string.IsNullOrEmpty(token),
+            currentTokenSource = _authService.GetTokenSource(token),
+            instructions = _authService.GetAuthenticationGuidance(),
+            quickSetup = new
+            {
+                githubToken = "Set environment variable: GITHUB_TOKEN=your_token_here",
+                azureCli = "Run: az login",
+                githubCli = "Run: gh auth login"
+            }
+        };
+
+        return JsonSerializer.Serialize(guidance, new JsonSerializerOptions { WriteIndented = true });
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
@@ -2,14 +2,15 @@
 // Licensed under the MIT License.
 using System.Reflection;
 using System.Text.Json;
-using Microsoft.Extensions.Azure;
-using ModelContextProtocol.Server;
 using Azure.AI.OpenAI;
 using Azure.Sdk.Tools.Cli.Commands;
 using Azure.Sdk.Tools.Cli.Extensions;
 using Azure.Sdk.Tools.Cli.Microagents;
 using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Services.APIView;
 using Azure.Sdk.Tools.Cli.Tools;
+using Microsoft.Extensions.Azure;
+using ModelContextProtocol.Server;
 using Azure.Sdk.Tools.Cli.Services.ClientUpdate;
 using Azure.Sdk.Tools.Cli.Telemetry;
 
@@ -31,6 +32,11 @@ namespace Azure.Sdk.Tools.Cli.Services
             services.AddSingleton<IDevOpsConnection, DevOpsConnection>();
             services.AddSingleton<IDevOpsService, DevOpsService>();
             services.AddSingleton<IGitHubService, GitHubService>();
+
+            // APIView Services
+            services.AddSingleton<IAPIViewAuthenticationService, APIViewAuthenticationService>();
+            services.AddSingleton<IAPIViewHttpService, APIViewHttpService>();
+            services.AddSingleton<IAPIViewService, APIViewService>();
 
             // Language Check Services (Composition-based)
             services.AddSingleton<ILanguageChecks, LanguageChecks>();
@@ -66,6 +72,7 @@ namespace Azure.Sdk.Tools.Cli.Services
 
             services.AddSingleton<IMicroagentHostService, MicroagentHostService>();
 
+            services.AddHttpClient();
             services.AddAzureClients(clientBuilder =>
             {
                 // For more information about this pattern: https://learn.microsoft.com/en-us/dotnet/azure/sdk/dependency-injection

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/APIView/APIViewTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/APIView/APIViewTool.cs
@@ -1,0 +1,381 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.ComponentModel;
+using Azure.Sdk.Tools.Cli.Commands;
+using Azure.Sdk.Tools.Cli.Contract;
+using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Models.Responses;
+using Azure.Sdk.Tools.Cli.Services;
+using ModelContextProtocol.Server;
+
+namespace Azure.Sdk.Tools.Cli.Tools.APIView;
+
+[McpServerToolType]
+[Description("Access APIView functionality including API structure, version diffs, comments, and review status")]
+public class APIViewTool : MCPTool
+{
+    private const string GetRevisionCommentsSubCommand = "get-revision-comments";
+    private const string GetTokenFileForRevisionSubCommand = "get-token-file-for-revision";
+    private const string ListRevisionsSubCommand = "list-revisions";
+    private const string GetLatestRevisionSubCommand = "get-latest-revision";
+    private const string CheckAuthenticationSubCommand = "check-authentication";
+    private const string GetAuthenticationGuidanceSubCommand = "get-authentication-guidance";
+    private readonly IAPIViewService _apiViewService;
+    private readonly ILogger<APIViewTool> _logger;
+    private readonly IOutputHelper _output;
+
+    private readonly Option<string> environmentOption = new("--environment",
+        description: "The APIView environment (defaults to production)", getDefaultValue: () => "production");
+
+    private readonly Option<string> authTokenOption = new("--auth-token",
+        "Authentication token for APIView (uses default authentication if not provided)");
+
+    // Optional options
+    private readonly Option<string> diffRevisionIdOption =
+        new("--diff-revision-id", "The APIView diff revision ID for comparison (optional)");
+
+    private readonly Option<string> reviewIdOptions = new("--review-id", "The APIView review ID") { IsRequired = true };
+
+    private readonly Option<string> outputFileOption = 
+        new("--output-file", "Output file path to save the revision content");
+
+    // Required options for different commands
+    private readonly Option<string> revisionIdOption =
+        new("--revision-id", "The APIView revision ID") { IsRequired = true };
+
+    public APIViewTool(ILogger<APIViewTool> logger, IOutputHelper output, IAPIViewService apiViewService)
+    {
+        _logger = logger;
+        _output = output;
+        _apiViewService = apiViewService;
+
+        CommandHierarchy =
+        [
+            SharedCommandGroups.APIView
+        ];
+    }
+
+    public override Command GetCommand()
+    {
+        Command parentCommand = new("api", "Access APIView functionality");
+
+        // Get revision comments command
+        Command getRevisionCommentsCmd =
+            new(GetRevisionCommentsSubCommand, "Get comments for a specific APIView revision");
+        getRevisionCommentsCmd.AddOption(revisionIdOption);
+        getRevisionCommentsCmd.AddOption(environmentOption);
+        getRevisionCommentsCmd.AddOption(authTokenOption);
+        getRevisionCommentsCmd.SetHandler(async ctx => { await HandleCommand(ctx, ctx.GetCancellationToken()); });
+        parentCommand.AddCommand(getRevisionCommentsCmd);
+
+        Command getRevisionDiffCmd = new(GetTokenFileForRevisionSubCommand,
+            "Get the token file for a specific APIView revision or diff revision");
+        getRevisionDiffCmd.AddOption(revisionIdOption);
+        getRevisionDiffCmd.AddOption(diffRevisionIdOption);
+        getRevisionDiffCmd.AddOption(reviewIdOptions);
+        getRevisionDiffCmd.AddOption(environmentOption);
+        getRevisionDiffCmd.AddOption(authTokenOption);
+        getRevisionDiffCmd.AddOption(outputFileOption);
+        getRevisionDiffCmd.SetHandler(async ctx => { await HandleCommand(ctx, ctx.GetCancellationToken()); });
+        parentCommand.AddCommand(getRevisionDiffCmd);
+
+        // List revisions command
+        Command listRevisionsCmd = new(ListRevisionsSubCommand, "List all revisions for a review");
+        listRevisionsCmd.AddOption(reviewIdOptions);
+        listRevisionsCmd.AddOption(environmentOption);
+        listRevisionsCmd.AddOption(authTokenOption);
+        listRevisionsCmd.SetHandler(async ctx => { await HandleCommand(ctx, ctx.GetCancellationToken()); });
+        parentCommand.AddCommand(listRevisionsCmd);
+
+        // Get latest revision command
+        Command getLatestRevisionCmd = new(GetLatestRevisionSubCommand, "Get the latest revision for a review");
+        getLatestRevisionCmd.AddOption(reviewIdOptions);
+        getLatestRevisionCmd.AddOption(environmentOption);
+        getLatestRevisionCmd.AddOption(authTokenOption);
+        getLatestRevisionCmd.AddOption(outputFileOption);
+        getLatestRevisionCmd.SetHandler(async ctx => { await HandleCommand(ctx, ctx.GetCancellationToken()); });
+        parentCommand.AddCommand(getLatestRevisionCmd);
+
+        // Authentication commands
+        Command checkAuthCmd = new(CheckAuthenticationSubCommand, "Check APIView authentication status");
+        checkAuthCmd.AddOption(environmentOption);
+        checkAuthCmd.SetHandler(async ctx => { await HandleCommand(ctx, ctx.GetCancellationToken()); });
+        parentCommand.AddCommand(checkAuthCmd);
+
+        Command getAuthGuidanceCmd = new(GetAuthenticationGuidanceSubCommand, "Get APIView authentication guidance");
+        getAuthGuidanceCmd.SetHandler(async ctx => { await HandleCommand(ctx, ctx.GetCancellationToken()); });
+        parentCommand.AddCommand(getAuthGuidanceCmd);
+
+        return parentCommand;
+    }
+
+    public override async Task HandleCommand(InvocationContext ctx, CancellationToken ct)
+    {
+        string commandName = ctx.ParseResult.CommandResult.Command.Name;
+        APIViewResponse result = commandName switch
+        {
+            GetRevisionCommentsSubCommand => await GetRevisionComments(ctx, ct),
+            GetTokenFileForRevisionSubCommand => await GetTokenCodeFileForRevision(ctx, ct),
+            ListRevisionsSubCommand => await ListRevisions(ctx, ct),
+            GetLatestRevisionSubCommand => await GetLatestRevision(ctx, ct),
+            CheckAuthenticationSubCommand => await CheckAuthentication(ctx, ct),
+            GetAuthenticationGuidanceSubCommand => await GetAuthenticationGuidance(ctx, ct),
+            _ => new APIViewResponse { ResponseError = $"Unknown command: {commandName}" }
+        };
+
+        ctx.ExitCode = ExitCode;
+        _output.Output(result);
+    }
+
+    [McpServerTool(Name = "azsdk_apiview_get_comments")]
+    [Description("Get all the comments of an APIView revision")]
+    public async Task<APIViewResponse> GetRevisionComments(
+        string revisionId,
+        string? environment = null,
+        string? authToken = null)
+    {
+        try
+        {
+            string? result = await _apiViewService.GetCommentByRevisionAsync(revisionId, environment, authToken);
+            if (result == null)
+            {
+                return new APIViewResponse
+                {
+                    Success = false, ResponseError = $"Failed to retrieve comments for revision {revisionId}"
+                };
+            }
+
+            return new APIViewResponse
+            {
+                Success = true, Message = $"Comments retrieved successfully {result}", Data = result
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get comments for revision {RevisionId}", revisionId);
+            SetFailure();
+            return new APIViewResponse { ResponseError = $"Failed to get comments: {ex.Message}" };
+        }
+    }
+
+
+
+    [McpServerTool(Name = "azsdk_apiview_check_authentication")]
+    [Description("Check APIView authentication status and available credentials")]
+    public async Task<APIViewResponse> CheckAuthentication(string? environment = null)
+    {
+        try
+        {
+            string result = await _apiViewService.CheckAuthenticationStatusAsync(environment);
+            return new APIViewResponse
+            {
+                Success = true, Message = "Authentication status retrieved successfully", Data = result
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to check authentication status");
+            SetFailure();
+            return new APIViewResponse { ResponseError = $"Failed to check authentication: {ex.Message}" };
+        }
+    }
+
+    [McpServerTool(Name = "azsdk_apiview_get_authentication_guidance")]
+    [Description("Get detailed guidance on how to authenticate with APIView")]
+    public async Task<APIViewResponse> GetAuthenticationGuidance()
+    {
+        try
+        {
+            string result = await _apiViewService.GetAuthenticationGuidanceAsync();
+            return new APIViewResponse
+            {
+                Success = true, Message = "Authentication guidance retrieved successfully", Data = result
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get authentication guidance");
+            SetFailure();
+            return new APIViewResponse { ResponseError = $"Failed to get authentication guidance: {ex.Message}" };
+        }
+    }
+
+    [McpServerTool(Name = "azsdk_apiview_list_revisions")]
+    [Description("List all revisions for an APIView review")]
+    public async Task<APIViewResponse> ListReviewRevisions(
+        string reviewId,
+        string? environment = null,
+        string? authToken = null)
+    {
+        try
+        {
+            string? result = await _apiViewService.ListReviewVersions(reviewId, environment ?? "production", authToken);
+            if (result == null)
+            {
+                return new APIViewResponse
+                {
+                    Success = false, ResponseError = $"Failed to retrieve revisions for review {reviewId}"
+                };
+            }
+
+            return new APIViewResponse
+            {
+                Success = true, Message = $"Revisions retrieved successfully for review {reviewId}", Data = result
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get revisions for review {ReviewId}", reviewId);
+            SetFailure();
+            return new APIViewResponse { ResponseError = $"Failed to get review revisions: {ex.Message}" };
+        }
+    }
+
+
+
+    private async Task<APIViewResponse> GetRevisionComments(InvocationContext ctx, CancellationToken ct)
+    {
+        string? revisionId = ctx.ParseResult.GetValueForOption(revisionIdOption);
+        string? environment = ctx.ParseResult.GetValueForOption(environmentOption);
+        string? authToken = ctx.ParseResult.GetValueForOption(authTokenOption);
+
+        Console.WriteLine("ENVIRONMENT" + environment);
+        if (string.IsNullOrEmpty(revisionId))
+        {
+            SetFailure();
+            return new APIViewResponse { ResponseError = "Revision ID is required" };
+        }
+
+        return await GetRevisionComments(revisionId, environment, authToken);
+    }
+
+    private async Task<APIViewResponse> GetTokenCodeFileForRevision(InvocationContext ctx, CancellationToken ct)
+    {
+        string? revisionId = ctx.ParseResult.GetValueForOption(revisionIdOption);
+        string? diffRevisionId = ctx.ParseResult.GetValueForOption(diffRevisionIdOption);
+        string? reviewId = ctx.ParseResult.GetValueForOption(reviewIdOptions);
+        string? environment = ctx.ParseResult.GetValueForOption(environmentOption);
+        string? authToken = ctx.ParseResult.GetValueForOption(authTokenOption);
+        string? outputFile = ctx.ParseResult.GetValueForOption(outputFileOption);
+
+        if (string.IsNullOrEmpty(revisionId) || string.IsNullOrEmpty(reviewId))
+        {
+            SetFailure();
+            return new APIViewResponse { ResponseError = "Revision ID and review ID are required" };
+        }
+
+        try
+        {
+            string? result = await _apiViewService.GetRevisionContent(reviewId, revisionId, diffRevisionId, environment ?? "production", authToken);
+            if (result == null)
+            {
+                return new APIViewResponse
+                {
+                    Success = false,
+                    ResponseError = $"Failed to retrieve revision content for revisions {revisionId} and {diffRevisionId}"
+                };
+            }
+
+            if (!string.IsNullOrEmpty(outputFile))
+            {
+                await File.WriteAllTextAsync(outputFile, result, ct);
+                return new APIViewResponse
+                {
+                    Success = true,
+                    Message = $"Revision content saved to file: {outputFile} ({result.Length:N0} characters)",
+                    Data = $"File saved: {outputFile}"
+                };
+            }
+
+            return new APIViewResponse
+            {
+                Success = true,
+                Message = $"Revision content retrieved successfully ({result.Length:N0} characters)",
+                Data = result
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get revision content between revisions {RevisionId} and {DiffRevisionId}",
+                revisionId, diffRevisionId);
+            SetFailure();
+            return new APIViewResponse { ResponseError = $"Failed to get revision content: {ex.Message}" };
+        }
+    }
+
+    private async Task<APIViewResponse> ListRevisions(InvocationContext ctx, CancellationToken ct)
+    {
+        string? reviewId = ctx.ParseResult.GetValueForOption(reviewIdOptions);
+        string? environment = ctx.ParseResult.GetValueForOption(environmentOption);
+        string? authToken = ctx.ParseResult.GetValueForOption(authTokenOption);
+
+        if (string.IsNullOrEmpty(reviewId))
+        {
+            SetFailure();
+            return new APIViewResponse { ResponseError = "Review ID is required" };
+        }
+
+        return await ListReviewRevisions(reviewId, environment, authToken);
+    }
+
+    private async Task<APIViewResponse> GetLatestRevision(InvocationContext ctx, CancellationToken ct)
+    {
+        string? reviewId = ctx.ParseResult.GetValueForOption(reviewIdOptions);
+        string? environment = ctx.ParseResult.GetValueForOption(environmentOption);
+        string? authToken = ctx.ParseResult.GetValueForOption(authTokenOption);
+        string? outputFile = ctx.ParseResult.GetValueForOption(outputFileOption);
+
+        if (string.IsNullOrEmpty(reviewId))
+        {
+            SetFailure();
+            return new APIViewResponse { ResponseError = "Review ID is required" };
+        }
+
+        try
+        {
+            string? result = await _apiViewService.GetLatestRevisionAsync(reviewId, environment ?? "production", authToken);
+            if (result == null)
+            {
+                return new APIViewResponse
+                {
+                    Success = false, ResponseError = $"Failed to retrieve latest revision for review {reviewId}"
+                };
+            }
+
+            if (!string.IsNullOrEmpty(outputFile))
+            {
+                await File.WriteAllTextAsync(outputFile, result, ct);
+                return new APIViewResponse
+                {
+                    Success = true,
+                    Message = $"Latest revision saved to file: {outputFile} ({result.Length:N0} characters)",
+                    Data = $"File saved: {outputFile}"
+                };
+            }
+
+            return new APIViewResponse
+            {
+                Success = true,
+                Message = $"Latest revision retrieved successfully ({result.Length:N0} characters)",
+                Data = result
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get latest revision for review {ReviewId}", reviewId);
+            SetFailure();
+            return new APIViewResponse { ResponseError = $"Failed to get latest revision: {ex.Message}" };
+        }
+    }
+
+    private async Task<APIViewResponse> CheckAuthentication(InvocationContext ctx, CancellationToken ct)
+    {
+        string? environment = ctx.ParseResult.GetValueForOption(environmentOption);
+        return await CheckAuthentication(environment);
+    }
+
+    private async Task<APIViewResponse> GetAuthenticationGuidance(InvocationContext ctx, CancellationToken ct)
+    {
+        return await GetAuthenticationGuidance();
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/APIView/APIViewTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/APIView/APIViewTool.cs
@@ -16,7 +16,7 @@ public class APIViewTool : MCPTool
 {
     private const string GetRevisionCommentsSubCommand = "get-revision-comments";
     private const string GetTokenFileForRevisionSubCommand = "get-token-file-for-revision";
-    private const string ListRevisionsSubCommand = "list-revisions";
+    private const string ListReviewVersionsSubCommand = "list-review-versions";
     private const string GetLatestRevisionSubCommand = "get-latest-revision";
     private const string CheckAuthenticationSubCommand = "check-authentication";
     private const string GetAuthenticationGuidanceSubCommand = "get-authentication-guidance";
@@ -80,7 +80,7 @@ public class APIViewTool : MCPTool
         parentCommand.AddCommand(getRevisionDiffCmd);
 
         // List revisions command
-        Command listRevisionsCmd = new(ListRevisionsSubCommand, "List all revisions for a review");
+        Command listRevisionsCmd = new(ListReviewVersionsSubCommand, "List all versions for a review");
         listRevisionsCmd.AddOption(reviewIdOptions);
         listRevisionsCmd.AddOption(environmentOption);
         listRevisionsCmd.AddOption(authTokenOption);
@@ -116,7 +116,7 @@ public class APIViewTool : MCPTool
         {
             GetRevisionCommentsSubCommand => await GetRevisionComments(ctx, ct),
             GetTokenFileForRevisionSubCommand => await GetTokenCodeFileForRevision(ctx, ct),
-            ListRevisionsSubCommand => await ListRevisions(ctx, ct),
+            ListReviewVersionsSubCommand => await ListReviewVersions(ctx, ct),
             GetLatestRevisionSubCommand => await GetLatestRevision(ctx, ct),
             CheckAuthenticationSubCommand => await CheckAuthentication(ctx, ct),
             GetAuthenticationGuidanceSubCommand => await GetAuthenticationGuidance(ctx, ct),
@@ -200,9 +200,9 @@ public class APIViewTool : MCPTool
         }
     }
 
-    [McpServerTool(Name = "azsdk_apiview_list_revisions")]
-    [Description("List all revisions for an APIView review")]
-    public async Task<APIViewResponse> ListReviewRevisions(
+    [McpServerTool(Name = "azsdk_apiview_list_review_versions")]
+    [Description("List all versions for an APIView review")]
+    public async Task<APIViewResponse> ListReviewVersions(
         string reviewId,
         string? environment = null,
         string? authToken = null)
@@ -239,7 +239,6 @@ public class APIViewTool : MCPTool
         string? environment = ctx.ParseResult.GetValueForOption(environmentOption);
         string? authToken = ctx.ParseResult.GetValueForOption(authTokenOption);
 
-        Console.WriteLine("ENVIRONMENT" + environment);
         if (string.IsNullOrEmpty(revisionId))
         {
             SetFailure();
@@ -303,7 +302,7 @@ public class APIViewTool : MCPTool
         }
     }
 
-    private async Task<APIViewResponse> ListRevisions(InvocationContext ctx, CancellationToken ct)
+    private async Task<APIViewResponse> ListReviewVersions(InvocationContext ctx, CancellationToken ct)
     {
         string? reviewId = ctx.ParseResult.GetValueForOption(reviewIdOptions);
         string? environment = ctx.ParseResult.GetValueForOption(environmentOption);
@@ -315,7 +314,7 @@ public class APIViewTool : MCPTool
             return new APIViewResponse { ResponseError = "Review ID is required" };
         }
 
-        return await ListReviewRevisions(reviewId, environment, authToken);
+        return await ListReviewVersions(reviewId, environment, authToken);
     }
 
     private async Task<APIViewResponse> GetLatestRevision(InvocationContext ctx, CancellationToken ct)


### PR DESCRIPTION
**Issue:** https://github.com/Azure/azure-sdk-tools/issues/10413
 
I implemented an initial effort to expose APIView functionality through both MCP tools and CLI commands.
 
**For MCP tooling, I exposed:**
- `azsdk_apiview_get_comments` - Get comments for revisions
- `azsdk_apiview_list_review_versions` - List all versions for a review
- `azsdk_apiview_check_authentication` - Check authentication status
- `azsdk_apiview_get_authentication_guidance` - Get setup help for authentication
 
**For CLI access, I additionally exposed:**
- `azsdk_apiview_get_latest_revision` - Get the latest revision content
- `get-token-file-for-revision` - Get revision content with optional diff
 
The last two commands were not exposed as MCP tools because they return large token file data, which doesn't seem particularly beneficial for conversational AI interactions.
 
One topic mentioned in the original issue but not addressed here is diff functionality. I want to discuss what we should return for diffs, as we'll probably need a new endpoint. I've split that effort into a separate task.

I will work on additional validation/unit testing, but other than that this is ready for review. 