### PR TITLE
[tsp-client] Fix init or update scenario

### DIFF
--- a/tools/tsp-client/src/commands.ts
+++ b/tools/tsp-client/src/commands.ts
@@ -132,7 +132,11 @@ async function initProcessDataAndWriteTspLocation(
     // If the update-if-exists flag is set, check if there's an existing tsp-location.yaml
     // and update it with the new values while maintaining previously existing data.
     Logger.debug(`Trying to read existing tsp-location.yaml at ${newPackageDir}`);
-    tspLocationData = await updateExistingTspLocation(tspLocationData, newPackageDir);
+    tspLocationData = await updateExistingTspLocation(
+      tspLocationData,
+      newPackageDir,
+      emitterPackageOverride,
+    );
   }
   await mkdir(newPackageDir, { recursive: true });
   await writeTspLocationYaml(tspLocationData, newPackageDir);

--- a/tools/tsp-client/src/commands.ts
+++ b/tools/tsp-client/src/commands.ts
@@ -115,7 +115,7 @@ async function initProcessDataAndWriteTspLocation(
       entrypoint: "main.tsp",
       configPath: tspConfigPath,
       overrides: {
-        outputDir: outputDir,
+        outputDir: repoRoot,
       },
     });
     emitterOutputDir = options.options?.[emitterData.emitter]?.["emitter-output-dir"];

