### PR TITLE
Implement update code-snippets for Java

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/JavaLanguageSpecificChecksTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/JavaLanguageSpecificChecksTests.cs
@@ -125,6 +125,30 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
                 .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, errorOutput)] });
         }
 
+         /// <summary>
+        /// Sets up successful Maven codesnippet update command.
+        /// </summary>
+        private void SetupSuccessfulSnippetUpdate()
+        {
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" || p.Command == "cmd.exe") && 
+                p.Args.Any(arg => arg.Contains("codesnippet-maven-plugin"))), 
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "BUILD SUCCESS")] });
+        }
+
+        /// <summary>
+        /// Sets up failed Maven codesnippet update command.
+        /// </summary>
+        private void SetupFailedSnippetUpdate()
+        {
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" || p.Command == "cmd.exe") && 
+                p.Args.Any(arg => arg.Contains("codesnippet-maven-plugin"))), 
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, "Codesnippet update failed")] });
+        }
+
         #endregion
         
         [Test]
@@ -330,11 +354,10 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
                 p.Args.Contains("-f") &&
                 p.Args.Contains(pomPath) &&
                 p.WorkingDirectory == JavaPackageDir &&
-                p.Timeout == TimeSpan.FromMinutes(10)), 
+                p.Timeout == TimeSpan.FromMinutes(10)),
                 It.IsAny<CancellationToken>()), Times.Once);
         }
 
-<<<<<<< HEAD
         #region LintCodeAsync Tests
 
         [Test]
@@ -345,17 +368,6 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
 
             // Act
             var result = await LangService.LintCodeAsync(JavaPackageDir, false, CancellationToken.None);
-=======
-        [Test]
-        public async Task TestUpdateSnippetsAsync_MavenNotAvailable_ReturnsError()
-        {
-            // Arrange
-            MockProcessHelper.Setup(x => x.Run(It.IsAny<ProcessOptions>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, "Maven not found")] });
-
-            // Act
-            var result = await LangService.UpdateSnippetsAsync(JavaPackageDir, CancellationToken.None);
->>>>>>> ea577eddf (Implement update code-snippets for Java)
 
             // Assert
             Assert.Multiple(() =>
@@ -366,7 +378,6 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
         }
 
         [Test]
-<<<<<<< HEAD
         public async Task TestLintCodeAsync_NoPomXml_ReturnsError()
         {
             // Arrange
@@ -402,51 +413,11 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
 
             // Act
             var result = await LangService.LintCodeAsync(JavaPackageDir, false, CancellationToken.None);
-=======
-        public async Task TestUpdateSnippetsAsync_NoPomXml_ReturnsError()
-        {
-            // Arrange - Use a temp directory without pom.xml for this test
-            var emptyDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-            Directory.CreateDirectory(emptyDir);
-            
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
-                ((p.Command == "mvn" || p.Command == "cmd.exe") || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
-
-            // Act
-            var result = await LangService.UpdateSnippetsAsync(emptyDir, CancellationToken.None);
-            
-            // Cleanup
-            try { Directory.Delete(emptyDir, true); } catch { }
-
-            // Assert
-            Assert.Multiple(() =>
-            {
-                Assert.That(result.ExitCode, Is.EqualTo(1));
-                Assert.That(result.ResponseError, Does.Contain("No pom.xml found"));
-                Assert.That(result.ResponseError, Does.Contain("This doesn't appear to be a Maven project"));
-            });
-        }
-
-        [Test]
-        public async Task TestUpdateSnippetsAsync_Success()
-        {
-            // Arrange
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
-
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("codesnippet:update-codesnippet")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "BUILD SUCCESS")] });
-
-            // Act
-            var result = await LangService.UpdateSnippetsAsync(JavaPackageDir, CancellationToken.None);
->>>>>>> ea577eddf (Implement update code-snippets for Java)
 
             // Assert
             Assert.Multiple(() =>
             {
                 Assert.That(result.ExitCode, Is.EqualTo(0));
-<<<<<<< HEAD
                 Assert.That(result.CheckStatusDetails, Does.Contain("Code linting passed"));
                 Assert.That(result.CheckStatusDetails, Does.Contain("All tools successful"));
                 Assert.That(result.CheckStatusDetails, Does.Contain("Checkstyle, SpotBugs, RevAPI"));
@@ -587,106 +558,23 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
 
         [Test]
         public async Task TestLintCodeAsync_Exception_ReturnsError()
-=======
-                Assert.That(result.CheckStatusDetails, Is.EqualTo("Code snippets updated successfully"));
-            });
-        }
-
-        [Test]
-        public async Task TestUpdateSnippetsAsync_PluginNotConfigured_ReturnsError()
-        {
-            // Arrange
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
-
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("codesnippet:update-codesnippet")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, "Plugin com.azure.tools:codesnippet-maven-plugin not found")] });
-
-            // Act
-            var result = await LangService.UpdateSnippetsAsync(JavaPackageDir, CancellationToken.None);
-
-            // Assert
-            Assert.Multiple(() =>
-            {
-                Assert.That(result.ExitCode, Is.EqualTo(1));
-                Assert.That(result.ResponseError, Does.Contain("Code snippet update failed"));
-                Assert.That(result.CheckStatusDetails, Does.Contain("Plugin com.azure.tools:codesnippet-maven-plugin not found"));
-            });
-        }
-
-        [Test]
-        public async Task TestUpdateSnippetsAsync_GeneralError_ReturnsGuidance()
-        {
-            // Arrange
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
-
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("codesnippet:update-codesnippet")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, "Build failed with general error")] });
-
-            // Act
-            var result = await LangService.UpdateSnippetsAsync(JavaPackageDir, CancellationToken.None);
-
-            // Assert
-            Assert.Multiple(() =>
-            {
-                Assert.That(result.ExitCode, Is.EqualTo(1));
-                Assert.That(result.ResponseError, Does.Contain("Code snippet update failed"));
-                Assert.That(result.ResponseError, Does.Contain("com.azure.tools:codesnippet-maven-plugin"));
-            });
-        }
-
-        [Test]
-        public async Task TestUpdateSnippetsAsync_WithCodesnippetOutput_ReturnsCodesnippetInfo()
-        {
-            // Arrange
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
-
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("codesnippet:update-codesnippet")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardOutput, "codesnippet plugin error: missing snippets found")] });
-
-            // Act
-            var result = await LangService.UpdateSnippetsAsync(JavaPackageDir, CancellationToken.None);
-
-            // Assert
-            Assert.Multiple(() =>
-            {
-                Assert.That(result.ExitCode, Is.EqualTo(1));
-                Assert.That(result.CheckStatusDetails, Does.Contain("codesnippet plugin error: missing snippets found"));
-                Assert.That(result.ResponseError, Does.Contain("Code snippet update failed"));
-            });
-        }
-
-        [Test]
-        public async Task TestUpdateSnippetsAsync_Exception_ReturnsError()
->>>>>>> ea577eddf (Implement update code-snippets for Java)
         {
             // Arrange
             MockProcessHelper.Setup(x => x.Run(It.IsAny<ProcessOptions>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new InvalidOperationException("Process execution failed"));
 
             // Act
-<<<<<<< HEAD
             var result = await LangService.LintCodeAsync(JavaPackageDir, false, CancellationToken.None);
-=======
-            var result = await LangService.UpdateSnippetsAsync(JavaPackageDir, CancellationToken.None);
->>>>>>> ea577eddf (Implement update code-snippets for Java)
 
             // Assert
             Assert.Multiple(() =>
             {
                 Assert.That(result.ExitCode, Is.EqualTo(1));
-<<<<<<< HEAD
                 Assert.That(result.ResponseError, Does.Contain("Error during code linting: Process execution failed"));
-=======
-                Assert.That(result.ResponseError, Does.Contain("Error during snippet update: Process execution failed"));
->>>>>>> ea577eddf (Implement update code-snippets for Java)
             });
         }
 
         [Test]
-<<<<<<< HEAD
         public async Task TestLintCodeAsync_VerifyCorrectMavenCommands()
         {
             // Arrange
@@ -715,6 +603,131 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
                 It.IsAny<CancellationToken>()), Times.Once);
         }
 
