### PR TITLE
Set different condition for csharp-api-parser-release

### DIFF
--- a/tools/apiview/parsers/csharp-api-parser/ci.yml
+++ b/tools/apiview/parsers/csharp-api-parser/ci.yml
@@ -24,4 +24,6 @@ pr:
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
   parameters:
+    ${{ if eq(variables['Build.SourceBranchName'], 'main') }}:
+      SkipReleaseStage: false
     PackageDirectory: $(Build.SourcesDirectory)/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser


### PR DESCRIPTION
The csharp parser is not getting release because the change on this condition on the main template, changing this to resume the release. 

Pipeline: https://dev.azure.com/azure-sdk/internal/_build?definitionId=7044&_a=summary
Last Release: July 1st