### PR TITLE
Remove API Lifecycle prompt from release plan creation instructions

### DIFF
--- a/eng/common/instructions/azsdk-tools/create-release-plan.instructions.md
+++ b/eng/common/instructions/azsdk-tools/create-release-plan.instructions.md
@@ -23,10 +23,6 @@ Follow these steps in order to create or manage a release plan for an API specif
 Collect the following required information from the user. Do not create a release plan with temporary values. Confirm the values with the user before proceeding to create the release plan.
 If any details are missing, prompt the user accordingly:
 
-- **API Lifecycle Stage**: Must be one of:
-    - Private Preview
-    - Public Preview  
-    - GA (Generally Available)
 - **Service Tree ID**: GUID format identifier for the service in Service Tree. Before creating release plan, always show the value to user and ask them to confirm it's a valid value in service tree.
 - **Product Service Tree ID**: GUID format identifier for the product in Service Tree. Before creating release plan, always show the value to user and ask them to confirm it's a valid value in service tree.
 - **Expected Release Timeline**: Format must be in "Month YYYY"


### PR DESCRIPTION
create release plan mcp tool does not ask for the API Lifecyle