### PR TITLE
Ensure that `ApiChangeDetectRequestUrl` always resolves

### DIFF
--- a/eng/common/pipelines/templates/steps/detect-api-changes.yml
+++ b/eng/common/pipelines/templates/steps/detect-api-changes.yml
@@ -10,7 +10,7 @@ steps:
         $apiChangeDetectRequestUrl = "https://apiview.dev/api/PullRequests/CreateAPIRevisionIfAPIHasChanges"
         echo "##vso[task.setvariable variable=ApiChangeDetectRequestUrl]$apiChangeDetectRequestUrl"
       displayName: "Set API change detect request URL"
-      condition: and(succeeded(), ${{ parameters.Condition}}, eq(variables['ApiChangeDetectRequestUrl'], ''))
+      condition: and(succeededOrFailed(), ${{ parameters.Condition}}, eq(variables['ApiChangeDetectRequestUrl'], ''))
 
     - task: Powershell@2
       inputs:


### PR DESCRIPTION
Missing `succeedOrFailed()`.

[Failing PR build showing this behavior](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5437288&view=logs&j=36df4387-3551-57fa-098c-b43a23930261&t=1532432e-9592-58b1-a69e-cd86555042c3&l=120)
[Context conversation](https://teams.microsoft.com/l/message/19:b97d98e6d22c41e0970a1150b484d935@thread.skype/1760120399777?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1760120399777&teamName=Azure%20SDK&channelName=Language%20-%20Python&createdTime=1760120399777)
