### PR TITLE
Use Format() override instead of ToString() for command responses

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/AnalyzePipelineResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/AnalyzePipelineResponse.cs
@@ -22,7 +22,7 @@ public class AnalyzePipelineResponse : CommandResponse
         WriteIndented = true,
     };
 
-    public override string ToString()
+    protected override string Format()
     {
         var output = "";
 
@@ -42,6 +42,6 @@ public class AnalyzePipelineResponse : CommandResponse
             output += string.Join(Environment.NewLine, FailedTasks.Select(t => t.ToString())) + Environment.NewLine;
         }
 
-        return ToString(output);
+        return output;
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/CLICheckResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/CLICheckResponse.cs
@@ -33,9 +33,9 @@ public class CLICheckResponse : CommandResponse
         CheckStatusDetails = processResult.Output;
     }
 
-    public override string ToString()
+    protected override string Format()
     {
-        return ToString(CheckStatusDetails);
+        return CheckStatusDetails;
     }
 }
 
@@ -52,9 +52,9 @@ public class CookbookCLICheckResponse : CLICheckResponse
         CookbookReference = cookbookReference;
     }
 
-    public override string ToString()
+    protected override string Format()
     {
-        return ToString(CheckStatusDetails);
+        return CheckStatusDetails;
     }
 }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/CodeownersValidationResult.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/CodeownersValidationResult.cs
@@ -23,7 +23,7 @@ public class CodeownersValidationResult : CommandResponse
     [JsonPropertyName("organizations")]
     public Dictionary<string, bool> Organizations { get; set; } = new();
 
