### PR TITLE
Add `windows arm64` to set of standalone builds for the `test-proxy`

### DIFF
--- a/tools/azsdk-cli/ci.yml
+++ b/tools/azsdk-cli/ci.yml
@@ -41,4 +41,3 @@ extends:
       - rid: win-x64
         framework: net8.0
         assembly: azsdk
-


### PR DESCRIPTION
@l0lawrence is our first ever windows arm64 user but if there is one then there will be more!

I decided to just give it a shot to see if would sign and publish properly and [it does](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5466946&view=results), so no reason not to support!