### PR TITLE
Implement FormatCode with spotless for Java

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/JavaLanguageSpecificChecksTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/JavaLanguageSpecificChecksTests.cs
@@ -1,0 +1,274 @@
+using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
+{
+    internal class JavaLanguageSpecificChecksTests
+    {
+        private string JavaPackageDir { get; set; }
+        private Mock<IProcessHelper> MockProcessHelper { get; set; }
+        private Mock<INpxHelper> MockNpxHelper { get; set; }
+        private Mock<IGitHelper> MockGitHelper { get; set; }
+        private JavaLanguageSpecificChecks LangService { get; set; }
+
+        [SetUp]
+        public void SetUp()
+        {
+            // Use TestAssets directory directly instead of temp directory
+            JavaPackageDir = Path.Combine(
+                Path.GetDirectoryName(typeof(JavaLanguageSpecificChecksTests).Assembly.Location)!,
+                "TestAssets", "Java");
+
+            MockProcessHelper = new Mock<IProcessHelper>();
+            MockNpxHelper = new Mock<INpxHelper>();
+            MockGitHelper = new Mock<IGitHelper>();
+
+            LangService = new JavaLanguageSpecificChecks(
+                MockProcessHelper.Object,
+                MockNpxHelper.Object,
+                MockGitHelper.Object,
+                NullLogger<JavaLanguageSpecificChecks>.Instance);
+        }
+
+        [Test]
+        public void TestSupportedLanguage()
+        {
+            Assert.That(LangService.SupportedLanguage, Is.EqualTo("Java"));
+        }
+
+        [Test]
+        public async Task TestFormatCodeAsync_MavenNotAvailable_ReturnsError()
+        {
+            // Arrange
+            MockProcessHelper.Setup(x => x.Run(It.IsAny<ProcessOptions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, "Maven not found")] });
+
+            // Act
+            var result = await LangService.FormatCodeAsync(JavaPackageDir, false, CancellationToken.None);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(1));
+                Assert.That(result.ResponseError, Does.Contain("Maven is not installed or not available in PATH"));
+            });
+        }
+
+        [Test]
+        public async Task TestFormatCodeAsync_NoPomXml_ReturnsError()
+        {
+            // Arrange - Use a temp directory without pom.xml for this test
+            var emptyDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(emptyDir);
+            
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
+                ((p.Command == "mvn" || p.Command == "cmd.exe") || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
+
+            // Act
+            var result = await LangService.FormatCodeAsync(emptyDir, false, CancellationToken.None);
+            
+            // Cleanup
+            try { Directory.Delete(emptyDir, true); } catch { }
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(1));
+                Assert.That(result.ResponseError, Does.Contain("No pom.xml found"));
+                Assert.That(result.ResponseError, Does.Contain("This doesn't appear to be a Maven project"));
+            });
+        }
+
+        [Test]
+        public async Task TestFormatCodeAsync_CheckMode_Success()
+        {
+            // Arrange
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
+
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("spotless:check")), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "BUILD SUCCESS")] });
+
+            // Act
+            var result = await LangService.FormatCodeAsync(JavaPackageDir, false, CancellationToken.None);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(0));
+                Assert.That(result.CheckStatusDetails, Is.EqualTo("Code formatting check passed - all files are properly formatted"));
+            });
+        }
+
+        [Test]
+        public async Task TestFormatCodeAsync_ApplyMode_Success()
+        {
+            // Arrange
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
+
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("spotless:apply")), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "BUILD SUCCESS")] });
+
+            // Act
+            var result = await LangService.FormatCodeAsync(JavaPackageDir, true, CancellationToken.None);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(0));
+                Assert.That(result.CheckStatusDetails, Is.EqualTo("Code formatting applied successfully"));
+            });
+        }
+
+        [Test]
+        public async Task TestFormatCodeAsync_CheckMode_FormattingNeeded()
+        {
+            // Arrange
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
+
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("spotless:check")), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardOutput, "The following files had format violations")] });
+
+            // Act
+            var result = await LangService.FormatCodeAsync(JavaPackageDir, false, CancellationToken.None);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(1));
+                Assert.That(result.CheckStatusDetails, Does.Contain("The following files had format violations"));
+                Assert.That(result.ResponseError, Does.Contain("Code formatting check failed"));
+                Assert.That(result.ResponseError, Does.Contain("mvn spotless:apply"));
+            });
+        }
+
+        [Test]
+        public async Task TestFormatCodeAsync_ApplyMode_Failure()
+        {
+            // Arrange
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
+
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("spotless:apply")), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardOutput, "spotless failed with errors")] });
+
+            // Act
+            var result = await LangService.FormatCodeAsync(JavaPackageDir, true, CancellationToken.None);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(1));
+                Assert.That(result.CheckStatusDetails, Does.Contain("spotless failed with errors"));
+                Assert.That(result.ResponseError, Does.Contain("Code formatting failed to apply"));
+            });
+        }
+
+        [Test]
+        public async Task TestFormatCodeAsync_PomInParentDirectory()
+        {
+            // Arrange
+            var subDir = Path.Combine(JavaPackageDir, "src", "main", "java");
+            Directory.CreateDirectory(subDir);
+            
+            var pomPath = Path.Combine(JavaPackageDir, "pom.xml");
+
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
+
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("spotless:check") && p.Args.Contains("-f")), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "BUILD SUCCESS")] });
+
+            // Act - run from subdirectory
+            var result = await LangService.FormatCodeAsync(subDir, false, CancellationToken.None);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(0));
+                Assert.That(result.CheckStatusDetails, Is.EqualTo("Code formatting check passed - all files are properly formatted"));
+            });
+
+            // Verify the correct pom.xml path was used
+            MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => 
+                p.Args.Contains("-f") && 
+                p.Args.Contains(pomPath)), 
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public async Task TestFormatCodeAsync_ExceptionHandling()
+        {
+            // Arrange
+            MockProcessHelper.Setup(x => x.Run(It.IsAny<ProcessOptions>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("Process execution failed"));
+
+            // Act
+            var result = await LangService.FormatCodeAsync(JavaPackageDir, false, CancellationToken.None);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(1));
+                Assert.That(result.ResponseError, Does.Contain("Error formatting code: Process execution failed"));
+            });
+        }
+
+        [Test]
+        public async Task TestFormatCodeAsync_VerifyCorrectMavenCommand_CheckMode()
+        {
+            // Arrange
+            var pomPath = Path.Combine(JavaPackageDir, "pom.xml");
+
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
+
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("spotless:check")), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "BUILD SUCCESS")] });
+
+            // Act
+            await LangService.FormatCodeAsync(JavaPackageDir, false, CancellationToken.None);
+
+            // Assert - verify the correct Maven command was called
+            MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" || p.Command == "cmd.exe") &&
+                p.Args.Contains("spotless:check") &&
+                p.Args.Contains("-f") &&
+                p.Args.Contains(pomPath) &&
+                p.WorkingDirectory == JavaPackageDir &&
+                p.Timeout == TimeSpan.FromMinutes(10)), 
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public async Task TestFormatCodeAsync_VerifyCorrectMavenCommand_ApplyMode()
+        {
+            // Arrange
+            var pomPath = Path.Combine(JavaPackageDir, "pom.xml");
+
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
+
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("spotless:apply")), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "BUILD SUCCESS")] });
+
+            // Act
+            await LangService.FormatCodeAsync(JavaPackageDir, true, CancellationToken.None);
+
+            // Assert - verify the correct Maven command was called
+            MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" || p.Command == "cmd.exe") &&
+                p.Args.Contains("spotless:apply") &&
+                p.Args.Contains("-f") &&
+                p.Args.Contains(pomPath) &&
+                p.WorkingDirectory == JavaPackageDir &&
+                p.Timeout == TimeSpan.FromMinutes(10)), 
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/TestAssets/Java/pom.xml
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/TestAssets/Java/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <groupId>com.azure</groupId>
+    <artifactId>test-project</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    
+    <name>Azure SDK Test Project</name>
+    <description>A test Maven project for Azure SDK tools</description>
+    
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>2.40.0</version>
+                <configuration>
+                    <java>
+                        <googleJavaFormat/>
+                    </java>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/JavaLanguageSpecificChecks.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/JavaLanguageSpecificChecks.cs
@@ -30,4 +30,95 @@ public class JavaLanguageSpecificChecks : ILanguageSpecificChecks
 
     public string SupportedLanguage => "Java";
 