-    public override string ToString()
+    protected override string Format()
     {
         var result = new StringBuilder();
         result.AppendLine($"Username: {Username}");

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/CommandResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/CommandResponse.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 
 namespace Azure.Sdk.Tools.Cli.Models;
 
-public class CommandResponse
+public abstract class CommandResponse
 {
     private int? exitCode = null;
     [JsonIgnore]
@@ -44,13 +44,12 @@ public class CommandResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<string>? NextSteps { get; set; }
 
-    protected string ToString(StringBuilder value)
-    {
-        return ToString(value.ToString());
-    }
+    protected abstract string Format();
 
-    protected string ToString(string value)
+    public override string ToString()
     {
+        var value = Format();
+
         List<string> messages = [];
         if (!string.IsNullOrEmpty(ResponseError))
         {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/DefaultCommandResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/DefaultCommandResponse.cs
@@ -25,7 +25,7 @@ public class DefaultCommandResponse : CommandResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public long Duration { get; set; }
 
-    public override string ToString()
+    protected override string Format()
     {
         var output = new StringBuilder();
         if (!string.IsNullOrEmpty(Message))
@@ -52,7 +52,7 @@ public class DefaultCommandResponse : CommandResponse
             output.AppendLine($"Duration: {Duration}ms");
         }
 
-        return ToString(output);
+        return output.ToString();
     }
 
     public static implicit operator DefaultCommandResponse(string s) => new() { Message = s };

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/DownloadResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/DownloadResponse.cs
@@ -20,8 +20,8 @@ public class DownloadResponse : CommandResponse
     [JsonPropertyName("total_files")]
     public int TotalFiles { get; set; }
 
-    public override string ToString()
+    protected override string Format()
     {
-        return ToString(Message);
+        return Message;
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ExampleServiceResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ExampleServiceResponse.cs
@@ -26,7 +26,7 @@ public class ExampleServiceResponse : CommandResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Dictionary<string, string>? Details { get; set; }
 
-    public override string ToString()
+    protected override string Format()
     {
         var sb = new StringBuilder();
 
@@ -54,6 +54,6 @@ public class ExampleServiceResponse : CommandResponse
             }
         }
 
-        return ToString(sb); // Calls base method to include error formatting
+        return sb.ToString();
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/FailedTestRunListResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/FailedTestRunListResponse.cs
@@ -9,13 +9,13 @@ public class FailedTestRunListResponse : CommandResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public List<FailedTestRunResponse> Items { get; set; } = [];
 
-    public override string ToString()
+    protected override string Format()
     {
         var output = new StringBuilder();
         foreach (var run in Items)
         {
             output.AppendLine(run.ToString());
         }
-        return ToString(output);
+        return output.ToString();
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/FailedTestRunResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/FailedTestRunResponse.cs
@@ -28,7 +28,7 @@ public class FailedTestRunResponse : CommandResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string Uri { get; set; }
 
-    public override string ToString()
+    protected override string Format()
     {
         var output = "";
         output += $"## {TestCaseTitle}{Environment.NewLine}";
@@ -44,6 +44,6 @@ public class FailedTestRunResponse : CommandResponse
         output += $"{Environment.NewLine}### Stack Trace{Environment.NewLine}{StackTrace}{Environment.NewLine}";
         output += $"### Error Message{Environment.NewLine}{ErrorMessage}{Environment.NewLine}";
 
-        return ToString(output);
+        return output;
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/LogAnalysisResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/LogAnalysisResponse.cs
@@ -20,7 +20,7 @@ public class LogAnalysisResponse : CommandResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string SuggestedFix { get; set; }
 
-    public override string ToString()
+    protected override string Format()
     {
         var output = $"### Summary:" + Environment.NewLine +
                      $"{Summary}" + Environment.NewLine + Environment.NewLine;
@@ -41,7 +41,7 @@ public class LogAnalysisResponse : CommandResponse
                       Environment.NewLine;
         }
 
-        return ToString(output);
+        return output;
     }
 }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ObjectCommandResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ObjectCommandResponse.cs
@@ -20,7 +20,7 @@ public class ObjectCommandResponse : CommandResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public object? Result { get; set; }
 
-    public override string ToString()
+    protected override string Format()
     {
         var result = new StringBuilder();
         if (!string.IsNullOrEmpty(Message))
@@ -31,6 +31,6 @@ public class ObjectCommandResponse : CommandResponse
         {
             result.AppendLine(JsonSerializer.Serialize(Result, serializerOptions));
         }
-        return ToString(result);
+        return result.ToString();
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/PackageResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/PackageResponse.cs
@@ -76,7 +76,7 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses
         [JsonPropertyName("Package readiness details")]
         public string PackageReadinessDetails { get; set; } = string.Empty;
 
-        public override string ToString()
+        protected override string Format()
         {
             //Create an output string with all the properties of the Package
             StringBuilder output = new StringBuilder();
@@ -120,7 +120,7 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses
             output.AppendLine($"### Is Package Ready: {IsPackageReady}");
             output.AppendLine($"### Package Readiness Details: {PackageReadinessDetails}");
             output.AppendLine($"### Planned Release Date: {PlannedReleaseDate}");
-            return ToString(output.ToString());
+            return output.ToString();
         }
     }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/SDKWorkflowResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/SDKWorkflowResponse.cs
@@ -15,7 +15,7 @@ public class SDKWorkflowResponse : CommandResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<string> Details { get; set; } = [];
 
-    public override string ToString()
+    protected override string Format()
     {
         var result = new StringBuilder();
         result.AppendLine($"Status: {Status}");
@@ -23,6 +23,6 @@ public class SDKWorkflowResponse : CommandResponse
         {
             result.AppendLine($"- {detail}");
         }
-        return ToString(result);
+        return result.ToString();
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/SdkReleaseResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/SdkReleaseResponse.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Azure.Sdk.Tools.Cli.Models.Responses
@@ -27,7 +26,7 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses
         [JsonPropertyName("Release status details")]
         public string ReleaseStatusDetails { get; set; } = string.Empty;
 
-        public override string ToString()
+        protected override string Format()
         {
             //Create an output string with all the properties of the package release
             StringBuilder output = new StringBuilder();
@@ -38,7 +37,7 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses
             output.AppendLine($"### Release Build Id: {PipelineBuildId}");
             output.AppendLine($"### Release Pipeline Status: {ReleasePipelineStatus}");
             output.AppendLine($"### Release Status Details: {ReleaseStatusDetails}");
-            return ToString(output.ToString());
+            return output.ToString();
         }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ServiceCodeownersResult.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ServiceCodeownersResult.cs
@@ -10,7 +10,7 @@ public class ServiceCodeownersResult : CommandResponse
     [JsonPropertyName("code_owners")]
     public List<CodeownersValidationResult> CodeOwners { get; set; } = new();
 
-    public override string ToString()
+    protected override string Format()
     {
         var lines = new List<string>
         {
@@ -26,6 +26,6 @@ public class ServiceCodeownersResult : CommandResponse
             }
         }
 
-        return ToString(string.Join(Environment.NewLine, lines));
+        return string.Join(Environment.NewLine, lines);
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ServiceLabelResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ServiceLabelResponse.cs
@@ -14,7 +14,7 @@ public class ServiceLabelResponse : CommandResponse
     [JsonPropertyName("label")]
     public string Label { get; set; } = string.Empty;
 
-    public override string ToString()
+    protected override string Format()
     {
         var output = $"Status: {Status}" + Environment.NewLine +
                      $"Label: {Label}";
@@ -24,6 +24,6 @@ public class ServiceLabelResponse : CommandResponse
             output += Environment.NewLine + $"Pull Request URL: {PullRequestUrl}";
         }
 
-        return ToString(output);
+        return output;
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/TspClientUpdateResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/TspClientUpdateResponse.cs
@@ -22,7 +22,7 @@ public class TspClientUpdateResponse : CommandResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ErrorCode { get; set; }
 
-    public override string ToString()
+    protected override string Format()
     {
         var sb = new StringBuilder();
         if (!string.IsNullOrEmpty(Message))
@@ -37,7 +37,7 @@ public class TspClientUpdateResponse : CommandResponse
         {
             sb.AppendLine($"ErrorCode: {ErrorCode}");
         }
-        return ToString(sb);
+        return sb.ToString();
     }
 }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/TspToolResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/TspToolResponse.cs
@@ -12,11 +12,11 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses
         [JsonPropertyName("is_successful")]
         public bool IsSuccessful { get; set; }
 
-        public override string ToString()
+        protected override string Format()
         {
             if (!IsSuccessful)
             {
-                return ToString(string.Empty);
+                return string.Empty;
             }
             else
             {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ValidationResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ValidationResponse.cs
@@ -24,8 +24,8 @@ public class ValidationResponse : CommandResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<string>? MissingFiles { get; set; }
 
-    public override string ToString()
+    protected override string Format()
     {
-        return ToString(Message);
+        return Message;
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/SpecCommonTools.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/SpecCommonTools.cs
@@ -55,7 +55,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.TypeSpec
                     return modifiedProjects;
 
                 default:
-                    return new() { ResponseError = $"Unknown command: '{command}'" };
+                    return new DefaultCommandResponse { ResponseError = $"Unknown command: '{command}'" };
             }
         }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/SpecValidationTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/SpecValidationTool.cs
@@ -48,7 +48,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.TypeSpec
 
                 default:
                     logger.LogError("Unknown command: {command}", command);
-                    return new() { ResponseError = $"Unknown command: '{command}'" };
+                    return new DefaultCommandResponse { ResponseError = $"Unknown command: '{command}'" };
             }
         }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/TspInitTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/TspInitTool.cs
@@ -90,7 +90,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.TypeSpec
             catch (Exception ex)
             {
                 logger.LogError(ex, "Error initializing TypeSpec project");
-                return new() { ResponseError = ex.Message };
+                return new DefaultCommandResponse { ResponseError = ex.Message };
             }
         }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/TypeSpecPublicRepoValidationTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/TypeSpecPublicRepoValidationTool.cs
@@ -43,7 +43,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.TypeSpec
                     return checkResult;
 
                 default:
-                    return new() { ResponseError = $"Unknown command: '{command}'" };
+                    return new DefaultCommandResponse { ResponseError = $"Unknown command: '{command}'" };
             }
         }
 

