### PR TITLE
Fix unhelpful error when no stress packages are found

### DIFF
--- a/eng/common/scripts/stress-testing/find-all-stress-packages.ps1
+++ b/eng/common/scripts/stress-testing/find-all-stress-packages.ps1
@@ -31,8 +31,10 @@ function FindStressPackages(
     $filters['stressTest'] = 'true'
     $packages = @()
     $chartFiles = Get-ChildItem -Recurse -Filter 'Chart.yaml' $directory
-    Write-Host "Found chart files:"
-    Write-Host ($chartFiles -join "`n")
+    if ($chartFiles) {
+        Write-Host "Found chart files:"
+        Write-Host ($chartFiles -join "`n")
+    }
 
     if (!$MatrixFileName) {
         $MatrixFileName = 'scenarios-matrix.yaml'

--- a/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
+++ b/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
@@ -172,6 +172,10 @@ function DeployStressTests(
                 -MatrixFilters $MatrixFilters `
                 -MatrixReplace $MatrixReplace `
                 -MatrixNonSparseParameters $MatrixNonSparseParameters)
+    if (!$pkgs -or !$pkgs.Length) {
+        Write-Warning "No stress test packages found in $searchDirectory"
+        exit 0
+    }
     Write-Host "" "Found $($pkgs.Length) stress test packages:"
     Write-Host $pkgs.Directory ""
     foreach ($pkg in $pkgs) {


### PR DESCRIPTION
When the packages array is empty we can error out trying to access the nested array items property `$pkgs.Directory`, which provides a misleading error to the user.