### PR TITLE
Added spec for 'package updater' tools

### DIFF
--- a/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
+++ b/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
@@ -262,7 +262,7 @@ Execution Steps:
 Outputs:
 
 ```json
-{"result":"succeeded", "changed_files":["..\\pom.xml","C:\\dev\\repos\\azure-sdk-for-java\\pom.xml"], "changed_count": 2, "message":"All relevant pom.xml files have been updated."}
+{"result":"succeeded", "changed_files":["..\\pom.xml","C:\\dev\\repos\\azure-sdk-for-java\\pom.xml"], "changed_files_count": 2, "message":"All relevant pom.xml files have been updated."}
 ```
 
 ```json

--- a/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
+++ b/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
@@ -68,9 +68,7 @@ Formalizing Stage 6 as cohesive tools improves reliability, supports automation-
 
 ### Language-Specific Limitations
 
-| Language   | Limitation | Impact | Workaround |
-|------------|------------|--------|------------|
-| JavaScript | Code formatting isn't hooked up to the emitter | Noisy diffs or linter failures | Run code formatting step in the `update-metadata` tool |
+No language-specific limitations are known at this time. If any language requires an exception, it will be documented here.
 
 ---
 

--- a/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
+++ b/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
@@ -108,7 +108,7 @@ The four tools are intentionally small, composable units. Each emits a machine-r
 | Timeout (default) | 5 minutes per tool invocation |
 | Output Schema | JSON with fields: result, message (see schema below) |
 | Idempotency | Multiple successive runs produce identical filesystem state except for timestamps/logs |
-| Script Implementation | MUST be PowerShell `.ps1`. SHOULD accept named parameters (e.g., `sdkRepoPath`). MUST use exit code `0` for success/partial/noop; non-zero only on outright failure. Legacy non-PS scripts should be wrapped by a small PowerShell shim. Scripts MUST write a concise stderr line prefixed with `ERROR:`; include suggested mitigation steps and links to docs in the message where possible. |
+| Script Implementation | MUST be PowerShell `.ps1`. SHOULD accept named parameters (e.g., `sdkRepoPath`). MUST use exit code `0` for success/noop; non-zero only on outright failure. Legacy non-PS scripts should be wrapped by a small PowerShell shim. Scripts MUST write a concise stderr line prefixed with `ERROR:`; include suggested mitigation steps and links to docs in the message where possible. |
 | Script Execution Environment | All scripts are executed using PowerShell Core (`pwsh`) terminal |
 | Next Steps Hint | Plain language phrase embedded in `message` (e.g., `next_steps: update version`) |
 | Missing Required Tools | If a required external tool is not present (for example: `dotnet`, `gofmt`, `pwsh`), prompt the user to run the `verify-setup` tool which validates and documents missing prerequisites. |
@@ -141,7 +141,7 @@ Outputs:
 ```
 
 ```json
-{"result":"noop", "message":"Data-plane changelog untouched; manual edits required", "next_steps": "update version"}
+{"result":"noop", "message":"Data-plane changelog untouched", "next_steps": "Manually edit the changelog, and update version"}
 ```
 
 Failure Modes:
@@ -201,7 +201,7 @@ Outputs:
 ```
 
 ```json
-{"result":"noop", "version": "", "release-date": "", "message":"Data-plane pre-release context; no version bump performed", "next_steps": "update metadata"}
+{"result":"noop", "version": "", "release-date": "", "message":"no version bump performed", "next_steps": "update metadata"}
 ```
 
 Failure Modes:
@@ -560,7 +560,7 @@ azsdk package update-changelog-content --package-path <absolute_folder_path_to_p
 **Expected Output (data-plane no-op):**
 
 ```text
