### PR TITLE
Use authenticated GitHub request when env variable is present

### DIFF
--- a/eng/common/scripts/Helpers/AzSdkTool-Helpers.ps1
+++ b/eng/common/scripts/Helpers/AzSdkTool-Helpers.ps1
@@ -107,6 +107,7 @@ function isNewVersion(
 
 function Get-GitHubApiHeaders {
     # Use GitHub cli to get an auth token if available
+    $token = ""
     if (Get-Command gh -ErrorAction SilentlyContinue) {
         try
         {


### PR DESCRIPTION
Send GitHub bearer header if token env variable is present to avoid rate limit for unauthenticated requests