+    public async Task<CLICheckResponse> FormatCodeAsync(string packagePath, bool fix = false, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            _logger.LogInformation("Starting code formatting for Java project at: {PackagePath}", packagePath);
+
+            // Check if Maven is available
+            var mavenCheckResult = await _processHelper.Run(new("mvn", ["--version"], timeout: TimeSpan.FromSeconds(10)), cancellationToken);
+            if (mavenCheckResult.ExitCode != 0)
+            {
+                _logger.LogError("Maven is not installed or not available in PATH");
+                return new CLICheckResponse(1, "", "Maven is not installed or not available in PATH. Please install Maven to use code formatting functionality.");
+            }
+
+            _logger.LogInformation("Maven is available: {MavenVersion}", mavenCheckResult.Output.Split('\n')[0].Trim());
+
+            // Find pom.xml in the package directory or its parents
+            var pomPath = FindPomXml(packagePath);
+            if (string.IsNullOrEmpty(pomPath))
+            {
+                _logger.LogError("No pom.xml found in {PackagePath} or its parent directories", packagePath);
+                return new CLICheckResponse(1, "", $"No pom.xml found in {packagePath} or its parent directories. This doesn't appear to be a Maven project.");
+            }
+
+            var pomDirectory = Path.GetDirectoryName(pomPath);
+            _logger.LogInformation("Using Maven project at: {PomDirectory}", pomDirectory);
+
+            // Determine the Maven goal based on fix parameter
+            var goal = fix ? "spotless:apply" : "spotless:check";
+            var command = "mvn";
+            var args = new[] { goal, "-f", pomPath };
+
+            _logger.LogInformation("Executing command: {Command} {Arguments}", command, string.Join(" ", args));
+            var timeout = TimeSpan.FromMinutes(10); // Maven operations can take time
+            var result = await _processHelper.Run(new(command, args, workingDirectory: pomDirectory, timeout: timeout), cancellationToken);
+
+            if (result.ExitCode == 0)
+            {
+                var message = fix ? "Code formatting applied successfully" : "Code formatting check passed - all files are properly formatted";
+                _logger.LogInformation(message);
+                return new CLICheckResponse(result.ExitCode, message);
+            }
+            else
+            {
+                var errorMessage = fix ? "Code formatting failed to apply" : "Code formatting check failed - some files need formatting";
+                _logger.LogWarning("{ErrorMessage} with exit code {ExitCode}", errorMessage, result.ExitCode);
+                
+                // Extract useful error information from output
+                var output = result.Output;
+                if (output.Contains("spotless"))
+                {
+                    // If the output contains spotless-related information, include it
+                    return new CLICheckResponse(result.ExitCode, output, errorMessage);
+                }
+                else
+                {
+                    // Provide helpful guidance
+                    var guidance = fix ? 
+                        "Run 'mvn spotless:apply' to automatically format code, or check if spotless-maven-plugin is configured in the pom.xml" :
+                        "Run 'mvn spotless:apply' to fix formatting issues, or use --fix flag with this command";
+                    return new CLICheckResponse(result.ExitCode, output, $"{errorMessage}. {guidance}");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error formatting code for Java project at: {PackagePath}", packagePath);
+            return new CLICheckResponse(1, "", $"Error formatting code: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Finds pom.xml file starting from the given directory and searching up the directory tree.
+    /// </summary>
+    /// <param name="startPath">The directory to start searching from</param>
+    /// <returns>Path to pom.xml file, or null if not found</returns>
+    private string? FindPomXml(string startPath)
+    {
+        var currentDir = new DirectoryInfo(startPath);
+        
+        while (currentDir != null)
+        {
+            var pomPath = Path.Combine(currentDir.FullName, "pom.xml");
+            if (File.Exists(pomPath))
+            {
+                return pomPath;
+            }
+            currentDir = currentDir.Parent;
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
Implemented `FormatCodeAsync` method in `JavaLanguageSpecificChecks.cs` that:

- Checks for Maven availability using `mvn --version`
- Searches for `pom.xml` starting from the package directory up through parent directories
- Uses `mvn spotless:check` for validation mode when `fix=false`
- Uses `mvn spotless:apply` for formatting mode when `fix=true`
- Provides comprehensive error handling and logging
- Returns appropriate CLICheckResponse with exit codes and messages