-"succeeded, Data-plane changelog no-op; manual edits required; next_steps: update version (if release)."
+"noop; Data-plane changelog untouched; next_steps: manually edit the changelog, and update version."
 ```
 
 ### package update version

--- a/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
+++ b/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
@@ -360,20 +360,6 @@ Update the version and release date for package at /repo/sdk/healthdataaiservice
 2. Run version update with the confirmed version.
 3. Report the result.
 
-### Scenario 3: Create CI Config for New SDK
-
-**Prompt:**
-
-```text
-Add initial CI configuration for a new SDK at /work/sdk/new-service/new-package.
-```
-
-**Expected Agent Activity:**
-
-1. Run CI update tool.
-2. Report the created configuration file.
-3. Suggest running update-changelog tool next.
-
 ---
 
 ## CLI Commands

--- a/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
+++ b/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
@@ -140,7 +140,7 @@ Outputs:
 Failure Modes:
 
 - Missing `CHANGELOG.md` → create template (mgmt-plane) or noop (data-plane).
-Note: we should consdier adding recovery support for the generation scenario after milestone 1.
+Note: we should consider adding recovery support for the generation scenario after milestone 1.
 - Script failure → `failed` with error output.
 
 ##### Update Changelog script

--- a/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
+++ b/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
@@ -86,6 +86,8 @@ Implement four individual CLI + MCP tools. Each tool:
 4. Otherwise falls back the CLI's built-in implementation for that language.
 5. Aggregates structured result JSON with a `result`, human-readable `message`, and optional `next_steps` hint guiding subsequent tool invocation.
 
+Note: see the [repo-tooling-contract](./specs/99-repo-tooling-contract.md) spec for more details.
+
 Provides a singular CLI + MCP command that orchestrates the four tools (update-ci → update-changelog → update-version → update-metadata) and returns a combined JSON summary (post milestone 1).
 
 ### Detailed Design
@@ -96,7 +98,7 @@ The four tools are intentionally small, composable units. Each emits a machine-r
 |--------|-------------------|
 | Invocation Mode | CLI and MCP (agent) alias; same semantics |
 | Input Path Validation | Must exist and contain a recognizable SDK language structure; errors early if not |
-| Language Logic Routing | Use the [`repository service`](https://github.com/Azure/azure-sdk-tools/pull/12696d) to load the language repo configuration. If a script is configured, invoke it; otherwise fall back to the CLI's built-in implementation |
+| Language Logic Routing | Use the `repository script service` to load the language repo configuration. If a script is configured, invoke it; otherwise fall back to the CLI's built-in implementation |
 | Timeout (default) | 5 minutes per tool invocation |
 | Output Schema | JSON with fields: result, message (see schema below) |
 | Idempotency | Multiple successive runs produce identical filesystem state except for timestamps/logs |
@@ -248,7 +250,7 @@ flowchart TD
     direction TB
     classifier[SDK Classifier]
     languageService[Language Service]
-    repoService[Repository Service]    
+    repoService[RepositoryScript Service]    
     serializer[Result Serializer]
   end
 
@@ -455,7 +457,7 @@ azsdk package update-metadata --package-path <absolute_folder_path_to_package>
 
 ### Phase 1: Core Tooling (Milestone 1)
 
-- Milestone: Implement CLI + MCP entrypoints for three tools including update-changelog, update-version, and update-metadata; integrate repository service; mgmt-plane happy path.
+- Milestone: Implement CLI + MCP entrypoints for three tools including update-changelog, update-version, and update-metadata; integrate repository script service; mgmt-plane happy path.
 - Timeline: 1 sprint.
 - Dependencies: language-specific logic implementation.
 

--- a/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
+++ b/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
@@ -78,7 +78,7 @@ Formalizing Stage 6 as cohesive tools improves reliability, supports automation-
 
 ### Overview
 
-Implement four individual CLI + MCP tools. Each tool:
+Implement three individual CLI + MCP tools. Each tool:
 
 1. Resolves package path & language.
 2. Loads configuration for the language repository.
@@ -87,8 +87,6 @@ Implement four individual CLI + MCP tools. Each tool:
 5. Aggregates structured result JSON with a `result`, human-readable `message`, and optional `next_steps` hint guiding subsequent tool invocation.
 
 Note: see the [repo-tooling-contract](./specs/99-repo-tooling-contract.md) spec for more details.
-
-Provides a singular CLI + MCP command that orchestrates the four tools (update-ci → update-changelog → update-version → update-metadata) and returns a combined JSON summary (post milestone 1).
 
 ### Detailed Design
 
@@ -234,7 +232,6 @@ Failure Modes:
 Typical CLI workflow:
 
 ```bash
-azsdk package update-ci --package-path /abs/sdk/path
 azsdk package update-changelog-content --package-path /abs/sdk/path
 azsdk package update-metadata --package-path /abs/sdk/path
 azsdk package update-version --package-path /abs/sdk/path --version 1.0.0 --release-date 2025-10-17
@@ -301,7 +298,7 @@ flowchart TD
       style P fill:#ffcdd2
 ```
 
-> **Note:** Other tools (version update, metadata update, CI update) follow a similar flowchart pattern.
+> **Note:** Other tools (version update, metadata update) follow a similar flowchart pattern.
 
 ---
 

--- a/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
+++ b/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
@@ -226,7 +226,7 @@ When the tool executes the language-specific `update-version` script it will pas
 | `sdkVersion` | Specifies the next version to set (explicit version string). | string | No |
 | `sdkReleaseDate` | Release date to write into changelog (YYYY-MM-DD). | string | No |
 
-Note: For management-plane (mgmt) packages, at least one of `--sdk-version` or `--sdk-release-type` MUST be provided; the script will fail with an error if neither is supplied or validation fails.
+Note: For management-plane (mgmt) packages, at least one of `sdkVersion` or `sdkReleaseType` MUST be provided; the script will fail with an error if neither is supplied or validation fails.
 
 **Example invocations:**
 
@@ -299,7 +299,7 @@ Purpose: Create or update CI pipeline configuration.
 
 Inputs:
 
-- `-package-path <abs path>` (required) – Absolute path to the root of the SDK package.
+- `--package-path <abs path>` (required) – Absolute path to the root of the SDK package.
 
 Behavior:
 
@@ -541,12 +541,12 @@ azsdk package ci update --package-path <absolute_folder_path_to_package>
 **Command:**
 
 ```bash
-azsdk package changelog update -package-path <absolute_folder_path_to_package>
+azsdk package changelog update --package-path <absolute_folder_path_to_package>
 ```
 
 **Options:**
 
-- `-package-path <path>`: Package root (required).
+- `--package-path <path>`: Package root (required).
 
 **Expected Output (mgmt):**
 
@@ -565,13 +565,13 @@ azsdk package changelog update -package-path <absolute_folder_path_to_package>
 **Command:**
 
 ```bash
