### PR TITLE
Restore azsdk-cli auto-PR label

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,8 +59,10 @@
 # Azure SDK Tools MCP
 #####################
 /eng/common/instructions/azsdk-tools/   @maririos @praveenkuttappan @MrJustinB 
-/tools/azsdk-cli/                       @azure/azsdk-cli
+# PRLabel: %azsdk-cli
 /tools/ai-evals/azsdk-mcp/              @jeo02 @smw-ms @praveenkuttappan @maririos
+# PRLabel: %azsdk-cli
+/tools/azsdk-cli/                       @azure/azsdk-cli
 
 
 ###########


### PR DESCRIPTION
Seems like this was inadvertently removed in https://github.com/Azure/azure-sdk-tools/pull/12415