--- a/tools/tsp-client/src/utils.ts
+++ b/tools/tsp-client/src/utils.ts
@@ -109,6 +109,7 @@ export async function writeTspLocationYaml(
 export async function updateExistingTspLocation(
   tspLocationData: TspLocation,
   projectPath: string,
+  emitterPackageJsonOverride?: string,
 ): Promise<TspLocation> {
   try {
     const existingTspLocation = await readTspLocation(projectPath);
@@ -117,13 +118,13 @@ export async function updateExistingTspLocation(
     const updatedTspLocation = { ...existingTspLocation };
 
     // Define the properties that can be updated
+    // NOTE: emitterPackageJsonPath is handled separately below because of the override logic
     const updatableProperties: (keyof TspLocation)[] = [
       "repo",
       "commit",
       "directory",
       "entrypointFile",
       "additionalDirectories",
-      "emitterPackageJsonPath",
     ];
 
     // Update each property if it has a valid value
@@ -134,6 +135,19 @@ export async function updateExistingTspLocation(
       }
     }
 
+    // Only add/replace emitterPackageJsonPath value if an override is provided, otherwise keep existing value or leave undefined
+    if (emitterPackageJsonOverride) {
+      if (existingTspLocation.emitterPackageJsonPath !== undefined) {
+        Logger.debug(
+          `Updating existing emitterPackageJsonPath ${existingTspLocation.emitterPackageJsonPath} with ${emitterPackageJsonOverride} in tsp-location.yaml`,
+        );
+      } else {
+        Logger.debug(
+          `Adding emitterPackageJsonPath ${emitterPackageJsonOverride} to tsp-location.yaml`,
+        );
+      }
+      updatedTspLocation.emitterPackageJsonPath = emitterPackageJsonOverride;
+    }
     return updatedTspLocation;
   } catch (error) {
     Logger.debug(`Will create a new tsp-location.yaml. Error reading tsp-location.yaml: ${error}`);

--- a/tools/tsp-client/src/utils.ts
+++ b/tools/tsp-client/src/utils.ts
@@ -1,12 +1,13 @@
 import { joinPaths, normalizeSlashes } from "@typespec/compiler";
 import { randomUUID } from "node:crypto";
 import { access, constants, mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Logger } from "./log.js";
 import { TspLocation } from "./typespec.js";
 import { normalizeDirectory, readTspLocation } from "./fs.js";
 import { parse as parseYaml } from "yaml";
+import { getRepoRoot } from "./git.js";
 
 const defaultTspClientConfigPath = joinPaths("eng", "tspclientconfig.yaml");
 
@@ -146,7 +147,9 @@ export async function updateExistingTspLocation(
           `Adding emitterPackageJsonPath ${emitterPackageJsonOverride} to tsp-location.yaml`,
         );
       }
-      updatedTspLocation.emitterPackageJsonPath = emitterPackageJsonOverride;
+      updatedTspLocation.emitterPackageJsonPath = normalizeSlashes(
+        relative(await getRepoRoot(projectPath), emitterPackageJsonOverride),
+      );
     }
     return updatedTspLocation;
   } catch (error) {

--- a/tools/tsp-client/test/commands.spec.ts
+++ b/tools/tsp-client/test/commands.spec.ts
@@ -47,6 +47,9 @@ describe.sequential("Verify commands", () => {
     await rm("./test/examples/initGlobalConfig/", { recursive: true });
     await rm("./test/examples/initGlobalConfigNoMatch/", { recursive: true });
     await rm(joinPaths(repoRoot, "sdk/contosowidgetmanager"), { recursive: true });
+    await rm(joinPaths("test/examples/sdk/alternate-emitter-package-json-path"), {
+      recursive: true,
+    });
   });
 
   it("Generate lock file", async () => {

--- a/tools/tsp-client/test/commands.spec.ts
+++ b/tools/tsp-client/test/commands.spec.ts
@@ -46,6 +46,7 @@ describe.sequential("Verify commands", () => {
     await rm("./test/examples/sdk/local-spec-sdk/TempTypeSpecFiles/", { recursive: true });
     await rm("./test/examples/initGlobalConfig/", { recursive: true });
     await rm("./test/examples/initGlobalConfigNoMatch/", { recursive: true });
+    await rm(joinPaths(repoRoot, "sdk/contosowidgetmanager"), { recursive: true });
   });
 
   it("Generate lock file", async () => {
@@ -380,6 +381,7 @@ describe.sequential("Verify commands", () => {
 
   it("Init with --update-if-exists", async () => {
     try {
+      const libraryPath = joinPaths(repoRoot, "sdk/contosowidgetmanager/contosowidgetmanager-rest");
       const args = {
         "output-dir": joinPaths(cwd(), "./test/examples/initOrUpdate/"),
         "tsp-config": joinPaths(
@@ -400,20 +402,8 @@ describe.sequential("Verify commands", () => {
         ],
         emitterPackageJsonPath: "tools/tsp-client/test/utils/emitter-package.json",
       };
-      await mkdir(
-        joinPaths(
-          cwd(),
-          "test/examples/initOrUpdate/sdk/contosowidgetmanager/contosowidgetmanager-rest",
-        ),
-        { recursive: true },
-      );
-      await writeTspLocationYaml(
-        existingTspLocation,
-        joinPaths(
-          cwd(),
-          "test/examples/initOrUpdate/sdk/contosowidgetmanager/contosowidgetmanager-rest",
-        ),
-      );
+      await mkdir(libraryPath, { recursive: true });
+      await writeTspLocationYaml(existingTspLocation, libraryPath);
       // Now run the init command with --update-if-exists with a local spec so that we can pass in a dummy commit for testing
       const outputDir = await initCommand(args);
       const tspLocation = await readTspLocation(outputDir);
@@ -426,7 +416,55 @@ describe.sequential("Verify commands", () => {
         ],
         emitterPackageJsonPath: "tools/tsp-client/test/utils/emitter-package.json",
       });
-      await rm("./test/examples/initOrUpdate/", { recursive: true });
+      await rm(joinPaths(repoRoot, "sdk/contosowidgetmanager"), { recursive: true });
+    } catch (error: any) {
+      assert.fail("Failed to init. Error: " + error);
+    }
+  });
+
+  it("Init with --update-if-exists and --emitter-package-json-path", async () => {
+    try {
+      const libraryPath = joinPaths(repoRoot, "sdk/contosowidgetmanager/contosowidgetmanager-rest");
+      const args = {
+        "output-dir": libraryPath,
+        "tsp-config": joinPaths(
+          cwd(),
+          "./test/examples/specification/contosowidgetmanager/Contoso.WidgetManager/",
+        ),
+        "update-if-exists": true,
+        commit: "abc",
+        "emitter-package-json-path": "test/utils/alternate-emitter-package.json",
+      };
+
+      // Add a tsp-location.yaml file to the output directory for the initOrUpdate test to simulate an existing project
+      const existingTspLocation: TspLocation = {
+        directory: "specification/contosowidgetmanager/Contoso.WidgetManager",
+        commit: "45924e49834c4e01c0713e6b7ca21f94be17e396",
+        repo: "Azure/azure-rest-api-specs",
+        additionalDirectories: [
+          "tools/tsp-client/test/examples/specification/contosowidgetmanager/Contoso.WidgetManager.Shared",
+        ],
+        emitterPackageJsonPath: "tools/tsp-client/test/utils/emitter-package.json",
+      };
+      await mkdir(libraryPath, {
+        recursive: true,
+      });
+      await writeTspLocationYaml(existingTspLocation, libraryPath);
+      // Now run the init command with --update-if-exists with a local spec so that we can pass in a dummy commit for testing
+      const outputDir = await initCommand(args);
+      const tspLocation = await readTspLocation(outputDir);
+      assert.deepEqual(tspLocation, {
+        directory: "specification/contosowidgetmanager/Contoso.WidgetManager",
+        commit: "abc",
+        repo: "Azure/azure-rest-api-specs",
+        additionalDirectories: [
+          "tools/tsp-client/test/examples/specification/contosowidgetmanager/Contoso.WidgetManager.Shared",
+        ],
+        // The emitterPackageJsonPath should be updated to the alternate emitter package path passed through the
+        // emitter-package-json-path argument
+        emitterPackageJsonPath: "tools/tsp-client/test/utils/alternate-emitter-package.json",
+      });
+      await rm(joinPaths(repoRoot, "sdk"), { recursive: true });
     } catch (error: any) {
       assert.fail("Failed to init. Error: " + error);
     }

--- a/tools/tsp-client/test/utils.spec.ts
+++ b/tools/tsp-client/test/utils.spec.ts
@@ -82,19 +82,50 @@ describe("Verify other utils functions", function () {
       commit: "1234567890abcdef",
       repo: "Azure/foo-repo",
       additionalDirectories: [],
+      // Init logic will resolve this value according to the first supported emitter it finds in the repo
+      // This value will always be ignored to not change any existing config when updateExistingTspLocation() is called
       emitterPackageJsonPath: "example.json",
     };
     const newPackageDir = joinPaths(cwd(), "test/examples/sdk/local-spec-sdk");
     const updatedTspLocationData = await updateExistingTspLocation(tspLocationData, newPackageDir);
     // Verify that directory, commit, repo, and additionalDirectories are updated correctly
     // Verify that the entrypointFile remains unchanged
+    // Verify that the emitterPackageJsonPath remains unchanged because no override is provided through the function parameter
     assert.deepEqual(updatedTspLocationData, {
       directory: "test-directory",
       commit: "1234567890abcdef",
       repo: "Azure/foo-repo",
       additionalDirectories: [],
       entrypointFile: "foo.tsp",
+    });
+  });
+
+  it("Check updateExistingTspLocation with override parameter", async function () {
+    const tspLocationData = {
+      directory: "test-directory",
+      commit: "1234567890abcdef",
+      repo: "Azure/foo-repo",
+      additionalDirectories: [],
+      // Init logic will resolve this value according to the first supported emitter it finds in the repo
+      // This value will always be ignored to not change any existing config when updateExistingTspLocation() is called
       emitterPackageJsonPath: "example.json",
+    };
+    const newPackageDir = joinPaths(cwd(), "test/examples/sdk/local-spec-sdk");
+    const updatedTspLocationData = await updateExistingTspLocation(
+      tspLocationData,
+      newPackageDir,
+      "foo.json",
+    );
+    // Verify that directory, commit, repo, and additionalDirectories are updated correctly
+    // Verify that the entrypointFile remains unchanged
+    // Verify that the emitterPackageJsonPath is updated to the override value
+    assert.deepEqual(updatedTspLocationData, {
+      directory: "test-directory",
+      commit: "1234567890abcdef",
+      repo: "Azure/foo-repo",
+      additionalDirectories: [],
+      entrypointFile: "foo.tsp",
+      emitterPackageJsonPath: "foo.json",
     });
   });
 });

--- a/tools/tsp-client/test/utils.spec.ts
+++ b/tools/tsp-client/test/utils.spec.ts
@@ -125,7 +125,7 @@ describe("Verify other utils functions", function () {
       repo: "Azure/foo-repo",
       additionalDirectories: [],
       entrypointFile: "foo.tsp",
-      emitterPackageJsonPath: "foo.json",
+      emitterPackageJsonPath: "tools/tsp-client/foo.json",
     });
   });
 });


### PR DESCRIPTION
This PR includes the following:
- A fix for the init or update scenario when there's already an existing emitterPackageJsonPath configured in a tsp-location.yaml
- Some test fixes and clean up
- Fix tsp-client init with emitter-output-dir when an alternate output-dir is passed in. 