### PR TITLE
Add support for linting Java code

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/JavaLanguageSpecificChecksTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/JavaLanguageSpecificChecksTests.cs
@@ -361,17 +361,23 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
             
             var emptyDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(emptyDir);
-            try { Directory.Delete(emptyDir, true); } catch { }
 
-            // Act
-            var result = await LangService.LintCodeAsync(emptyDir, false, CancellationToken.None);
-
-            // Assert
-            Assert.Multiple(() =>
+            try
             {
-                Assert.That(result.ExitCode, Is.EqualTo(1));
-                Assert.That(result.ResponseError, Does.Contain("No pom.xml found"));
-            });
+                // Act
+                var result = await LangService.LintCodeAsync(emptyDir, false, CancellationToken.None);
+
+                // Assert
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result.ExitCode, Is.EqualTo(1));
+                    Assert.That(result.ResponseError, Does.Contain("No pom.xml found"));
+                });
+            }
+            finally
+            {
+                try { Directory.Delete(emptyDir, true); } catch { }
+            }
         }
 
         [Test]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/JavaLanguageSpecificChecksTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/JavaLanguageSpecificChecksTests.cs
@@ -11,7 +11,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
         private Mock<IProcessHelper> MockProcessHelper { get; set; }
         private JavaLanguageSpecificChecks LangService { get; set; }
 
-       [SetUp]
+        [SetUp]
         public void SetUp()
         {
             // Use TestAssets directory directly instead of temp directory
@@ -635,8 +635,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
         {
             if (IsSpotBugsCommand(options))
             {
-                return options.Args.Any(arg => arg.Contains("-Dspotbugs.failOnViolation=false")) &&
-                       options.Args.Any(arg => arg.Contains("-Dspotbugs.failsOnError=false"));
+                return options.Args.Any(arg => arg.Contains("-Dspotbugs.failOnError=false"));
             }
             return false;
         }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/JavaLanguageSpecificChecksTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/JavaLanguageSpecificChecksTests.cs
@@ -9,11 +9,9 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
     {
         private string JavaPackageDir { get; set; }
         private Mock<IProcessHelper> MockProcessHelper { get; set; }
-        private Mock<INpxHelper> MockNpxHelper { get; set; }
-        private Mock<IGitHelper> MockGitHelper { get; set; }
         private JavaLanguageSpecificChecks LangService { get; set; }
 
-        [SetUp]
+       [SetUp]
         public void SetUp()
         {
             // Use TestAssets directory directly instead of temp directory
@@ -22,22 +20,118 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
                 "TestAssets", "Java");
 
             MockProcessHelper = new Mock<IProcessHelper>();
-            MockNpxHelper = new Mock<INpxHelper>();
-            MockGitHelper = new Mock<IGitHelper>();
 
             LangService = new JavaLanguageSpecificChecks(
                 MockProcessHelper.Object,
-                MockNpxHelper.Object,
-                MockGitHelper.Object,
                 NullLogger<JavaLanguageSpecificChecks>.Instance);
         }
+
+        #region Setup Helpers
+
+        /// <summary>
+        /// Sets up successful Maven version check for both Unix and Windows platforms.
+        /// </summary>
+        private void SetupSuccessfulMavenVersionCheck()
+        {
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" && p.Args.Contains("--version")) || 
+                (p.Command == "cmd.exe" && p.Args.Contains("mvn") && p.Args.Contains("--version"))), 
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
+        }
+
+        /// <summary>
+        /// Sets up failed Maven version check for both Unix and Windows platforms.
+        /// </summary>
+        private void SetupFailedMavenVersionCheck()
+        {
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" && p.Args.Contains("--version")) || 
+                (p.Command == "cmd.exe" && p.Args.Contains("mvn") && p.Args.Contains("--version"))), 
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, "Maven not found")] });
+        }
+
+        /// <summary>
+        /// Sets up successful Maven spotless check command.
+        /// </summary>
+        private void SetupSuccessfulSpotlessCheck()
+        {
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("spotless:check")), 
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "BUILD SUCCESS")] });
+        }
+
+        /// <summary>
+        /// Sets up successful Maven spotless apply command.
+        /// </summary>
+        private void SetupSuccessfulSpotlessApply()
+        {
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("spotless:apply")), 
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "BUILD SUCCESS")] });
+        }
+
+        /// <summary>
+        /// Sets up failed Maven spotless check command with formatting violations.
+        /// </summary>
+        private void SetupFailedSpotlessCheck()
+        {
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("spotless:check")), 
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardOutput, "The following files had format violations")] });
+        }
+
+        /// <summary>
+        /// Sets up failed Maven spotless apply command.
+        /// </summary>
+        private void SetupFailedSpotlessApply()
+        {
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("spotless:apply")), 
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardOutput, "spotless failed with errors")] });
+        }
+
+        /// <summary>
+        /// Sets up successful Maven install command (Azure SDK approach).
+        /// </summary>
+        private void SetupSuccessfulMavenInstall()
+        {
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("install")), 
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { 
+                    ExitCode = 0, 
+                    OutputDetails = [(StdioLevel.StandardOutput, 
+                        "[INFO] BUILD SUCCESS\n" +
+                        "[INFO] Total time: 30.123 s\n" +
+                        "[INFO] Finished at: 2025-01-09T10:30:00-08:00"
+                    )] 
+                });
+        }
+
+        /// <summary>
+        /// Sets up Maven install command that fails with specific tool errors.
+        /// </summary>
+        private void SetupMavenInstallWithToolErrors(string errorOutput)
+        {
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("install")), 
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, errorOutput)] });
+        }
+
+        #endregion
         
         [Test]
         public async Task TestFormatCodeAsync_MavenNotAvailable_ReturnsError()
         {
             // Arrange
-            MockProcessHelper.Setup(x => x.Run(It.IsAny<ProcessOptions>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, "Maven not found")] });
+            SetupFailedMavenVersionCheck();
 
             // Act
             var result = await LangService.FormatCodeAsync(JavaPackageDir, false, CancellationToken.None);
@@ -57,9 +151,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
             var emptyDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(emptyDir);
             
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
-                ((p.Command == "mvn" || p.Command == "cmd.exe") || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
+            SetupSuccessfulMavenVersionCheck();
 
             // Act
             var result = await LangService.FormatCodeAsync(emptyDir, false, CancellationToken.None);
@@ -80,11 +172,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
         public async Task TestFormatCodeAsync_CheckMode_Success()
         {
             // Arrange
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
-
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("spotless:check")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "BUILD SUCCESS")] });
+            SetupSuccessfulMavenVersionCheck();
+            SetupSuccessfulSpotlessCheck();
 
             // Act
             var result = await LangService.FormatCodeAsync(JavaPackageDir, false, CancellationToken.None);
@@ -101,11 +190,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
         public async Task TestFormatCodeAsync_ApplyMode_Success()
         {
             // Arrange
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
-
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("spotless:apply")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "BUILD SUCCESS")] });
+            SetupSuccessfulMavenVersionCheck();
+            SetupSuccessfulSpotlessApply();
 
             // Act
             var result = await LangService.FormatCodeAsync(JavaPackageDir, true, CancellationToken.None);
@@ -122,11 +208,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
         public async Task TestFormatCodeAsync_CheckMode_FormattingNeeded()
         {
             // Arrange
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
-
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("spotless:check")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardOutput, "The following files had format violations")] });
+            SetupSuccessfulMavenVersionCheck();
+            SetupFailedSpotlessCheck();
 
             // Act
             var result = await LangService.FormatCodeAsync(JavaPackageDir, false, CancellationToken.None);
@@ -137,7 +220,9 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
                 Assert.That(result.ExitCode, Is.EqualTo(1));
                 Assert.That(result.CheckStatusDetails, Does.Contain("The following files had format violations"));
                 Assert.That(result.ResponseError, Does.Contain("Code formatting check failed"));
-                Assert.That(result.ResponseError, Does.Contain("mvn spotless:apply"));
+                Assert.That(result.NextSteps, Is.Not.Null);
+                Assert.That(result.NextSteps, Has.Count.EqualTo(1));
+                Assert.That(result.NextSteps![0], Does.Contain("mvn spotless:apply"));
             });
         }
 
