### PR TITLE
Generate HTML view for evals

### DIFF
--- a/tools/ai-evals/azsdk-mcp/Evaluators/ExpectedToolInputEvaluator.cs
+++ b/tools/ai-evals/azsdk-mcp/Evaluators/ExpectedToolInputEvaluator.cs
@@ -30,8 +30,8 @@ namespace Azure.Sdk.Tools.McpEvals.Evaluators
             }
 
             // Get tool calls to compare them
-            var expectedToolCalls = await GetToolContent(context.ChatMessages, context.ToolNames, true);
-            var actualToolCalls = await GetToolContent(modelResponse.Messages, context.ToolNames, false);
+            var expectedToolCalls = GetToolContent(context.ChatMessages, context.ToolNames, true);
+            var actualToolCalls = GetToolContent(modelResponse.Messages, context.ToolNames, false);
 
             // Make sure we have tool calls to compare
             if (!expectedToolCalls.Any())
@@ -144,7 +144,7 @@ namespace Azure.Sdk.Tools.McpEvals.Evaluators
             }
         }
 
-        private async Task<IEnumerable<FunctionCallContent>> GetToolContent(IEnumerable<ChatMessage> messages, IEnumerable<string> toolNames, bool simplify)
+        private IEnumerable<FunctionCallContent> GetToolContent(IEnumerable<ChatMessage> messages, IEnumerable<string> toolNames, bool simplify)
         {
             var result = messages
                 .Where(message => message.Role == ChatRole.Assistant)

--- a/tools/ai-evals/azsdk-mcp/Scenarios/Scenario.cs
+++ b/tools/ai-evals/azsdk-mcp/Scenarios/Scenario.cs
@@ -1,5 +1,12 @@
+using AwesomeAssertions.Specialized;
+using Azure.Sdk.Tools.McpEvals.Evaluators;
 using Azure.Sdk.Tools.McpEvals.Helpers;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.AI.Evaluation;
+using Microsoft.Extensions.AI.Evaluation.Quality;
+using Microsoft.Extensions.AI.Evaluation.Reporting;
+using Microsoft.Extensions.AI.Evaluation.Reporting.Formats.Html;
+using Microsoft.Extensions.AI.Evaluation.Reporting.Storage;
 using ModelContextProtocol.Client;
 using NUnit.Framework;
 
@@ -9,18 +16,48 @@ namespace Azure.Sdk.Tools.McpEvals.Scenarios
     public partial class Scenario
     {
         // Static services shared across all tests
-        protected static IChatClient? ChatClient;
-        protected static IMcpClient? McpClient;
-        protected static ChatCompletion? ChatCompletion;
-        protected static IEnumerable<string> ToolNames;
+        protected static IChatClient? s_chatClient;
+        protected static IMcpClient? s_mcpClient;
+        protected static ChatCompletion? s_chatCompletion;
+        protected static IEnumerable<string> s_toolNames;
+        protected static ReportingConfiguration s_reportingConfiguration;
+        protected static ChatConfiguration s_chatConfig;
+        private static string s_executionName;
+        private string ScenarioName => $"{TestContext.CurrentContext.Test.ClassName}.{TestContext.CurrentContext.Test.Name}";
+        private string ReportingPath => Path.Combine(TestContext.CurrentContext.TestDirectory, "reports");
+
 
         [OneTimeSetUp]
         public async Task GlobalSetup()
         {
-            ChatClient = TestSetup.GetChatClient();
-            McpClient = await TestSetup.GetMcpClientAsync();
-            ChatCompletion = TestSetup.GetChatCompletion(ChatClient, McpClient);
-            ToolNames = (await McpClient.ListToolsAsync()).Select(tool => tool.Name)!;
+            s_chatClient = TestSetup.GetChatClient();
+            s_mcpClient = await TestSetup.GetMcpClientAsync();
+            s_chatConfig = new ChatConfiguration(s_chatClient);
+            s_chatCompletion = TestSetup.GetChatCompletion(s_chatClient, s_mcpClient);
+            s_toolNames = (await s_mcpClient.ListToolsAsync()).Select(tool => tool.Name)!;
+            s_executionName = $"{DateTime.Now:yyyyMMddTHHmmss}";
+        }
+
+
+        [OneTimeTearDown]
+        public async Task GlobalTearDown()
+        {
+            // Generate a HTML report for all the evaluations run
+            IEvaluationResultStore resultStore = new DiskBasedResultStore(ReportingPath);
+            var allResults = new List<ScenarioRunResult>();
+
+            await foreach (string executionName in resultStore.GetLatestExecutionNamesAsync(count: 1))
+            {
+                await foreach (ScenarioRunResult scenarioResult in resultStore.ReadResultsAsync(executionName))
+                {
+                    allResults.Add(scenarioResult);
+                }
+            }
+
+            var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+            string reportFilePath = Path.Combine(ReportingPath, $"report-{timestamp}.html");
+            IEvaluationReportWriter reportWriter = new HtmlReportWriter(reportFilePath);
+            await reportWriter.WriteReportAsync(allResults);
         }
     }
 }


### PR DESCRIPTION
- Resolves #12041 
- Gives a nice summary of the evaluation results. 
- Since I still have not tackled recordings/storing the results I am storing this locally. 
- Also fixed a async method that should not have been async woops. 

<img width="2552" height="1284" alt="image" src="https://github.com/user-attachments/assets/286b2ff7-b63b-484a-918a-a269f6d7e6a6" />
