### PR TITLE
Add new MCP tool to update language exclusion justification

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
@@ -83,6 +83,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
                 Title = "Mock Release Plan",
                 Description = "This is a mock release plan for testing purposes."
             };
+            releasePlan.IsDataPlane = workItemId > 1000;
+            releasePlan.IsManagementPlane = !releasePlan.IsDataPlane;
             return Task.FromResult(releasePlan);
         }
 
@@ -122,11 +124,11 @@ namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
             return Task.FromResult(new Dictionary<string, List<string>>());
         }
 
-        Task<WorkItem> IDevOpsService.UpdateWorkItem(int workItemId, Dictionary<string, string> fields)
+        Task<WorkItem> IDevOpsService.UpdateWorkItemAsync(int workItemId, Dictionary<string, string> fields)
         {
             var workItem = new WorkItem
             {
-                Id = 1,
+                Id = workItemId,
                 Fields = new Dictionary<string, object>
                 {
                     { "System.Title", "Updated work item" },

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlanManualTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlanManualTests.cs
@@ -65,6 +65,21 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
 
         [Test] // disabled by default because it makes real API calls
         [Ignore("Manual test - requires real API calls")]
+        public async Task Test_UpdateExclusionJustificationWithLanguage()
+        {
+            int releasePlanWorkItemId = 28940; // replace with a real release plan ID
+            string exclusionJustification = "Updated justification for exclusion.";
+            var updateStatus = await this.releasePlan.UpdateLanguageExclusionJustification(releasePlanWorkItemId, exclusionJustification, "Java");
+            Assert.IsNotNull(updateStatus);
+            Assert.That(updateStatus.Message, Does.Contain("Updated language exclusion"));
+
+            var releasePlanInfo = await this.devOpsService.GetReleasePlanForWorkItemAsync(releasePlanWorkItemId);
+            Assert.That(exclusionJustification, Is.EqualTo(releasePlanInfo.LanguageExclusionRequesterNote));
+        }
+
+
+        [Test] // disabled by default because it makes real API calls
+        [Ignore("Manual test - requires real API calls")]
         public async Task Test_Get_ReleaseExclusionStatus()
         {
             int releasePlan = 28940; // replace with a real release plan ID

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlanManualTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlanManualTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Tests.Mocks.Services;
+using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
+using Azure.Sdk.Tools.Cli.Tools.ReleasePlan;
+using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Helpers;
+using Moq;
+
+namespace Azure.Sdk.Tools.Cli.Tests.Tools
+{
+    internal class ReleasePlanManualTests
+    {
+        private IAzureService azureService;
+        private IDevOpsService devOpsService;
+        private ReleasePlanTool releasePlan;
+        private TestLogger<ReleasePlanTool> logger;
+        private IGitHubService gitHubService;
+        private ITypeSpecHelper typeSpecHelper;
+        private IUserHelper userHelper;
+        private IEnvironmentHelper environmentHelper;
+
+        public ReleasePlanManualTests()
+        {
+            azureService = new AzureService();
+            var devopsLogger = new TestLogger<DevOpsService>();
+            var devopsConnection = new DevOpsConnection(azureService);
+            devOpsService = new DevOpsService(devopsLogger, devopsConnection);
+
+            logger = new TestLogger<ReleasePlanTool>();
+            gitHubService = new Mock<IGitHubService>().Object;
+
+            var typeSpecHelperMock = new Mock<ITypeSpecHelper>();
+            typeSpecHelperMock.Setup(x => x.IsRepoPathForPublicSpecRepo(It.IsAny<string>())).Returns(true);
+            typeSpecHelper = typeSpecHelperMock.Object;
+
+            var userHelperMock = new Mock<IUserHelper>();
+            userHelperMock.Setup(x => x.GetUserEmail()).ReturnsAsync("test@example.com");
+            userHelper = userHelperMock.Object;
+
+            var environmentHelperMock = new Mock<IEnvironmentHelper>();
+            environmentHelperMock.Setup(x => x.GetBooleanVariable(It.IsAny<string>(), It.IsAny<bool>())).Returns(false);
+            environmentHelper = environmentHelperMock.Object;
+            releasePlan = new ReleasePlanTool(devOpsService, typeSpecHelper, logger, userHelper, gitHubService, environmentHelper);
+        }
+
+        [Test] // disabled by default because it makes real API calls
+        [Ignore("Manual test - requires real API calls")]
+        public async Task Test_UpdateExclusionJustification()
+        {
+            int releasePlanWorkItemId = 28940; // replace with a real release plan ID
+            string exclusionJustification = "Updated justification for exclusion.";
+            var updateStatus = await this.releasePlan.UpdateLanguageExclusionJustification(releasePlanWorkItemId, exclusionJustification);
+            Assert.IsNotNull(updateStatus);
+            Assert.That(updateStatus.Message, Does.Contain("Updated language exclusion"));
+
+            var releasePlanInfo = await this.devOpsService.GetReleasePlanForWorkItemAsync(releasePlanWorkItemId);
+            Assert.That(exclusionJustification, Is.EqualTo(releasePlanInfo.LanguageExclusionRequesterNote));
+        }
+
+        [Test] // disabled by default because it makes real API calls
+        [Ignore("Manual test - requires real API calls")]
+        public async Task Test_Get_ReleaseExclusionStatus()
+        {
+            int releasePlan = 28940; // replace with a real release plan ID
+            var releasePlanInfo = await this.devOpsService.GetReleasePlanForWorkItemAsync(releasePlan);
+            Assert.IsNotNull(releasePlanInfo);
+            
+            var pythonSdk = releasePlanInfo.SDKInfo.FirstOrDefault(sdk => sdk.Language.Equals("Python", StringComparison.OrdinalIgnoreCase));
+            Assert.IsNotNull(pythonSdk);
+            Assert.That(pythonSdk.ReleaseExclusionStatus, Is.EqualTo("Requested"));
+        }
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlanToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlanToolTests.cs
@@ -229,5 +229,34 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             updateStatus = await releasePlanTool.UpdateSDKDetailsInReleasePlan(100, sdkDetails);
             Assert.That(updateStatus.Message, Does.Contain("Updated SDK details in release plan"));
         }
+
+        [Test]
+        public async Task Test_Update_SDK_Details_Mgmt_language_excl()
+        {
+            string sdkDetails = "[{\"language\":\".NET\",\"packageName\":\"Azure.ResourceManager.Contoso\"},{\"language\":\"JavaScript\",\"packageName\":\"@azure/arm-contoso\"}]";
+            var updateStatus = await releasePlanTool.UpdateSDKDetailsInReleasePlan(100, sdkDetails);
+            Assert.That(updateStatus.Message, Does.Contain("Updated SDK details in release plan"));
+            Assert.That(updateStatus.Message, Does.Contain("Important: The following languages were excluded in the release plan. SDK must be released for all languages."));
+            Assert.True(updateStatus.NextSteps?.Contains("Prompt the user for justification for excluded languages and update it in the release plan.") ?? false);
+        }
+
+
+        [Test]
+        public async Task Test_Update_SDK_Details_Data_language_excl()
+        {
+            string sdkDetails = "[{\"language\":\".NET\",\"packageName\":\"Azure.Contoso\"},{\"language\":\"JavaScript\",\"packageName\":\"@azure/contoso\"}]";
+            var updateStatus = await releasePlanTool.UpdateSDKDetailsInReleasePlan(1001, sdkDetails);
+            Assert.That(updateStatus.Message, Does.Contain("Updated SDK details in release plan"));
+            Assert.That(updateStatus.Message, Does.Contain("Important: The following languages were excluded in the release plan. SDK must be released for all languages."));
+            Assert.That(updateStatus.NextSteps?.Contains("Prompt the user for justification for excluded languages and update it in the release plan.") ?? false);
+        }
+
+        [Test]
+        public  async Task Test_update_language_exclusion_justification()
+        {
+            var updateStatus = await releasePlanTool.UpdateLanguageExclusionJustification(100, "This is a test justification for excluding certain languages.");
+            Assert.That(updateStatus.Message, Does.Contain("Updated language exclusion justification in release plan"));
+        }
+
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
@@ -11,7 +11,7 @@
     <NoWarn>ASP0000;CS8603;CS8618;CS8625;CS8604</NoWarn>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AssemblyName>azsdk</AssemblyName>
-    <VersionPrefix>0.5.1</VersionPrefix>
+    <VersionPrefix>0.5.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <!-- Package metadata -->
     <PackageReleaseNotes>See CHANGELOG.md for release notes</PackageReleaseNotes>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Release History
 
+## 0.5.2 (Unreleased)
+
+### Features
+
+- Added new tool to update language exclusion justification and also to mark as language as excluded from release.
+
+### Breaking Changes
+
+- None
+
+### Bugs Fixed
+
+- None
+
 ## 0.5.1 (2025-10-07)
 
 ### Features

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ReleasePlanDetails.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ReleasePlanDetails.cs
@@ -33,6 +33,8 @@ namespace Azure.Sdk.Tools.Cli.Models
         public string SDKLanguages { get; set; } = string.Empty;
         public bool IsSpecApproved { get; set; } = false;
         public int ApiSpecWorkItemId { get; set; } = 0;
+        public string LanguageExclusionRequesterNote { get; set; } = string.Empty;
+        public string LanguageExclusionApproverNote { get; set; } = string.Empty;
 
         public Microsoft.VisualStudio.Services.WebApi.Patch.Json.JsonPatchDocument GetPatchDocument()
         {
@@ -134,5 +136,8 @@ namespace Azure.Sdk.Tools.Cli.Models
         public string GenerationPipelineUrl { get; set; } = string.Empty;
         public string SdkPullRequestUrl { get; set; } = string.Empty;
         public string PackageName { get; set; } = string.Empty;
+        public string ReleaseStatus { get; set; } = string.Empty;
+        public string PullRequestStatus { get; set; } = string.Empty;
+        public string ReleaseExclusionStatus { get; set; } = string.Empty;
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -100,7 +100,7 @@ namespace Azure.Sdk.Tools.Cli.Services
         public Task<PackageResponse> GetPackageWorkItemAsync(string packageName, string language, string packageVersion = "");
         public Task<Build> RunPipelineAsync(int pipelineDefinitionId, Dictionary<string, string> templateParams, string apiSpecBranchRef = "main");
         public Task<Dictionary<string, List<string>>> GetPipelineLlmArtifacts(string project, int buildId);
-        public Task<WorkItem> UpdateWorkItem(int workItemId, Dictionary<string, string> fields);
+        public Task<WorkItem> UpdateWorkItemAsync(int workItemId, Dictionary<string, string> fields);
     }
 
     public partial class DevOpsService(ILogger<DevOpsService> logger, IDevOpsConnection connection) : IDevOpsService
@@ -156,7 +156,9 @@ namespace Azure.Sdk.Tools.Cli.Services
                 IsCreatedByAgent = workItem.Fields.TryGetValue("Custom.IsCreatedByAgent", out value) && "Copilot".Equals(value?.ToString()),
                 ReleasePlanSubmittedByEmail = workItem.Fields.TryGetValue("Custom.ReleasePlanSubmittedByEmail", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 SDKLanguages = workItem.Fields.TryGetValue("Custom.SDKLanguages", out value) ? value?.ToString() ?? string.Empty : string.Empty,
-                IsSpecApproved = workItem.Fields.TryGetValue("Custom.APISpecApprovalStatus", out value) && "Approved".Equals(value?.ToString())
+                IsSpecApproved = workItem.Fields.TryGetValue("Custom.APISpecApprovalStatus", out value) && "Approved".Equals(value?.ToString()),
+                LanguageExclusionRequesterNote = workItem.Fields.TryGetValue("Custom.ReleaseExclusionRequestNote", out value) ? value?.ToString() ?? string.Empty : string.Empty,
+                LanguageExclusionApproverNote = workItem.Fields.TryGetValue("Custom.ReleaseExclusionApprovalNote", out value) ? value?.ToString() ?? string.Empty : string.Empty
             };
 
             var languages = new string[] { "Dotnet", "JavaScript", "Python", "Java", "Go" };
@@ -165,6 +167,9 @@ namespace Azure.Sdk.Tools.Cli.Services
                 var sdkGenPipelineUrl = workItem.Fields.TryGetValue($"Custom.SDKGenerationPipelineFor{lang}", out value) ? value?.ToString() ?? string.Empty : string.Empty;
                 var sdkPullRequestUrl = workItem.Fields.TryGetValue($"Custom.SDKPullRequestFor{lang}", out value) ? value?.ToString() ?? string.Empty : string.Empty;
                 var packageName = workItem.Fields.TryGetValue($"Custom.{lang}PackageName", out value) ? value?.ToString() ?? string.Empty : string.Empty;
+                var releaseStatus = workItem.Fields.TryGetValue($"Custom.ReleaseStatusFor{lang}", out value) ? value?.ToString() ?? string.Empty : string.Empty;
+                var pullRequestStatus = workItem.Fields.TryGetValue($"Custom.SDKPullRequestStatusFor{lang}", out value) ? value?.ToString() ?? string.Empty : string.Empty;
+                var exclusionStatus = workItem.Fields.TryGetValue($"Custom.ReleaseExclusionStatusFor{lang}", out value) ? value?.ToString() ?? string.Empty : string.Empty;
 
                 if (!string.IsNullOrEmpty(sdkGenPipelineUrl) || !string.IsNullOrEmpty(sdkPullRequestUrl) || !string.IsNullOrEmpty(packageName))
                 {
@@ -173,8 +178,10 @@ namespace Azure.Sdk.Tools.Cli.Services
                         {
                             Language = MapLanguageIdToName(lang),
                             GenerationPipelineUrl = sdkGenPipelineUrl,
-                            SdkPullRequestUrl = sdkPullRequestUrl,
-                            PackageName = packageName
+                            SdkPullRequestUrl = sdkPullRequestUrl,          
+                            ReleaseStatus = releaseStatus,
+                            PackageName = packageName,
+                            ReleaseExclusionStatus = exclusionStatus
                         }
                     );
                 }
@@ -280,7 +287,7 @@ namespace Azure.Sdk.Tools.Cli.Services
                 await LinkWorkItemAsChildAsync(releasePlanWorkItemId, apiSpecWorkItem.Url);
 
                 // Update release plan status to in progress
-                releasePlanWorkItem = await UpdateWorkItem(releasePlanWorkItemId, new Dictionary<string, string>
+                releasePlanWorkItem = await UpdateWorkItemAsync(releasePlanWorkItemId, new Dictionary<string, string>
                 {
                     { "System.State", "In Progress" }
                 });
@@ -391,7 +398,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             }
         }
 
-        private static string MapLanguageToId(string language)
+        public static string MapLanguageToId(string language)
         {
             var lang = language.ToLower();
             return lang switch
@@ -406,7 +413,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             };
         }
 
-        private static string MapLanguageIdToName(string language)
+        public static string MapLanguageIdToName(string language)
         {
             var lang = language.ToLower();
             return lang switch
@@ -1131,7 +1138,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             return await GetLlmArtifactsAuthenticated(project, buildId);
         }
 
-        public async Task<WorkItem> UpdateWorkItem(int workItemId, Dictionary<string, string> fields)
+        public async Task<WorkItem> UpdateWorkItemAsync(int workItemId, Dictionary<string, string> fields)
         {
             var jsonLinkDocument = new Microsoft.VisualStudio.Services.WebApi.Patch.Json.JsonPatchDocument();
             foreach (var item in fields)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -377,16 +377,16 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 }
 
                 // Check if any language is excluded
-                var excludedLangauges = supportedLanguages.Except(SdkInfos.Select(sdk => sdk.Language), StringComparer.OrdinalIgnoreCase);
-                if (excludedLangauges.Any())
+                var excludedLanguages = supportedLanguages.Except(SdkInfos.Select(sdk => sdk.Language), StringComparer.OrdinalIgnoreCase);
+                if (excludedLanguages.Any())
                 {
-                    logger.LogDebug("Languages excluded in release plan. Work Item: {releasePlanWorkItemId}, languages: {excludedLangauges}", releasePlanWorkItemId, string.Join(", ", excludedLangauges));
+                    logger.LogDebug("Languages excluded in release plan. Work Item: {releasePlanWorkItemId}, languages: {excludedLanguages}", releasePlanWorkItemId, string.Join(", ", excludedLanguages));
                     sb.AppendLine($"Important: The following languages were excluded in the release plan. SDK must be released for all languages. [{string.Join(", ", supportedLanguages)}]");
                     sb.AppendLine("Explanation is required for any language exclusion. Please provide a justification for each excluded language.");
 
                     // Mark excluded language as 'Requested' in the release plan work item.
                     Dictionary<string, string> fieldsToUpdate = [];
-                    foreach (var lang in excludedLangauges)
+                    foreach (var lang in excludedLanguages)
                     {
                         fieldsToUpdate[$"Custom.ReleaseExclusionStatusFor{DevOpsService.MapLanguageToId(lang)}"] = "Requested";
                     }
@@ -519,7 +519,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
 
                 if (!string.IsNullOrEmpty(language))
                 {
-                    fieldsToUpdate[$"Custom.ReleaseExclusionStatusFor{ DevOpsService.MapLanguageToId(language)}"] = "Requested";
+                    fieldsToUpdate[$"Custom.ReleaseExclusionStatusFor{DevOpsService.MapLanguageToId(language)}"] = "Requested";
                 }
 
                 var updatedWorkItem = await devOpsService.UpdateWorkItemAsync(releasePlanWorkItem, fieldsToUpdate);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -397,7 +397,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 return new DefaultCommandResponse
                 {
                     Message = sb.ToString(),
-                    NextSteps = excludedLangauges.Any() ? ["Prompt the user for justification for excluded languages and update it in the release plan."] : []
+                    NextSteps = excludedLanguages.Any() ? ["Prompt the user for justification for excluded languages and update it in the release plan."] : []
                 };
             }
             catch (Exception ex)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -489,8 +489,9 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             }
         }
 