-azsdk package version update -package-path <absolute_folder_path_to_package> -sdk-release-type <stable|beta>
+azsdk package version update --package-path <absolute_folder_path_to_package> --release-type <stable|beta>
 ```
 
 **Options:**
 
-- `-package-path <path>`: Package root (required).
-- `-sdk-release-type <stable|beta>`: Determines increment strategy (required for mgmt; optional for data-plane release context).
+- `--package-path <path>`: Package root (required).
+- `--release-type <stable|beta>`: Determines increment strategy (required for mgmt; optional for data-plane release context).
 
 **Expected Output:**
 
@@ -590,12 +590,12 @@ azsdk package version update -package-path <absolute_folder_path_to_package> -sd
 **Command:**
 
 ```bash
-azsdk package metadata update -package-path <absolute_folder_path_to_package>
+azsdk package metadata update --package-path <absolute_folder_path_to_package>
 ```
 
 **Options:**
 
-- `-package-path <path>`: Package root (required).
+- `--package-path <path>`: Package root (required).
 
 **Expected Output:**
 
@@ -666,7 +666,7 @@ azsdk package metadata update -package-path <absolute_folder_path_to_package>
 | Metric Name | Description | Purpose |
 |-------------|-------------|---------|
 | tool_run_count | Count of executions per tool per language | Adoption tracking |
-| tool_failure_rate | Failures / total runs | Reliability signal and priority remidation |
+| tool_failure_rate | Failures / total runs | Reliability signal and priority remediation |
 | avg_duration_ms | Mean execution time per tool | Performance tuning |
 | version_mismatch_detected | Count of times version update found inconsistent files | Detect systemic config issues |
 

--- a/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
+++ b/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
@@ -115,11 +115,11 @@ The four tools are intentionally small, composable units. Each emits a machine-r
 
 #### 1. Changelog Update Tool
 
-Name (CLI): `azsdk package update changelog`
+Name (CLI): `azsdk package update-changelog-content`
 
 Name (MCP): `azsdk_package_update_changelog`
 
-Purpose: Ensure changelog is auto-generated and has an entry for the upcoming release (management-plane) or provide guidance (data-plane) where manual editing is expected.
+Purpose: Ensure changelog is auto-generated and has an entry for the upcoming release (management-plane) or provide guidance (data-plane) where manual editing is expected. This tool only modifies changelog content and does not change release date or version numbers.
 
 Inputs:
 
@@ -128,8 +128,7 @@ Inputs:
 Execution Steps (Mgmt-Plane):
 
 1. Invoke changelog generation script or tool.
-2. Insert (or update) latest section with release date placeholder / actual date.
-3. Normalize section ordering / formatting.
+2. Normalize section ordering / formatting.
 
 Execution Steps (Data-Plane):
 
@@ -148,6 +147,7 @@ Outputs:
 Failure Modes:
 
 - Missing `CHANGELOG.md` → create template (mgmt-plane) or noop (data-plane).
+Note: we should consdier adding recovery support for the generation scenario after milestone 1.
 - Script failure → `failed` with error output.
 
 ##### Update Changelog script
@@ -171,7 +171,7 @@ update-changelog.ps1 \
 
 #### 2. Version Update Tool
 
-Name (CLI): `azsdk package update version`
+Name (CLI): `azsdk package update-version`
 
 Name (MCP): `azsdk_package_update_version`
 
@@ -237,7 +237,7 @@ update-version.ps1 \
 
 #### 3. Metadata Update Tool
 
-Name (CLI): `azsdk package update metadata`
+Name (CLI): `azsdk package update-metadata`
 
 Name (MCP): `azsdk_package_update_metadata`
 
@@ -286,7 +286,7 @@ update-metadata.ps1 \
 
 #### 4. CI Update Tool
 
-Name (CLI): `azsdk package update ci`
+Name (CLI): `azsdk package update-ci`
 
 Name (MCP): `azsdk_package_update_ci`
 
@@ -337,11 +337,11 @@ update-ci.ps1 \
 
 #### 5. Aggregated Tool (chained execution)
 
-Name (CLI): `azsdk package update all`
+Name (CLI): `azsdk package update-all`
 
 Name (MCP): `azsdk_package_update_all`
 
-> **Note:** Support for this tool is planned for post‑milestone-1.
+> **Note:** Support for this tool is planned for post‑milestone-1. Consider making the tool attempt safe, deterministic fixes where reasonable instead of immediately failing and delegating remediation to the caller.
 
 Purpose: provide a single entrypoint that orchestrates the four tools in a deterministic sequence for common release-prep workflows.
 
@@ -380,10 +380,10 @@ Example aggregated output (successful):
 Typical CLI workflow:
 
 ```bash
-azsdk package update ci --package-path /abs/sdk/path
-azsdk package update changelog --package-path /abs/sdk/path
-azsdk package update metadata --package-path /abs/sdk/path
-azsdk package update version --package-path /abs/sdk/path --version 1.0.0 --release-date 2025-10-17
+azsdk package update-ci --package-path /abs/sdk/path
+azsdk package update-changelog-content --package-path /abs/sdk/path
+azsdk package update-metadata --package-path /abs/sdk/path
+azsdk package update-version --package-path /abs/sdk/path --version 1.0.0 --release-date 2025-10-17
 ```
 
 ### Architecture Diagram
@@ -488,7 +488,7 @@ Update the package at /home/dev/sdk/healthdataaiservices/Azure.ResourceManager.H
 **Prompt:**
 
 ```text
