### PR TITLE
Add workflow discovery and execution granularity

### DIFF
--- a/packages/python-packages/apiview-copilot/cli.py
+++ b/packages/python-packages/apiview-copilot/cli.py
@@ -168,13 +168,13 @@ def _local_review(
     reviewer.close()
 
 
-def run_test_case(language: str, test_file: str, num_runs: int = 1, testcase: List[str] = None):
+def run_test_case(language: str, test_file: str, num_runs: int = 1, test_cases: List[str] = None):
     """
     Runs one or all eval test cases.
     """
     from evals._runner import EvalRunner
 
-    runner = EvalRunner(language=language, test_path=test_file, num_runs=num_runs, testcase=testcase)
+    runner = EvalRunner(language=language, test_path=test_file, num_runs=num_runs, test_cases=test_cases)
     runner.run()
 
 
@@ -1109,7 +1109,7 @@ class CliCommandsLoader(CLICommandsLoader):
                 "num_runs", type=int, options_list=["--num-runs", "-n"], help="Number of times to run the test case."
             )
             ac.argument(
-                "testcase", type=str, nargs='*', options_list=["--testcase", "-c"], help="List of test cases to run."
+                "test_cases", type=str, nargs='*', options_list=["--test-cases", "-c"], help="List of test cases to run."
             )
         with ArgumentsContext(self, "eval create") as ac:
             ac.argument("test_case", type=str, help="The name of the test case")

