### PR TITLE
Do not pass SdkRepoBranch to pipeline trigger when branch name is not…

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -550,7 +550,6 @@ namespace Azure.Sdk.Tools.Cli.Services
 
             var templateParams = new Dictionary<string, string>
             {
-                 { "SdkRepoBranch", sdkRepoBranch},
                  { "ConfigType", "TypeSpec"},
                  { "ConfigPath", $"{typespecProjectRoot}/tspconfig.yaml" },
                  { "ApiVersion", apiVersion },
@@ -558,6 +557,12 @@ namespace Azure.Sdk.Tools.Cli.Services
                  { "CreatePullRequest", "true" },
                  { "ReleasePlanWorkItemId", $"{workItemId}"}
             };
+
+            if (!string.IsNullOrEmpty(sdkRepoBranch))
+            {
+                templateParams["SdkRepoBranch"] = sdkRepoBranch;
+            }
+
             var build = await RunPipelineAsync(pipelineDefinitionId, templateParams, apiSpecBranchRef);
             var pipelineRunUrl = GetPipelineUrl(build.Id);
             logger.LogInformation($"Started pipeline run {pipelineRunUrl} to generate SDK.");


### PR DESCRIPTION
PR has changes to avoid passing empty sdk branch name to queue DevOps pipeline because that causes validation failure on DevOps side. DevOps pipeline has a non empty value as default so we cannot pass empty value.