### PR TITLE
Skip updating pull request URL in work item when value is empty

### DIFF
--- a/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
+++ b/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
@@ -1091,9 +1091,9 @@ function Update-PullRequestInReleasePlan($releasePlanWorkItemId, $pullRequestUrl
     }
     $fields += "`"SDKPullRequestStatusFor$($devopsFieldLanguage)=$status`""
 
-    Write-Host "Updating Release Plan [$releasePlanWorkItemId] with Pull Request URL for language [$languageName]."
+    Write-Host "Updating release plan [$releasePlanWorkItemId] with pull request details for language [$languageName]."
     $workItem = UpdateWorkItem -id $releasePlanWorkItemId -fields $fields
-    Write-Host "Updated Pull Request URL [$pullRequestUrl] for [$languageName] in Release Plan [$releasePlanWorkItemId]"
+    Write-Host "Updated pull request details for [$languageName] in release plan [$releasePlanWorkItemId]"
 }
 
 function Get-ReleasePlan-Link($releasePlanWorkItemId)


### PR DESCRIPTION
Pull request link variable is empty in the pipeline when regenerating SDK for an existing PR because regeneration request just pushes SDK to existing branch and not creating a new PR.  Release plan linking script should not clear existing PR link from work item when pr variable is empty.