### PR TITLE
Update dependabot config for npm directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,12 @@ updates:
         update-types: ["version-update:semver-patch"]
   
   - package-ecosystem: "npm"
-    directory: "/eng/common/"
+    directory: "/eng/common/tsp-client"
     schedule:
       interval: "daily"
     versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/eng/common/spelling"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
The folder needs to be exact folder of `package.json` and lock file and a parent folder of them doesn't work.