-Update the version for package at /repo/sdk/healthdataaiservices/Azure.Health.Deidentification.
+Update the version and release date for package at /repo/sdk/healthdataaiservices/Azure.Health.Deidentification.
 ```
 
 **Expected Agent Activity:**
@@ -520,7 +520,7 @@ Add initial CI configuration for a new SDK at /work/sdk/new-service/new-package.
 **Command:**
 
 ```bash
-azsdk package update ci --package-path <absolute_folder_path_to_package>
+azsdk package update-ci --package-path <absolute_folder_path_to_package>
 ```
 
 **Options:**
@@ -544,7 +544,7 @@ azsdk package update ci --package-path <absolute_folder_path_to_package>
 **Command:**
 
 ```bash
-azsdk package update changelog --package-path <absolute_folder_path_to_package>
+azsdk package update-changelog-content --package-path <absolute_folder_path_to_package>
 ```
 
 **Options:**
@@ -568,7 +568,7 @@ azsdk package update changelog --package-path <absolute_folder_path_to_package>
 **Command:**
 
 ```bash
-azsdk package update version --package-path <absolute_folder_path_to_package> --release-type <stable|beta>
+azsdk package update-version --package-path <absolute_folder_path_to_package> --release-type <stable|beta>
 ```
 
 **Options:**
@@ -593,7 +593,7 @@ azsdk package update version --package-path <absolute_folder_path_to_package> --
 **Command:**
 
 ```bash
-azsdk package update metadata --package-path <absolute_folder_path_to_package>
+azsdk package update-metadata --package-path <absolute_folder_path_to_package>
 ```
 
 **Options:**

--- a/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
+++ b/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
@@ -241,7 +241,15 @@ Name (CLI): `azsdk package update-metadata`
 
 Name (MCP): `azsdk_package_update_metadata`
 
-Purpose: Update additional language-specific metadata and documentation, such as `_metadata.json`, `pom.xml` etc., export API surface (.NET).
+Purpose: Update additional language-specific metadata and documentation.
+
+Target files per language:
+
+- .NET: API view artifacts under `{package-path}/api/`.
+- Java: `pom.xml` files in both the `azure-sdk-for-java` repo root and the `service` folder.
+- Python: `_metadata.json` and `pyproject.toml`.
+- JavaScript: N/A (no targets).
+- Go: N/A (no targets).
 
 Inputs:
 

--- a/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
+++ b/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
@@ -53,7 +53,7 @@ Formalizing Stage 6 as cohesive tools improves reliability, supports automation-
 
 ### Goals
 
-- [ ] Provide four composable, idempotent tools exposed via CLI and MCP agent: CI Update, Changelog Update, Version Update, Metadata Update.
+- [ ] Provide three composable, idempotent tools exposed via CLI and MCP agent: Changelog Update, Version Update, Metadata Update.
 - [ ] Normalize execution order and expected outputs across all supported languages.
 - [ ] Encode management-plane vs data-plane behavioral differences explicitly (especially version & changelog logic).
 - [ ] Emit structured JSON results (status + message + next steps hints) enabling orchestration by AI agents and pipelines.
@@ -86,11 +86,11 @@ Implement three individual CLI + MCP tools. Each tool:
 4. Otherwise falls back the CLI's built-in implementation for that language.
 5. Aggregates structured result JSON with a `result`, human-readable `message`, and optional `next_steps` hint guiding subsequent tool invocation.
 
-Note: see the [repo-tooling-contract](./specs/99-repo-tooling-contract.md) spec for more details.
+Note: see the [repo-tooling-contract](./99-repo-tooling-contract.md) spec for more details.
 
 ### Detailed Design
 
-The four tools are intentionally small, composable units. Each emits a machine-readable JSON payload to enable deterministic chaining by an agent or CI workflow. All tools share common behaviors:
+The three tools are intentionally small, composable units. Each emits a machine-readable JSON payload to enable deterministic chaining by an agent or CI workflow. All tools share common behaviors:
 
 | Area | Expected Behavior |
 |--------|-------------------|
@@ -310,7 +310,7 @@ flowchart TD
 
 This tool set is complete when:
 
-- [ ] All four tools emit structured JSON with consistent schema.
+- [ ] All three tools emit structured JSON with consistent schema.
 - [ ] Management-plane package run updates version + changelog automatically.
       Exception: Java returns `no-op` for `update-version` tool.
 - [ ] Data-plane run returns advisory for changelog and version.

--- a/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
+++ b/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
@@ -109,6 +109,7 @@ The four tools are intentionally small, composable units. Each emits a machine-r
 | Output Schema | JSON with fields: result, message (see schema below) |
 | Idempotency | Multiple successive runs produce identical filesystem state except for timestamps/logs |
 | Script Implementation | MUST be PowerShell `.ps1`. SHOULD accept named parameters (e.g., `sdkRepoPath`). MUST use exit code `0` for success/partial/noop; non-zero only on outright failure. Legacy non-PS scripts should be wrapped by a small PowerShell shim. Scripts MUST write a concise stderr line prefixed with `ERROR:`; include suggested mitigation steps and links to docs in the message where possible. |
+| Script Execution Environment | All scripts are executed using PowerShell Core (`pwsh`) terminal |
 | Next Steps Hint | Plain language phrase embedded in `message` (e.g., `next_steps: update version`) |
 | Missing Required Tools | If a required external tool is not present (for example: `dotnet`, `gofmt`, `pwsh`), prompt the user to run the `verify-setup` tool which validates and documents missing prerequisites. |
 
@@ -155,8 +156,8 @@ When the tool executes the language-specific `update-changelog` script it will p
 
 | Parameter | Description | Type | Required |
 |-----------|-------------|-----:|:--------:|
-| `sdkRepoPath` | Absolute path to the root folder of the local SDK repository. | string | Yes |
-| `packagePath` | Absolute path to the root folder of the local SDK project (package). | string | Yes |
+| `SdkRepoPath` | Absolute path to the root folder of the local SDK repository. | string | Yes |
+| `PackagePath` | Absolute path to the root folder of the local SDK project (package). | string | Yes |
 
 Note: The script only needs to cover mgmt-plane.
 
@@ -164,8 +165,8 @@ Note: The script only needs to cover mgmt-plane.
 
 ```powershell
 update-changelog.ps1 \
