### PR TITLE
Set up vcpkg cache variables in eng/common

### DIFF
--- a/eng/common/pipelines/templates/steps/set-vcpkg-cache-vars.yml
+++ b/eng/common/pipelines/templates/steps/set-vcpkg-cache-vars.yml
@@ -1,0 +1,19 @@
+steps:
+  - pwsh: |
+      Write-Host "Setting vcpkg cache variables for read only access to vcpkg binary and asset caches"
+      Write-Host '##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azcopy,https://azuresdkartifacts.blob.core.windows.net/public-vcpkg-container,read'
+      Write-Host '##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES_SECRET;issecret=true;]clear;x-azurl,https://azuresdkartifacts.blob.core.windows.net/public-vcpkg-container,,read'
+    displayName: Set vcpkg variables
+
+  - ${{if eq(variables['System.TeamProject'], 'internal') }}:
+    - task: AzurePowerShell@5
+      displayName: Set Vcpkg Write-mode Cache
+      inputs:
+        azureSubscription: 'Azure SDK Artifacts'
+        ScriptType: FilePath
+        ScriptPath: eng/common/scripts/Set-VcpkgWriteModeCache.ps1
+        azurePowerShellVersion: LatestVersion
+        pwsh: true
+      # This step is idempotent and can be run multiple times in cases of
+      # failure and partial execution.
+      retryCountOnTaskFailure: 3

--- a/eng/common/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/common/scripts/Set-VcpkgWriteModeCache.ps1
@@ -4,7 +4,7 @@ param(
   [string] $StorageContainerName = 'public-vcpkg-container'
 )
 
-. "$PSScriptRoot/../common/scripts/Helpers/PSModule-Helpers.ps1"
+. "$PSScriptRoot/Helpers/PSModule-Helpers.ps1"
 
 Write-Host "`$env:PSModulePath = $($env:PSModulePath)"
 
@@ -20,7 +20,7 @@ else {
 $modulePaths = $env:PSModulePath -split $moduleSeperator
 $modulePaths = $modulePaths.Where({ !$_.StartsWith($hostedAgentModulePath) })
 $AzModuleCachePath = (Get-ChildItem "$hostedAgentModulePath/az_*" -Attributes Directory) -join $moduleSeperator
-if ($AzModuleCachePath -and $env.PSModulePath -notcontains $AzModuleCachePath) {
+if ($AzModuleCachePath -and $env:PSModulePath -notcontains $AzModuleCachePath) {
   $modulePaths += $AzModuleCachePath
 }
 

--- a/eng/common/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/common/scripts/Set-VcpkgWriteModeCache.ps1
@@ -1,0 +1,46 @@
+#!/bin/env pwsh
+param(
+  [string] $StorageAccountName = 'azuresdkartifacts',
+  [string] $StorageContainerName = 'public-vcpkg-container'
+)
+
+. "$PSScriptRoot/../common/scripts/Helpers/PSModule-Helpers.ps1"
+
+Write-Host "`$env:PSModulePath = $($env:PSModulePath)"
+
+# Work around double backslash
+if ($IsWindows) {
+  $hostedAgentModulePath = $env:SystemDrive + "\\Modules"
+  $moduleSeperator = ";"
+}
+else {
+  $hostedAgentModulePath = "/usr/share"
+  $moduleSeperator = ":"
+}
+$modulePaths = $env:PSModulePath -split $moduleSeperator
+$modulePaths = $modulePaths.Where({ !$_.StartsWith($hostedAgentModulePath) })
+$AzModuleCachePath = (Get-ChildItem "$hostedAgentModulePath/az_*" -Attributes Directory) -join $moduleSeperator
+if ($AzModuleCachePath -and $env.PSModulePath -notcontains $AzModuleCachePath) {
+  $modulePaths += $AzModuleCachePath
+}
+
+$env:PSModulePath = $modulePaths -join $moduleSeperator
+
+Install-ModuleIfNotInstalled "Az.Storage" "4.3.0" | Import-Module
+
+$ctx = New-AzStorageContext `
+  -StorageAccountName $StorageAccountName `
+  -UseConnectedAccount
+
+$vcpkgBinarySourceSas = New-AzStorageContainerSASToken `
+  -Name $StorageContainerName `
+  -Permission "rwcl" `
+  -Context $ctx `
+  -ExpiryTime (Get-Date).AddHours(1)
+
+Write-Host "Ensure redaction of SAS tokens in logs"
+Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SAS_TOKEN;issecret=true;]$vcpkgBinarySourceSas"
+
+Write-Host "Setting vcpkg binary cache to read and write"
+Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azcopy-sas,https://$StorageAccountName.blob.core.windows.net/$StorageContainerName,$vcpkgBinarySourceSas,readwrite"
+Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES_SECRET;issecret=true;]clear;x-azurl,https://$StorageAccountName.blob.core.windows.net/$StorageContainerName,$vcpkgBinarySourceSas,readwrite"

--- a/eng/common/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/common/scripts/Set-VcpkgWriteModeCache.ps1
@@ -4,30 +4,6 @@ param(
   [string] $StorageContainerName = 'public-vcpkg-container'
 )
 
