### PR TITLE
Remove extraneous unconditional bicep invocation

### DIFF
--- a/eng/common/TestResources/TestResources-Helpers.ps1
+++ b/eng/common/TestResources/TestResources-Helpers.ps1
@@ -185,8 +185,6 @@ function LintBicepFile([string] $path) {
     }
 
     # Work around lack of config file override: https://github.com/Azure/bicep/issues/5013
-    $output = bicep lint $path 2>&1
-
     if ($useBicepCli) {
         $output = bicep lint $path 2>&1
     } else {


### PR DESCRIPTION
Fails if you don't have `bicep` installed but do have `az bicep` and was unnecessary since the check below it did it anyway.
