### PR TITLE
[AVC] Remove ability to select environment independently

### DIFF
--- a/packages/python-packages/apiview-copilot/cli.py
+++ b/packages/python-packages/apiview-copilot/cli.py
@@ -701,6 +701,8 @@ def report_metrics(start_date: str, end_date: str, markdown: bool = False, save:
     environment = os.getenv("ENVIRONMENT_NAME", None)
     if not environment:
         raise ValueError("ENVIRONMENT_NAME environment variable is not set. Must be 'production' or 'staging'.")
+    if environment not in ("production", "staging"):
+        raise ValueError(f"ENVIRONMENT_NAME must be 'production' or 'staging', got '{environment}'.")
     return get_metrics_report(start_date, end_date, environment, markdown, save)
 
 


### PR DESCRIPTION
Environment is consistently set with the AVC CLI using your `.env` file. This parameter would allow you to put staging metrics in production and vice versa. This PR corrects that.

It also updates the permission grant command to give readWrite access to the AVC CosmosDB, which is necessary to write metrics to the DB. 