### PR TITLE
[sample generation] Fix dotnet sample discovery

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/DotNetPackageInfoHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/DotNetPackageInfoHelperTests.cs
@@ -48,8 +48,8 @@ public class DotNetPackageInfoHelperTests
         // Arrange
         var (packagePath, gitHelper) = CreateTestPackage();
         
-        CreateTestFile(packagePath, "tests/samples/Sample01_Basic.cs", "namespace Test; public class Sample01_Basic { }");
-        CreateTestFile(packagePath, "tests/samples/BasicSample.cs", "namespace Test; public class BasicSample { }");
+        CreateTestFile(packagePath, "tests/samples/Sample01_Basic.cs", "#region Snippet:BasicSample\nnamespace Test; public class Sample01_Basic { }\n#endregion");
+        CreateTestFile(packagePath, "tests/samples/BasicSample.cs", "#region Snippet:AnotherSample\nnamespace Test; public class BasicSample { }\n#endregion");
         
         // Create non-sample files
         CreateTestFile(packagePath, "tests/unit/other.cs", "namespace Test; public class NotASample { }");
@@ -70,8 +70,8 @@ public class DotNetPackageInfoHelperTests
         var (packagePath, gitHelper) = CreateTestPackage();
         
         // Create snippet files that should be detected
-        CreateTestFile(packagePath, "tests/snippets/Snippet01_Basic.cs", "namespace Test; public class Snippet01_Basic { }");
-        CreateTestFile(packagePath, "tests/snippets/BasicSnippet.cs", "namespace Test; public class BasicSnippet { }");
+        CreateTestFile(packagePath, "tests/snippets/Snippet01_Basic.cs", "#region Snippet:BasicSnippet\nnamespace Test; public class Snippet01_Basic { }\n#endregion");
+        CreateTestFile(packagePath, "tests/snippets/BasicSnippet.cs", "#region Snippet:AnotherSnippet\nnamespace Test; public class BasicSnippet { }\n#endregion");
         
         // Create non-sample files
         CreateTestFile(packagePath, "tests/unit/UnitTest.cs", "namespace Test; public class UnitTest { }");
@@ -119,14 +119,14 @@ public class DotNetPackageInfoHelperTests
     }
 
     [Test]
-    public async Task FindSamplesDirectory_WithCaseInsensitiveSampleFiles_ReturnsCorrectDirectory()
+    public async Task FindSamplesDirectory_WithSnippetRegions_ReturnsCorrectDirectory()
     {
         // Arrange
         var (packagePath, gitHelper) = CreateTestPackage();
         
-        // Create sample files with different casing
-        CreateTestFile(packagePath, "tests/examples/SAMPLE_Basic.cs", "namespace Test; public class SAMPLE_Basic { }");
-        CreateTestFile(packagePath, "tests/examples/ExampleSNIPPET.cs", "namespace Test; public class ExampleSNIPPET { }");
+        // Create files with snippet regions
+        CreateTestFile(packagePath, "tests/examples/SAMPLE_Basic.cs", "#region Snippet:ExampleSnippet\nnamespace Test; public class SAMPLE_Basic { }\n#endregion");
+        CreateTestFile(packagePath, "tests/examples/ExampleSNIPPET.cs", "#region Snippet:AnotherExample\nnamespace Test; public class ExampleSNIPPET { }\n#endregion");
         
         var helper = new DotNetPackageInfoHelper(gitHelper, new TestLogger<DotNetPackageInfoHelper>());
         
@@ -138,14 +138,14 @@ public class DotNetPackageInfoHelperTests
     }
 
     [Test]
