### PR TITLE
[azsdk-cli] Inject micro agent host service as scoped

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
@@ -66,7 +66,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             services.AddSingleton<IPowershellHelper, PowershellHelper>();
             services.AddSingleton<IProcessHelper, ProcessHelper>();
 
-            services.AddSingleton<IMicroagentHostService, MicroagentHostService>();
+            services.AddScoped<IMicroagentHostService, MicroagentHostService>();
 
             services.AddAzureClients(clientBuilder =>
             {


### PR DESCRIPTION
The dependency on the scoped `TokenUsageHelper` requires the host service to be injected as scoped.

> 2025-09-17 11:30:49.024 [warning] [server stderr] Unhandled exception. System.AggregateException: Some services are not able to be constructed (Error while validating the service descriptor 'ServiceType: Azure.Sdk.Tools.Cli.Microagents.IMicroagentHostService Lifetime: Singleton ImplementationType: Azure.Sdk.Tools.Cli.Microagents.MicroagentHostService': Cannot consume scoped service 'Azure.Sdk.Tools.Cli.Helpers.TokenUsageHelper' from singleton 'Azure.Sdk.Tools.Cli.Microagents.IMicroagentHostService'.)