### PR TITLE
Use write-output for matrix script to support upstream callers

### DIFF
--- a/eng/common/scripts/job-matrix/Create-JobMatrix.ps1
+++ b/eng/common/scripts/job-matrix/Create-JobMatrix.ps1
@@ -54,7 +54,9 @@ LogGroupEnd
 $serialized = SerializePipelineMatrix $matrix
 
 Write-Host "Generated matrix:"
-Write-Host $serialized.pretty
+
+# Write-Output required to support other scripts that call this script directly
+Write-Output $serialized.pretty
 
 if ($CI) {
     Write-Output "##vso[task.setVariable variable=matrix;isOutput=true]$($serialized.compressed)"


### PR DESCRIPTION
Stress test matrix generation is broken because it depended on `write-output` to get a return value from calling the generation script directly.

> java-storage-file-share/charts/stress-test-addons/templates/_util.tpl:38:80: executing "stress-test-addons.util.mergeStressContext" at <$_scenario.Scenario>: can't evaluate field Scenario in type string