-. "$PSScriptRoot/Helpers/PSModule-Helpers.ps1"
-
-Write-Host "`$env:PSModulePath = $($env:PSModulePath)"
-
-# Work around double backslash
-if ($IsWindows) {
-  $hostedAgentModulePath = $env:SystemDrive + "\\Modules"
-  $moduleSeperator = ";"
-}
-else {
-  $hostedAgentModulePath = "/usr/share"
-  $moduleSeperator = ":"
-}
-$modulePaths = $env:PSModulePath -split $moduleSeperator
-$modulePaths = $modulePaths.Where({ !$_.StartsWith($hostedAgentModulePath) })
-$AzModuleCachePath = (Get-ChildItem "$hostedAgentModulePath/az_*" -Attributes Directory) -join $moduleSeperator
-if ($AzModuleCachePath -and $env:PSModulePath -notcontains $AzModuleCachePath) {
-  $modulePaths += $AzModuleCachePath
-}
-
-$env:PSModulePath = $modulePaths -join $moduleSeperator
-
-Install-ModuleIfNotInstalled "Az.Storage" "4.3.0" | Import-Module
-
 $ctx = New-AzStorageContext `
   -StorageAccountName $StorageAccountName `
   -UseConnectedAccount

--- a/eng/common/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/common/scripts/Set-VcpkgWriteModeCache.ps1
@@ -14,7 +14,7 @@ $vcpkgBinarySourceSas = New-AzStorageContainerSASToken `
   -Context $ctx `
   -ExpiryTime (Get-Date).AddHours(1)
 
-Write-Host "Ensure redaction of SAS tokens in logs"
+# Ensure redaction of SAS tokens in logs
 Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SAS_TOKEN;issecret=true;]$vcpkgBinarySourceSas"
 
 Write-Host "Setting vcpkg binary cache to read and write"

--- a/tools/apiview/parsers/cpp-api-parser/ci.yml
+++ b/tools/apiview/parsers/cpp-api-parser/ci.yml
@@ -72,17 +72,7 @@ stages:
             displayName: Create cmake build directory.
             workingDirectory: '$(Build.SourcesDirectory)/tools/apiview/parsers/cpp-api-parser'
             condition: succeeded()
-          - task: AzurePowerShell@5
-            displayName: Set Vcpkg Write-mode Cache
-            inputs:
-              azureSubscription: 'Azure SDK Artifacts'
-              ScriptType: FilePath
-              ScriptPath: eng/scripts/Set-VcpkgWriteModeCache.ps1
-              azurePowerShellVersion: LatestVersion
-              pwsh: true
-            # This step is idempotent and can be run multiple times in cases of
-            # failure and partial execution.
-            retryCountOnTaskFailure: 3
+          - template: /eng/common/pipelines/templates/steps/set-vcpkg-cache-vars.yml
           - pwsh: |
               cmake.exe -G "Visual Studio 17 2022" -DCMAKE_CXX_STANDARD:STRING="20" -DCMAKE_TOOLCHAIN_FILE:STRING=${env:VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake -DVCPKG_BUILD_TYPE:STRING="release" -DVCPKG_OVERLAY_TRIPLETS:STRING="../vcpkg-triplets" -DMSVC_RUNTIME_LIBRARY:STRING="MultiThreadedDebug" -DVCPKG_TARGET_TRIPLET:STRING="x64-windows-static-release" ..
             displayName: Cmake Generate.

--- a/tools/apiview/parsers/cpp-api-parser/ci.yml
+++ b/tools/apiview/parsers/cpp-api-parser/ci.yml
@@ -72,7 +72,17 @@ stages:
             displayName: Create cmake build directory.
             workingDirectory: '$(Build.SourcesDirectory)/tools/apiview/parsers/cpp-api-parser'
             condition: succeeded()
-          - template: /eng/common/pipelines/templates/steps/set-vcpkg-cache-vars.yml
+          - task: AzurePowerShell@5
+            displayName: Set Vcpkg Write-mode Cache
+            inputs:
+              azureSubscription: 'Azure SDK Artifacts'
+              ScriptType: FilePath
+              ScriptPath: eng/scripts/Set-VcpkgWriteModeCache.ps1
+              azurePowerShellVersion: LatestVersion
+              pwsh: true
+            # This step is idempotent and can be run multiple times in cases of
+            # failure and partial execution.
+            retryCountOnTaskFailure: 3
           - pwsh: |
               cmake.exe -G "Visual Studio 17 2022" -DCMAKE_CXX_STANDARD:STRING="20" -DCMAKE_TOOLCHAIN_FILE:STRING=${env:VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake -DVCPKG_BUILD_TYPE:STRING="release" -DVCPKG_OVERLAY_TRIPLETS:STRING="../vcpkg-triplets" -DMSVC_RUNTIME_LIBRARY:STRING="MultiThreadedDebug" -DVCPKG_TARGET_TRIPLET:STRING="x64-windows-static-release" ..
             displayName: Cmake Generate.


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-tools/issues/12291

A recent change to vcpkg broke caching scenarios. It's a matter of time before those breaks spread to other parts of our EngSys. Consolidating vcpkg cache configurations in a single place will make it easier to roll out fixes.

The two important steps for setting vcpkg cache variables are: 
1. Setting the initial variables for read-only access (not required but helpful in almost all situations) 
2. Setting variables for write access in `internal` builds

This template performs steps that will work in existing invocations. Some implementations like Rust include extra steps. Those steps can be taken in other places when migrating to eng/common vcpkg. 

Places where something like this is used: 
* C - https://github.com/Azure/azure-sdk-for-c/blob/main/eng/pipelines/templates/steps/vcpkg.yml
* C++ - https://github.com/Azure/azure-sdk-for-cpp/blob/main/eng/pipelines/templates/steps/vcpkg.yml
* Rust - https://github.com/Azure/azure-sdk-for-rust/blob/main/eng/pipelines/templates/steps/vcpkg.yml
* Tools (C++ API View) - https://github.com/Azure/azure-sdk-tools/blob/main/tools/apiview/parsers/cpp-api-parser/ci.yml#L75