### PR TITLE
Added 'ArtifactsJson' parameter to test pipeline template

### DIFF
--- a/eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
+++ b/eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
@@ -19,7 +19,7 @@ parameters:
   default: ''
 
 steps:
-- ${{ if eq(parameters.TestPipeline, 'true') }}:
+- ${{ if eq(parameters.TestPipeline, true) }}:
     - task: PowerShell@2
       displayName: Prep template pipeline for release
       condition: and(succeeded(), ne(variables['Skip.SetTestPipelineVersion'], 'true'))

--- a/eng/common/scripts/SetTestPipelineVersion.ps1
+++ b/eng/common/scripts/SetTestPipelineVersion.ps1
@@ -48,7 +48,7 @@ if ($artifacts) {
   # When using ArtifactsJson, process each artifact with its name and groupId (if applicable)
   try {
     foreach ($artifact in $artifacts) {
-      $packageName = $artifact.name      
+      $packageName = $artifact.name
       $newVersion = [AzureEngSemanticVersion]::new("1.0.0")
       $prefix = "$packageName$TagSeparator"
 


### PR DESCRIPTION
This is to support the `template-v2` test projects in Java SDK repo.

- Added `artifacts` parameter
- Concatenated `groupId` from the `artifacts` parameter in case of Java