### PR TITLE
add token usage data to telemetry

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Extensions/OpenTelemetryExtensions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Extensions/OpenTelemetryExtensions.cs
@@ -8,8 +8,6 @@ using Azure.Sdk.Tools.Cli.Telemetry;
 using Azure.Sdk.Tools.Cli.Telemetry.InformationProvider;
 using Azure.Monitor.OpenTelemetry.Exporter;
 using Microsoft.Extensions.Azure;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -31,13 +29,9 @@ public static class OpenTelemetryExtensions
                 {
                     options.Version = assemblyName.Version.ToString();
                 }
-#if !DEBUG
                 var collectTelemetry = Environment.GetEnvironmentVariable("AZSDKTOOLS_COLLECT_TELEMETRY");
                 options.IsTelemetryEnabled = string.IsNullOrEmpty(collectTelemetry)
                     || (bool.TryParse(collectTelemetry, out var shouldCollect) && shouldCollect);
-#else
-                options.IsTelemetryEnabled = false;
-#endif
             });
 
         services.AddSingleton<ITelemetryService, TelemetryService>();

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TokenUsageHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TokenUsageHelper.cs
@@ -1,9 +1,13 @@
+using System.Diagnostics;
+using static Azure.Sdk.Tools.Cli.Telemetry.TelemetryConstants;
+
 namespace Azure.Sdk.Tools.Cli.Helpers;
 
 public class TokenUsageHelper(IRawOutputHelper outputHelper)
 {
     protected double PromptTokens { get; set; } = 0;
     protected double CompletionTokens { get; set; } = 0;
+    public double TotalTokens => PromptTokens + CompletionTokens;
     protected IEnumerable<string> ModelsUsed { get; set; } = [];
 
     public void Add(string model, long inputTokens, long outputTokens)
@@ -11,6 +15,11 @@ public class TokenUsageHelper(IRawOutputHelper outputHelper)
         ModelsUsed = ModelsUsed.Union([model]);
         PromptTokens += inputTokens;
         CompletionTokens += outputTokens;
+
+        Activity.Current?.SetCustomProperty(TagName.PromptTokens, PromptTokens.ToString("F0"));
+        Activity.Current?.SetCustomProperty(TagName.CompletionTokens, CompletionTokens.ToString("F0"));
+        Activity.Current?.SetCustomProperty(TagName.TotalTokens, TotalTokens.ToString("F0"));
+        Activity.Current?.SetCustomProperty(TagName.ModelsUsed, string.Join(",", ModelsUsed.OrderBy(m => m)));
     }
 
     public void LogUsage()
@@ -18,7 +27,7 @@ public class TokenUsageHelper(IRawOutputHelper outputHelper)
         var models = string.Join(", ", ModelsUsed);
 
         outputHelper.OutputConsole("--------------------------------------------------------------------------------");
-        outputHelper.OutputConsole($"[token usage][{models}] input: {PromptTokens}, output: {CompletionTokens}, total: {PromptTokens + CompletionTokens}");
+        outputHelper.OutputConsole($"[token usage][{models}] input: {PromptTokens}, output: {CompletionTokens}, total: {TotalTokens}");
         outputHelper.OutputConsole("--------------------------------------------------------------------------------");
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/PackageInfo.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/PackageInfo.cs
@@ -4,15 +4,6 @@ using System.Text.Json.Serialization;
 
 namespace Azure.Sdk.Tools.Cli.Models;
 
-public enum SdkType
-{
-    [JsonPropertyName("")]
-    Unknown,
-    [JsonPropertyName("mgmt")]
-    Management,
-    [JsonPropertyName("client")]
-    Dataplane
-}
 /// <summary>
 /// Plain data model representing inferred information about an Azure SDK package.
 /// </summary>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/SdkType.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/SdkType.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace Azure.Sdk.Tools.Cli.Models;
+
+public enum SdkType
+{
+    [JsonPropertyName("")]
+    Unknown,
+    [JsonPropertyName("mgmt")]
+    Management,
+    [JsonPropertyName("client")]
+    Dataplane
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryConstants.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryConstants.cs
@@ -26,6 +26,16 @@ internal static class TelemetryConstants
         public const string CommandArgs = "CommandArgs";
         public const string CommandResponse = "CommandResponse";
         public const string DebugTag = "IsDebugEnvironment";
+
+        // Custom Properties that get promoted to tags
+        public const string Language = "language";
+        public const string PackageName = "package_name";
+        public const string TypeSpecProject = "typespec_project";
+        public const string SdkType = "sdk_type";
+        public const string PromptTokens = "prompt_tokens";
+        public const string CompletionTokens = "completion_tokens";
+        public const string TotalTokens = "total_tokens";
+        public const string ModelsUsed = "models_used";
     }
 
     internal class ActivityName

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryProcessor.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryProcessor.cs
@@ -1,5 +1,6 @@
-using OpenTelemetry;
 using System.Diagnostics;
+using OpenTelemetry;
+using Azure.Sdk.Tools.Cli.Models;
 
 namespace Azure.Sdk.Tools.Cli.Telemetry;
 