+        #region UpdateSnippetsAsync Tests
+
+        [Test]
+        public async Task TestUpdateSnippetsAsync_MavenNotAvailable_ReturnsError()
+        {
+            // Arrange
+            SetupFailedMavenVersionCheck();
+
+            // Act
+            var result = await LangService.UpdateSnippetsAsync(JavaPackageDir, CancellationToken.None);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(1));
+                Assert.That(result.ResponseError, Does.Contain("Maven is not installed or not available in PATH"));
+            });
+        }
+
+        [Test]
+        public async Task TestUpdateSnippetsAsync_NoPomXml_ReturnsError()
+        {
+            // Arrange
+            var emptyDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(emptyDir);
+            
+            SetupSuccessfulMavenVersionCheck();
+
+            // Act
+            var result = await LangService.UpdateSnippetsAsync(emptyDir, CancellationToken.None);
+            
+            // Cleanup
+            try { Directory.Delete(emptyDir, true); } catch { }
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(1));
+                Assert.That(result.ResponseError, Does.Contain("No pom.xml found"));
+                Assert.That(result.ResponseError, Does.Contain("This doesn't appear to be a Maven project"));
+            });
+        }
+
+        [Test]
+        public async Task TestUpdateSnippetsAsync_Success()
+        {
+            // Arrange
+            SetupSuccessfulMavenVersionCheck();
+            SetupSuccessfulSnippetUpdate();
+
+            // Act
+            var result = await LangService.UpdateSnippetsAsync(JavaPackageDir, CancellationToken.None);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(0));
+                Assert.That(result.CheckStatusDetails, Is.EqualTo("Code snippets updated successfully"));
+            });
+        }
+
+        [Test]
+        public async Task TestUpdateSnippetsAsync_Failure()
+        {
+            // Arrange
+            SetupSuccessfulMavenVersionCheck();
+            SetupFailedSnippetUpdate();
+
+            // Act
+            var result = await LangService.UpdateSnippetsAsync(JavaPackageDir, CancellationToken.None);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(1));
+                Assert.That(result.ResponseError, Does.Contain("Code snippet update failed"));
+                Assert.That(result.NextSteps, Is.Not.Null);
+                Assert.That(result.NextSteps, Has.Count.EqualTo(1));
+                Assert.That(result.NextSteps![0], Does.Contain("codesnippet-maven-plugin"));
+            });
+        }
+
+        [Test]
+        public async Task TestUpdateSnippetsAsync_ExceptionHandling()
+        {
+            // Arrange
+            MockProcessHelper.Setup(x => x.Run(It.IsAny<ProcessOptions>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("Process execution failed"));
+
+            // Act
+            var result = await LangService.UpdateSnippetsAsync(JavaPackageDir, CancellationToken.None);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(1));
+                Assert.That(result.ResponseError, Does.Contain("Error during code snippet update: Process execution failed"));
+            });
+        }
+
+        [Test]
+        public async Task TestUpdateSnippetsAsync_VerifyCorrectMavenCommand()
+        {
+            // Arrange
+            var pomPath = Path.Combine(JavaPackageDir, "pom.xml");
+            SetupSuccessfulMavenVersionCheck();
+            SetupSuccessfulSnippetUpdate();
+
+            // Act
+            await LangService.UpdateSnippetsAsync(JavaPackageDir, CancellationToken.None);
+
+            // Assert - verify the correct Maven command was called with -am flag
+            MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" || p.Command == "cmd.exe") &&
+                p.Args.Any(arg => arg.Contains("codesnippet-maven-plugin:update-snippets")) &&
+                p.Args.Contains("-am") &&
+                p.Args.Contains("-f") &&
+                p.Args.Contains(pomPath) &&
+                p.WorkingDirectory == JavaPackageDir &&
+                p.Timeout == TimeSpan.FromMinutes(5)), 
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        #endregion
+
         #region Helper Methods for Cross-Platform Command Validation
 
         /// <summary>