-      -sdkRepoPath C:\dev\repos\azure-sdk-for-net \
-      -packagePath C:\dev\repos\azure-sdk-for-net\services\newservice
+      -SdkRepoPath C:\dev\repos\azure-sdk-for-net \
+      -PackagePath C:\dev\repos\azure-sdk-for-net\services\newservice
 ```
 
 #### 2. Version Update Tool
@@ -216,22 +217,22 @@ When the tool executes the language-specific `update-version` script it will pas
 
 | Parameter | Description | Type | Required |
 |-----------|-------------|------:|:--------:|
-| `sdkRepoPath` | Absolute path to the root folder of the local SDK repository. | string | Yes |
-| `packagePath` | Absolute path to the root folder of the local SDK project (package). | string | Yes |
-| `sdkReleaseType` | Specifies whether the next version is `beta` or `stable`. | string | No |
-| `sdkVersion` | Specifies the next version to set (explicit version string). | string | No |
-| `sdkReleaseDate` | Release date to write into changelog (YYYY-MM-DD). | string | No |
+| `SdkRepoPath` | Absolute path to the root folder of the local SDK repository. | string | Yes |
+| `PackagePath` | Absolute path to the root folder of the local SDK project (package). | string | Yes |
+| `SdkReleaseType` | Specifies whether the next version is `beta` or `stable`. | string | No |
+| `SdkVersion` | Specifies the next version to set (explicit version string). | string | No |
+| `SdkReleaseDate` | Release date to write into changelog (YYYY-MM-DD). | string | No |
 
-Note: For management-plane (mgmt) packages, at least one of `sdkVersion` or `sdkReleaseType` MUST be provided; the script will fail with an error if neither is supplied or validation fails.
+Note: For management-plane (mgmt) packages, at least one of `SdkVersion` or `SdkReleaseType` MUST be provided; the script will fail with an error if neither is supplied or validation fails.
 
 **Example invocations:**
 
 ```powershell
 update-version.ps1 \
-      -sdkRepoPath C:\dev\repos\azure-sdk-for-net \
-      -packagePath C:\dev\repos\azure-sdk-for-net\services\newservice \
-      -sdkReleaseType stable \
-      -sdkReleaseDate 2025-10-17
+      -SdkRepoPath C:\dev\repos\azure-sdk-for-net \
+      -PackagePath C:\dev\repos\azure-sdk-for-net\services\newservice \
+      -SdkReleaseType stable \
+      -SdkReleaseDate 2025-10-17
 ```
 
 #### 3. Metadata Update Tool
@@ -272,15 +273,15 @@ When the tool executes the language-specific `update-metadata` script it will pa
 
 | Parameter | Description | Type | Required |
 |-----------|-------------|-----:|:--------:|
-| `sdkRepoPath` | Absolute path to the root folder of the local SDK repository. | string | Yes |
-| `packagePath` | Absolute path to the root folder of the local SDK project (package). | string | Yes |
+| `SdkRepoPath` | Absolute path to the root folder of the local SDK repository. | string | Yes |
+| `PackagePath` | Absolute path to the root folder of the local SDK project (package). | string | Yes |
 
 **Example invocations:**
 
 ```powershell
 update-metadata.ps1 \
-      -sdkRepoPath C:\dev\repos\azure-sdk-for-net \
-      -packagePath C:\dev\repos\azure-sdk-for-net\services\newservice
+      -SdkRepoPath C:\dev\repos\azure-sdk-for-net \
+      -PackagePath C:\dev\repos\azure-sdk-for-net\services\newservice
 ```
 
 #### 4. CI Update Tool
@@ -319,15 +320,15 @@ When the tool executes the language-specific `update-ci` script it will pass the
 
 | Parameter | Description | Type | Required |
 |-----------|-------------|-----:|:--------:|
-| `sdkRepoPath` | Absolute path to the root folder of the local SDK repository. | string | Yes |
-| `packagePath` | Absolute path to the root folder of the local SDK project (package). | string | Yes |
+| `SdkRepoPath` | Absolute path to the root folder of the local SDK repository. | string | Yes |
+| `PackagePath` | Absolute path to the root folder of the local SDK project (package). | string | Yes |
 
 **Example invocations:**
 
 ```powershell
 update-ci.ps1 \
