### PR TITLE
Revise tsp-client usage instructions in README

### DIFF
--- a/eng/common/tsp-client/README.md
+++ b/eng/common/tsp-client/README.md
@@ -25,7 +25,8 @@ npm ci
 
 ## Usage
 
-After installation, you can run tsp-client using `npm exec --prefix` from the root directory of your SDK repository.
+After installation, you can run `tsp-client` using `npm exec --prefix {path_to_the_eng/common/tsp-client}`. 
+Note that you should *not* navigate into the `eng/common/tsp-client` folder, since several `tsp-client` commands require the current working directory to be the client library's root.
 
 ```bash
 # Set the tsp-client directory path relative to your current working directory


### PR DESCRIPTION
Updated usage instructions to use `npm exec --prefix` for running tsp-client commands. The reason is `tsp-client` requires the working directory to be the root folder of SDK repository.