### PR TITLE
Support build command in swagger config

### DIFF
--- a/tools/spec-gen-sdk/src/automation/workflowPackage.ts
+++ b/tools/spec-gen-sdk/src/automation/workflowPackage.ts
@@ -35,7 +35,13 @@ export const workflowPkgMain = async (context: WorkflowContext, pkg: PackageData
 };
 
 export const workflowPkgCallBuildScript = async (context: WorkflowContext, pkg: PackageData) => {
-  const runOptions = context.swaggerToSdkConfig.packageOptions.buildScript;
+  const generateScript = context.swaggerToSdkConfig.generateOptions.generateScript;
+  if (generateScript) {
+    context.logger.info('GenerateScript configured in swagger_to_sdk_config.json; skipping buildScript.');
+    return;
+  }
+
+  const runOptions = context.swaggerToSdkConfig.packageOptions.buildScript; 
   if (!runOptions) {
     context.logger.info('buildScript of packageOptions is not configured in swagger_to_sdk_config.json.');
     return;

--- a/tools/spec-gen-sdk/test/automation/workflowPackage.test.ts
+++ b/tools/spec-gen-sdk/test/automation/workflowPackage.test.ts
@@ -113,6 +113,9 @@ describe('workflowPackage', () => {
             breakingChangeDetect: /BREAKING CHANGE/,
           },
         },
+        generateOptions: {
+          generateScript: 'generate.sh'
+        },
         artifactOptions: {
           artifactPathFromFileSearch: {
             searchRegex: /\.jar$/,
@@ -158,13 +161,21 @@ describe('workflowPackage', () => {
   });
 
   describe('workflowPkgCallBuildScript', () => {
+    it('should skip if buildScript is configured & generateScript is not configured', async () => {
+      mockContext.swaggerToSdkConfig.packageOptions.buildScript = undefined;
+      await workflowPkgCallBuildScript(mockContext, mockPackage);
+      expect(mockContext.logger.info).toHaveBeenCalledWith(expect.stringContaining('GenerateScript configured in swagger_to_sdk_config.json; skipping buildScript.'));
+    });
+
     it('should skip if buildScript is not configured', async () => {
       mockContext.swaggerToSdkConfig.packageOptions.buildScript = undefined;
+      mockContext.swaggerToSdkConfig.generateOptions.generateScript = undefined;
       await workflowPkgCallBuildScript(mockContext, mockPackage);
       expect(mockContext.logger.info).toHaveBeenCalledWith(expect.stringContaining('not configured'));
     });
 
     it('should execute build script with package paths', async () => {
+      mockContext.swaggerToSdkConfig.generateOptions.generateScript = undefined;
       await workflowPkgCallBuildScript(mockContext, mockPackage);
       expect(mockContext.logger.log).toHaveBeenCalledWith('section', 'Call BuildScript');
     });


### PR DESCRIPTION
This pull request introduces a conditional check to skip the build script execution in the workflow automation logic if a `generateScript` option is configured. This change ensures that when `generateScript` is set, the build script is not redundantly run, improving the workflow's efficiency and clarity.

Build script execution logic:

* Added a check in `workflowPkgCallBuildScript` to skip running the build script if `generateScript` is configured in `swagger_to_sdk_config.json`, with a corresponding log message for visibility.