### PR TITLE
[AVC] Do not expose `openapi.json`

### DIFF
--- a/packages/python-packages/apiview-copilot/app.py
+++ b/packages/python-packages/apiview-copilot/app.py
@@ -35,7 +35,7 @@ JOB_RETENTION_SECONDS = 1800  # 30 minutes
 db_manager = get_database_manager()
 settings = SettingsManager()
 
-app = FastAPI()
+app = FastAPI(openapi_url=None, docs_url=None, redoc_url=None)
 
 logger = logging.getLogger("uvicorn")  # Use Uvicorn's logger
 


### PR DESCRIPTION
See ICM ticket
https://portal.microsofticm.com/imp/v5/incidents/details/696023874/summary

Ensures that FastAPI does not expose openapi.json to comply with Liberty Shield security initiative.