-        [McpServerTool(Name = "azsdk_update_language_exclusion_justification"), Description("Update language exclusion justification in release plan work item. This tool is called to update justification for excluded languages in the release plan.")]
-        public async Task<DefaultCommandResponse> UpdateLanguageExclusionJustification(int releasePlanWorkItem, string justification)
+        [McpServerTool(Name = "azsdk_update_language_exclusion_justification"), Description("Update language exclusion justification in release plan work item. This tool is called to update justification for excluded languages in the release plan. " +
+            "Optionally pass a language name to explicitly request exclusion for a specific language.")]
+        public async Task<DefaultCommandResponse> UpdateLanguageExclusionJustification(int releasePlanWorkItem, string justification, string language = "")
         {
             try
             {
@@ -515,6 +516,12 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 {
                     { "Custom.ReleaseExclusionRequestNote", justification }
                 };
+
+                if (!string.IsNullOrEmpty(language))
+                {
+                    fieldsToUpdate[$"Custom.ReleaseExclusionStatusFor{ DevOpsService.MapLanguageToId(language)}"] = "Requested";
+                }
+
                 var updatedWorkItem = await devOpsService.UpdateWorkItemAsync(releasePlanWorkItem, fieldsToUpdate);
                 if (updatedWorkItem == null)
                 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -53,9 +53,13 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
         private const string namespaceApprovalRepoOwner = "Azure";
 
 
-        private readonly HashSet<string> supportedLanguages = [
-            ".NET","Java","Python","JavaScript","Go"
+        private readonly HashSet<string> languagesforDataplane = [
+            ".NET","Java","Python","JavaScript"
         ];
+
+        private readonly HashSet<string> languagesforMgmtplane = [
+           ".NET","Java","Python","JavaScript","Go"
+       ];
 
         [GeneratedRegex("https:\\/\\/github.com\\/Azure\\/azure-sdk\\/issues\\/([0-9]+)")]
         private static partial Regex NameSpaceIssueUrlRegex();
@@ -342,12 +346,22 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     return "Failed to deserialize SDK details.";
                 }
 
+                // Get release plan
+                var releasePlan = await devOpsService.GetReleasePlanForWorkItemAsync(releasePlanWorkItemId);
+                if (releasePlan == null)
+                {
+                    return new DefaultCommandResponse { ResponseError = $"No release plan found with work item ID {releasePlanWorkItemId}" };
+                }
+
+                var supportedLanguages = releasePlan.IsManagementPlane ? languagesforMgmtplane : languagesforDataplane;
                 // Validate SDK language name
                 if (SdkInfos.Any(sdk => !supportedLanguages.Contains(sdk.Language, StringComparer.OrdinalIgnoreCase)))
                 {
                     return $"Unsupported SDK language found. Supported languages are: {string.Join(", ", supportedLanguages)}";
                 }
 
+                StringBuilder sb = new();
+                // Update SDK package name and languages in work item
                 var updated = await devOpsService.UpdateReleasePlanSDKDetailsAsync(releasePlanWorkItemId, SdkInfos);
                 if (!updated)
                 {
@@ -355,14 +369,36 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 }
                 else
                 {
-                    StringBuilder sb = new("Updated SDK details in release plan.");
-                    sb.AppendLine();
+                    sb.Append("Updated SDK details in release plan.").AppendLine();
                     foreach (var sdk in SdkInfos)
                     {
                         sb.AppendLine($"Language: {sdk.Language}, Package name: {sdk.PackageName}");
                     }
-                    return sb.ToString();
                 }
+
+                // Check if any language is excluded
+                var excludedLangauges = supportedLanguages.Except(SdkInfos.Select(sdk => sdk.Language), StringComparer.OrdinalIgnoreCase);
+                if (excludedLangauges.Any())
+                {
+                    logger.LogDebug("Languages excluded in release plan. Work Item: {releasePlanWorkItemId}, languages: {excludedLangauges}", releasePlanWorkItemId, string.Join(", ", excludedLangauges));
+                    sb.AppendLine($"Important: The following languages were excluded in the release plan. SDK must be released for all languages. [{string.Join(", ", supportedLanguages)}]");
+                    sb.AppendLine("Explanation is required for any language exclusion. Please provide a justification for each excluded language.");
+
+                    // Mark excluded language as 'Requested' in the release plan work item.
+                    Dictionary<string, string> fieldsToUpdate = [];
+                    foreach (var lang in excludedLangauges)
+                    {
+                        fieldsToUpdate[$"Custom.ReleaseExclusionStatusFor{DevOpsService.MapLanguageToId(lang)}"] = "Requested";
+                    }
+                    await devOpsService.UpdateWorkItemAsync(releasePlanWorkItemId, fieldsToUpdate);
+                    logger.LogDebug("Marked excluded languages as 'Requested' in release plan work item {releasePlanWorkItemId}.", releasePlanWorkItemId);
+                }
+
+                return new DefaultCommandResponse
+                {
+                    Message = sb.ToString(),
+                    NextSteps = excludedLangauges.Any() ? ["Prompt the user for justification for excluded languages and update it in the release plan."] : []
+                };
             }
             catch (Exception ex)
             {
@@ -450,6 +486,53 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 {
                     ResponseError = $"Failed to verify package namespace approval: {ex.Message}"
                 };
+            }
+        }
+
+        [McpServerTool(Name = "azsdk_update_language_exclusion_justification"), Description("Update language exclusion justification in release plan work item. This tool is called to update justification for excluded languages in the release plan.")]
+        public async Task<DefaultCommandResponse> UpdateLanguageExclusionJustification(int releasePlanWorkItem, string justification)
+        {
+            try
+            {
+                if (releasePlanWorkItem <= 0)
+                {
+                    return "Invalid release plan ID.";
+                }
+                if (string.IsNullOrEmpty(justification))
+                {
+                    return "No justification provided to update the release plan.";
+                }
+
+                // Get release plan
+                var releasePlan = await devOpsService.GetReleasePlanForWorkItemAsync(releasePlanWorkItem);
+                if (releasePlan == null)
+                {
+                    return new DefaultCommandResponse { ResponseError = $"No release plan found with work item ID {releasePlanWorkItem}" };
+                }
+
+                // Update language exclusion justification in work item
+                Dictionary<string, string> fieldsToUpdate = new()
+                {
+                    { "Custom.ReleaseExclusionRequestNote", justification }
+                };
+                var updatedWorkItem = await devOpsService.UpdateWorkItemAsync(releasePlanWorkItem, fieldsToUpdate);
+                if (updatedWorkItem == null)
+                {
+                    return new DefaultCommandResponse { ResponseError = "Failed to update the language exclusion justification in release plan." };
+                }
+                else
+                {
+                    return new DefaultCommandResponse
+                    {
+                        Message = "Updated language exclusion justification in release plan.",
+                        NextSteps = []
+                    };
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to update release plan with language exclusion justification");
+                return new DefaultCommandResponse { ResponseError = $"Failed to update release plan with language exclusion justification: {ex.Message}" };
             }
         }
     }


### PR DESCRIPTION
This PR has changes to:
- Add a new MCP tool to update justification for language exclusion in release plan work item
- Mark a language as `exclusion requested` if a required language is missing when updating SDK details.
- Request a specific language to be marked as excluded from release.