### PR TITLE
[AVC] Add commands to assist in constructing evals

### DIFF
--- a/packages/python-packages/apiview-copilot/cli.py
+++ b/packages/python-packages/apiview-copilot/cli.py
@@ -407,6 +407,28 @@ def get_all_guidelines(language: str, markdown: bool = False):
         print(json.dumps(context, indent=2, cls=CustomJSONEncoder))
 
 
+def extract_document_section(apiview_path: str, size: int, index: int = 1):
+    """
+    Extracts a section of a document for testing purposes.
+
+    apiview_path: Path to the document file.
+    size: Size of the section to extract.
+    index: Index of the section to extract (default is 1).
+    """
+    from src._sectioned_document import SectionedDocument
+
+    if not os.path.exists(apiview_path):
+        raise ValueError(f"File {apiview_path} does not exist.")
+    with open(apiview_path, "r", encoding="utf-8") as f:
+        content = f.read()
+    sectioned = SectionedDocument(lines=content.splitlines(), max_chunk_size=size)
+    try:
+        section = sectioned.sections[index - 1]
+        print(str(section))
+    except IndexError:
+        print(f"Error: Index {index} out of range. Document has {len(sectioned.sections)} sections.")
+
+
 def search_knowledge_base(
     language: Optional[str] = None,
     text: Optional[str] = None,
@@ -918,6 +940,7 @@ class CliCommandsLoader(CLICommandsLoader):
             g.command("run", "run_test_case")
             g.command("create", "create_test_case")
             g.command("deconstruct", "deconstruct_test_case")
+            g.command("extract-section", "extract_document_section")
         with CommandGroup(self, "app", "__main__#{}") as g:
             g.command("deploy", "deploy_flask_app")
         with CommandGroup(self, "search", "__main__#{}") as g:
@@ -1025,17 +1048,27 @@ class CliCommandsLoader(CLICommandsLoader):
                 options_list=["--test-file", "-f"],
                 help="The full path to the JSONL test file.",
             )
+            ac.argument(
+                "apiview_path",
+                options_list=["--apiview-path", "-p"],
+                type=str,
+                help="The full path to the txt file containing the APIView text",
+            )
+        with ArgumentsContext(self, "eval extract-section") as ac:
+            ac.argument("size", type=int, help="The size of the section to extract.")
+            ac.argument(
+                "index",
+                type=int,
+                help="The index of the section to extract (default is 1).",
+                default=1,
+                options_list=["--index", "-i"],
+            )
         with ArgumentsContext(self, "eval run") as ac:
             ac.argument(
                 "num_runs", type=int, options_list=["--num-runs", "-n"], help="Number of times to run the test case."
             )
         with ArgumentsContext(self, "eval create") as ac:
             ac.argument("test_case", type=str, help="The name of the test case")
-            ac.argument(
-                "apiview_path",
-                type=str,
-                help="The full path to the txt file containing the APIView text",
-            )
             ac.argument(
                 "expected_path",
                 type=str,

--- a/packages/python-packages/apiview-copilot/src/_sectioned_document.py
+++ b/packages/python-packages/apiview-copilot/src/_sectioned_document.py
@@ -67,7 +67,7 @@ class SectionedDocument:
         if max_chunk_size == 1:
             raise ValueError("max_chunk_size must be greater than 1")
 
-        self.sections = []
+        self.sections: List[Section] = []
         # Step 1: Create initial fine-grained sections based on indentation
         if line_data is None:
             line_data = []


### PR DESCRIPTION
Closes #12145.

- Adds `avc eval extract-section` to get a representative chunk for evaluation
- Adds `avc search all-guidelines` to get all the guidelines for a given language

**Usage**

1. Extract all guidelines for a guidelines-based eval:
`avc search all-guidelines -l python --markdown > context.txt`

2. Extract a section of document for use in a guidelines-based eval:
`avc eval extract-section -p <PATH_TO_APIVIEW> --size <SIZE> -i 1 > section.txt`
