### PR TITLE
Reorder error and warning log line processing

### DIFF
--- a/eng/common/scripts/logging.ps1
+++ b/eng/common/scripts/logging.ps1
@@ -114,11 +114,11 @@ function LogJobFailure() {
 
 function ProcessMsBuildLogLine($line) {
   if (Test-SupportsDevOpsLogging) {
-    if ($line -like "*: warning*") {
-      return ("##vso[task.LogIssue type=warning;]$line" -replace "`n", "%0D%0A")
-    }
-    elseif ($line -like "*: error*") {
+    if ($line -like "*: error*") {
       return ("##vso[task.LogIssue type=error;]$line" -replace "`n", "%0D%0A")
+    }
+    elseif ($line -like "*: warning*") {
+      return ("##vso[task.LogIssue type=warning;]$line" -replace "`n", "%0D%0A")
     }
   }
   return $line


### PR DESCRIPTION
For lines that have both `: error` and `: warning` lets prefer the error. 
`/mnt/vss/_work/1/s/sdk/core/Azure.Core.TestFramework/src/Azure.Core.TestFramework.csproj : error NU1904: Warning As Error: Package`