### PR TITLE
[Merge-Branch.ps1] Restore both working tree and index

### DIFF
--- a/eng/scripts/Merge-Branch.ps1
+++ b/eng/scripts/Merge-Branch.ps1
@@ -56,8 +56,8 @@ if ($LASTEXITCODE -and -not $mergeOutput.EndsWith('Automatic merge failed; fix c
 
 # update paths matching "theirs", except for "ours" and "merge", to the state in $SourceBranch
 if ($Theirs.Length) {
-    Write-Verbose "git restore -s $SourceBranch --worktree --ignore-unmerged -- $theirIncludes $ourExcludes $mergeExcludes"
-    git restore -s $SourceBranch --worktree --ignore-unmerged -- $theirIncludes $ourExcludes $mergeExcludes
+    Write-Verbose "git restore -s $SourceBranch --staged --worktree --ignore-unmerged -- $theirIncludes $ourExcludes $mergeExcludes"
+    git restore -s $SourceBranch --staged --worktree --ignore-unmerged -- $theirIncludes $ourExcludes $mergeExcludes
     if ($LASTEXITCODE) { ErrorExit $LASTEXITCODE }
     Write-Verbose "git add -A"
     git add -A
@@ -66,8 +66,8 @@ if ($Theirs.Length) {
 
 # update paths matching "ours", except for "merge", to their pre-merge state
 if ($Ours.Length) {
-    Write-Verbose "git restore -s (git rev-parse HEAD) --worktree --ignore-unmerged -- $ourIncludes $mergeExcludes"
-    git restore -s (git rev-parse HEAD) --worktree --ignore-unmerged -- $ourIncludes $mergeExcludes
+    Write-Verbose "git restore -s (git rev-parse HEAD) --staged --worktree --ignore-unmerged -- $ourIncludes $mergeExcludes"
+    git restore -s (git rev-parse HEAD) --staged --worktree --ignore-unmerged -- $ourIncludes $mergeExcludes
     if ($LASTEXITCODE) { ErrorExit $LASTEXITCODE }
     Write-Verbose "git add -A"
     git add -A
@@ -75,8 +75,8 @@ if ($Ours.Length) {
 }
 
 if ($AcceptTheirsForFinalMerge) {
-    Write-Verbose "git restore -s $SourceBranch --worktree --ignore-unmerged -- $mergeIncludes"
-    git restore -s $SourceBranch --worktree --ignore-unmerged -- $mergeIncludes
+    Write-Verbose "git restore -s $SourceBranch --staged --worktree --ignore-unmerged -- $mergeIncludes"
+    git restore -s $SourceBranch --staged --worktree --ignore-unmerged -- $mergeIncludes
     if ($LASTEXITCODE) { ErrorExit $LASTEXITCODE }
     Write-Verbose "git add -A"
     git add -A


### PR DESCRIPTION
- Handles case where line endings differ between branches
- Fixes #11998

Log of failed mirror: https://dev.azure.com/azure-sdk/internal/internal%20Team/_build/results?buildId=5499800&view=logs&j=b5398758-6341-5a90-e082-88d59643ae40&t=f07d761e-3d18-56a0-44da-8007c8228944&l=551

```
VERBOSE: git restore -s (git rev-parse HEAD) --worktree --ignore-unmerged -- :(top,glob)specification :(top,glob,exclude)specification/common-types
VERBOSE: git add -A
warning: in the working copy of 'specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2023-11-15-preview/throughputpool.json', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-02-15-preview/throughputpool.json', CRLF will be replaced by LF the next time Git touches it

```

Before this fix, when only using `--worktree`, the two files first on this list, end up with an inconsistent state between the index and worktree.  This causes the files to be added to the mirror PR.

```
$ git ls-files --eol specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/*/throughputpool.json
i/lf    w/crlf  attr/text=auto eol=lf   specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2023-11-15-preview/throughputpool.json
i/lf    w/crlf  attr/text=auto eol=lf   specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-02-15-preview/throughputpool.json
i/lf    w/lf    attr/text=auto eol=lf   specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-05-15-preview/throughputpool.json
```

After this fix, the state is consistent, so the files are excluded from the mirror PR (as intended):

```
$ git ls-files --eol specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/*/throughputpool.json
i/crlf  w/crlf  attr/text=auto eol=lf   specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2023-11-15-preview/throughputpool.json
i/crlf  w/crlf  attr/text=auto eol=lf   specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-02-15-preview/throughputpool.json
i/lf    w/lf    attr/text=auto eol=lf   specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-05-15-preview/throughputpool.json
```

An alternative fix would be to run `git add --renormalize .` in all the branches we care about `main`, `RPSaaSMaster`, etc.  After this, all files should use `lf` in the index, so there would be no inconsistencies.  But, I think it's better to fix the script for all repos, if possible.