@@ -724,71 +737,6 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
         private static bool IsMavenVersionCheck(ProcessOptions options) =>
             (options.Command == "mvn" && options.Args.Contains("--version")) ||
             (options.Command == "cmd.exe" && options.Args.Contains("mvn") && options.Args.Contains("--version"));
-
-        /// <summary>
-        /// Checks if the ProcessOptions represents a Checkstyle command.
-        /// Handles both Unix and Windows patterns.
-        /// </summary>
-        private static bool IsCheckstyleCommand(ProcessOptions options) =>
-            (options.Command == "mvn" && options.Args.Contains("checkstyle:check")) ||
-            (options.Command == "cmd.exe" && options.Args.Contains("mvn") && options.Args.Contains("checkstyle:check"));
-
-        /// <summary>
-        /// Checks if the ProcessOptions represents a SpotBugs command.
-        /// Handles both Unix and Windows patterns.
-        /// </summary>
-        private static bool IsSpotBugsCommand(ProcessOptions options) =>
-            (options.Command == "mvn" && options.Args.Contains("spotbugs:check")) ||
-            (options.Command == "cmd.exe" && options.Args.Contains("mvn") && options.Args.Contains("spotbugs:check"));
-
-        /// <summary>
-        /// Checks if the ProcessOptions represents a RevAPI command.
-        /// Handles both Unix and Windows patterns.
-        /// </summary>
-        private static bool IsRevAPICommand(ProcessOptions options) =>
-            (options.Command == "mvn" && options.Args.Contains("revapi:check")) ||
-            (options.Command == "cmd.exe" && options.Args.Contains("mvn") && options.Args.Contains("revapi:check"));
-
-        /// <summary>
-        /// Checks if the ProcessOptions represents a Checkstyle command with fix parameters.
-        /// Handles both Unix (mvn) and Windows (cmd.exe /C mvn) patterns.
-        /// </summary>
-        private static bool IsCheckstyleFixCommand(ProcessOptions options)
-        {
-            if (IsCheckstyleCommand(options))
-            {
-                return options.Args.Any(arg => arg.Contains("-Dcheckstyle.failOnViolation=false")) &&
-                       options.Args.Any(arg => arg.Contains("-Dcheckstyle.failsOnError=false"));
-            }
-            return false;
-        }
-
-        /// <summary>
-        /// Checks if the ProcessOptions represents a SpotBugs command with fix parameters.
-        /// Handles both Unix (mvn) and Windows (cmd.exe /C mvn) patterns.
-        /// </summary>
-        private static bool IsSpotBugsFixCommand(ProcessOptions options)
-        {
-            if (IsSpotBugsCommand(options))
-            {
-                return options.Args.Any(arg => arg.Contains("-Dspotbugs.failOnError=false"));
-            }
-            return false;
-        }
-
-        /// <summary>
-        /// Checks if the ProcessOptions represents a RevAPI command with fix parameters.
-        /// Handles both Unix (mvn) and Windows (cmd.exe /C mvn) patterns.
-        /// </summary>
-        private static bool IsRevAPIFixCommand(ProcessOptions options)
-        {
-            if (IsRevAPICommand(options))
-            {
-                return options.Args.Any(arg => arg.Contains("-Drevapi.failOnViolation=false")) &&
-                       options.Args.Any(arg => arg.Contains("-Drevapi.failsOnError=false"));
-            }
-            return false;
-        }
 
         /// <summary>
         /// Checks if the ProcessOptions represents a Maven install command (Azure SDK approach).
@@ -803,31 +751,5 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
         #endregion
 
         #endregion