-    public async Task FindSamplesDirectory_WithMixedSampleAndSnippetFiles_ReturnsFirstFoundDirectory()
+    public async Task FindSamplesDirectory_WithMultipleDirectories_ReturnsFirstFoundDirectory()
     {
         // Arrange
         var (packagePath, gitHelper) = CreateTestPackage();
         
-        // Create both sample and snippet files (first directory alphabetically should be returned)
-        CreateTestFile(packagePath, "tests/examples/BasicSample.cs", "namespace Test; public class BasicSample { }");
-        CreateTestFile(packagePath, "tests/snippets/BasicSnippet.cs", "namespace Test; public class BasicSnippet { }");
+        // Create files with snippet regions in multiple directories
+        CreateTestFile(packagePath, "tests/examples/BasicSample.cs", "#region Snippet:ExampleSnippet\nnamespace Test; public class BasicSample { }\n#endregion");
+        CreateTestFile(packagePath, "tests/snippets/BasicSnippet.cs", "#region Snippet:AnotherSnippet\nnamespace Test; public class BasicSnippet { }\n#endregion");
         
         var helper = new DotNetPackageInfoHelper(gitHelper, new TestLogger<DotNetPackageInfoHelper>());
         

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/DotNetPackageInfoHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/DotNetPackageInfoHelperTests.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
+using Azure.Sdk.Tools.Cli.Services;
+using LibGit2Sharp;
+using Moq;
+
+namespace Azure.Sdk.Tools.Cli.Tests.Helpers;
+
+[TestFixture]
+public class DotNetPackageInfoHelperTests
+{
+    private TempDirectory _tempDir = null!;
+
+    [SetUp]
+    public void SetUp() => _tempDir = TempDirectory.Create("dotnet_package_info_tests");
+
+    [TearDown]
+    public void TearDown() => _tempDir.Dispose();
+
+    private (string packagePath, GitHelper gitHelper) CreateTestPackage()
+    {
+        var repoRoot = Path.Combine(_tempDir.DirectoryPath, "test-repo");
+        Directory.CreateDirectory(repoRoot);
+        if (!Directory.Exists(Path.Combine(repoRoot, ".git"))) { Repository.Init(repoRoot); }
+        var packagePath = Path.Combine(repoRoot, "sdk", "storage", "storage-blob");
+        Directory.CreateDirectory(packagePath);
+        var ghMock = new Mock<IGitHubService>();
+        var gitHelper = new GitHelper(ghMock.Object, new TestLogger<GitHelper>());
+        return (packagePath, gitHelper);
+    }
+
+    private void CreateTestFile(string packagePath, string relativePath, string content)
+    {
+        var fullPath = Path.Combine(packagePath, relativePath);
+        var directory = Path.GetDirectoryName(fullPath);
+        if (directory != null && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+        File.WriteAllText(fullPath, content);
+    }
+
+    [Test]
+    public async Task FindSamplesDirectory_WithSampleFiles_ReturnsSamplesDirectory()
+    {
+        // Arrange
+        var (packagePath, gitHelper) = CreateTestPackage();
+        
+        CreateTestFile(packagePath, "tests/samples/Sample01_Basic.cs", "namespace Test; public class Sample01_Basic { }");
+        CreateTestFile(packagePath, "tests/samples/BasicSample.cs", "namespace Test; public class BasicSample { }");
+        
+        // Create non-sample files
+        CreateTestFile(packagePath, "tests/unit/other.cs", "namespace Test; public class NotASample { }");
+        
+        var helper = new DotNetPackageInfoHelper(gitHelper, new TestLogger<DotNetPackageInfoHelper>());
+        
+        // Act
+        var packageInfo = await helper.ResolvePackageInfo(packagePath);
+        
+        // Assert
+        Assert.That(packageInfo.SamplesDirectory, Is.EqualTo(Path.Combine(packagePath, "tests", "samples")));
+    }
+
+    [Test]
+    public async Task FindSamplesDirectory_WithSnippetFiles_ReturnsSamplesDirectory()
+    {
+        // Arrange
+        var (packagePath, gitHelper) = CreateTestPackage();
+        
+        // Create snippet files that should be detected
+        CreateTestFile(packagePath, "tests/snippets/Snippet01_Basic.cs", "namespace Test; public class Snippet01_Basic { }");
+        CreateTestFile(packagePath, "tests/snippets/BasicSnippet.cs", "namespace Test; public class BasicSnippet { }");
+        
+        // Create non-sample files
+        CreateTestFile(packagePath, "tests/unit/UnitTest.cs", "namespace Test; public class UnitTest { }");
+        
+        var helper = new DotNetPackageInfoHelper(gitHelper, new TestLogger<DotNetPackageInfoHelper>());
+        
+        // Act
+        var packageInfo = await helper.ResolvePackageInfo(packagePath);
+        
+        // Assert
+        Assert.That(packageInfo.SamplesDirectory, Is.EqualTo(Path.Combine(packagePath, "tests", "snippets")));
+    }
+    
+    [Test]
+    public async Task FindSamplesDirectory_WithNoSampleFiles_ReturnsDefaultPath()
+    {
+        // Arrange
+        var (packagePath, gitHelper) = CreateTestPackage();
+        
+        // Create non-sample files only
+        CreateTestFile(packagePath, "tests/unit/other.cs", "namespace Test; public class NotASample { }");
+        
+        var helper = new DotNetPackageInfoHelper(gitHelper, new TestLogger<DotNetPackageInfoHelper>());
+        
+        // Act
+        var packageInfo = await helper.ResolvePackageInfo(packagePath);
+        
+        // Assert
+        Assert.That(packageInfo.SamplesDirectory, Is.EqualTo(Path.Combine(packagePath, "tests", "samples")));
+    }
+    
+    [Test]
+    public async Task FindSamplesDirectory_WithNoTestsDirectory_ReturnsDefaultPath()
+    {
+        // Arrange
+        var (packagePath, gitHelper) = CreateTestPackage();
+        
+        var helper = new DotNetPackageInfoHelper(gitHelper, new TestLogger<DotNetPackageInfoHelper>());
+        
+        // Act
+        var packageInfo = await helper.ResolvePackageInfo(packagePath);
+        
+        // Assert
+        Assert.That(packageInfo.SamplesDirectory, Is.EqualTo(Path.Combine(packagePath, "tests", "samples")));
+    }
+
+    [Test]
+    public async Task FindSamplesDirectory_WithCaseInsensitiveSampleFiles_ReturnsCorrectDirectory()
+    {
+        // Arrange
+        var (packagePath, gitHelper) = CreateTestPackage();
+        
+        // Create sample files with different casing
+        CreateTestFile(packagePath, "tests/examples/SAMPLE_Basic.cs", "namespace Test; public class SAMPLE_Basic { }");
+        CreateTestFile(packagePath, "tests/examples/ExampleSNIPPET.cs", "namespace Test; public class ExampleSNIPPET { }");
+        
+        var helper = new DotNetPackageInfoHelper(gitHelper, new TestLogger<DotNetPackageInfoHelper>());
+        
+        // Act
+        var packageInfo = await helper.ResolvePackageInfo(packagePath);
+        
+        // Assert
+        Assert.That(packageInfo.SamplesDirectory, Is.EqualTo(Path.Combine(packagePath, "tests", "examples")));
+    }
+
+    [Test]
+    public async Task FindSamplesDirectory_WithMixedSampleAndSnippetFiles_ReturnsFirstFoundDirectory()
+    {
+        // Arrange
+        var (packagePath, gitHelper) = CreateTestPackage();
+        
+        // Create both sample and snippet files (first directory alphabetically should be returned)
+        CreateTestFile(packagePath, "tests/examples/BasicSample.cs", "namespace Test; public class BasicSample { }");
+        CreateTestFile(packagePath, "tests/snippets/BasicSnippet.cs", "namespace Test; public class BasicSnippet { }");
+        
+        var helper = new DotNetPackageInfoHelper(gitHelper, new TestLogger<DotNetPackageInfoHelper>());
+        
+        // Act
+        var packageInfo = await helper.ResolvePackageInfo(packagePath);
+        
+        // Assert - should return the first directory found (alphabetically, "examples" comes before "snippets")
+        Assert.That(packageInfo.SamplesDirectory, Is.EqualTo(Path.Combine(packagePath, "tests", "examples")));
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/PackageInfo/DotNetPackageInfoHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/PackageInfo/DotNetPackageInfoHelper.cs
@@ -142,8 +142,8 @@ public sealed class DotNetPackageInfoHelper(IGitHelper gitHelper, ILogger<DotNet
                 return GetDefaultSamplesDirectory(packagePath);
             }
 
-            // Get all subdirectories under tests
-            var testSubdirectories = Directory.GetDirectories(testsPath);
+            // Get all subdirectories under tests (sorted for consistent behavior across platforms)
+            var testSubdirectories = Directory.GetDirectories(testsPath).OrderBy(d => d).ToArray();
             
             foreach (var directory in testSubdirectories)
             {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/PackageInfo/DotNetPackageInfoHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/PackageInfo/DotNetPackageInfoHelper.cs
@@ -9,6 +9,12 @@ namespace Azure.Sdk.Tools.Cli.Helpers;
 /// </summary>
 public sealed class DotNetPackageInfoHelper(IGitHelper gitHelper, ILogger<DotNetPackageInfoHelper> logger) : IPackageInfoHelper
 {
+    /// <summary>
+    /// Gets the default samples directory path relative to the package path.
+    /// </summary>
+    /// <param name="packagePath">The package path</param>
+    /// <returns>The default samples directory path</returns>
+    private static string GetDefaultSamplesDirectory(string packagePath) => Path.Combine(packagePath, "tests", "samples");
     public async Task<PackageInfo> ResolvePackageInfo(string packagePath, CancellationToken ct = default)
     {
         logger.LogDebug("Resolving .NET package info for path: {packagePath}", packagePath);
@@ -24,6 +30,8 @@ public sealed class DotNetPackageInfoHelper(IGitHelper gitHelper, ILogger<DotNet
             logger.LogWarning("Could not determine package version for .NET package at {fullPath}", fullPath);
         }
         
+        var samplesDirectory = FindSamplesDirectory(fullPath);
+        
         var model = new PackageInfo
         {
             PackagePath = fullPath,
@@ -33,7 +41,7 @@ public sealed class DotNetPackageInfoHelper(IGitHelper gitHelper, ILogger<DotNet
             PackageVersion = packageVersion,
             ServiceName = Path.GetFileName(Path.GetDirectoryName(fullPath)) ?? string.Empty,
             Language = Models.SdkLanguage.DotNet,
-            SamplesDirectory = Path.Combine(fullPath, "tests", "samples")
+            SamplesDirectory = samplesDirectory
         };
         
         logger.LogDebug("Resolved .NET package: {packageName} v{packageVersion} at {relativePath}", 
@@ -115,6 +123,55 @@ public sealed class DotNetPackageInfoHelper(IGitHelper gitHelper, ILogger<DotNet
         {
             logger.LogError(ex, "Error reading .NET package info from {packagePath}", packagePath);
             return (null, null);
+        }
+    }
+
+    /// <summary>
+    /// Finds the samples directory by looking for folders under tests that contain files with "sample" or "snippet" in their name
+    /// </summary>
+    /// <param name="packagePath">The package path to search under</param>
+    /// <returns>The path to the samples directory, or a default path if not found</returns>
+    private string FindSamplesDirectory(string packagePath)
+    {
+        try
+        {
+            var testsPath = Path.Combine(packagePath, "tests");
+            if (!Directory.Exists(testsPath))
+            {
+                logger.LogTrace("Tests directory not found at {testsPath}", testsPath);
+                return GetDefaultSamplesDirectory(packagePath);
+            }
+
+            // Get all subdirectories under tests
+            var testSubdirectories = Directory.GetDirectories(testsPath);
+            
+            foreach (var directory in testSubdirectories)
+            {
+                // Look for .cs files containing "sample" or "snippet" in their name (case-insensitive)
+                var sampleFiles = Directory.GetFiles(directory, "*.cs", SearchOption.TopDirectoryOnly)
+                    .Where(file =>
+                    {
+                        var fileName = Path.GetFileNameWithoutExtension(file);
+                        return fileName.Contains("sample", StringComparison.OrdinalIgnoreCase) ||
+                            fileName.Contains("snippet", StringComparison.OrdinalIgnoreCase);
+                    })
+                    .ToArray();
+                
+                if (sampleFiles.Length > 0)
+                {
+                    logger.LogTrace("Found samples directory at {directory} with {count} sample/snippet files", 
+                        directory, sampleFiles.Length);
+                    return directory;
+                }
+            }
+            
+            logger.LogTrace("No samples directory found under {testsPath}, using default", testsPath);
+            return GetDefaultSamplesDirectory(packagePath);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Error searching for samples directory under {packagePath}, using default", packagePath);
+            return GetDefaultSamplesDirectory(packagePath);
         }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Samples/SampleGeneration/PythonSampleLanguageContext.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Samples/SampleGeneration/PythonSampleLanguageContext.cs
@@ -16,7 +16,7 @@ public sealed class PythonSampleLanguageContext : SampleLanguageContext
     protected override string GetLanguageSpecificInstructions() => @"
 Language-specific instructions for Python:
 - Filenames must be descriptive without file extension (e.g., ""create_key"", ""retrieve_key"")
-- IMPORTANT: When relevant, generate TWO separate samples for each scenario: one ending with 'sync' (synchronous) and one ending with 'async' (asynchronous) under a nested async_samples folder
+- IMPORTANT: When relevant, generate TWO separate samples for each scenario: one ending with 'sync' (synchronous) and one ending with 'async' (asynchronous)
 - Follow this template:
 ";
     public override string GetSampleExample() => @"# ------------------------------------


### PR DESCRIPTION
Fix dotnet sample discovery to look for the "samples" and "snippets" folders with different casing.