### PR TITLE
[API View] Update cshpar parser version

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Languages/CSharpLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/CSharpLanguageService.cs
@@ -14,7 +14,7 @@ namespace APIViewWeb
         public override string Name { get; } = "C#";
         public override string[] Extensions { get; } = { ".dll" };
         public override string ProcessName => _csharpParserToolPath;
-        public override string VersionString { get; } = "29.7";
+        public override string VersionString { get; } = "29.8";
 
         public CSharpLanguageService(IConfiguration configuration, TelemetryClient telemetryClient) : base(telemetryClient)
         {

--- a/src/dotnet/APIView/apiview.yml
+++ b/src/dotnet/APIView/apiview.yml
@@ -4,7 +4,7 @@ parameters:
     default: 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json'
   - name: CSharpAPIParserVersion
     type: string
-    default: '1.0.0-dev.20251020.1'
+    default: '1.0.0-dev.20251022.1'
   - name: JavaScriptAPIParser
     type: string
     default: '@azure-tools/ts-genapi@2.0.5'

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
@@ -47,7 +47,7 @@ namespace CSharpAPIParser.TreeToken
 
         public ICodeFileBuilderSymbolOrderProvider SymbolOrderProvider { get; set; } = new CodeFileBuilderSymbolOrderProvider();
 
-        public const string CurrentVersion = "29.7";
+        public const string CurrentVersion = "29.8";
 
         private IEnumerable<INamespaceSymbol> EnumerateNamespaces(IAssemblySymbol assemblySymbol)
         {


### PR DESCRIPTION
Updating csharp parser version to use version generated at: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5485658&view=results