### PR TITLE
[APIView] Fix incorrect JSON property name casing in CorrelationId

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Models/AIReviewModel.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/AIReviewModel.cs
@@ -26,8 +26,7 @@ namespace APIViewWeb.Models
         public string Source { get; set; }
         [JsonPropertyName("is_generic")]
         public bool IsGeneric { get; set; }
-
-        [JsonPropertyName("correlationId")]
+        [JsonPropertyName("correlation_id")]
         public string CorrelationId { get; set; }
         [JsonPropertyName("severity")]
         public string Severity { get; set; }


### PR DESCRIPTION
A typo in the name here results in correlation id not being parsed from copilot output. 