@@ -11,16 +12,40 @@ public sealed class TelemetryProcessor : BaseProcessor<Activity>
 
     public override void OnEnd(Activity activity)
     {
-        // TODO: Add progress/logging for MCP clients so we can see the spans in debug mode
-        // without it being treated as a parse failure when using AddConsoleExporter()
-
-        // Do any post-processing work here
-        /*
-        var toolName = activity.GetTagItem("mcp.tool.name") as string;
-        if (!string.IsNullOrEmpty(toolName))
+        // Tool/Command telemetry
+        if (activity.GetCustomProperty(TelemetryConstants.TagName.Language) is string language)
         {
-            activity.SetTag("CustomToolProperty", toolName);
+            activity.SetTag(TelemetryConstants.TagName.Language, language);
         }
-        */
+        if (activity.GetCustomProperty(TelemetryConstants.TagName.PackageName) is string packageName)
+        {
+            activity.SetTag(TelemetryConstants.TagName.PackageName, packageName);
+        }
+        if (activity.GetCustomProperty(TelemetryConstants.TagName.TypeSpecProject) is string typeSpecProject)
+        {
+            activity.SetTag(TelemetryConstants.TagName.TypeSpecProject, typeSpecProject);
+        }
+        if (activity.GetCustomProperty(TelemetryConstants.TagName.SdkType) is SdkType sdkType)
+        {
+            activity.SetTag(TelemetryConstants.TagName.SdkType, sdkType);
+        }
+
+        // TokenUsageHelper telemetry
+        if (activity.GetCustomProperty(TelemetryConstants.TagName.PromptTokens) is string promptTokens)
+        {
+            activity.SetTag(TelemetryConstants.TagName.PromptTokens, promptTokens);
+        }
+        if (activity.GetCustomProperty(TelemetryConstants.TagName.CompletionTokens) is string completionTokens)
+        {
+            activity.SetTag(TelemetryConstants.TagName.CompletionTokens, completionTokens);
+        }
+        if (activity.GetCustomProperty(TelemetryConstants.TagName.TotalTokens) is string totalTokens)
+        {
+            activity.SetTag(TelemetryConstants.TagName.TotalTokens, totalTokens);
+        }
+        if (activity.GetCustomProperty(TelemetryConstants.TagName.ModelsUsed) is string modelsUsed)
+        {
+            activity.SetTag(TelemetryConstants.TagName.ModelsUsed, modelsUsed);
+        }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Core/MCPToolBase.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Core/MCPToolBase.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.CommandLine;
-using System.CommandLine.Parsing;
 using System.Diagnostics;
 using Azure.Sdk.Tools.Cli.Commands;
 using Azure.Sdk.Tools.Cli.Helpers;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Example/ExampleTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Example/ExampleTool.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.CommandLine;
-using System.CommandLine.Parsing;
 using System.ComponentModel;
 using Azure.AI.OpenAI;
 using ModelContextProtocol.Server;


### PR DESCRIPTION
This PR adds data for token usage to our telemetry for commands that make backend calls to openai via microagent or azure agent service.

It does this by updating the telemetry processor to look for a list of properties that may have been set via `Activity.SetCustomProperty()` and promoting them to tags. Classes within an activity scope can set these properties via `Activity.Current?.SetCustomProperty()`. In the future, we will ideally add some middleware to the MCP server and the CLI parser to auto-set tags like package, language, etc. based on well known parameters.

It also changes the telemetry opt-out in debug mode to just remove the exporter (skip upload). This way we can still get the telemetry properties dumped to console when `--debug` is enabled (very useful for testing).


**OLD DISCUSSION FROM PRIOR CHANGES, IGNORE NOT RELEVANT**

[EDIT] I am going to try out the approach suggested in https://github.com/Azure/azure-sdk-tools/pull/12567#issuecomment-3424008171 relevant to my questions/concerns below:

I'm not confident in the approach I took here, so would love to get feedback. The core issue I faced is that we register the token usage helper in DI with `AddScoped` but the telemetry service is a singleton via `AddSingleton`. The benefit of scoped is that we get tracking of token usage by any class within the request scope. That means if we have multiple backend agent calls from one MCP tool call, those will all get added to the token usage count that we submit for the telemetry event without having to propagate a token usage helper instance ourselves (DI does it for us). However because the telemetry service is a singleton it can't take a dependency on the scoped token usage helper. I think we still want telemetry service as a singleton so that we can track a root/parent activity id to record all tool calls that exist within an MCP server session, as detailed in our telemetry spec.

What I have done to work around this is introduce a static `TelemetryContext` class that we add to our `TelemetryProcessor`. The processor is wired up when we initialize the telemetry service and handles `OnEnd` events for any `Activity`, so that we can add the final token usage to the event before it gets uploaded. Now at the start of any CLI command or MCP tool call we invoke `TelemetryContext.Reset(tokenUsageHelper)` using the injected token usage helper, and any future scoped tracker classes could also be added onto the context.

Overall this approach of managing state by patching a global object feels super brittle, as it's easy to miss that `Reset()` needs to be called if we ever refactor or add new modes. I'd love if anyone has ideas about a simpler way that I could do this.

This will change slightly after #12566 goes in but the main logic for review will be as presented.