-      -sdkRepoPath C:\dev\repos\azure-sdk-for-net \
-      -packagePath C:\dev\repos\azure-sdk-for-net\services\newservice
+      -SdkRepoPath C:\dev\repos\azure-sdk-for-net \
+      -PackagePath C:\dev\repos\azure-sdk-for-net\services\newservice
 ```
 
 #### 5. Aggregated Tool (chained execution)

--- a/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
+++ b/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
@@ -115,9 +115,9 @@ The four tools are intentionally small, composable units. Each emits a machine-r
 
 #### 1. Changelog Update Tool
 
-Name (CLI): `azsdk package changelog update`
+Name (CLI): `azsdk package update changelog`
 
-Name (MCP): `azsdk_package_changelog_update`
+Name (MCP): `azsdk_package_update_changelog`
 
 Purpose: Ensure changelog is auto-generated and has an entry for the upcoming release (management-plane) or provide guidance (data-plane) where manual editing is expected.
 
@@ -171,9 +171,9 @@ update-changelog.ps1 \
 
 #### 2. Version Update Tool
 
-Name (CLI): `azsdk package version update`
+Name (CLI): `azsdk package update version`
 
-Name (MCP): `azsdk_package_version_update`
+Name (MCP): `azsdk_package_update_version`
 
 Purpose: Increment and propagate package version across all authoritative version surfaces (e.g., `pom.xml`, `_version.py`, `*.csproj`, `package.json`, `go.mod`, `CHANGELOG.md`).
 
@@ -237,9 +237,9 @@ update-version.ps1 \
 
 #### 3. Metadata Update Tool
 
-Name (CLI): `azsdk package metadata update`
+Name (CLI): `azsdk package update metadata`
 
-Name (MCP): `azsdk_package_metadata_update`
+Name (MCP): `azsdk_package_update_metadata`
 
 Purpose: Update additional language-specific metadata and documentation, such as `_metadata.json`, `pom.xml` etc., export API surface (.NET).
 
@@ -286,9 +286,9 @@ update-metadata.ps1 \
 
 #### 4. CI Update Tool
 
-Name (CLI): `azsdk package ci update`
+Name (CLI): `azsdk package update ci`
 
-Name (MCP): `azsdk_package_ci_update`
+Name (MCP): `azsdk_package_update_ci`
 
 > **Note:** Support for this tool is planned for post‑milestone-1.
 
@@ -337,9 +337,9 @@ update-ci.ps1 \
 
 #### 5. Aggregated Tool (chained execution)
 
-Name (CLI): `azsdk package update`
+Name (CLI): `azsdk package update all`
 
-Name (MCP): `azsdk_package_update`
+Name (MCP): `azsdk_package_update_all`
 
 > **Note:** Support for this tool is planned for post‑milestone-1.
 
@@ -380,10 +380,10 @@ Example aggregated output (successful):
 Typical CLI workflow:
 
 ```bash
-azsdk package ci update --package-path /abs/sdk/path
-azsdk package changelog update --package-path /abs/sdk/path
-azsdk package metadata update --package-path /abs/sdk/path
-azsdk package version update --package-path /abs/sdk/path --version 1.0.0 --release-date 2025-10-17
+azsdk package update ci --package-path /abs/sdk/path
+azsdk package update changelog --package-path /abs/sdk/path
+azsdk package update metadata --package-path /abs/sdk/path
+azsdk package update version --package-path /abs/sdk/path --version 1.0.0 --release-date 2025-10-17
 ```
 
 ### Architecture Diagram
@@ -515,12 +515,12 @@ Add initial CI configuration for a new SDK at /work/sdk/new-service/new-package.
 
 ## CLI Commands
 
-### package ci update
+### package update ci
 
 **Command:**
 
 ```bash
-azsdk package ci update --package-path <absolute_folder_path_to_package>
+azsdk package update ci --package-path <absolute_folder_path_to_package>
 ```
 
 **Options:**
@@ -539,12 +539,12 @@ azsdk package ci update --package-path <absolute_folder_path_to_package>
 "failed, script exited 1: missing pwsh"
 ```
 
-### package changelog update
+### package update changelog
 
 **Command:**
 
 ```bash
-azsdk package changelog update --package-path <absolute_folder_path_to_package>
+azsdk package update changelog --package-path <absolute_folder_path_to_package>
 ```
 
 **Options:**
@@ -563,12 +563,12 @@ azsdk package changelog update --package-path <absolute_folder_path_to_package>
 "succeeded, Data-plane changelog no-op; manual edits required; next_steps: update version (if release)."
 ```
 
-### package version update
+### package update version
 
 **Command:**
 
 ```bash
-azsdk package version update --package-path <absolute_folder_path_to_package> --release-type <stable|beta>
+azsdk package update version --package-path <absolute_folder_path_to_package> --release-type <stable|beta>
 ```
 
 **Options:**
@@ -588,12 +588,12 @@ azsdk package version update --package-path <absolute_folder_path_to_package> --
 "failed, ERROR: the input version is invalid. next_steps: refer to aka-link to provide a valid version."
 ```
 