@@ -145,11 +230,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
         public async Task TestFormatCodeAsync_ApplyMode_Failure()
         {
             // Arrange
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
-
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("spotless:apply")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardOutput, "spotless failed with errors")] });
+            SetupSuccessfulMavenVersionCheck();
+            SetupFailedSpotlessApply();
 
             // Act
             var result = await LangService.FormatCodeAsync(JavaPackageDir, true, CancellationToken.None);
@@ -164,35 +246,30 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
         }
 
         [Test]
-        public async Task TestFormatCodeAsync_PomInParentDirectory()
+        public async Task TestFormatCodeAsync_NoPomInPackageDirectory_ReturnsError()
         {
             // Arrange
             var subDir = Path.Combine(JavaPackageDir, "src", "main", "java");
             Directory.CreateDirectory(subDir);
             
-            var pomPath = Path.Combine(JavaPackageDir, "pom.xml");
+            // Create pom.xml in parent directory but not in the package directory we're testing
+            var parentPomPath = Path.Combine(JavaPackageDir, "pom.xml");
+            File.WriteAllText(parentPomPath, "<project></project>");
 
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
+            SetupSuccessfulMavenVersionCheck();
 
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("spotless:check") && p.Args.Contains("-f")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "BUILD SUCCESS")] });
-
-            // Act - run from subdirectory
+            // Act - run from subdirectory where there's no pom.xml
             var result = await LangService.FormatCodeAsync(subDir, false, CancellationToken.None);
 
             // Assert
             Assert.Multiple(() =>
             {
-                Assert.That(result.ExitCode, Is.EqualTo(0));
-                Assert.That(result.CheckStatusDetails, Is.EqualTo("Code formatting check passed - all files are properly formatted"));
+                Assert.That(result.ExitCode, Is.EqualTo(1));
+                Assert.That(result.CheckStatusDetails, Is.Empty);
+                Assert.That(result.ResponseError, Does.Contain("No pom.xml found"));
+                Assert.That(result.ResponseError, Does.Contain("This doesn't appear to be a Maven project"));
+                Assert.That(result.NextSteps, Has.Count.GreaterThan(0));
             });
-
-            // Verify the correct pom.xml path was used
-            MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => 
-                p.Args.Contains("-f") && 
-                p.Args.Contains(pomPath)), 
-                It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Test]
@@ -209,7 +286,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
             Assert.Multiple(() =>
             {
                 Assert.That(result.ExitCode, Is.EqualTo(1));
-                Assert.That(result.ResponseError, Does.Contain("Error formatting code: Process execution failed"));
+                Assert.That(result.ResponseError, Does.Contain("Error during code formatting: Process execution failed"));
             });
         }
 
@@ -218,12 +295,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
         {
             // Arrange
             var pomPath = Path.Combine(JavaPackageDir, "pom.xml");
-
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
-
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("spotless:check")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "BUILD SUCCESS")] });
+            SetupSuccessfulMavenVersionCheck();
+            SetupSuccessfulSpotlessCheck();
 
             // Act
             await LangService.FormatCodeAsync(JavaPackageDir, false, CancellationToken.None);
@@ -244,12 +317,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
         {
             // Arrange
             var pomPath = Path.Combine(JavaPackageDir, "pom.xml");
-
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("--version")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
-
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => (p.Command == "mvn" || p.Command == "cmd.exe") && p.Args.Contains("spotless:apply")), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "BUILD SUCCESS")] });
+            SetupSuccessfulMavenVersionCheck();
+            SetupSuccessfulSpotlessApply();
 
             // Act
             await LangService.FormatCodeAsync(JavaPackageDir, true, CancellationToken.None);
@@ -270,15 +339,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
         [Test]
         public async Task TestLintCodeAsync_MavenNotInstalled_ReturnsError()
         {
-            // Arrange - Reset mock to avoid interference from other test setups
-            MockProcessHelper.Reset();
-            
-            // Mock Maven version check - match both Unix and Windows patterns
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
-                (p.Command == "mvn" && p.Args.Contains("--version")) || 
-                (p.Command == "cmd.exe" && p.Args.Contains("mvn") && p.Args.Contains("--version"))), 
-                It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, "Maven not found")] });
+            // Arrange
+            SetupFailedMavenVersionCheck();
 
             // Act
             var result = await LangService.LintCodeAsync(JavaPackageDir, false, CancellationToken.None);
@@ -294,16 +356,9 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
         [Test]
         public async Task TestLintCodeAsync_NoPomXml_ReturnsError()
         {
-            // Arrange - Reset mock to avoid interference from other test setups
-            MockProcessHelper.Reset();
+            // Arrange
+            SetupSuccessfulMavenVersionCheck();
             
-            // Mock Maven version check - match both Unix and Windows patterns
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
-                (p.Command == "mvn" && p.Args.Contains("--version")) || 
-                (p.Command == "cmd.exe" && p.Args.Contains("mvn") && p.Args.Contains("--version"))), 
-                It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
-
             var emptyDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(emptyDir);
             try { Directory.Delete(emptyDir, true); } catch { }
@@ -322,33 +377,9 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
         [Test]
         public async Task TestLintCodeAsync_AllToolsPass_ReturnsSuccess()
         {
-            // Arrange - Reset mock to avoid interference from other test setups
-            MockProcessHelper.Reset();
-            
-            var capturedOptions = new List<ProcessOptions>();
-            MockProcessHelper.Setup(x => x.Run(It.IsAny<ProcessOptions>(), It.IsAny<CancellationToken>()))
-                .Callback<ProcessOptions, CancellationToken>((options, _) => capturedOptions.Add(options))
-                .ReturnsAsync((ProcessOptions options, CancellationToken _) =>
-                {
-                    if (IsMavenVersionCheck(options))
-                    {
-                        return new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] };
-                    }
-                    if (IsMavenInstallCommand(options))
-                    {
-                        // Simulate successful Azure SDK-style Maven install with clean linting output
-                        return new ProcessResult { 
-                            ExitCode = 0, 
-                            OutputDetails = [(StdioLevel.StandardOutput, 
-                                "[INFO] BUILD SUCCESS\n" +
-                                "[INFO] Total time: 30.123 s\n" +
-                                "[INFO] Finished at: 2025-01-09T10:30:00-08:00"
-                            )] 
-                        };
-                    }
-                    
-                    return new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, "Unknown command")] };
-                });
+            // Arrange
+            SetupSuccessfulMavenVersionCheck();
+            SetupSuccessfulMavenInstall();
 
             // Act
             var result = await LangService.LintCodeAsync(JavaPackageDir, false, CancellationToken.None);
@@ -362,35 +393,18 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
                 Assert.That(result.CheckStatusDetails, Does.Contain("Checkstyle, SpotBugs, RevAPI"));
             });
 
-            // Verify captured commands - Azure SDK approach uses install, not individual plugin calls
-            Assert.That(capturedOptions, Has.Count.EqualTo(2)); // Maven version + install command  
-            Assert.That(capturedOptions.Any(IsMavenVersionCheck), Is.True, "Maven version check should be called");
-            Assert.That(capturedOptions.Any(IsMavenInstallCommand), Is.True, "Maven install should be called");
+            // Verify Maven commands were called correctly
+            MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => IsMavenVersionCheck(p)), It.IsAny<CancellationToken>()), Times.Once);
+            MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => IsMavenInstallCommand(p)), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Test]
         public async Task TestLintCodeAsync_CheckstyleFails_ReturnsError()
         {
-            // Arrange - Reset mock to avoid interference from other test setups
-            MockProcessHelper.Reset();
-            
-            var capturedOptions = new List<ProcessOptions>();
-            MockProcessHelper.Setup(x => x.Run(It.IsAny<ProcessOptions>(), It.IsAny<CancellationToken>()))
-                .Callback<ProcessOptions, CancellationToken>((options, _) => capturedOptions.Add(options))
-                .ReturnsAsync((ProcessOptions options, CancellationToken _) =>
-                {
-                    if (IsMavenVersionCheck(options))
-                    {
-                        return new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] };
-                    }
-                    if (IsMavenInstallCommand(options))
-                    {
-                        var errorOutput = "[ERROR] Failed to execute goal com.puppycrawl.tools:checkstyle:9.3:check (default) on project test: You have 5 Checkstyle violations.";
-                        return new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, errorOutput)] };
-                    }
-                    
-                    return new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, "Unknown command")] };
-                });
+            // Arrange
+            SetupSuccessfulMavenVersionCheck();
+            var checkstyleErrorOutput = "[ERROR] Failed to execute goal com.puppycrawl.tools:checkstyle:9.3:check (default) on project test: You have 5 Checkstyle violations.";
+            SetupMavenInstallWithToolErrors(checkstyleErrorOutput);
 
             // Act
             var result = await LangService.LintCodeAsync(JavaPackageDir, false, CancellationToken.None);