-=======
-        public async Task TestUpdateSnippetsAsync_VerifyCorrectMavenCommand()
-        {
-            // Arrange
-            var pomPath = Path.Combine(JavaPackageDir, "pom.xml");
-            
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
-
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("codesnippet:update-codesnippet")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "BUILD SUCCESS")] });
-
-            // Act
-            await LangService.UpdateSnippetsAsync(JavaPackageDir, CancellationToken.None);
-
-            // Assert - verify the correct Maven command was called
-            MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => 
-                (p.Command == "mvn" || p.Command == "cmd.exe") &&
-                p.Args.Contains("codesnippet:update-codesnippet") &&
-                p.Args.Contains("-f") &&
-                p.Args.Contains(pomPath) &&
-                p.WorkingDirectory == JavaPackageDir &&
-                p.Timeout == TimeSpan.FromMinutes(10)), 
-                It.IsAny<CancellationToken>()), Times.Once);
-        }
->>>>>>> ea577eddf (Implement update code-snippets for Java)
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/JavaLanguageSpecificChecksTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/JavaLanguageSpecificChecksTests.cs
@@ -149,6 +149,43 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
                 .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, "Codesnippet update failed")] });
         }
 
+        /// <summary>
+        /// Sets up successful Maven javadoc command.
+        /// </summary>
+        private void SetupSuccessfulJavadoc()
+        {
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" || p.Command == "cmd.exe") && 
+                p.Args.Contains("javadoc:jar")), 
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { 
+                    ExitCode = 0, 
+                    OutputDetails = [(StdioLevel.StandardOutput, 
+                        "[INFO] Building jar: /path/to/target/test-1.0-javadoc.jar\n" +
+                        "[INFO] BUILD SUCCESS"
+                    )] 
+                });
+        }
+
+        /// <summary>
+        /// Sets up failed Maven javadoc command.
+        /// </summary>
+        private void SetupFailedJavadoc()
+        {
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" || p.Command == "cmd.exe") && 
+                p.Args.Contains("javadoc:jar")), 
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { 
+                    ExitCode = 1, 
+                    OutputDetails = [(StdioLevel.StandardError, 
+                        "[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.4.1:jar (default) on project test: MavenReportException: Error while generating Javadoc:\n" +
+                        "[ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.\n" +
+                        "[ERROR] Command line was: /usr/lib/jvm/java-11-openjdk/bin/javadoc @options @packages"
+                    )] 
+                });
+        }
+
         #endregion
         
         [Test]
@@ -410,6 +447,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
             // Arrange
             SetupSuccessfulMavenVersionCheck();
             SetupSuccessfulMavenInstall();
+            SetupSuccessfulJavadoc();
 
             // Act
             var result = await LangService.LintCodeAsync(JavaPackageDir, false, CancellationToken.None);
@@ -420,12 +458,13 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
                 Assert.That(result.ExitCode, Is.EqualTo(0));
                 Assert.That(result.CheckStatusDetails, Does.Contain("Code linting passed"));
                 Assert.That(result.CheckStatusDetails, Does.Contain("All tools successful"));
-                Assert.That(result.CheckStatusDetails, Does.Contain("Checkstyle, SpotBugs, RevAPI"));
+                Assert.That(result.CheckStatusDetails, Does.Contain("Checkstyle, SpotBugs, RevAPI, Javadoc"));
             });
 
             // Verify Maven commands were called correctly
             MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => IsMavenVersionCheck(p)), It.IsAny<CancellationToken>()), Times.Once);
             MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => IsMavenInstallCommand(p)), It.IsAny<CancellationToken>()), Times.Once);
+            MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => IsJavadocCommand(p)), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Test]
@@ -435,16 +474,18 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
             SetupSuccessfulMavenVersionCheck();
             var checkstyleErrorOutput = "[ERROR] Failed to execute goal com.puppycrawl.tools:checkstyle:9.3:check (default) on project test: You have 5 Checkstyle violations.";
             SetupMavenInstallWithToolErrors(checkstyleErrorOutput);
+            SetupSuccessfulJavadoc(); // Javadoc succeeds, but Checkstyle fails
 
             // Act
             var result = await LangService.LintCodeAsync(JavaPackageDir, false, CancellationToken.None);
 
-            // Assert - Azure SDK approach: Maven install failed with Checkstyle errors
+            // Assert - Azure SDK approach: Maven install failed with Checkstyle errors, but javadoc passed
             Assert.Multiple(() =>
             {
                 Assert.That(result.ExitCode, Is.EqualTo(1));
                 Assert.That(result.ResponseError, Does.Contain("Code linting found issues"));
                 Assert.That(result.ResponseError, Does.Contain("Checkstyle"));
+                Assert.That(result.ResponseError, Does.Contain("Clean tools: SpotBugs, RevAPI, Javadoc"));
                 Assert.That(result.CheckStatusDetails, Does.Contain("checkstyle"));
                 Assert.That(result.NextSteps, Is.Not.Null);
                 Assert.That(result.NextSteps, Has.Count.GreaterThan(0));
@@ -454,6 +495,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
             // Verify Maven commands were called correctly
             MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => IsMavenVersionCheck(p)), It.IsAny<CancellationToken>()), Times.Once);
             MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => IsMavenInstallCommand(p)), It.IsAny<CancellationToken>()), Times.Once);
