### PR TITLE
Enhance function name retrieval to be case-insensitive in tryFindFunctionWithApiVersion

### DIFF
--- a/tools/js-sdk-release-tools/src/xlc/apiVersion/utils.ts
+++ b/tools/js-sdk-release-tools/src/xlc/apiVersion/utils.ts
@@ -19,10 +19,25 @@ function tryFindVersionInFunctionBody(func: FunctionDeclaration): string | undef
     return extractApiVersionFromText(text);
 }
 
+function getFunctionNameCaseInsensitive(sourceFile: SourceFile, functionName: string): string {
+    const allFunctions = sourceFile.getFunctions();
+    const matchingFunction = allFunctions.find(func => {
+        const name = func.getName();
+        return name && name.toLowerCase() === functionName.toLowerCase();
+    });
+    
+    return matchingFunction?.getName() || functionName;
+}
+
 function tryFindFunctionWithApiVersion(clientPath: string, functionName: string): FunctionDeclaration | undefined {
     const sourceFile = getTsSourceFile(clientPath);
-    const createClientFunction = sourceFile?.getFunction(functionName);
-    return createClientFunction;
+    if (!sourceFile) return undefined;
+    
+    // Get the exact function name with correct case
+    const exactFunctionName = getFunctionNameCaseInsensitive(sourceFile, functionName);
+    
+    // Get the function using the exact name
+    return sourceFile.getFunction(exactFunctionName);
 }
 
 const extractApiVersionFromText = (text: string): string | undefined => {


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-tools/issues/12161

Test pipeline:https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5400886&view=results