--- a/packages/python-packages/apiview-copilot/cli.py
+++ b/packages/python-packages/apiview-copilot/cli.py
@@ -168,13 +168,13 @@ def _local_review(
     reviewer.close()
 
 
-def run_test_case(language: str, test_file: str, num_runs: int = 3):
+def run_test_case(language: str, test_file: str, num_runs: int = 1, testcase: List[str] = None):
     """
     Runs one or all eval test cases.
     """
     from evals._runner import EvalRunner
 
-    runner = EvalRunner(language=language, test_path=test_file, num_runs=num_runs)
+    runner = EvalRunner(language=language, test_path=test_file, num_runs=num_runs, testcase=testcase)
     runner.run()
 
 
@@ -1107,6 +1107,9 @@ class CliCommandsLoader(CLICommandsLoader):
         with ArgumentsContext(self, "eval run") as ac:
             ac.argument(
                 "num_runs", type=int, options_list=["--num-runs", "-n"], help="Number of times to run the test case."
+            )
+            ac.argument(
+                "testcase", type=str, nargs='*', options_list=["--testcase", "-c"], help="List of test cases to run."
             )
         with ArgumentsContext(self, "eval create") as ac:
             ac.argument("test_case", type=str, help="The name of the test case")

--- a/packages/python-packages/apiview-copilot/evals/_runner.py
+++ b/packages/python-packages/apiview-copilot/evals/_runner.py
@@ -3,7 +3,7 @@ import tempfile
 import json
 import pathlib
 import sys
-from typing import List
+from typing import Optional, List
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -12,44 +12,65 @@ from azure.identity import AzurePipelinesCredential
 from src._settings import SettingsManager
 from tabulate import tabulate
 
-from evals._config_loader import load_workflow_config, WorkflowConfigError, get_evaluator_class
-import evals._custom
+import evals._custom # Unused but needed to instantiate custom evaluators
+from evals._config_loader import (
+    WorkflowConfig, 
+    WorkflowConfigError, 
+    load_workflow_config, 
+    load_workflow_directory, 
+    get_evaluator_class
+)
 
 DEFAULT_NUM_RUNS: int = 1
 
 class EvalRunner:
-    """Class to run evals for APIView copilot."""
+    """Evaluation runner for APIView copilot workflows.
+    
+    Supports both single-workflow execution and batch processing of all
+    workflows for a given language. Handles test case filtering, multiple
+    runs, and result aggregation.
+    
+    Args:
+        language: Programming language to evaluate (e.g., 'python', 'java')
+        test_path: Path to specific workflow YAML file (optional)
+        test_cases: List of test case names to filter (requires test_path)
+        num_runs: Number of evaluation runs to perform per test file
+        
+    Raises:
+        ValueError: When inputs are invalid or incompatible
+    """
 
-    def __init__(self, *, language: str, test_path: str, test_cases: list[str] = None, num_runs: int = DEFAULT_NUM_RUNS):
+    def __init__(self, *, language: str, test_path: Optional[str], test_cases: Optional[List[str]] = None, num_runs: int = DEFAULT_NUM_RUNS):
         self.language = language
         self.test_path = test_path
         self.test_cases = test_cases
         self.num_runs = num_runs
         self.settings = SettingsManager()
 
-        self._workflow_config = None
-        self._is_workflow = False
+        self._workflow_configs: List[WorkflowConfig] = []
 
-        path_obj = pathlib.Path(test_path)
-        
-        try:
-            self._workflow_config = load_workflow_config(path_obj)
-        except WorkflowConfigError as e:
-            raise ValueError(f"Invalid workflow config: {e}") from e
+        if test_path is None:
+            # No test file specified - discover all workflows for specified language
+            self._workflow_configs = self._discover_all_workflows()
+        else:
+            path_obj = pathlib.Path(test_path)
+            try:
+                workflow_config = load_workflow_config(path_obj)
+                self._workflow_configs = [workflow_config]
+            except WorkflowConfigError as e:
+                raise ValueError(f"Invalid workflow config: {e}") from e
 
-        self._tests_directory = self._workflow_config.tests_path.parent
-        self._test_files: List[pathlib.Path] = [self._workflow_config.tests_path]
-        
-        evaluation_kind = self._workflow_config.kind
-        self._evaluator_class = get_evaluator_class(evaluation_kind)
+        if not self._workflow_configs:
+            raise ValueError(f"No valid workflows found for language '{language}'")
 
     def run(self):
-        """Run the evaluation over the resolved test files."""
-        evaluator = self._evaluator_class(self._workflow_config)
-        guideline_ids = set()
-        all_run_results = []
-        temp_files = []
+        """Orchestrate the evaluation process."""
+        credentials = self._setup_credentials()
+        all_workflow_results = self._execute_workflows(credentials)
+        self._present_results(all_workflow_results)
 
+    def _setup_credentials(self) -> dict:
+        """Setup Azure credentials and evaluation configuration."""
         azure_ai_project = {
             "subscription_id": self.settings.get("EVALS_SUBSCRIPTION"),
             "resource_group_name": self.settings.get("EVALS_RG"),
@@ -61,7 +82,7 @@ class EvalRunner:
             client_id = os.environ.get("AZURESUBSCRIPTION_CLIENT_ID")
             tenant_id = os.environ.get("AZURESUBSCRIPTION_TENANT_ID")
             system_access_token = os.environ.get("SYSTEM_ACCESSTOKEN")
-            kwargs = {
+            return {
                 "credential": AzurePipelinesCredential(
                     service_connection_id=service_connection_id,
                     client_id=client_id,
@@ -70,10 +91,32 @@ class EvalRunner:
                 )
             }
         else:
-            kwargs = {}
+            return {}
 
+    def _execute_workflows(self, credentials: dict) -> dict:
+        """Execute all configured workflows and collect results."""
+        all_workflow_results = {}
+        
+        for workflow_idx, workflow_config in enumerate(self._workflow_configs):
+            print(f"\n=== Running Workflow {workflow_idx + 1}/{len(self._workflow_configs)}: {workflow_config.name} ===")
+            
+            workflow_result = self._execute_single_workflow(workflow_config, credentials)
+            all_workflow_results[workflow_config.name] = workflow_result
+            
+        return all_workflow_results
+
+    def _execute_single_workflow(self, workflow_config: WorkflowConfig, credentials: dict) -> dict:
+        """Execute a single workflow and return its results."""
+        evaluator_class = get_evaluator_class(workflow_config.kind)
+        evaluator = evaluator_class(workflow_config)
+        
+        workflow_run_results = []
+        temp_files = []
+        
         try:
-            for file in self._test_files:
+            test_files = [workflow_config.tests_path]
+            
+            for file in test_files:
                 if not file.exists():
                     raise ValueError(f"Test file not found: {file}")
 
@@ -82,45 +125,87 @@ class EvalRunner:
                 if filtered_file_path != str(file):
                     temp_files.append(filtered_file_path)
                 
-                file_run_results = []
-                for run in range(self.num_runs):
-                    print(f"Running evals {run + 1}/{self.num_runs} for {file.name}...")
-                    if self.test_cases:
-                        print(f"  (Filtered to testcases: {[testcase for testcase in self.test_cases]})")
-                    result = evaluate(
-                        data=filtered_file_path,
-                        evaluators={"metrics": evaluator},
-                        evaluator_config={"metrics": evaluator.evaluator_config},
-                        target=evaluator.target_function,
-                        # FIXME: Should this be True? Probably?
-                        fail_on_evaluator_errors=False,
-                        # azure_ai_project=azure_ai_project,
-                        **kwargs
-                    )
-                    file_run_results.append({file.name: result})
-                all_run_results.extend(file_run_results)
+                file_run_results = self._execute_test_file_runs(file, filtered_file_path, evaluator, credentials)
+                workflow_run_results.extend(file_run_results)
         finally:
-            for temp_file in temp_files:
-                try:
-                    os.unlink(temp_file)
-                except Exception as e:
-                    print(f"Error removing temporary file {temp_file}: {e}")
+            self._cleanup_temp_files(temp_files)
 
-        if not all_run_results:
+        if not workflow_run_results:
             raise ValueError("No results produced.")
 
-        # Delegate all result processing to the evaluator
-        processed_results = evaluator.process_results(all_run_results, guideline_ids)
-        evaluator.show_results(processed_results)
-        evaluator.post_process(
-            processed_results,
-            self.language,
-            str(self._tests_directory),
-            guideline_ids,
-        )
+        guideline_ids = set()
+        processed_results = evaluator.process_results(workflow_run_results, guideline_ids)
+
+        return {
+            'processed_results': processed_results,
+            'evaluator': evaluator,
+            'workflow_config': workflow_config,
+            'guideline_ids': guideline_ids
+        }
+
+    def _execute_test_file_runs(self, file: pathlib.Path, filtered_file_path: str, evaluator, credentials: dict) -> list:
+        """Execute multiple runs for a single test file."""
+        file_run_results = []
+        
+        for run in range(self.num_runs):
+            print(f"Running evals {run + 1}/{self.num_runs} for {file.name}...")
+            if self.test_cases:
+                print(f"  (Filtered to testcases: {[testcase for testcase in self.test_cases]})")
+            
+            result = evaluate(
+                data=filtered_file_path,
+                evaluators={"metrics": evaluator},
+                evaluator_config={"metrics": evaluator.evaluator_config},
+                target=evaluator.target_function,
+                # FIXME: Should this be True? Probably?
+                fail_on_evaluator_errors=False,
+                # azure_ai_project=azure_ai_project,
+                **credentials
+            )
+            file_run_results.append({file.name: result})
+            
+        return file_run_results
+
+    def _cleanup_temp_files(self, temp_files: list) -> None:
+        """Clean up temporary files created during execution."""
+        for temp_file in temp_files:
+            try:
+                os.unlink(temp_file)
+            except Exception as e:
+                print(f"Error removing temporary file {temp_file}: {e}")
+
+    def _present_results(self, all_workflow_results: dict) -> None:
+        """Present evaluation results and run post-processing."""
+        overall_guideline_ids = set()
+        
+        for workflow_data in all_workflow_results.values():
+            overall_guideline_ids.update(workflow_data['guideline_ids'])
+        
+        self._show_aggregated_results(all_workflow_results)
+        self._run_post_processing(all_workflow_results, overall_guideline_ids)
 
     def in_ci(self) -> bool:
         return bool(os.getenv("TF_BUILD"))
+    
+    def _discover_all_workflows(self) -> List[WorkflowConfig]:
+        """Discover all workflow files for the specified language."""
+        if not self.language:
+            raise ValueError("Language (-l/--language) must be specified when a workflow file (-f/--test-file) is not provided.")
+        if self.test_cases:
+            raise ValueError(
+                "Cannot specify test cases (-c/--test-cases) without specifying a workflow file (-f/--test-file). "
+                "To run specific test cases, provide a workflow file."
+            )
+
+        workflows_dir = pathlib.Path(__file__).parent / "workflows" / self.language
+        
+        if not workflows_dir.exists():
+            raise ValueError(f"No workflows directory found for language '{self.language}' at {workflows_dir}")
+        
+        try:
+            return load_workflow_directory(workflows_dir)
+        except WorkflowConfigError as e:
+            raise ValueError(f"Error loading workflows from {workflows_dir}: {e}") from e
     
     def _filter_jsonl_data(self, file_path: str) -> str:
         """Filter JSONL data by testcase if specified, return path to filtered temp file."""
@@ -165,3 +250,32 @@ class EvalRunner:
             
         except Exception as e:
             raise ValueError(f"Error filtering testcase data: {e}")
+        
+    def _show_aggregated_results(self, all_workflow_results: dict) -> None:
+        """Show results for all workflows in a unified manner."""
+        print(f"\n{'='*80}")
+        print(f"Evaluation results summary ({len(all_workflow_results)} workflows)")
+        print(f"{'='*80}")
+        
+        for workflow_name, workflow_data in all_workflow_results.items():
+            print(f"\n--- {workflow_name.upper()} ---")
+            evaluator = workflow_data['evaluator']
+            processed_results = workflow_data['processed_results']
+            evaluator.show_results(processed_results)
+
+    def _run_post_processing(self, all_workflow_results: dict, overall_guideline_ids: set) -> None:
+        """Run post-processing for all workflows."""
+        for workflow_name, workflow_data in all_workflow_results.items():
+            evaluator = workflow_data['evaluator']
+            processed_results = workflow_data['processed_results']
+            workflow_config = workflow_data['workflow_config']
+            guideline_ids = workflow_data['guideline_ids']
+            
+            tests_directory = str(workflow_config.tests_path.parent)
+            
+            evaluator.post_process(
+                processed_results,
+                self.language,
+                tests_directory,
+                guideline_ids,
+            )

--- a/packages/python-packages/apiview-copilot/evals/_runner.py
+++ b/packages/python-packages/apiview-copilot/evals/_runner.py
@@ -152,7 +152,7 @@ class EvalRunner:
                 print(f"  (Filtered to testcases: {[testcase for testcase in self.test_cases]})")
             
             result = evaluate(
-                data=str(filtered_file_path),  # evaluate() API expects string path
+                data=str(filtered_file_path),
                 evaluators={"metrics": evaluator},
                 evaluator_config={"metrics": evaluator.evaluator_config},
                 target=evaluator.target_function,

--- a/packages/python-packages/apiview-copilot/evals/_runner.py
+++ b/packages/python-packages/apiview-copilot/evals/_runner.py
@@ -142,6 +142,7 @@ class EvalRunner:
                         if data.get('testcase') == self.testcase:
                             filtered_lines.append(line)
                             found_testcase = True
+                            break
                     except json.JSONDecodeError as e:
                         raise ValueError(f"Invalid JSON on line {line_num} in {file_path}: {e}")
             

--- a/packages/python-packages/apiview-copilot/evals/_runner.py
+++ b/packages/python-packages/apiview-copilot/evals/_runner.py
@@ -1,4 +1,6 @@
 import os
+import tempfile
+import json
 import pathlib
 import sys
 from typing import List
@@ -18,9 +20,10 @@ DEFAULT_NUM_RUNS: int = 1
 class EvalRunner:
     """Class to run evals for APIView copilot."""
 
-    def __init__(self, *, language: str, test_path: str, num_runs: int = DEFAULT_NUM_RUNS):
+    def __init__(self, *, language: str, test_path: str, testcase: str, num_runs: int = DEFAULT_NUM_RUNS):
         self.language = language
         self.test_path = test_path
+        self.testcase = testcase
         self.num_runs = num_runs
         self.settings = SettingsManager()
 
@@ -45,6 +48,7 @@ class EvalRunner:
         evaluator = self._evaluator_class(self._workflow_config)
         guideline_ids = set()
         all_run_results = []
+        temp_files = []
 
         azure_ai_project = {
             "subscription_id": self.settings.get("EVALS_SUBSCRIPTION"),
@@ -68,24 +72,38 @@ class EvalRunner:
         else:
             kwargs = {}
 
-        for file in self._test_files:
-            if not file.exists():
-                raise ValueError(f"Test file not found: {file}")
-            file_run_results = []
-            for run in range(self.num_runs):
-                print(f"Running evals {run + 1}/{self.num_runs} for {file.name}...")
-                result = evaluate(
-                    data=str(file),
-                    evaluators={"metrics": evaluator},
-                    evaluator_config={"metrics": evaluator.evaluator_config},
-                    target=evaluator.target_function,
-                    # FIXME: Should this be True? Probably?
-                    fail_on_evaluator_errors=False,
-                    # azure_ai_project=azure_ai_project,
-                    **kwargs,
-                )
-                file_run_results.append({file.name: result})
-            all_run_results.extend(file_run_results)
+        try:
+            for file in self._test_files:
+                if not file.exists():
+                    raise ValueError(f"Test file not found: {file}")
+
+                filtered_file_path = self._filter_jsonl_data(str(file))
+                if filtered_file_path != str(file):
+                    temp_files.append(filtered_file_path)
+                
+                file_run_results = []
+                for run in range(self.num_runs):
+                    print(f"Running evals {run + 1}/{self.num_runs} for {file.name}...")
+                    if self.testcase:
+                        print(f"  (Filtered to testcase: {self.testcase})")
+                    result = evaluate(
+                        data=filtered_file_path,
+                        evaluators={"metrics": evaluator},
+                        evaluator_config={"metrics": evaluator.evaluator_config},
+                        target=evaluator.target_function,
+                        # FIXME: Should this be True? Probably?
+                        fail_on_evaluator_errors=False,
+                        # azure_ai_project=azure_ai_project,
+                        **kwargs
+                    )
+                    file_run_results.append({file.name: result})
+                all_run_results.extend(file_run_results)
+        finally:
+            for temp_file in temp_files:
+                try:
+                    os.unlink(temp_file)
+                except Exception as e:
+                    print(f"Error removing temporary file {temp_file}: {e}")
 
         if not all_run_results:
             raise ValueError("No results produced.")
@@ -102,3 +120,50 @@ class EvalRunner:
 
     def in_ci(self) -> bool:
         return bool(os.getenv("TF_BUILD"))
+    
+    def _filter_jsonl_data(self, file_path: str) -> str:
+        """Filter JSONL data by testcase if specified, return path to filtered temp file."""
+        if not self.testcase:
+            return file_path
+        
+        original_path = pathlib.Path(file_path)
+        filtered_lines = []
+        found_testcase = False
+        
+        try:
+            with open(original_path, 'r', encoding='utf-8') as f:
+                for line_num, line in enumerate(f, 1):
+                    line = line.strip()
+                    if not line:
+                        continue
+                        
+                    try:
+                        data = json.loads(line)
+                        if data.get('testcase') == self.testcase:
+                            filtered_lines.append(line)
+                            found_testcase = True
+                    except json.JSONDecodeError as e:
+                        raise ValueError(f"Invalid JSON on line {line_num} in {file_path}: {e}")
+            
+            if not found_testcase:
+                raise ValueError(f"Testcase '{self.testcase}' not found in {file_path}")
+            
+            if not filtered_lines:
+                raise ValueError(f"No valid data found for testcase '{self.testcase}'")
+                
+            # Create temporary file with filtered data
+            temp_file = tempfile.NamedTemporaryFile(
+                mode='w', 
+                suffix='.jsonl', 
+                delete=False,
+                encoding='utf-8'
+            )
+            
+            for line in filtered_lines:
+                temp_file.write(line + '\n')
+            temp_file.close()
+            
+            return temp_file.name
+            
+        except Exception as e:
+            raise ValueError(f"Error filtering testcase data: {e}")

--- a/packages/python-packages/apiview-copilot/evals/run.py
+++ b/packages/python-packages/apiview-copilot/evals/run.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--test-file",
-        "-t",
+        "-f",
         type=str,
         required=True,
         help="Path to workflow YAML.",

--- a/packages/python-packages/apiview-copilot/evals/run.py
+++ b/packages/python-packages/apiview-copilot/evals/run.py
@@ -27,10 +27,17 @@ if __name__ == "__main__":
         required=True,
         help="Path to workflow YAML.",
     )
+    parser.add_argument(
+        "--testcase",
+        "-c",
+        type=str,
+        help="Filter to run only the specified testcase (by testcase field value)."
+    )
     args = parser.parse_args()
     runner = EvalRunner(
         language=args.language, 
         test_path=args.test_file,
+        testcase=args.testcase,
         num_runs=args.num_runs
     )
     runner.run()

--- a/packages/python-packages/apiview-copilot/evals/run.py
+++ b/packages/python-packages/apiview-copilot/evals/run.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
         help="Path to workflow YAML.",
     )
     parser.add_argument(
-        "--testcase",
+        "--test-cases",
         "-c",
         type=str,
         help="Filter to run only the specified testcases",
@@ -38,7 +38,7 @@ if __name__ == "__main__":
     runner = EvalRunner(
         language=args.language, 
         test_path=args.test_file,
-        testcase=args.testcase,
+        test_cases=args.test_cases,
         num_runs=args.num_runs
     )
     runner.run()

--- a/packages/python-packages/apiview-copilot/evals/run.py
+++ b/packages/python-packages/apiview-copilot/evals/run.py
@@ -24,14 +24,13 @@ if __name__ == "__main__":
         "--test-file",
         "-f",
         type=str,
-        required=True,
-        help="Path to workflow YAML.",
+        help="Path to workflow YAML. If not provided, runs all workflows for the language.",
     )
     parser.add_argument(
         "--test-cases",
         "-c",
         type=str,
-        help="Filter to run only the specified testcases",
+        help="Filter to run only the specified testcase.",
         nargs='*'
     )
     args = parser.parse_args()

--- a/packages/python-packages/apiview-copilot/evals/run.py
+++ b/packages/python-packages/apiview-copilot/evals/run.py
@@ -31,7 +31,8 @@ if __name__ == "__main__":
         "--testcase",
         "-c",
         type=str,
-        help="Filter to run only the specified testcase (by testcase field value)."
+        help="Filter to run only the specified testcases",
+        nargs='*'
     )
     args = parser.parse_args()
     runner = EvalRunner(

--- a/packages/python-packages/apiview-copilot/evals/workflows/apiview.yaml
+++ b/packages/python-packages/apiview-copilot/evals/workflows/apiview.yaml
@@ -1,3 +1,0 @@
-name: apiview
-kind: apiview
-tests: ../tests/python/apiview.jsonl

--- a/packages/python-packages/apiview-copilot/evals/workflows/python/apiview.yaml
+++ b/packages/python-packages/apiview-copilot/evals/workflows/python/apiview.yaml
@@ -1,0 +1,3 @@
+name: apiview
+kind: apiview
+tests: ../../tests/python/apiview.jsonl

--- a/packages/python-packages/apiview-copilot/evals/workflows/python/mention-action.yaml
+++ b/packages/python-packages/apiview-copilot/evals/workflows/python/mention-action.yaml
@@ -1,7 +1,7 @@
 name: mention-action
 kind: prompt
-tests: ../tests/python/mention-action.jsonl
-prompty: ../../prompts/mention/parse_conversation_action.prompty
+tests: ../../tests/python/mention-action.jsonl
+prompty: ../../../prompts/mention/parse_conversation_action.prompty
 evaluation_config:
   comparison_field: recommendation
   display_name: Recommendation

--- a/packages/python-packages/apiview-copilot/evals/workflows/python/thread-resolution-action.yaml
+++ b/packages/python-packages/apiview-copilot/evals/workflows/python/thread-resolution-action.yaml
@@ -1,7 +1,7 @@
 name: thread-resolution-action
 kind: prompt
-tests: ../tests/python/thread-resolution-action.jsonl
-prompty: ../../prompts/thread_resolution/parse_thread_resolution_action.prompty
+tests: ../../tests/python/thread-resolution-action.jsonl
+prompty: ../../../prompts/thread_resolution/parse_thread_resolution_action.prompty
 evaluation_config:
   comparison_field: action
   display_name: Action


### PR DESCRIPTION
Adds support for running multiple workflows with more execution control

### Workflow Organization

- Moved workflow files into language-specific subdirectories (workflows/python/)
- Updated relative paths in workflow YAML files to accommodate new structure

Moving workflows into language subdirectories allows for auto-discovery when a workflow file is not provided.

### Execution Granularity
- Added support for running all workflows when no specific test file is provided
- Made --test-file parameter optional (defaults to discovering all workflows for the specified language)

## New usage pattern
```bash
# Run all workflows for a language
python run.py -l python

# Run specific workflow (existing behavior)
python run.py -l python -f workflows/python/apiview.yaml

# Run specific test cases within a workflow
python run.py -l python -f workflows/python/apiview.yaml -c test_case_1 test_case_2
```