### PR TITLE
Expose package SdkType in Apiview URI

### DIFF
--- a/eng/common/scripts/Detect-Api-Changes.ps1
+++ b/eng/common/scripts/Detect-Api-Changes.ps1
@@ -22,7 +22,7 @@ Param (
 $configFileDir = Join-Path -Path $ArtifactPath "PackageInfo"
 
 # Submit API review request and return status whether current revision is approved or pending or failed to create review
-function Submit-Request($filePath, $packageName)
+function Submit-Request($filePath, $packageName, $packageType)
 {
     $repoName = $RepoFullName
     if (!$repoName) {
@@ -39,6 +39,7 @@ function Submit-Request($filePath, $packageName)
     $query.Add('packageName', $packageName)
     $query.Add('language', $LanguageShort)
     $query.Add('project', $DevopsProject)
+    $query.Add('packageType', $packageType)
     $reviewFileFullName = Join-Path -Path $ArtifactPath $packageName $reviewFileName
     # If CI generates token file then it passes both token file name and original file (filePath) to APIView
     # If both files are passed then APIView downloads the parent directory as a zip
@@ -126,6 +127,7 @@ foreach ($packageInfoFile in $packageInfoFiles)
 {
     $packageInfo = Get-Content $packageInfoFile | ConvertFrom-Json
     $pkgArtifactName = $packageInfo.ArtifactName ?? $packageInfo.Name
+    $packageType = $packageInfo.SdkType
 
     LogInfo "Processing $($pkgArtifactName)"
 
@@ -157,7 +159,7 @@ foreach ($packageInfoFile in $packageInfoFiles)
         if ($isRequired -eq $True)
         {
             $filePath = $pkgPath.Replace($ArtifactPath , "").Replace("\", "/")
-            $respCode = Submit-Request -filePath $filePath -packageName $pkgArtifactName
+            $respCode = Submit-Request -filePath $filePath -packageName $pkgArtifactName -packageType $packageType
             if ($respCode -ne '200')
             {
                 $responses[$pkgArtifactName] = $respCode


### PR DESCRIPTION
Closes https://github.com/Azure/azure-sdk-tools/issues/12242

corresponding PR for API view side changes:
https://github.com/Azure/azure-sdk-tools/pull/12398

Same as https://github.com/Azure/azure-sdk-tools/pull/12323, this pr could not merge due to build issue, creating a new branch to resolve the issue.

This PR updates the API review submission scripts to include package type information in API review requests. The changes enable the scripts to pass the SdkType property from package metadata through to the APIView service.

Key Changes:

Added $packageType parameter to API review submission functions
Extracted package type from packageInfo.SdkType metadata
Updated function calls to pass package type through the request chain