### PR TITLE
[azsdk-cli] Support custom log analysis prompts

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Microagents/MicroagentHostServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Microagents/MicroagentHostServiceTests.cs
@@ -61,7 +61,9 @@ internal class MicroagentHostServiceTests
             BinaryData.FromString("""{"Result":"Success"}""")
         );
 
+#pragma warning disable OPENAI001
         var chatCompletion = OpenAIChatModelFactory.ChatCompletion(role: ChatMessageRole.Assistant, toolCalls: [exitToolCall]);
+#pragma warning restore OPENAI001
 
         var agentDefinition = new Microagent<string>
         {
@@ -105,9 +107,11 @@ internal class MicroagentHostServiceTests
             Tools = [tool],
         };
 
+#pragma warning disable OPENAI001
         chatClientMock.SetupSequence(client => client.CompleteChatAsync(It.IsAny<IReadOnlyList<ChatMessage>>(), It.IsAny<ChatCompletionOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ClientResult.FromValue(OpenAIChatModelFactory.ChatCompletion(role: ChatMessageRole.Assistant, toolCalls: [regularToolCall]), Mock.Of<PipelineResponse>()))
             .ReturnsAsync(ClientResult.FromValue(OpenAIChatModelFactory.ChatCompletion(role: ChatMessageRole.Assistant, toolCalls: [exitToolCall]), Mock.Of<PipelineResponse>()));
+#pragma warning restore OPENAI001
 
         // Act
         var result = await microagentHostService.RunAgentToCompletion(microagent);
@@ -146,10 +150,12 @@ internal class MicroagentHostServiceTests
             MaxToolCalls = 2,
         };
 
+#pragma warning disable OPENAI001
         chatClientMock.SetupSequence(client => client.CompleteChatAsync(It.IsAny<IReadOnlyList<ChatMessage>>(), It.IsAny<ChatCompletionOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ClientResult.FromValue(OpenAIChatModelFactory.ChatCompletion(role: ChatMessageRole.Assistant, toolCalls: [regularToolCall]), Mock.Of<PipelineResponse>()))
             .ReturnsAsync(ClientResult.FromValue(OpenAIChatModelFactory.ChatCompletion(role: ChatMessageRole.Assistant, toolCalls: [regularToolCall]), Mock.Of<PipelineResponse>()))
             .ReturnsAsync(ClientResult.FromValue(OpenAIChatModelFactory.ChatCompletion(role: ChatMessageRole.Assistant, toolCalls: [exitToolCall]), Mock.Of<PipelineResponse>()));
+#pragma warning restore OPENAI001
 
         // Act/Assert
         Assert.ThrowsAsync<Exception>(async () =>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/GoLanguageSpecificChecksTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/GoLanguageSpecificChecksTests.cs
@@ -26,7 +26,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
 
             if (!await LangService.CheckDependencies(CancellationToken.None))
             {
-                Assert.Ignore("go and golangci-lint aren't installed, can't run GoLanguageSpecificChecksTests");
+                Assert.Ignore("golang tooling dependencies are not installed, can't run GoLanguageSpecificChecksTests");
             }
 
             var resp = await LangService.CreateEmptyPackage(GoPackageDir, "untitleddotloop", CancellationToken.None);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.Agents.Persistent" Version="1.0.0" />
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="Azure.AI.Agents.Persistent" Version="1.2.0-beta.5" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.3.0-beta.2" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.12.0" />
     <PackageReference Include="Microsoft.Graph" Version="5.79.0" />

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/GoLanguageSpecificChecks.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/GoLanguageSpecificChecks.cs
@@ -49,7 +49,7 @@ public class GoLanguageSpecificChecks : ILanguageSpecificChecks
         }
         catch (Exception ex)
         {
-            _logger.LogDebug($"Exception occurred while checking dependencies {ex}");
+            _logger.LogDebug(ex, "Exception occurred while checking dependencies");
             return false;
         }
     }


### PR DESCRIPTION
- Support custom prompts from the command line and MCP clients for log analysis
- Only delete used agent resources
- Bump ai sdk dependencies
- Fix bug where ctrl-c in the agent tool does return exit code 1 (if a tool calls another method that has a try/catch => response error handler then the operation canceled exception will get swallowed).

Resolves #11655 