@@ -402,12 +416,14 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
                 Assert.That(result.ResponseError, Does.Contain("Code linting found issues"));
                 Assert.That(result.ResponseError, Does.Contain("Checkstyle"));
                 Assert.That(result.CheckStatusDetails, Does.Contain("checkstyle"));
+                Assert.That(result.NextSteps, Is.Not.Null);
+                Assert.That(result.NextSteps, Has.Count.GreaterThan(0));
+                Assert.That(result.NextSteps!.Any(step => step.Contains("Checkstyle")), Is.True);
             });
 
-            // Verify captured commands - Azure SDK approach uses install
-            Assert.That(capturedOptions, Has.Count.EqualTo(2)); // Maven version + install command
-            Assert.That(capturedOptions.Any(IsMavenVersionCheck), Is.True, "Maven version check should be called");
-            Assert.That(capturedOptions.Any(IsMavenInstallCommand), Is.True, "Maven install should be called");
+            // Verify Maven commands were called correctly
+            MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => IsMavenVersionCheck(p)), It.IsAny<CancellationToken>()), Times.Once);
+            MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => IsMavenInstallCommand(p)), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Test]
@@ -448,6 +464,11 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
                 Assert.That(result.CheckStatusDetails, Does.Contain("checkstyle"));
                 Assert.That(result.CheckStatusDetails, Does.Contain("spotbugs-maven-plugin"));
                 Assert.That(result.CheckStatusDetails, Does.Contain("revapi-maven-plugin"));
+                Assert.That(result.NextSteps, Is.Not.Null);
+                Assert.That(result.NextSteps, Has.Count.GreaterThan(0));
+                Assert.That(result.NextSteps!.Any(step => step.Contains("Checkstyle")), Is.True);
+                Assert.That(result.NextSteps!.Any(step => step.Contains("SpotBugs")), Is.True);
+                Assert.That(result.NextSteps!.Any(step => step.Contains("RevAPI")), Is.True);
             });
 
             // Verify captured commands - Azure SDK approach uses single install
@@ -508,14 +529,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
         [Test]
         public async Task TestLintCodeAsync_Exception_ReturnsError()
         {
-            // Arrange - Reset mock to avoid interference from other test setups
-            MockProcessHelper.Reset();
-            
-            // Mock Maven version check - match both Unix and Windows patterns
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
-                (p.Command == "mvn" && p.Args.Contains("--version")) || 
-                (p.Command == "cmd.exe" && p.Args.Contains("mvn") && p.Args.Contains("--version"))), 
-                It.IsAny<CancellationToken>()))
+            // Arrange
+            MockProcessHelper.Setup(x => x.Run(It.IsAny<ProcessOptions>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new InvalidOperationException("Process execution failed"));
 
             // Act
@@ -532,23 +547,10 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
         [Test]
         public async Task TestLintCodeAsync_VerifyCorrectMavenCommands()
         {
-            // Arrange - Reset mock to avoid interference from other test setups
-            MockProcessHelper.Reset();
-            
+            // Arrange
             var pomPath = Path.Combine(JavaPackageDir, "pom.xml");
-            // Mock Maven version check - match both Unix and Windows patterns
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
-                (p.Command == "mvn" && p.Args.Contains("--version")) || 
-                (p.Command == "cmd.exe" && p.Args.Contains("mvn") && p.Args.Contains("--version"))), 
-                It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
-
-            // Setup Azure SDK style Maven install to pass - match both Unix and Windows patterns
-            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
-                (p.Command == "mvn" && p.Args.Contains("install")) || 
-                (p.Command == "cmd.exe" && p.Args.Contains("mvn") && p.Args.Contains("install"))), 
-                It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "BUILD SUCCESS")] });
+            SetupSuccessfulMavenVersionCheck();
+            SetupSuccessfulMavenInstall();
 
             // Act
             await LangService.LintCodeAsync(JavaPackageDir, false, CancellationToken.None);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/JavaLanguageSpecificChecksTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/JavaLanguageSpecificChecksTests.cs
@@ -264,5 +264,401 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages
                 p.Timeout == TimeSpan.FromMinutes(10)), 
                 It.IsAny<CancellationToken>()), Times.Once);
         }
