### PR TITLE
[ApiView] Fix copilot required for approval - regression

### DIFF
--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.spec.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.spec.ts
@@ -308,5 +308,102 @@ describe('ReviewPageOptionsComponent', () => {
         expect(shouldDisable).toBe(true); // Should disable because copilot required but not completed
       });
     });
+
+    describe('updateApprovalStates', () => {
+      beforeEach(() => {
+        // Reset to default state for each test
+        component.isCopilotReviewSupported = true;
+        component.userProfile = { userName: 'testuser' } as UserProfile;
+        component.activeAPIRevision = {
+          approvers: [],
+          packageVersion: '1.0.0'
+        } as unknown as APIRevision;
+        component.review = {
+          language: 'C#',
+          packageName: 'Azure.SomePackage'
+        } as Review;
+        component.canToggleApproveAPIRevision = true;
+      });
+
+      it('should not disable approval when copilot review is not supported', () => {
+        component.isCopilotReviewSupported = false;
+        component.activeAPIRevision!.approvers = [];
+        
+        component['updateApprovalStates'](true, false);
+        
+        expect(component.isAPIRevisionApprovalDisabled).toBe(false);
+      });
+
+      it('should not disable approval for preview versions', () => {
+        component.activeAPIRevision!.packageVersion = '1.0.0-beta.1';
+        component.activeAPIRevision!.approvers = [];
+        spyOn(component as any, 'isPreviewVersion').and.returnValue(true);
+        
+        component['updateApprovalStates'](true, false);
+        
+        expect(component.isAPIRevisionApprovalDisabled).toBe(false);
+      });
+
+      it('should not disable approval when user has already approved', () => {
+        component.activeAPIRevision!.approvers = ['testuser'];
+        
+        component['updateApprovalStates'](true, false);
+        
+        expect(component.isAPIRevisionApprovalDisabled).toBe(false);
+      });
+
+      it('should disable approval when copilot review is required but not completed', () => {
+        component.activeAPIRevision!.approvers = [];
+        
+        component['updateApprovalStates'](true, false);
+        
+        expect(component.isAPIRevisionApprovalDisabled).toBe(true);
+      });
+
+      it('should not disable approval when copilot review is completed', () => {
+        component.activeAPIRevision!.approvers = [];
+        
+        component['updateApprovalStates'](true, true);
+        
+        expect(component.isAPIRevisionApprovalDisabled).toBe(false);
+      });
+
+      it('should not disable approval when copilot review is not required', () => {
+        component.activeAPIRevision!.approvers = [];
+        
+        component['updateApprovalStates'](false, false);
+        
+        expect(component.isAPIRevisionApprovalDisabled).toBe(false);
+      });
+
+      it('should handle copilot not supported overriding requirement', () => {
+        component.isCopilotReviewSupported = false;
+        component.activeAPIRevision!.approvers = [];
+        
+        component['updateApprovalStates'](true, false);
+        
+        expect(component.isAPIRevisionApprovalDisabled).toBe(false);
+      });
+
+      it('should handle preview version overriding copilot requirement', () => {
+        component.activeAPIRevision!.packageVersion = '2.0.0-alpha.3';
+        component.activeAPIRevision!.approvers = [];
+        spyOn(component as any, 'isPreviewVersion').and.returnValue(true);
+        
+        component['updateApprovalStates'](true, false);
+        
+        expect(component.isAPIRevisionApprovalDisabled).toBe(false);
+      });
+
+      it('should set correct button classes when approval is disabled', () => {
+        component.activeAPIRevision!.approvers = [];
+        
+        component['updateApprovalStates'](true, false);
+        
+        expect(component.isAPIRevisionApprovalDisabled).toBe(true);
+        expect(component.apiRevisionApprovalBtnClass).toBe("btn btn-outline-secondary disabled");
+        expect(component.apiRevisionApprovalMessage).toBe("To approve the current API revision, it must first be reviewed by Copilot");
+      });
+    });
   });
 });

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.ts
@@ -396,7 +396,7 @@ export class ReviewPageOptionsComponent implements OnInit, OnChanges {
     this.activeAPIRevisionIsApprovedByCurrentUser = this.activeAPIRevision?.approvers.includes(this.userProfile?.userName!)!;
     this.canToggleApproveAPIRevision = (!this.diffAPIRevision || this.diffAPIRevision.approvers.length > 0);
 
-    this.isAPIRevisionApprovalDisabled = isReviewByCopilotRequired && !isVersionReviewedByCopilot && !this.activeAPIRevisionIsApprovedByCurrentUser;
+    this.isAPIRevisionApprovalDisabled = this.shouldDisableApproval(isReviewByCopilotRequired, isVersionReviewedByCopilot);
 
     if (this.canToggleApproveAPIRevision) {
       if (this.isAPIRevisionApprovalDisabled) {


### PR DESCRIPTION
The copilot review is requested everywhere, ignoring what is filtered by language, or GA, this is only happening on staging.

I think there was an issue resolving merge conflicts that caused this code removed 