-### package metadata update
+### package update metadata
 
 **Command:**
 
 ```bash
-azsdk package metadata update --package-path <absolute_folder_path_to_package>
+azsdk package update metadata --package-path <absolute_folder_path_to_package>
 ```
 
 **Options:**

--- a/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
+++ b/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
@@ -21,7 +21,7 @@
 
 - **Stage 6**: The standardized SDK preparation stage after code/tests/samples validation and before creating the release preparation PR.
 - **Metadata and Documentation Update**: Consolidated set of actions to ensure non-source assets (README, changelog, CI config, version numbers, additional descriptors) are accurate and consistent.
-- **Tool**: A discrete CLI (and MCP agent-exposed) command implementing one cohesive post-generation preparation task.
+- **Tool**: A discrete CLI and MCP agent-exposed command implementing one cohesive post-generation preparation task.
 
 ---
 

--- a/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
+++ b/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
@@ -64,7 +64,7 @@ Formalizing Stage 6 as cohesive tools improves reliability, supports automation-
 | Exception | Description | Impact | Workaround |
 |---|---|---|---|
 | Data‑Plane Deferred Version Bump | Data‑plane packages typically defer version adjustment and release‑date updates until the release‑preparedness phase. | The `update-version` tool may be a no‑op for data‑plane flows during Stage 6. | Keep version changes manually for milestone 1. |
-| Changelog Auto‑Generation (Data‑Plane) | Automatic changelog generation is not performed for data‑plane packages; manual editing is expected. | The `update-changelog` tool should not auto‑generate entries for data‑plane packages and should instead surface guidance. | Return a `noop` result with `next_steps` prompting manual edits. Consider future LLM integration to automate this post milestone 1. |
+| Changelog Auto‑Generation (Data‑Plane) | Automatic changelog generation is not performed for data‑plane packages; manual editing is expected. | The `update-changelog-content` tool should not auto‑generate entries for data‑plane packages and should instead surface guidance. | Return a `noop` result with `next_steps` prompting manual edits. Consider future LLM integration to automate this post milestone 1. |
 
 ### Language-Specific Limitations
 
@@ -107,7 +107,7 @@ The three tools are intentionally small, composable units. Each emits a machine-
 
 Name (CLI): `azsdk package update-changelog-content`
 
-Name (MCP): `azsdk_package_update_changelog`
+Name (MCP): `azsdk_package_update_changelog-content`
 
 Purpose: Ensure changelog is auto-generated and has an entry for the upcoming release (management-plane) or provide guidance (data-plane) where manual editing is expected. This tool only modifies changelog content and does not change release date or version numbers.
 
@@ -263,7 +263,7 @@ flowchart TD
 
 ### Workflow Diagram
 
-#### Update-Changelog (mgmt-plane)
+#### Update-Changelog-Content (mgmt-plane)
 
 ```mermaid
 flowchart TD
@@ -274,19 +274,19 @@ flowchart TD
     
       E --> F{Repository root found?}
       F -->|No| G[Return failure: Failed to discover SDK repo]
-      F -->|Yes| H[Get update-changelog configuration] 
+      F -->|Yes| H[Get update-changelog-content configuration] 
     
       H --> I{Configuration retrieval successful?}
-      I -->|No| J[Return failure: Failed to get update-changelog configuration] 
+      I -->|No| J[Return failure: Failed to get update-changelog-content configuration] 
       I -->|Yes| K{Configuration type?}
     
-      K -->|Script| L[Run update-changelog script]
+      K -->|Script| L[Run update-changelog-content script]
       K -->|None| M[Run CLI built-in code] 
     
       L --> N[Prepare result] 
       M --> N
     
-      N --> O{update-changelog process completed?} 
+      N --> O{update-changelog-content process completed?} 
       O -->|Failed| P[Return failure with exit code and output]
       O -->|Success| Q[Return success]
     
@@ -440,7 +440,7 @@ azsdk package update-metadata --package-path <absolute_folder_path_to_package>
 
 ### Phase 1: Core Tooling (Milestone 1)
 
-- Milestone: Implement CLI + MCP entrypoints for three tools including update-changelog, update-version, and update-metadata; integrate repository script service; mgmt-plane happy path.
+- Milestone: Implement CLI + MCP entrypoints for three tools including update-changelog-content, update-version, and update-metadata; integrate repository script service; mgmt-plane happy path.
 - Timeline: 1 sprint.
 - Dependencies: language-specific logic implementation.
 

--- a/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
+++ b/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
@@ -86,7 +86,28 @@ Implement three individual CLI + MCP tools. Each tool:
 4. Otherwise falls back the CLI's built-in implementation for that language.
 5. Aggregates structured result JSON with a `result`, human-readable `message`, and optional `next_steps` hint guiding subsequent tool invocation.
 
-Note: see the [repo-tooling-contract](./99-repo-tooling-contract.md) spec for more details.
+#### Configuration for the language respository
+
+Each language repository includes a `swagger_to_sdk_config.json` under its `eng` folder. Per-language script entrypoints are declared in the `packageOptions` section using repository-root–relative paths. The CLI will resolve those paths against the discovered repo root, convert them to absolute paths before invoking, and validate file existence before execution.
+
+Example configuration,
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/Azure/azure-sdk-tools/main/tools/spec-gen-sdk/src/types/SwaggerToSdkConfigSchema.json",
+  "packageOptions": {
+    "updateChangelogContentScript": {
+      "path": "./eng/scripts/Automation-Sdk-UpdateChangelogContent.ps1"
+    },
+    "updateVersionScript": {
+      "path": "./eng/scripts/Automation-Sdk-UpdateVersion.ps1"
+    },
+    "updateMetadataScript": {
+      "path": "./eng/scripts/Automation-Sdk-UpdateMetadata.ps1"
+    }
+  }
+}
+```
 
 ### Detailed Design
 