+            MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => IsJavadocCommand(p)), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Test]
@@ -478,6 +520,11 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
                                         "[ERROR] Failed to execute goal org.revapi:revapi-maven-plugin:0.15.1:check (default) on project test: API problems detected";
                         return new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, errorOutput)] };
                     }
+                    if (IsJavadocCommand(options))
+                    {
+                        var javadocError = "[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.4.1:jar (default) on project test: MavenReportException: Error while generating Javadoc";
+                        return new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, javadocError)] };
+                    }
                     
                     return new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, "Unknown command")] };
                 });
@@ -485,26 +532,30 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
             // Act
             var result = await LangService.LintCodeAsync(JavaPackageDir, false, CancellationToken.None);
 
-            // Assert - Azure SDK approach: All tools failed in single Maven install command  
+            // Assert - Azure SDK approach: All tools failed (Maven install command + javadoc)
             Assert.Multiple(() =>
             {
                 Assert.That(result.ExitCode, Is.EqualTo(1));
                 Assert.That(result.ResponseError, Does.Contain("Code linting found issues"));
-                Assert.That(result.ResponseError, Does.Contain("Checkstyle, SpotBugs, RevAPI"));
+                Assert.That(result.ResponseError, Does.Contain("Checkstyle, SpotBugs, RevAPI, Javadoc"));
                 Assert.That(result.CheckStatusDetails, Does.Contain("checkstyle"));
                 Assert.That(result.CheckStatusDetails, Does.Contain("spotbugs-maven-plugin"));
                 Assert.That(result.CheckStatusDetails, Does.Contain("revapi-maven-plugin"));
+                Assert.That(result.CheckStatusDetails, Does.Contain("--- Javadoc Validation ---"));
+                Assert.That(result.CheckStatusDetails, Does.Contain("maven-javadoc-plugin"));
                 Assert.That(result.NextSteps, Is.Not.Null);
                 Assert.That(result.NextSteps, Has.Count.GreaterThan(0));
                 Assert.That(result.NextSteps!.Any(step => step.Contains("Checkstyle")), Is.True);
                 Assert.That(result.NextSteps!.Any(step => step.Contains("SpotBugs")), Is.True);
                 Assert.That(result.NextSteps!.Any(step => step.Contains("RevAPI")), Is.True);
+                Assert.That(result.NextSteps!.Any(step => step.Contains("Javadoc")), Is.True);
             });
 
-            // Verify captured commands - Azure SDK approach uses single install
-            Assert.That(capturedOptions, Has.Count.EqualTo(2)); // Maven version + install command
+            // Verify captured commands - Azure SDK approach uses install + javadoc commands
+            Assert.That(capturedOptions, Has.Count.EqualTo(3)); // Maven version + install + javadoc commands
             Assert.That(capturedOptions.Any(IsMavenVersionCheck), Is.True, "Maven version check should be called");
             Assert.That(capturedOptions.Any(IsMavenInstallCommand), Is.True, "Maven install should be called");
+            Assert.That(capturedOptions.Any(IsJavadocCommand), Is.True, "Javadoc command should be called");
         }
 
         [Test]
@@ -532,6 +583,10 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
                         }
                         return new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, "Missing fix parameter")] };
                     }
+                    if (IsJavadocCommand(options))
+                    {
+                        return new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "[INFO] Building jar: /path/to/target/test-1.0-javadoc.jar")] };
+                    }
                     
                     return new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, "Unknown command")] };
                 });
@@ -540,9 +595,10 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
             await LangService.LintCodeAsync(JavaPackageDir, true, CancellationToken.None);
 
             // Assert - verify the Maven install command was called with fix parameters
-            Assert.That(capturedOptions, Has.Count.EqualTo(2)); // Maven version + install command
+            Assert.That(capturedOptions, Has.Count.EqualTo(3)); // Maven version + install + javadoc commands
             Assert.That(capturedOptions.Any(IsMavenVersionCheck), Is.True, "Maven version check should be called");
             Assert.That(capturedOptions.Any(IsMavenInstallCommand), Is.True, "Maven install should be called");
+            Assert.That(capturedOptions.Any(IsJavadocCommand), Is.True, "Javadoc command should be called");
             
             // Verify the install command includes the correct RevAPI fix parameter
             var installCommand = capturedOptions.FirstOrDefault(IsMavenInstallCommand);
@@ -596,6 +652,93 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
                 p.Args.Contains("-Dcodesnippet.skip=true") &&
                 p.Args.Contains("-Dspotless.apply.skip=true") &&
                 p.Args.Contains("-am") &&
