### PR TITLE
Add azure sdk onboarding knowledge to python tenant

### DIFF
--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-backend/config/tenant.go
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-backend/config/tenant.go
@@ -29,7 +29,7 @@ var SourceTopK = map[model.Source]int{
 
 var tenantConfigMap = map[model.TenantID]TenantConfig{
 	model.TenantID_PythonChannelQaBot: {
-		Sources: append([]model.Source{model.Source_AzureSDKForPython, model.Source_AzureSDKForPythonWiki, model.Source_AzureSDKGuidelines}, typespecSources...),
+		Sources: append([]model.Source{model.Source_AzureSDKForPython, model.Source_AzureSDKForPythonWiki, model.Source_AzureSDKGuidelines, model.Source_AzureSDKDocsEng}, typespecSources...),
 		SourceFilter: map[model.Source]string{
 			model.Source_AzureSDKGuidelines: "search.ismatch('python_*', 'title')",
 		},


### PR DESCRIPTION
For the recent evaluation task for python, it seems there are a lot of badcases related to sdk onboarding. I would like to add the sdk onboarding knowledge to python tenant to improve the performance.
[AzureSDKQaBot-Evaluation-Python](https://microsoftapc-my.sharepoint.com/:x:/r/personal/jiaqzhang_microsoft_com/_layouts/15/Doc.aspx?sourcedoc=%7B48421488-D3B6-473A-B6DF-16FF97B7F83A%7D&file=[AzureSDKQaBot-Evaluation-Python.xlsx](https://microsoftapc-my.sharepoint.com/:x:/r/personal/jiaqzhang_microsoft_com/_layouts/15/Doc.aspx?sourcedoc=%7B48421488-D3B6-473A-B6DF-16FF97B7F83A%7D&file=AzureSDKQaBot-Evaluation-Python.xlsx&action=default&mobileredirect=true)&action=default&mobileredirect=true)
<img width="1998" height="718" alt="image" src="https://github.com/user-attachments/assets/c9962011-ec5d-4b35-b8e5-b8d8c15cd193" />

### Test
I've done some local tests, it seems bot could resolve the badcases by using sdk onboarding knowledge
<img width="2491" height="1536" alt="Screenshot 2025-10-16 143053" src="https://github.com/user-attachments/assets/1a5b3263-a621-4b52-97e4-b8921c9943c2" />
<img width="1941" height="1194" alt="Screenshot 2025-10-16 142626" src="https://github.com/user-attachments/assets/6d9191f2-3804-47b8-bb27-5a67978e88a7" />

And for the good case, it also works well.
<img width="2381" height="1471" alt="image" src="https://github.com/user-attachments/assets/287f722f-7acf-4a94-8941-e7957e6dbba7" />

