### PR TITLE
Set pr creator to empty when it's bot

### DIFF
--- a/eng/common/scripts/Get-PullRequestCreator.ps1
+++ b/eng/common/scripts/Get-PullRequestCreator.ps1
@@ -18,15 +18,7 @@ try
 {
     $pullRequest = Get-GithubPullRequest -RepoOwner $RepoOwner -RepoName $RepoName `
     -PullRequestNumber $PullRequestNumber -AuthToken $AuthToken
-
-    $prCreator = $pullRequest.user.login
-
-    # Set the prCreator variable to empty if the PR creator is dependabot or copilot
-    if ($prCreator -ilike "dependabot*" -or $prCreator -ilike "copilot*")
-    {
-        $prCreator = ""
-    }
-    Write-Host "##vso[task.setvariable variable=System.PullRequest.Creator;]$($prCreator)"
+    Write-Host "##vso[task.setvariable variable=System.PullRequest.Creator;]$($pullRequest.user.login)"
 }
 catch
 {

--- a/eng/common/scripts/Get-PullRequestCreator.ps1
+++ b/eng/common/scripts/Get-PullRequestCreator.ps1
@@ -18,7 +18,15 @@ try
 {
     $pullRequest = Get-GithubPullRequest -RepoOwner $RepoOwner -RepoName $RepoName `
     -PullRequestNumber $PullRequestNumber -AuthToken $AuthToken
-    Write-Host "##vso[task.setvariable variable=System.PullRequest.Creator;]$($pullRequest.user.login)"
+
+    $prCreator = $pullRequest.user.login
+
+    # Set the prCreator variable to empty if the PR creator is dependabot or copilot
+    if ($prCreator -ilike "dependabot*" -or $prCreator -ilike "copilot*")
+    {
+        $prCreator = ""
+    }
+    Write-Host "##vso[task.setvariable variable=System.PullRequest.Creator;]$($prCreator)"
 }
 catch
 {

--- a/eng/common/scripts/Submit-PullRequest.ps1
+++ b/eng/common/scripts/Submit-PullRequest.ps1
@@ -130,8 +130,8 @@ else {
 
     # ensure that the user that was used to create the PR is not attempted to add as a reviewer
     # we cast to an array to ensure that length-1 arrays actually stay as array values
-    # we also filter out dependabot and copilot users who don't have write permission to avoid errors
-    $cleanedUsers = @(SplitParameterArray -members $UserReviewers) | ? { $_ -ne $prOwnerUser -and $null -ne $_ -and $_ -inotlike "dependabot*" -and $_ -inotlike "copilot*" }
+    # we also filter out dependabot user who doesn't have write permission to avoid errors
+    $cleanedUsers = @(SplitParameterArray -members $UserReviewers) | ? { $_ -ne $prOwnerUser -and $null -ne $_ -and $_ -inotlike "dependabot*" }
     $cleanedTeamReviewers = @(SplitParameterArray -members $TeamReviewers) | ? { $_ -ne $prOwnerUser -and $null -ne $_ }
 
     if ($cleanedUsers -or $cleanedTeamReviewers) {


### PR DESCRIPTION
Now we have `dependabot` enabled in `azure-sdk-tools` repo, and [the sync PRs](https://github.com/Azure/azure-sdk-tools/pull/12188) failed in assigning to the bot.

The cause could be GitHub doesn't allow to assign an issue to someone which don't have the write permission. 