+                p.Args.Contains("-f") &&
+                p.Args.Contains(pomPath) &&
+                p.WorkingDirectory == JavaPackageDir &&
+                p.Timeout == TimeSpan.FromMinutes(15)), 
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public async Task TestLintCodeAsync_JavadocFails_ReturnsError()
+        {
+            // Arrange
+            SetupSuccessfulMavenVersionCheck();
+            SetupSuccessfulMavenInstall();
+            SetupFailedJavadoc();
+
+            // Act
+            var result = await LangService.LintCodeAsync(JavaPackageDir, false, CancellationToken.None);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(1));
+                Assert.That(result.ResponseError, Does.Contain("Code linting found issues"));
+                Assert.That(result.ResponseError, Does.Contain("Javadoc"));
+                Assert.That(result.CheckStatusDetails, Does.Contain("--- Javadoc Validation ---"));
+                Assert.That(result.CheckStatusDetails, Does.Contain("maven-javadoc-plugin"));
+                Assert.That(result.NextSteps, Is.Not.Null);
+                Assert.That(result.NextSteps!.Any(step => step.Contains("Javadoc")), Is.True);
+                Assert.That(result.NextSteps!.Any(step => step.Contains("javadoc comments")), Is.True);
+            });
+
+            // Verify Maven commands were called correctly
+            MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => IsMavenVersionCheck(p)), It.IsAny<CancellationToken>()), Times.Once);
+            MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => IsMavenInstallCommand(p)), It.IsAny<CancellationToken>()), Times.Once);
+            MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => IsJavadocCommand(p)), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public async Task TestLintCodeAsync_CheckstyleAndJavadocFail_ReturnsError()
+        {
+            // Arrange
+            SetupSuccessfulMavenVersionCheck();
+            var checkstyleErrorOutput = "[ERROR] Failed to execute goal com.puppycrawl.tools:checkstyle:9.3:check (default) on project test: You have 5 Checkstyle violations.";
+            SetupMavenInstallWithToolErrors(checkstyleErrorOutput);
+            SetupFailedJavadoc();
+
+            // Act
+            var result = await LangService.LintCodeAsync(JavaPackageDir, false, CancellationToken.None);
+
+            // Assert - Both Checkstyle and Javadoc should report issues
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(1));
+                Assert.That(result.ResponseError, Does.Contain("Code linting found issues"));
+                Assert.That(result.ResponseError, Does.Contain("Checkstyle, Javadoc"));
+                Assert.That(result.CheckStatusDetails, Does.Contain("checkstyle"));
+                Assert.That(result.CheckStatusDetails, Does.Contain("--- Javadoc Validation ---"));
+                Assert.That(result.CheckStatusDetails, Does.Contain("maven-javadoc-plugin"));
+                Assert.That(result.NextSteps, Is.Not.Null);
+                Assert.That(result.NextSteps!.Any(step => step.Contains("Checkstyle")), Is.True);
+                Assert.That(result.NextSteps!.Any(step => step.Contains("Javadoc")), Is.True);
+                Assert.That(result.NextSteps!.Any(step => step.Contains("-Dmaven.javadoc.skip=true")), Is.True);
+            });
+
+            // Verify Maven commands were called correctly
+            MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => IsMavenVersionCheck(p)), It.IsAny<CancellationToken>()), Times.Once);
+            MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => IsMavenInstallCommand(p)), It.IsAny<CancellationToken>()), Times.Once);
+            MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => IsJavadocCommand(p)), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public async Task TestLintCodeAsync_JavadocCommandParameters_AreCorrect()
+        {
+            // Arrange
+            SetupSuccessfulMavenVersionCheck();
+            SetupSuccessfulMavenInstall();
+            SetupSuccessfulJavadoc();
+
+            // Act
+            await LangService.LintCodeAsync(JavaPackageDir, false, CancellationToken.None);
+
+            // Assert - verify the javadoc command was called with correct parameters
+            var pomPath = Path.Combine(JavaPackageDir, "pom.xml");
+            MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" || p.Command == "cmd.exe") &&
+                p.Args.Contains("--no-transfer-progress") &&
+                p.Args.Contains("javadoc:jar") &&
                 p.Args.Contains("-f") &&
                 p.Args.Contains(pomPath) &&
                 p.WorkingDirectory == JavaPackageDir &&
@@ -717,8 +860,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
             // Assert - verify the correct Maven command was called with -am flag
             MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => 
                 (p.Command == "mvn" || p.Command == "cmd.exe") &&
-                p.Args.Any(arg => arg.Contains("codesnippet-maven-plugin:update-snippets")) &&
-                p.Args.Contains("-am") &&
+                p.Args.Any(arg => arg.Contains("com.azure.tools:codesnippet-maven-plugin:update-codesnippet")) &&
                 p.Args.Contains("-f") &&
                 p.Args.Contains(pomPath) &&
                 p.WorkingDirectory == JavaPackageDir &&
@@ -746,6 +888,16 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
         {
             return (options.Command == "mvn" && options.Args.Contains("install")) ||
                    (options.Command == "cmd.exe" && options.Args.Contains("mvn") && options.Args.Contains("install"));
+        }
+
+        /// <summary>
+        /// Checks if the ProcessOptions represents a Maven javadoc command.
+        /// Handles both Unix (mvn) and Windows (cmd.exe /C mvn) patterns.
+        /// </summary>
+        private static bool IsJavadocCommand(ProcessOptions options)
+        {
+            return (options.Command == "mvn" && options.Args.Contains("javadoc:jar")) ||
+                   (options.Command == "cmd.exe" && options.Args.Contains("mvn") && options.Args.Contains("javadoc:jar"));
         }
 
         #endregion

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/JavaLanguageSpecificChecks.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/JavaLanguageSpecificChecks.cs
@@ -4,19 +4,6 @@ using Azure.Sdk.Tools.Cli.Helpers;
 namespace Azure.Sdk.Tools.Cli.Services;
 
 /// <summary>
-/// Configuration for a Maven operation execution.
-/// </summary>
-internal record JavaMavenOperation
-{
-    public required string OperationName { get; init; }
-    public required string Goal { get; init; }
-    public required string SuccessMessage { get; init; }
-    public required string ErrorMessage { get; init; }
-    public required string OutputKeyword { get; init; }
-    public required string Guidance { get; init; }
-}
-
-/// <summary>
 /// Java-specific implementation of language repository service.
 /// Uses tools like Maven, Gradle, javac, etc. for Java development workflows.
 /// </summary>
@@ -28,6 +15,7 @@ public class JavaLanguageSpecificChecks : ILanguageSpecificChecks
     // Maven operation timeouts
     private static readonly TimeSpan MavenFormatTimeout = TimeSpan.FromMinutes(10);
     private static readonly TimeSpan MavenLintTimeout = TimeSpan.FromMinutes(15);
+    private static readonly TimeSpan MavenSnippetTimeout = TimeSpan.FromMinutes(5);
 
     // Common NextSteps messages
     private static readonly string[] mavenInstallationNextSteps = [
@@ -57,79 +45,34 @@ public class JavaLanguageSpecificChecks : ILanguageSpecificChecks
 
     public async Task<CLICheckResponse> FormatCodeAsync(string packagePath, bool fix = false, CancellationToken cancellationToken = default)
     {
-        var operation = new JavaMavenOperation
-        {
-            OperationName = "code formatting",
-            Goal = fix ? "spotless:apply" : "spotless:check",
-            SuccessMessage = fix ? "Code formatting applied successfully" : "Code formatting check passed - all files are properly formatted",
-            ErrorMessage = fix ? "Code formatting failed to apply" : "Code formatting check failed - some files need formatting",
-            OutputKeyword = "spotless",
-            Guidance = fix ? 
-                "Run 'mvn spotless:apply' to automatically format code, or check if spotless-maven-plugin is configured in the pom.xml" :
-                "Run 'mvn spotless:apply' to fix formatting issues, or use --fix flag with this command"
-        };
-
-        return await ExecuteMavenOperationAsync(packagePath, operation, cancellationToken);
-    }
-
-    public async Task<CLICheckResponse> UpdateSnippetsAsync(string packagePath, CancellationToken cancellationToken = default)
-    {
-        var operation = new JavaMavenOperation
-        {
-            OperationName = "snippet update",
-            Goal = "codesnippet:update-codesnippet",
-            SuccessMessage = "Code snippets updated successfully",
-            ErrorMessage = "Code snippet update failed",
-            OutputKeyword = "codesnippet",
-            Guidance = "Check if com.azure.tools:codesnippet-maven-plugin is configured in the pom.xml. " +
-                      "The plugin should be available for snippet processing in Azure SDK for Java projects."
-        };
-
-        return await ExecuteMavenOperationAsync(packagePath, operation, cancellationToken);
-    }
-
-    /// <summary>
-    /// Executes a Maven operation with shared logic for Maven availability check, 
-    /// pom.xml discovery, command execution, and error handling.
-    /// </summary>
-    /// <param name="packagePath">Path to the package directory</param>
-    /// <param name="operation">Configuration for the Maven operation</param>
-    /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>Result of the Maven operation</returns>
-    private async Task<CLICheckResponse> ExecuteMavenOperationAsync(string packagePath, JavaMavenOperation operation, CancellationToken cancellationToken)
-    {
         try
         {
-            _logger.LogInformation("Starting {OperationName} for Java project at: {PackagePath}", operation.OperationName, packagePath);
+            _logger.LogInformation("Starting code formatting for Java project at: {PackagePath}", packagePath);
 
             // Validate Maven and POM prerequisites
             var pomPath = Path.Combine(packagePath, "pom.xml");
             var prerequisiteCheck = await ValidateMavenPrerequisitesAsync(packagePath, pomPath, cancellationToken);
             if (prerequisiteCheck != null)
             {
-<<<<<<< HEAD
                 return prerequisiteCheck;
-=======
-                _logger.LogError("Maven is not installed or not available in PATH");
-                return new CLICheckResponse(1, "", $"Maven is not installed or not available in PATH. Please install Maven to use {operation.OperationName} functionality.");
->>>>>>> ea577eddf (Implement update code-snippets for Java)
             }
 
 
-            // Execute the Maven goal
+            // Determine the Maven goal based on fix parameter
+            var goal = fix ? "spotless:apply" : "spotless:check";
             var command = "mvn";
-            var args = new[] { operation.Goal, "-f", pomPath };
+            var args = new[] { goal, "-f", pomPath };
 
             var result = await _processHelper.Run(new(command, args, workingDirectory: packagePath, timeout: MavenFormatTimeout), cancellationToken);
 
             if (result.ExitCode == 0)
             {
-                _logger.LogInformation(operation.SuccessMessage);
-                return new CLICheckResponse(result.ExitCode, operation.SuccessMessage);
+                var message = fix ? "Code formatting applied successfully" : "Code formatting check passed - all files are properly formatted";
+                _logger.LogInformation(message);
+                return new CLICheckResponse(result.ExitCode, message);
             }
             else
             {
-<<<<<<< HEAD
                 var errorMessage = fix ? "Code formatting failed to apply" : "Code formatting check failed - some files need formatting";
                 _logger.LogWarning("{ErrorMessage} with exit code {ExitCode}", errorMessage, result.ExitCode);
 
@@ -142,27 +85,10 @@ public class JavaLanguageSpecificChecks : ILanguageSpecificChecks
                 {
                     NextSteps = [nextSteps]
                 };
-=======
-                _logger.LogWarning("{ErrorMessage} with exit code {ExitCode}", operation.ErrorMessage, result.ExitCode);
-                
-                // Extract useful error information from output
-                var output = result.Output;
-                if (output.Contains(operation.OutputKeyword))
-                {
-                    // If the output contains operation-specific information, include it
-                    return new CLICheckResponse(result.ExitCode, output, operation.ErrorMessage);
-                }
-                else
-                {
-                    // Provide helpful guidance
-                    return new CLICheckResponse(result.ExitCode, output, $"{operation.ErrorMessage}. {operation.Guidance}");
-                }
->>>>>>> ea577eddf (Implement update code-snippets for Java)
             }
         }
         catch (Exception ex)
         {
-<<<<<<< HEAD
             _logger.LogError(ex, "Error during code formatting for Java project at: {PackagePath}", packagePath);
             return new CLICheckResponse(1, "", $"Error during code formatting: {ex.Message}")
             {
@@ -267,10 +193,6 @@ public class JavaLanguageSpecificChecks : ILanguageSpecificChecks
             {
                 NextSteps = [.. exceptionHandlingNextSteps, "Verify that the project's pom.xml is valid and contains required linting plugins"]
             };
-=======
-            _logger.LogError(ex, "Error during {OperationName} for Java project at: {PackagePath}", operation.OperationName, packagePath);
-            return new CLICheckResponse(1, "", $"Error during {operation.OperationName}: {ex.Message}");
->>>>>>> ea577eddf (Implement update code-snippets for Java)
         }
     }
 
@@ -324,6 +246,55 @@ public class JavaLanguageSpecificChecks : ILanguageSpecificChecks
             checkstyleRan, checkstyleHasIssues, spotbugsRan, spotbugsHasIssues, revapiRan, revapiHasIssues);
 
         return results;
+    }
+
+    public async Task<CLICheckResponse> UpdateSnippetsAsync(string packagePath, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            _logger.LogInformation("Starting code snippet update for Java project at: {PackagePath}", packagePath);
+
+            // Validate Maven and POM prerequisites
+            var pomPath = Path.Combine(packagePath, "pom.xml");
+            var prerequisiteCheck = await ValidateMavenPrerequisitesAsync(packagePath, pomPath, cancellationToken);
+            if (prerequisiteCheck != null)
+            {
+                return prerequisiteCheck;
+            }
+
+            // Use Azure SDK approach: mvn codesnippet:update-codesnippet with --no-transfer-progress
+            // This matches the Azure SDK for Java pipeline approach as seen in Compare-CurrentToCodegeneration.ps1
+            var command = Environment.OSVersion.Platform == PlatformID.Win32NT ? "cmd.exe" : "mvn";
+            var args = Environment.OSVersion.Platform == PlatformID.Win32NT 
+                ? new[] { "/C", "mvn", "--no-transfer-progress", "com.azure.tools:codesnippet-maven-plugin:update-snippets", "-am", "-f", pomPath }
+                : new[] { "--no-transfer-progress", "com.azure.tools:codesnippet-maven-plugin:update-snippets", "-am", "-f", pomPath };
+
+            var result = await _processHelper.Run(new(command, args, workingDirectory: packagePath, timeout: MavenSnippetTimeout), cancellationToken);
+
+            if (result.ExitCode == 0)
+            {
+                _logger.LogInformation("Code snippets updated successfully");
+                return new CLICheckResponse(result.ExitCode, "Code snippets updated successfully");
+            }
+            else
+            {
+                _logger.LogWarning("Code snippet update failed with exit code {ExitCode}", result.ExitCode);
+
+                var output = result.Output;
+                return new CLICheckResponse(result.ExitCode, output, "Code snippet update failed - some snippets may be outdated or missing")
+                {
+                    NextSteps = ["Ensure that code snippets in documentation match the actual code implementation, or check if codesnippet-maven-plugin is configured in the pom.xml"]
+                };
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during code snippet update for Java project at: {PackagePath}", packagePath);
+            return new CLICheckResponse(1, "", $"Error during code snippet update: {ex.Message}")
+            {
+                NextSteps = [.. exceptionHandlingNextSteps]
+            };
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Implemented `UpdateSnippetsAsync ` method in `JavaLanguageSpecificChecks.cs` that:

- Checks for Maven availability using `mvn --version`
- Uses codesnippet:update-codesnippet goal from `com.azure.tools:codesnippet-maven-plugin`
- Executes `mvn codesnippet:update-codesnippet -f <pomPath>`
- Provides comprehensive error handling and logging
- Returns appropriate CLICheckResponse with exit codes and messages

Added Javadoc Validation Step: Following the Azure SDK for Java pipeline pattern, I added a separate mvn javadoc:jar command that runs after the main linting step.

<img width="500" height="897" alt="image" src="https://github.com/user-attachments/assets/47941683-fff0-4a1e-b9c2-166ed96fed3c" />
