### PR TITLE
CPEX Attestation: Add Warning for unknown states

### DIFF
--- a/eng/scripts/Invoke-CPEX-Attestation-Automation.ps1
+++ b/eng/scripts/Invoke-CPEX-Attestation-Automation.ps1
@@ -71,7 +71,7 @@ function SendEmailNotification($emailTo, $emailCC, $emailSubject, $emailBody) {
         $body = @{ EmailTo = $emailTo; EmailCC = $emailCC; Subject = $emailSubject; Body = $emailBody} | ConvertTo-Json -Depth 3
         $response = Invoke-RestMethod -Uri $AzureSDKEmailUri -Method Post -Body $body -ContentType "application/json"
     } catch {
-        Write-Warning "Failed to send email.`nTo: $emailTo`nCC: $emailCC`nSubject: $emailSubject`nBody: $emailBody`nException message: $($_.Exception.Message)"
+        Write-Error "Failed to send email.`nTo: $emailTo`nCC: $emailCC`nSubject: $emailSubject`nBody: $emailBody`nException message: $($_.Exception.Message)"
     }
 }
 


### PR DESCRIPTION
Fixes bug where Kpi Id was set equal to comment message when lifecycle was unknown