+
+        #region LintCodeAsync Tests
+
+        [Test]
+        public async Task TestLintCodeAsync_MavenNotInstalled_ReturnsError()
+        {
+            // Arrange - Reset mock to avoid interference from other test setups
+            MockProcessHelper.Reset();
+            
+            // Mock Maven version check - match both Unix and Windows patterns
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" && p.Args.Contains("--version")) || 
+                (p.Command == "cmd.exe" && p.Args.Contains("mvn") && p.Args.Contains("--version"))), 
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, "Maven not found")] });
+
+            // Act
+            var result = await LangService.LintCodeAsync(JavaPackageDir, false, CancellationToken.None);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(1));
+                Assert.That(result.ResponseError, Does.Contain("Maven is not installed or not available in PATH"));
+            });
+        }
+
+        [Test]
+        public async Task TestLintCodeAsync_NoPomXml_ReturnsError()
+        {
+            // Arrange - Reset mock to avoid interference from other test setups
+            MockProcessHelper.Reset();
+            
+            // Mock Maven version check - match both Unix and Windows patterns
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" && p.Args.Contains("--version")) || 
+                (p.Command == "cmd.exe" && p.Args.Contains("mvn") && p.Args.Contains("--version"))), 
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
+
+            var emptyDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(emptyDir);
+            try { Directory.Delete(emptyDir, true); } catch { }
+
+            // Act
+            var result = await LangService.LintCodeAsync(emptyDir, false, CancellationToken.None);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(1));
+                Assert.That(result.ResponseError, Does.Contain("No pom.xml found"));
+            });
+        }
+
+        [Test]
+        public async Task TestLintCodeAsync_AllToolsPass_ReturnsSuccess()
+        {
+            // Arrange - Reset mock to avoid interference from other test setups
+            MockProcessHelper.Reset();
+            
+            var capturedOptions = new List<ProcessOptions>();
+            MockProcessHelper.Setup(x => x.Run(It.IsAny<ProcessOptions>(), It.IsAny<CancellationToken>()))
+                .Callback<ProcessOptions, CancellationToken>((options, _) => capturedOptions.Add(options))
+                .ReturnsAsync((ProcessOptions options, CancellationToken _) =>
+                {
+                    if (IsMavenVersionCheck(options))
+                    {
+                        return new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] };
+                    }
+                    if (IsMavenInstallCommand(options))
+                    {
+                        // Simulate successful Azure SDK-style Maven install with clean linting output
+                        return new ProcessResult { 
+                            ExitCode = 0, 
+                            OutputDetails = [(StdioLevel.StandardOutput, 
+                                "[INFO] BUILD SUCCESS\n" +
+                                "[INFO] Total time: 30.123 s\n" +
+                                "[INFO] Finished at: 2025-01-09T10:30:00-08:00"
+                            )] 
+                        };
+                    }
+                    
+                    return new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, "Unknown command")] };
+                });
+
+            // Act
+            var result = await LangService.LintCodeAsync(JavaPackageDir, false, CancellationToken.None);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(0));
+                Assert.That(result.CheckStatusDetails, Does.Contain("Code linting passed"));
+                Assert.That(result.CheckStatusDetails, Does.Contain("All tools successful"));
+                Assert.That(result.CheckStatusDetails, Does.Contain("Checkstyle, SpotBugs, RevAPI"));
+            });
+
+            // Verify captured commands - Azure SDK approach uses install, not individual plugin calls
+            Assert.That(capturedOptions, Has.Count.EqualTo(2)); // Maven version + install command  
+            Assert.That(capturedOptions.Any(IsMavenVersionCheck), Is.True, "Maven version check should be called");
+            Assert.That(capturedOptions.Any(IsMavenInstallCommand), Is.True, "Maven install should be called");
+        }
+
+        [Test]
+        public async Task TestLintCodeAsync_CheckstyleFails_ReturnsError()
+        {
+            // Arrange - Reset mock to avoid interference from other test setups
+            MockProcessHelper.Reset();
+            
+            var capturedOptions = new List<ProcessOptions>();
+            MockProcessHelper.Setup(x => x.Run(It.IsAny<ProcessOptions>(), It.IsAny<CancellationToken>()))
+                .Callback<ProcessOptions, CancellationToken>((options, _) => capturedOptions.Add(options))
+                .ReturnsAsync((ProcessOptions options, CancellationToken _) =>
+                {
+                    if (IsMavenVersionCheck(options))
+                    {
+                        return new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] };
+                    }
+                    if (IsMavenInstallCommand(options))
+                    {
+                        var errorOutput = "[ERROR] Failed to execute goal com.puppycrawl.tools:checkstyle:9.3:check (default) on project test: You have 5 Checkstyle violations.";
+                        return new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, errorOutput)] };
+                    }
+                    
+                    return new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, "Unknown command")] };
+                });
+
+            // Act
+            var result = await LangService.LintCodeAsync(JavaPackageDir, false, CancellationToken.None);
+
+            // Assert - Azure SDK approach: Maven install failed with Checkstyle errors
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(1));
+                Assert.That(result.ResponseError, Does.Contain("Code linting found issues"));
+                Assert.That(result.ResponseError, Does.Contain("Checkstyle"));
+                Assert.That(result.CheckStatusDetails, Does.Contain("checkstyle"));
+            });
+
+            // Verify captured commands - Azure SDK approach uses install
+            Assert.That(capturedOptions, Has.Count.EqualTo(2)); // Maven version + install command
+            Assert.That(capturedOptions.Any(IsMavenVersionCheck), Is.True, "Maven version check should be called");
+            Assert.That(capturedOptions.Any(IsMavenInstallCommand), Is.True, "Maven install should be called");
+        }
+
+        [Test]
+        public async Task TestLintCodeAsync_AllToolsFail_ReturnsError()
+        {
+            // Arrange - Reset mock to avoid interference from other test setups
+            MockProcessHelper.Reset();
+            
+            var capturedOptions = new List<ProcessOptions>();
+            MockProcessHelper.Setup(x => x.Run(It.IsAny<ProcessOptions>(), It.IsAny<CancellationToken>()))
+                .Callback<ProcessOptions, CancellationToken>((options, _) => capturedOptions.Add(options))
+                .ReturnsAsync((ProcessOptions options, CancellationToken _) =>
+                {
+                    if (IsMavenVersionCheck(options))
+                    {
+                        return new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] };
+                    }
+                    if (IsMavenInstallCommand(options))
+                    {
+                        var errorOutput = "[ERROR] Failed to execute goal com.puppycrawl.tools:checkstyle:9.3:check (default) on project test: You have 5 Checkstyle violations.\n" +
+                                        "[ERROR] Failed to execute goal com.github.spotbugs:spotbugs-maven-plugin:4.8.2.0:check (default) on project test: BugInstance size is 2\n" +
+                                        "[ERROR] Failed to execute goal org.revapi:revapi-maven-plugin:0.15.1:check (default) on project test: API problems detected";
+                        return new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, errorOutput)] };
+                    }
+                    
+                    return new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, "Unknown command")] };
+                });
+
+            // Act
+            var result = await LangService.LintCodeAsync(JavaPackageDir, false, CancellationToken.None);
+
+            // Assert - Azure SDK approach: All tools failed in single Maven install command  
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(1));
+                Assert.That(result.ResponseError, Does.Contain("Code linting found issues"));
+                Assert.That(result.ResponseError, Does.Contain("Checkstyle, SpotBugs, RevAPI"));
+                Assert.That(result.CheckStatusDetails, Does.Contain("checkstyle"));
+                Assert.That(result.CheckStatusDetails, Does.Contain("spotbugs-maven-plugin"));
+                Assert.That(result.CheckStatusDetails, Does.Contain("revapi-maven-plugin"));
+            });
+
+            // Verify captured commands - Azure SDK approach uses single install
+            Assert.That(capturedOptions, Has.Count.EqualTo(2)); // Maven version + install command
+            Assert.That(capturedOptions.Any(IsMavenVersionCheck), Is.True, "Maven version check should be called");
+            Assert.That(capturedOptions.Any(IsMavenInstallCommand), Is.True, "Maven install should be called");
+        }
+
+        [Test]
+        public async Task TestLintCodeAsync_WithFix_UsesFailOnViolationFalse()
+        {
+            // Arrange - Reset mock to avoid interference from other test setups
+            MockProcessHelper.Reset();
+            
+            var capturedOptions = new List<ProcessOptions>();
+            MockProcessHelper.Setup(x => x.Run(It.IsAny<ProcessOptions>(), It.IsAny<CancellationToken>()))
+                .Callback<ProcessOptions, CancellationToken>((options, _) => capturedOptions.Add(options))
+                .ReturnsAsync((ProcessOptions options, CancellationToken _) =>
+                {
+                    if (IsMavenVersionCheck(options))
+                    {
+                        return new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] };
+                    }
+                    if (IsMavenInstallCommand(options))
+                    {
+                        // Verify it has the correct RevAPI property for fix mode
+                        var argsString = string.Join(" ", options.Args);
+                        if (argsString.Contains("-Drevapi.failBuildOnProblemsFound=false"))
+                        {
+                            return new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "BUILD SUCCESS")] };
+                        }
+                        return new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, "Missing fix parameter")] };
+                    }
+                    
+                    return new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, "Unknown command")] };
+                });
+
+            // Act
+            await LangService.LintCodeAsync(JavaPackageDir, true, CancellationToken.None);
+
+            // Assert - verify the Maven install command was called with fix parameters
+            Assert.That(capturedOptions, Has.Count.EqualTo(2)); // Maven version + install command
+            Assert.That(capturedOptions.Any(IsMavenVersionCheck), Is.True, "Maven version check should be called");
+            Assert.That(capturedOptions.Any(IsMavenInstallCommand), Is.True, "Maven install should be called");
+            
+            // Verify the install command includes the correct RevAPI fix parameter
+            var installCommand = capturedOptions.FirstOrDefault(IsMavenInstallCommand);
+            Assert.That(installCommand, Is.Not.Null);
+            var argsString = string.Join(" ", installCommand.Args);
+            Assert.That(argsString, Does.Contain("-Drevapi.failBuildOnProblemsFound=false"));
+            
+            // Verify pom.xml path is included in Maven install command
+            var pomPath = Path.Combine(JavaPackageDir, "pom.xml");
+            Assert.That(installCommand.Args.Contains("-f"), Is.True, "Maven install command should include -f flag");
+            Assert.That(installCommand.Args.Contains(pomPath), Is.True, "Maven install command should include pom.xml path");
+        }
+
+        [Test]
+        public async Task TestLintCodeAsync_Exception_ReturnsError()
+        {
+            // Arrange - Reset mock to avoid interference from other test setups
+            MockProcessHelper.Reset();
+            
+            // Mock Maven version check - match both Unix and Windows patterns
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" && p.Args.Contains("--version")) || 
+                (p.Command == "cmd.exe" && p.Args.Contains("mvn") && p.Args.Contains("--version"))), 
+                It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("Process execution failed"));
+
+            // Act
+            var result = await LangService.LintCodeAsync(JavaPackageDir, false, CancellationToken.None);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(1));
+                Assert.That(result.ResponseError, Does.Contain("Error during code linting: Process execution failed"));
+            });
+        }
+
+        [Test]
+        public async Task TestLintCodeAsync_VerifyCorrectMavenCommands()
+        {
+            // Arrange - Reset mock to avoid interference from other test setups
+            MockProcessHelper.Reset();
+            
+            var pomPath = Path.Combine(JavaPackageDir, "pom.xml");
+            // Mock Maven version check - match both Unix and Windows patterns
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" && p.Args.Contains("--version")) || 
+                (p.Command == "cmd.exe" && p.Args.Contains("mvn") && p.Args.Contains("--version"))), 
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Apache Maven 3.9.9")] });
+
+            // Setup Azure SDK style Maven install to pass - match both Unix and Windows patterns
+            MockProcessHelper.Setup(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" && p.Args.Contains("install")) || 
+                (p.Command == "cmd.exe" && p.Args.Contains("mvn") && p.Args.Contains("install"))), 
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "BUILD SUCCESS")] });
+
+            // Act
+            await LangService.LintCodeAsync(JavaPackageDir, false, CancellationToken.None);
+
+            // Assert - verify Azure SDK style Maven install command was called correctly
+            MockProcessHelper.Verify(x => x.Run(It.Is<ProcessOptions>(p => 
+                (p.Command == "mvn" || p.Command == "cmd.exe") &&
+                p.Args.Contains("install") &&
+                p.Args.Contains("--no-transfer-progress") &&
+                p.Args.Contains("-DskipTests") &&
+                p.Args.Contains("-Dgpg.skip") &&
+                p.Args.Contains("-Dmaven.javadoc.skip=true") &&
+                p.Args.Contains("-Dcodesnippet.skip=true") &&
+                p.Args.Contains("-Dspotless.apply.skip=true") &&
+                p.Args.Contains("-am") &&
+                p.Args.Contains("-f") &&
+                p.Args.Contains(pomPath) &&
+                p.WorkingDirectory == JavaPackageDir &&
+                p.Timeout == TimeSpan.FromMinutes(15)), 
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        #region Helper Methods for Cross-Platform Command Validation
+
+        /// <summary>
+        /// Checks if the ProcessOptions represents a Maven version check command.
+        /// Handles both Unix (mvn --version) and Windows (cmd.exe /C mvn --version) patterns.
+        /// </summary>
+        private static bool IsMavenVersionCheck(ProcessOptions options) =>
+            (options.Command == "mvn" && options.Args.Contains("--version")) ||
+            (options.Command == "cmd.exe" && options.Args.Contains("mvn") && options.Args.Contains("--version"));
+
+        /// <summary>
+        /// Checks if the ProcessOptions represents a Checkstyle command.
+        /// Handles both Unix and Windows patterns.
+        /// </summary>
+        private static bool IsCheckstyleCommand(ProcessOptions options) =>
+            (options.Command == "mvn" && options.Args.Contains("checkstyle:check")) ||
+            (options.Command == "cmd.exe" && options.Args.Contains("mvn") && options.Args.Contains("checkstyle:check"));
+
+        /// <summary>
+        /// Checks if the ProcessOptions represents a SpotBugs command.
+        /// Handles both Unix and Windows patterns.
+        /// </summary>
+        private static bool IsSpotBugsCommand(ProcessOptions options) =>
+            (options.Command == "mvn" && options.Args.Contains("spotbugs:check")) ||
+            (options.Command == "cmd.exe" && options.Args.Contains("mvn") && options.Args.Contains("spotbugs:check"));
+
+        /// <summary>
+        /// Checks if the ProcessOptions represents a RevAPI command.
+        /// Handles both Unix and Windows patterns.
+        /// </summary>
+        private static bool IsRevAPICommand(ProcessOptions options) =>
+            (options.Command == "mvn" && options.Args.Contains("revapi:check")) ||
+            (options.Command == "cmd.exe" && options.Args.Contains("mvn") && options.Args.Contains("revapi:check"));
+
+        /// <summary>
+        /// Checks if the ProcessOptions represents a Checkstyle command with fix parameters.
+        /// Handles both Unix (mvn) and Windows (cmd.exe /C mvn) patterns.
+        /// </summary>
+        private static bool IsCheckstyleFixCommand(ProcessOptions options)
+        {
+            if (IsCheckstyleCommand(options))
+            {
+                return options.Args.Any(arg => arg.Contains("-Dcheckstyle.failOnViolation=false")) &&
+                       options.Args.Any(arg => arg.Contains("-Dcheckstyle.failsOnError=false"));
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if the ProcessOptions represents a SpotBugs command with fix parameters.
+        /// Handles both Unix (mvn) and Windows (cmd.exe /C mvn) patterns.
+        /// </summary>
+        private static bool IsSpotBugsFixCommand(ProcessOptions options)
+        {
+            if (IsSpotBugsCommand(options))
+            {
+                return options.Args.Any(arg => arg.Contains("-Dspotbugs.failOnViolation=false")) &&
+                       options.Args.Any(arg => arg.Contains("-Dspotbugs.failsOnError=false"));
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if the ProcessOptions represents a RevAPI command with fix parameters.
+        /// Handles both Unix (mvn) and Windows (cmd.exe /C mvn) patterns.
+        /// </summary>
+        private static bool IsRevAPIFixCommand(ProcessOptions options)
+        {
+            if (IsRevAPICommand(options))
+            {
+                return options.Args.Any(arg => arg.Contains("-Drevapi.failOnViolation=false")) &&
+                       options.Args.Any(arg => arg.Contains("-Drevapi.failsOnError=false"));
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if the ProcessOptions represents a Maven install command (Azure SDK approach).
+        /// Handles both Unix (mvn) and Windows (cmd.exe /C mvn) patterns.
+        /// </summary>
+        private static bool IsMavenInstallCommand(ProcessOptions options)
+        {
+            return (options.Command == "mvn" && options.Args.Contains("install")) ||
+                   (options.Command == "cmd.exe" && options.Args.Contains("mvn") && options.Args.Contains("install"));
+        }
+
+        #endregion
+
+        #endregion
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/JavaLanguageSpecificChecks.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/JavaLanguageSpecificChecks.cs
@@ -10,19 +10,35 @@ namespace Azure.Sdk.Tools.Cli.Services;
 public class JavaLanguageSpecificChecks : ILanguageSpecificChecks
 {
     private readonly IProcessHelper _processHelper;
-    private readonly INpxHelper _npxHelper;
-    private readonly IGitHelper _gitHelper;
     private readonly ILogger<JavaLanguageSpecificChecks> _logger;
+
+    // Maven operation timeouts
+    private static readonly TimeSpan MavenFormatTimeout = TimeSpan.FromMinutes(10);
+    private static readonly TimeSpan MavenLintTimeout = TimeSpan.FromMinutes(15);
+
+    // Common NextSteps messages
+    private static readonly string[] mavenInstallationNextSteps = [
+        "Install Apache Maven from https://maven.apache.org/download.cgi",
+        "Ensure Maven is added to your system PATH environment variable",
+        "Verify installation by running 'mvn --version' in terminal"
+    ];
+
+    private static readonly string[] pomNotFoundNextSteps = [
+        "Ensure you're running this command from within a Maven project directory",
+        "Verify that a pom.xml file exists in the package directory"
+    ];
+
+    private static readonly string[] exceptionHandlingNextSteps = [
+        "Check that Maven and Java are properly installed and configured",
+        "Verify that the project's pom.xml is valid and not corrupted",
+        "Check Maven logs for more detailed error information"
+    ];
 
     public JavaLanguageSpecificChecks(
         IProcessHelper processHelper,
-        INpxHelper npxHelper,
-        IGitHelper gitHelper,
         ILogger<JavaLanguageSpecificChecks> logger)
     {
         _processHelper = processHelper;
-        _npxHelper = npxHelper;
-        _gitHelper = gitHelper;
         _logger = logger;
     }
 
@@ -32,35 +48,21 @@ public class JavaLanguageSpecificChecks : ILanguageSpecificChecks
         {
             _logger.LogInformation("Starting code formatting for Java project at: {PackagePath}", packagePath);
 
-            // Check if Maven is available
-            var mavenCheckResult = await _processHelper.Run(new("mvn", ["--version"], timeout: TimeSpan.FromSeconds(10)), cancellationToken);
-            if (mavenCheckResult.ExitCode != 0)
+            // Validate Maven and POM prerequisites
+            var pomPath = Path.Combine(packagePath, "pom.xml");
+            var prerequisiteCheck = await ValidateMavenPrerequisitesAsync(packagePath, pomPath, cancellationToken);
+            if (prerequisiteCheck != null)
             {
-                _logger.LogError("Maven is not installed or not available in PATH");
-                return new CLICheckResponse(1, "", "Maven is not installed or not available in PATH. Please install Maven to use code formatting functionality.");
+                return prerequisiteCheck;
             }
 
-            _logger.LogInformation("Maven is available: {MavenVersion}", mavenCheckResult.Output.Split('\n')[0].Trim());
-
-            // Find pom.xml in the package directory or its parents
-            var pomPath = FindPomXml(packagePath);
-            if (string.IsNullOrEmpty(pomPath))
-            {
-                _logger.LogError("No pom.xml found in {PackagePath} or its parent directories", packagePath);
-                return new CLICheckResponse(1, "", $"No pom.xml found in {packagePath} or its parent directories. This doesn't appear to be a Maven project.");
-            }
-
-            var pomDirectory = Path.GetDirectoryName(pomPath);
-            _logger.LogInformation("Using Maven project at: {PomDirectory}", pomDirectory);
 
             // Determine the Maven goal based on fix parameter
             var goal = fix ? "spotless:apply" : "spotless:check";
             var command = "mvn";
             var args = new[] { goal, "-f", pomPath };
 
-            _logger.LogInformation("Executing command: {Command} {Arguments}", command, string.Join(" ", args));
-            var timeout = TimeSpan.FromMinutes(10); // Maven operations can take time
-            var result = await _processHelper.Run(new(command, args, workingDirectory: pomDirectory, timeout: timeout), cancellationToken);
+            var result = await _processHelper.Run(new(command, args, workingDirectory: packagePath, timeout: MavenFormatTimeout), cancellationToken);
 
             if (result.ExitCode == 0)
             {
@@ -72,28 +74,25 @@ public class JavaLanguageSpecificChecks : ILanguageSpecificChecks
             {
                 var errorMessage = fix ? "Code formatting failed to apply" : "Code formatting check failed - some files need formatting";
                 _logger.LogWarning("{ErrorMessage} with exit code {ExitCode}", errorMessage, result.ExitCode);
-                
-                // Extract useful error information from output
+
                 var output = result.Output;
-                if (output.Contains("spotless"))
+                var nextSteps = fix ?
+                    "Review the error output and check if spotless-maven-plugin is properly configured in the pom.xml" :
+                    "Run with --fix flag to automatically format code, or run 'mvn spotless:apply' manually";
+
+                return new CLICheckResponse(result.ExitCode, output, errorMessage)
                 {
-                    // If the output contains spotless-related information, include it
-                    return new CLICheckResponse(result.ExitCode, output, errorMessage);
-                }
-                else
-                {
-                    // Provide helpful guidance
-                    var guidance = fix ? 
-                        "Run 'mvn spotless:apply' to automatically format code, or check if spotless-maven-plugin is configured in the pom.xml" :
-                        "Run 'mvn spotless:apply' to fix formatting issues, or use --fix flag with this command";
-                    return new CLICheckResponse(result.ExitCode, output, $"{errorMessage}. {guidance}");
-                }
+                    NextSteps = [nextSteps]
+                };
             }
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error formatting code for Java project at: {PackagePath}", packagePath);
-            return new CLICheckResponse(1, "", $"Error formatting code: {ex.Message}");
+            _logger.LogError(ex, "Error during code formatting for Java project at: {PackagePath}", packagePath);
+            return new CLICheckResponse(1, "", $"Error during code formatting: {ex.Message}")
+            {
+                NextSteps = [.. exceptionHandlingNextSteps]
+            };
         }
     }
 
@@ -103,26 +102,13 @@ public class JavaLanguageSpecificChecks : ILanguageSpecificChecks
         {
             _logger.LogInformation("Starting code linting for Java project at: {PackagePath} (Fix: {Fix})", packagePath, fix);
 
-            // Check if Maven is available
-            var mavenCheckResult = await _processHelper.Run(new("mvn", ["--version"], timeout: TimeSpan.FromSeconds(10)), cancellationToken);
-            if (mavenCheckResult.ExitCode != 0)
+            // Validate Maven and POM prerequisites
+            var pomPath = Path.Combine(packagePath, "pom.xml");
+            var prerequisiteCheck = await ValidateMavenPrerequisitesAsync(packagePath, pomPath, cancellationToken);
+            if (prerequisiteCheck != null)
             {
-                _logger.LogError("Maven is not installed or not available in PATH");
-                return new CLICheckResponse(1, "", "Maven is not installed or not available in PATH. Please install Maven to use code linting functionality.");
+                return prerequisiteCheck;
             }
-
-            _logger.LogInformation("Maven is available: {MavenVersion}", mavenCheckResult.Output.Split('\n')[0].Trim());
-
-            // Find pom.xml in the package directory or its parents
-            var pomPath = FindPomXml(packagePath);
-            if (string.IsNullOrEmpty(pomPath))
-            {
-                _logger.LogError("No pom.xml found in {PackagePath} or its parent directories", packagePath);
-                return new CLICheckResponse(1, "", $"No pom.xml found in {packagePath} or its parent directories. This doesn't appear to be a Maven project.");
-            }
-
-            var pomDirectory = Path.GetDirectoryName(pomPath)!;
-            _logger.LogInformation("Using Maven project at: {PomDirectory}", pomDirectory);
 
             // Use Azure SDK approach: mvn install with linting properties (based on run-and-validate-linting.yml)
             // This matches the Azure SDK for Java pipeline which runs linting during install phase
@@ -136,36 +122,22 @@ public class JavaLanguageSpecificChecks : ILanguageSpecificChecks
                 "-Dmaven.javadoc.skip=true",
                 "-Dcodesnippet.skip=true",
                 "-Dspotless.apply.skip=true",
-                "-Dshade.skip=true", 
+                "-Dshade.skip=true",
                 "-Dmaven.antrun.skip=true",
                 "-am",
                 "-f", pomPath
             };
 
-            if (fix)
-            {
-                // When fixing, allow violations but don't fail build
-                args.AddRange([
-                    "-Dcheckstyle.failOnViolation=false",
-                    "-Dcheckstyle.failsOnError=false", 
-                    "-Dspotbugs.failOnError=false",
-                    "-Drevapi.failBuildOnProblemsFound=false"
-                ]);
-            }
-            else
-            {
-                // When not fixing, still don't fail build but collect results for analysis
-                args.AddRange([
-                    "-Dcheckstyle.failOnViolation=false",
-                    "-Dcheckstyle.failsOnError=false",
-                    "-Dspotbugs.failOnError=false", 
-                    "-Drevapi.failBuildOnProblemsFound=false"
-                ]);
-            }
+            // Configure linting behavior to match Azure SDK pipeline
+            // Note: There's no automated "fix" mode for linting - all tools require manual review
+            args.AddRange([
+                "-Dcheckstyle.failOnViolation=false",
+                "-Dcheckstyle.failsOnError=false",
+                "-Dspotbugs.failOnError=false",
+                "-Drevapi.failBuildOnProblemsFound=false"
+            ]);
 
-            _logger.LogInformation("Executing Azure Java SDK-style linting: {Command} {Arguments}", command, string.Join(" ", args));
-            var timeout = TimeSpan.FromMinutes(15);
-            var result = await _processHelper.Run(new(command, [.. args], workingDirectory: pomDirectory, timeout: timeout), cancellationToken);
+            var result = await _processHelper.Run(new(command, [.. args], workingDirectory: packagePath, timeout: MavenLintTimeout), cancellationToken);
 
             // Parse Maven output to determine which linting tools found issues
             var output = result.Output;
@@ -176,7 +148,7 @@ public class JavaLanguageSpecificChecks : ILanguageSpecificChecks
 
             if (failedTools.Count == 0)
             {
-                var message = result.ExitCode == 0 
+                var message = result.ExitCode == 0
                     ? $"Code linting passed - All tools successful: {string.Join(", ", passedTools.Select(t => t.Tool))}"
                     : "Code linting completed, but build had other issues. Check Maven output for details.";
                 _logger.LogInformation(message);
@@ -186,24 +158,40 @@ public class JavaLanguageSpecificChecks : ILanguageSpecificChecks
             {
                 var failedToolNames = string.Join(", ", failedTools.Select(t => t.Tool));
                 var passedToolNames = passedTools.Count > 0 ? string.Join(", ", passedTools.Select(t => t.Tool)) : "None";
-                
+
                 var errorMessage = $"Code linting found issues - Tools with issues: {failedToolNames}. Clean tools: {passedToolNames}";
                 _logger.LogWarning(errorMessage);
 
-                var guidance = "To fix linting issues:\n" +
-                             "• Checkstyle: Follow Java coding standards and fix style violations\n" +
-                             "• SpotBugs: Review and fix potential bugs and code quality issues\n" +
-                             "• RevAPI: Ensure API changes are backward compatible or properly documented\n" +
-                             "• Run with --fix flag to attempt automatic fixes where possible\n" +
-                             "• Use -Dcheckstyle.skip=true, -Dspotbugs.skip=true, -Drevapi.skip=true to skip specific tools during development";
+                var nextSteps = new List<string>();
+                if (failedTools.Any(t => t.Tool == "Checkstyle"))
+                {
+                    nextSteps.Add("Checkstyle: Review and manually fix code quality violations - no auto-fix available");
+                }
+                if (failedTools.Any(t => t.Tool == "SpotBugs"))
+                {
+                    nextSteps.Add("SpotBugs: Review and manually fix potential bugs - no auto-fix available");
+                }
+                if (failedTools.Any(t => t.Tool == "RevAPI"))
+                {
+                    nextSteps.Add("RevAPI: Manually review API compatibility - requires design decisions");
+                }
 
-                return new CLICheckResponse(1, output, $"{errorMessage}. {guidance}");
+                nextSteps.Add("Review the linting errors and fix them manually - no auto-fix available");
+                nextSteps.Add("Use -Dcheckstyle.skip=true, -Dspotbugs.skip=true, -Drevapi.skip=true to skip specific tools during development");
+
+                return new CLICheckResponse(result.ExitCode, output, errorMessage)
+                {
+                    NextSteps = nextSteps
+                };
             }
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error during code linting for Java project at: {PackagePath}", packagePath);
-            return new CLICheckResponse(1, "", $"Error during code linting: {ex.Message}");
+            return new CLICheckResponse(1, "", $"Error during code linting: {ex.Message}")
+            {
+                NextSteps = [.. exceptionHandlingNextSteps, "Verify that the project's pom.xml is valid and contains required linting plugins"]
+            };
         }
     }
 
@@ -217,7 +205,7 @@ public class JavaLanguageSpecificChecks : ILanguageSpecificChecks
     private List<(string Tool, bool HasIssues)> ParseLintingResults(string output, int exitCode)
     {
         var results = new List<(string Tool, bool HasIssues)>();
-        
+
         // Check for Checkstyle execution and results
         var checkstyleRan = output.Contains("checkstyle:") && output.Contains(":check");
         var checkstyleHasIssues = false;
@@ -229,7 +217,7 @@ public class JavaLanguageSpecificChecks : ILanguageSpecificChecks
             checkstyleHasIssues = !checkstyleSuccess;
         }
         results.Add(("Checkstyle", checkstyleHasIssues));
-        
+
         // Check for SpotBugs execution and results
         var spotbugsRan = output.Contains("spotbugs:") && output.Contains(":check");
         var spotbugsHasIssues = false;
@@ -241,7 +229,7 @@ public class JavaLanguageSpecificChecks : ILanguageSpecificChecks
             spotbugsHasIssues = !spotbugsSuccess;
         }
         results.Add(("SpotBugs", spotbugsHasIssues));
-        
+
         // Check for RevAPI execution and results
         var revapiRan = output.Contains("revapi:") && output.Contains(":check");
         var revapiHasIssues = false;
@@ -252,31 +240,46 @@ public class JavaLanguageSpecificChecks : ILanguageSpecificChecks
             revapiHasIssues = !revapiSuccess;
         }
         results.Add(("RevAPI", revapiHasIssues));
-        
-        _logger.LogInformation("Linting results parsed: Checkstyle ran={CheckstyleRan} issues={CheckstyleIssues}, SpotBugs ran={SpotBugsRan} issues={SpotBugsIssues}, RevAPI ran={RevapiRan} issues={RevapiIssues}", 
+
+        _logger.LogInformation("Linting results parsed: Checkstyle ran={CheckstyleRan} issues={CheckstyleIssues}, SpotBugs ran={SpotBugsRan} issues={SpotBugsIssues}, RevAPI ran={RevapiRan} issues={RevapiIssues}",
             checkstyleRan, checkstyleHasIssues, spotbugsRan, spotbugsHasIssues, revapiRan, revapiHasIssues);
-            
+
         return results;
     }
 
     /// <summary>
-    /// Finds pom.xml file starting from the given directory and searching up the directory tree.
+    /// Validates Maven installation and POM.xml existence for both formatting and linting operations.
     /// </summary>
-    /// <param name="startPath">The directory to start searching from</param>
-    /// <returns>Path to pom.xml file, or null if not found</returns>
-    private string? FindPomXml(string startPath)
+    /// <param name="packagePath">The package directory path</param>
+    /// <param name="pomPath">The path to the pom.xml file</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>CLICheckResponse with error details if validation fails, null if validation passes</returns>
+    private async Task<CLICheckResponse?> ValidateMavenPrerequisitesAsync(string packagePath, string pomPath, CancellationToken cancellationToken)
     {
-        var currentDir = new DirectoryInfo(startPath);
-        
-        while (currentDir != null)
+        // Check if Maven is available
+        var mavenCheckResult = await _processHelper.Run(new("mvn", ["--version"], timeout: TimeSpan.FromSeconds(10)), cancellationToken);
+        if (mavenCheckResult.ExitCode != 0)
         {
-            var pomPath = Path.Combine(currentDir.FullName, "pom.xml");
-            if (File.Exists(pomPath))
+            _logger.LogError("Maven is not installed or not available in PATH");
+            return new CLICheckResponse(mavenCheckResult.ExitCode, "", "Maven is not installed or not available in PATH.")
             {
-                return pomPath;
-            }
-            currentDir = currentDir.Parent;
+                NextSteps = [.. mavenInstallationNextSteps]
+            };
         }
-        return null;
+
+        _logger.LogInformation("Maven is available: {MavenVersion}", mavenCheckResult.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)[0].Trim());
+
+        // Check for pom.xml in the package directory
+        if (!File.Exists(pomPath))
+        {
+            _logger.LogError("No pom.xml found in {PackagePath}", packagePath);
+            return new CLICheckResponse(1, "", $"No pom.xml found in {packagePath}. This doesn't appear to be a Maven project.")
+            {
+                NextSteps = [.. pomNotFoundNextSteps]
+            };
+        }
+
+        _logger.LogInformation("Using Maven project at: {PackagePath}", packagePath);
+        return null; // No error, prerequisites are valid
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/JavaLanguageSpecificChecks.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/JavaLanguageSpecificChecks.cs
@@ -1,7 +1,5 @@
-using System.Runtime.InteropServices;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Helpers;
-using Microsoft.Extensions.Logging;
 
 namespace Azure.Sdk.Tools.Cli.Services;
 
@@ -97,6 +95,168 @@ public class JavaLanguageSpecificChecks : ILanguageSpecificChecks
             _logger.LogError(ex, "Error formatting code for Java project at: {PackagePath}", packagePath);
             return new CLICheckResponse(1, "", $"Error formatting code: {ex.Message}");
         }
+    }
+
+    public async Task<CLICheckResponse> LintCodeAsync(string packagePath, bool fix = false, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            _logger.LogInformation("Starting code linting for Java project at: {PackagePath} (Fix: {Fix})", packagePath, fix);
+
+            // Check if Maven is available
+            var mavenCheckResult = await _processHelper.Run(new("mvn", ["--version"], timeout: TimeSpan.FromSeconds(10)), cancellationToken);
+            if (mavenCheckResult.ExitCode != 0)
+            {
+                _logger.LogError("Maven is not installed or not available in PATH");
+                return new CLICheckResponse(1, "", "Maven is not installed or not available in PATH. Please install Maven to use code linting functionality.");
+            }
+
+            _logger.LogInformation("Maven is available: {MavenVersion}", mavenCheckResult.Output.Split('\n')[0].Trim());
+
+            // Find pom.xml in the package directory or its parents
+            var pomPath = FindPomXml(packagePath);
+            if (string.IsNullOrEmpty(pomPath))
+            {
+                _logger.LogError("No pom.xml found in {PackagePath} or its parent directories", packagePath);
+                return new CLICheckResponse(1, "", $"No pom.xml found in {packagePath} or its parent directories. This doesn't appear to be a Maven project.");
+            }
+
+            var pomDirectory = Path.GetDirectoryName(pomPath)!;
+            _logger.LogInformation("Using Maven project at: {PomDirectory}", pomDirectory);
+
+            // Use Azure SDK approach: mvn install with linting properties (based on run-and-validate-linting.yml)
+            // This matches the Azure SDK for Java pipeline which runs linting during install phase
+            var command = "mvn";
+            var args = new List<string>
+            {
+                "install",
+                "--no-transfer-progress",
+                "-DskipTests",
+                "-Dgpg.skip",
+                "-Dmaven.javadoc.skip=true",
+                "-Dcodesnippet.skip=true",
+                "-Dspotless.apply.skip=true",
+                "-Dshade.skip=true", 
+                "-Dmaven.antrun.skip=true",
+                "-am",
+                "-f", pomPath
+            };
+
+            if (fix)
+            {
+                // When fixing, allow violations but don't fail build
+                args.AddRange([
+                    "-Dcheckstyle.failOnViolation=false",
+                    "-Dcheckstyle.failsOnError=false", 
+                    "-Dspotbugs.failOnError=false",
+                    "-Drevapi.failBuildOnProblemsFound=false"
+                ]);
+            }
+            else
+            {
+                // When not fixing, still don't fail build but collect results for analysis
+                args.AddRange([
+                    "-Dcheckstyle.failOnViolation=false",
+                    "-Dcheckstyle.failsOnError=false",
+                    "-Dspotbugs.failOnError=false", 
+                    "-Drevapi.failBuildOnProblemsFound=false"
+                ]);
+            }
+
+            _logger.LogInformation("Executing Azure Java SDK-style linting: {Command} {Arguments}", command, string.Join(" ", args));
+            var timeout = TimeSpan.FromMinutes(15);
+            var result = await _processHelper.Run(new(command, [.. args], workingDirectory: pomDirectory, timeout: timeout), cancellationToken);
+
+            // Parse Maven output to determine which linting tools found issues
+            var output = result.Output;
+            var lintingResults = ParseLintingResults(output, result.ExitCode);
+
+            var failedTools = lintingResults.Where(r => r.HasIssues).ToList();
+            var passedTools = lintingResults.Where(r => !r.HasIssues).ToList();
+
+            if (failedTools.Count == 0)
+            {
+                var message = result.ExitCode == 0 
+                    ? $"Code linting passed - All tools successful: {string.Join(", ", passedTools.Select(t => t.Tool))}"
+                    : "Code linting completed, but build had other issues. Check Maven output for details.";
+                _logger.LogInformation(message);
+                return new CLICheckResponse(result.ExitCode, message);
+            }
+            else
+            {
+                var failedToolNames = string.Join(", ", failedTools.Select(t => t.Tool));
+                var passedToolNames = passedTools.Count > 0 ? string.Join(", ", passedTools.Select(t => t.Tool)) : "None";
+                
+                var errorMessage = $"Code linting found issues - Tools with issues: {failedToolNames}. Clean tools: {passedToolNames}";
+                _logger.LogWarning(errorMessage);
+
+                var guidance = "To fix linting issues:\n" +
+                             "• Checkstyle: Follow Java coding standards and fix style violations\n" +
+                             "• SpotBugs: Review and fix potential bugs and code quality issues\n" +
+                             "• RevAPI: Ensure API changes are backward compatible or properly documented\n" +
+                             "• Run with --fix flag to attempt automatic fixes where possible\n" +
+                             "• Use -Dcheckstyle.skip=true, -Dspotbugs.skip=true, -Drevapi.skip=true to skip specific tools during development";
+
+                return new CLICheckResponse(1, output, $"{errorMessage}. {guidance}");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during code linting for Java project at: {PackagePath}", packagePath);
+            return new CLICheckResponse(1, "", $"Error during code linting: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Parses Maven output to determine which linting tools found issues.
+    /// Based on Azure SDK for Java pipeline patterns that run linting during install phase.
+    /// </summary>
+    /// <param name="output">Maven command output</param>
+    /// <param name="exitCode">Maven command exit code</param>
+    /// <returns>List of linting results per tool</returns>
+    private List<(string Tool, bool HasIssues)> ParseLintingResults(string output, int exitCode)
+    {
+        var results = new List<(string Tool, bool HasIssues)>();
+        
+        // Check for Checkstyle execution and results
+        var checkstyleRan = output.Contains("checkstyle:") && output.Contains(":check");
+        var checkstyleHasIssues = false;
+        if (checkstyleRan)
+        {
+            // Look for explicit success indicators - if not found, assume there are issues
+            var checkstyleSuccess = output.Contains("You have 0 Checkstyle violations.") ||
+                                   output.Contains("Audit done."); // Sometimes just shows "Audit done." for clean runs
+            checkstyleHasIssues = !checkstyleSuccess;
+        }
+        results.Add(("Checkstyle", checkstyleHasIssues));
+        
+        // Check for SpotBugs execution and results
+        var spotbugsRan = output.Contains("spotbugs:") && output.Contains(":check");
+        var spotbugsHasIssues = false;
+        if (spotbugsRan)
+        {
+            // Look for explicit success indicators - SpotBugs reports success patterns
+            var spotbugsSuccess = (output.Contains("BugInstance size is 0") && output.Contains("No errors/warnings found")) ||
+                                 output.Contains("Error size is 0") && output.Contains("No errors/warnings found");
+            spotbugsHasIssues = !spotbugsSuccess;
+        }
+        results.Add(("SpotBugs", spotbugsHasIssues));
+        
+        // Check for RevAPI execution and results
+        var revapiRan = output.Contains("revapi:") && output.Contains(":check");
+        var revapiHasIssues = false;
+        if (revapiRan)
+        {
+            // Look for explicit success indicators
+            var revapiSuccess = output.Contains("API checks completed without failures.");
+            revapiHasIssues = !revapiSuccess;
+        }
+        results.Add(("RevAPI", revapiHasIssues));
+        
+        _logger.LogInformation("Linting results parsed: Checkstyle ran={CheckstyleRan} issues={CheckstyleIssues}, SpotBugs ran={SpotBugsRan} issues={SpotBugsIssues}, RevAPI ran={RevapiRan} issues={RevapiIssues}", 
+            checkstyleRan, checkstyleHasIssues, spotbugsRan, spotbugsHasIssues, revapiRan, revapiHasIssues);
+            
+        return results;
     }
 
     /// <summary>


### PR DESCRIPTION
This PR 
- Implements LintCodeAsync method with Maven dependency validation, pom.xml discovery, and linting execution

LintCodeAsync (Code Quality Linting)
- Tools: checkstyle:check, spotbugs:check, revapi:check
- Purpose: Finds code quality/correctness violations
- Auto-fix: ❌ NO - All require manual review and code changes

<img width="525" height="1152" alt="image" src="https://github.com/user-attachments/assets/99f21472-4f57-4fc0-86fb-f18152c4ac60" />