--- a/tools/azsdk-cli/docs/new-tool.md
+++ b/tools/azsdk-cli/docs/new-tool.md
@@ -325,12 +325,13 @@ A custom response class is not always necessary. It should be defined when the t
 All tool response classes must:
 
 1. **Inherit from `Response`** base class
-1. **Override `ToString()`** to format properties in a human readable way and return the base `ToString()` method to handle error formatting.
+1. **Override `Format()`** to format properties in a human readable way.
 1. **Set JSON serializer attributes** on all properties.
 
 Tools that may have error cases but no need for a custom type should use `DefaultCommandResponse` as
-the return type. The `.Result` property takes `object`, but it may not
-serialize or stringify correctly if `ToString()` is not overridden.
+the return type. The `.Result` property takes `object`, but must override `Format()` to serialize/stringify
+the value.
+
 
 ### Response Class Template
 
@@ -354,7 +355,7 @@ public class YourResponseType : Response
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Message { get; set; }
 
-    public override string ToString()
+    protected override string Format()
     {
         var output = new StringBuilder();
         if (!string.IsNullOrEmpty(Message))
@@ -365,7 +366,7 @@ public class YourResponseType : Response
         {
             output.AppendLine($"Result: {Result?.ToString() ?? "null"}");
         }
-        return ToString(output);
+        return output.ToString();
     }
 }
 ```
@@ -576,7 +577,7 @@ internal class YourToolTests
 
 ### 3. Responses
 - **Create/use response classes for both CLI and JSON consumption**
-- **Provide meaningful ToString() implementations** in response classes for CLI output
+- **Provide meaningful Format() implementations** in response classes for CLI output
 
 ### 4. MCP Server Integration
 - **Use descriptive MCP tool names** (snake_case: `azsdk_analyze_pipeline`)


### PR DESCRIPTION
Use Format() override instead of ToString() for command responses

The current approach to output formatting for classes inheriting from `CommandResponse` was brittle in that you weren't required to call the underlying `base.ToString(<value>)` method. This method always needs to be called so that we can add `ResponseError` to the CLI/MCP output in the base class.

With the new class structure each child class is required to implement `Format()` which will be called in the underlying `base.ToString()` method. This way anytime a child response class is stringified the base error processing logic will always run.

The new approach also makes it simpler to implement a child response class as you don't need to be aware of the base class internals and will be prompted by the compiler if you don't implement `Format()`.