### PR TITLE
Set-VcpkgWriteModeCache -- add token timeout param 

### DIFF
--- a/eng/common/pipelines/templates/steps/set-vcpkg-cache-vars.yml
+++ b/eng/common/pipelines/templates/steps/set-vcpkg-cache-vars.yml
@@ -1,3 +1,9 @@
+
+parameters:
+  - name: TokenTimeoutInHours
+    type: number
+    default: 1
+
 steps:
   - pwsh: |
       Write-Host "Setting vcpkg cache variables for read only access to vcpkg binary and asset caches"
@@ -12,6 +18,7 @@ steps:
         azureSubscription: 'Azure SDK Artifacts'
         ScriptType: FilePath
         ScriptPath: eng/common/scripts/Set-VcpkgWriteModeCache.ps1
+        ScriptArguments: -TokenTimeoutInHours ${{ parameters.TokenTimeoutInHours }}
         azurePowerShellVersion: LatestVersion
         pwsh: true
       # This step is idempotent and can be run multiple times in cases of

--- a/eng/common/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/common/scripts/Set-VcpkgWriteModeCache.ps1
@@ -1,7 +1,8 @@
 #!/bin/env pwsh
 param(
   [string] $StorageAccountName = 'azuresdkartifacts',
-  [string] $StorageContainerName = 'public-vcpkg-container'
+  [string] $StorageContainerName = 'public-vcpkg-container',
+  [int] $TokenTimeoutInHours = 1
 )
 
 $ctx = New-AzStorageContext `
@@ -12,7 +13,7 @@ $vcpkgBinarySourceSas = New-AzStorageContainerSASToken `
   -Name $StorageContainerName `
   -Permission "rwcl" `
   -Context $ctx `
-  -ExpiryTime (Get-Date).AddHours(1)
+  -ExpiryTime (Get-Date).AddHours($TokenTimeoutInHours)
 
 # Ensure redaction of SAS tokens in logs
 Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SAS_TOKEN;issecret=true;]$vcpkgBinarySourceSas"


### PR DESCRIPTION
In some cases (C++ API View) a `cmake generate` task can take multiple hours to complete successfully. In that time the storage token for the cache expires. While the job doesn't fail because of a cache authentication error, we lose the benefits of the cache. 

Example failure: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5425321&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=00170b8f-1061-5420-820e-1eb883d5ca57&l=200


Example of the pipeline working with a longer token timeout: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5462833&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=00170b8f-1061-5420-820e-1eb883d5ca57&l=106

