### PR TITLE
[azsdk-cli] fix microagent returning null result

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Microagents/MicroagentHostService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Microagents/MicroagentHostService.cs
@@ -120,6 +120,6 @@ public class MicroagentHostService(AzureOpenAIClient openAI, ILogger<MicroagentH
     private class MicroagentResult<T>
     {
         [Description("The result of the agent run. Output the result requested exactly, without additional padding, explanation, or code fences unless requested.")]
-        public T Result { get; set; }
+        public required T Result { get; set; }
     }
 }


### PR DESCRIPTION
debugging with @l0lawrence we found that the agent sometimes returns null to the exit tool which it really shouldn't do. This is because the root property in the result was not marked as `required`.