--- a/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
+++ b/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
@@ -84,7 +84,7 @@ Implement four individual CLI + MCP tools. Each tool:
 1. Resolves package path & language.
 2. Loads configuration for the language repository.
 3. If a script is configured, executes the script.
-4. Otherwise falls back to run the code implemented inside the tool(CLI).
+4. Otherwise falls back the CLI's built-in implementation for that language.
 5. Aggregates structured result JSON with a `result`, human-readable `message`, and optional `next_steps` hint guiding subsequent tool invocation.
 
 Provides a singular CLI + MCP command that orchestrates the four tools (update-ci → update-changelog → update-version → update-metadata) and returns a combined JSON summary (post milestone 1).
@@ -97,7 +97,7 @@ The four tools are intentionally small, composable units. Each emits a machine-r
 |--------|-------------------|
 | Invocation Mode | CLI and MCP (agent) alias; same semantics |
 | Input Path Validation | Must exist and contain a recognizable SDK language structure; errors early if not |
-| Language Logic Routing | Use the [`repository service`](https://github.com/benbp/azure-sdk-tools/blob/3aeb49b0c9bde3c6752e369369245fb8c743a759/tools/azsdk-cli/docs/specs/7-repo-tooling-contract.md) to load the language repo configuration. If a script is configured, invoke it; otherwise fall back to the CLI's built-in implementation |
+| Language Logic Routing | Use the [`repository service`](https://github.com/Azure/azure-sdk-tools/pull/12696d) to load the language repo configuration. If a script is configured, invoke it; otherwise fall back to the CLI's built-in implementation |
 | Timeout (default) | 5 minutes per tool invocation |
 | Output Schema | JSON with fields: result, message (see schema below) |
 | Idempotency | Multiple successive runs produce identical filesystem state except for timestamps/logs |

--- a/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
+++ b/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
@@ -247,14 +247,14 @@ flowchart TD
   subgraph azsdk_cli
     direction TB
     classifier[SDK Classifier]
-    service[Repository Service]
-    executor[Command Executor]
+    languageService[Language Service]
+    repoService[Repository Service]    
     serializer[Result Serializer]
   end
 
-  classifier --> service
-  service --> executor
-  executor --> serializer
+  classifier --> languageService
+  languageService --> repoService
+  repoService --> serializer
 
   style azsdk_cli fill:#e3f2fd,stroke:#0277bd
   style Agent fill:#e1f5fe,stroke:#0288d1

--- a/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
+++ b/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
@@ -84,7 +84,7 @@ Implement four individual CLI + MCP tools. Each tool:
 1. Resolves package path & language.
 2. Loads configuration for the language repository.
 3. If a script is configured, executes the script.
-4. Otherwise falls back to run the code implementated inside the tool(CLI).
+4. Otherwise falls back to run the code implemented inside the tool(CLI).
 5. Aggregates structured result JSON with a `result`, human-readable `message`, and optional `next_steps` hint guiding subsequent tool invocation.
 
 Provides a singular CLI + MCP command that orchestrates the four tools (update-ci → update-changelog → update-version → update-metadata) and returns a combined JSON summary (post milestone 1).

--- a/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
+++ b/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
@@ -78,11 +78,7 @@ Formalizing Stage 6 as four cohesive tools improves reliability, supports automa
 
 | Language   | Limitation | Impact | Workaround |
 |------------|------------|--------|------------|
-| .NET       | Requires API export step | Extra time / possible failure if tools missing | Fail with actionable guidance |
-| Java       | `pom.xml` consistency required | Build failure if missed | Validate & patch automatically |
-| JavaScript | README snippet accuracy depends on snippet validator | Potential stale install commands | Run snippet validation separately earlier |
-| Python     | `_metadata.json` variance | Packaging warnings | Enforce schema during metadata update |
-| Go         | Formatting (gofmt) essential | Diff noise in PRs | Auto-run formatter in metadata update |
+| JavaScript | Code formatting isn't hooked up to the emitter | Noisy diffs or linter failures | Run code formatting step in the `update-metadata.ps1` script |
 
 ---
 


### PR DESCRIPTION

- Ported the [original docs specs](https://microsoft-my.sharepoint.com/:w:/p/raychen/IQAhDpImqdGbSIqU7iXKHUOqAaQ8j7Rw_sGUOtxjq55pxwc?e=ukoWtP)  into the new spec layout.

- Added new content and clarifications to match the updated format.

- See issue https://github.com/Azure/azure-sdk-tools/issues/11827 for scope and follow-ups.