### PR TITLE
[API View] Filter comments that were resolved in other revisions

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/LeanControllers/ReviewsController.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanControllers/ReviewsController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using ApiView;
 using APIViewWeb.Extensions;
 using APIViewWeb.Helpers;
 using APIViewWeb.Hubs;
@@ -219,8 +220,8 @@ namespace APIViewWeb.LeanControllers
 
             if (activeAPIRevision.Files[0].ParserStyle == ParserStyle.Tree)
             {
-                var comments = await _commentsManager.GetCommentsAsync(reviewId, commentType: CommentType.APIRevision);
-                var activeRevisionReviewCodeFile = await _codeFileRepository.GetCodeFileFromStorageAsync(revisionId: activeAPIRevision.Id, codeFileId: activeAPIRevision.Files[0].FileId);
+                IEnumerable<CommentItemModel> comments = await _commentsManager.GetCommentsAsync(reviewId, commentType: CommentType.APIRevision);
+                CodeFile activeRevisionReviewCodeFile = await _codeFileRepository.GetCodeFileFromStorageAsync(revisionId: activeAPIRevision.Id, codeFileId: activeAPIRevision.Files[0].FileId);
 
                 if (activeRevisionReviewCodeFile.ContentGenerationInProgress)
                 {
@@ -228,10 +229,11 @@ namespace APIViewWeb.LeanControllers
                     return new LeanJsonResult("Content generation in progress", StatusCodes.Status202Accepted, languageServices.ReviewGenerationPipelineUrl);
                 }
 
+                List<CommentItemModel> filteredComments = comments.Where(c => !c.IsResolved || c.APIRevisionId == activeApiRevisionId).ToList();
                 var codePanelRawData = new CodePanelRawData()
                 {
                     activeRevisionCodeFile = activeRevisionReviewCodeFile,
-                    Comments = comments
+                    Comments = filteredComments
                 };
 
                 if (diffAPIRevision != null)


### PR DESCRIPTION
fixes: https://github.com/Azure/azure-sdk-tools/issues/12539

To provide some cleanup, this PR filters out resolved comments that belong to different revisions. Since these are already resolved comments, this is a safe change.

## Before
<img width="1244" height="660" alt="image" src="https://github.com/user-attachments/assets/8bb9d35a-0e4d-40ae-aa8b-0e6ccc0d6e2f" />

## After 
<img width="1243" height="510" alt="image" src="https://github.com/user-attachments/assets/dfd04a42-8883-403d-b34b-6603de6f0b4b" />
