### PR TITLE
Add override for BuildPrompt in BasePromptTemplate

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/BasePromptTemplate.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/BasePromptTemplate.cs
@@ -16,6 +16,13 @@ public abstract class BasePromptTemplate
     public abstract string Description { get; }
 
     /// <summary>
+    /// Builds the complete prompt using the configured parameters.
+    /// This method must be implemented by derived classes to provide their specific prompt building logic.
+    /// </summary>
+    /// <returns>Complete structured prompt</returns>
+    public abstract string BuildPrompt();
+
+    /// <summary>
     /// Builds a complete prompt with safety guidelines and structured sections.
     /// </summary>
     protected string BuildStructuredPrompt(string taskInstructions, string? constraints = null, string? examples = null, string? outputRequirements = null)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/ReadMeGenerationTemplate.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/ReadMeGenerationTemplate.cs
@@ -37,7 +37,7 @@ public class ReadMeGenerationTemplate : BasePromptTemplate
     /// Builds the complete README generation prompt using the configured parameters.
     /// </summary>
     /// <returns>Complete structured prompt for README generation</returns>
-    public string BuildPrompt()
+    public override string BuildPrompt()
     {
         var taskInstructions = BuildTaskInstructions(_templateContent, _serviceDocumentation, _packagePath);
         var constraints = BuildTaskConstraints(_additionalRules);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/SpellingValidationTemplate.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/SpellingValidationTemplate.cs
@@ -34,7 +34,7 @@ public class SpellingValidationTemplate : BasePromptTemplate
     /// Builds the complete spelling validation prompt using the configured parameters.
     /// </summary>
     /// <returns>Complete structured prompt for spelling validation</returns>
-    public string BuildPrompt()
+    public override string BuildPrompt()
     {
         var taskInstructions = BuildTaskInstructions(_cspellOutput, _repositoryContext);
         var constraints = BuildTaskConstraints(_additionalRules);

--- a/tools/azsdk-cli/docs/new-tool.md
+++ b/tools/azsdk-cli/docs/new-tool.md
@@ -417,7 +417,7 @@ public class MyCustomTemplate : BasePromptTemplate
     /// <param name="inputData">The data to analyze</param>
     /// <param name="analysisType">Type of analysis to perform</param>
     /// <returns>Complete structured prompt for custom analysis</returns>
-    public string BuildPrompt(string inputData, string analysisType = "general")
+    public override string BuildPrompt(string inputData, string analysisType = "general")
     {
         var taskInstructions = $"""
         You are a data analysis assistant.


### PR DESCRIPTION
Make [BuildPrompt()] an abstract method in [BasePromptTemplate] that derived classes must override. This ensure that every prompt template class must implement a [BuildPrompt] method and that it properly integrates with the base class's [BuildStructuredPrompt] method for consistency and safety.