### PR TITLE
[perf.yml] Only checkout PerfAutomation from azure-sdk-tools

### DIFF
--- a/eng/common/pipelines/templates/jobs/perf.yml
+++ b/eng/common/pipelines/templates/jobs/perf.yml
@@ -105,9 +105,16 @@ jobs:
       - Name: ${{ parameters.LanguageRepoName }}
         Commitish: ${{ parameters.LanguageRepoCommitish }}
         WorkingDirectory: $(System.DefaultWorkingDirectory)
+
+  - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+    parameters:
+      Paths:
+      - 'tools/perf-automation/Azure.Sdk.Tools.PerfAutomation'
+      Repositories:
       - Name: Azure/azure-sdk-tools
         Commitish: ${{ parameters.ToolsRepoCommitish }}
         WorkingDirectory: $(System.DefaultWorkingDirectory)/azure-sdk-tools
+      SkipCheckoutNone: true
 
   - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
     parameters:


### PR DESCRIPTION
- Other files in azure-sdk-tools repo are unnecessary
- Unnecessary checkout hurts perf and increases security footprint

Verification Run: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5483253&view=results