### PR TITLE
[sample generation] Support extra context and content inlining from relative links

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Azure.Sdk.Tools.Cli.Tests.csproj
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Azure.Sdk.Tools.Cli.Tests.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.15" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/PromptHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/PromptHelperTests.cs
@@ -1,116 +1,384 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Azure.Sdk.Tools.Cli.Helpers;
 using Microsoft.Extensions.Logging;
+using Moq;
 using NUnit.Framework;
-using System.IO;
-using System.Threading.Tasks;
+using System.Text;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Helpers
 {
     [TestFixture]
     public class PromptHelperTests
     {
-        private ILogger _logger;
+        private Mock<ILogger> _mockLogger = null!;
+        private string _tempDirectory = null!;
+        private string _testFile1Path = null!;
+        private string _testFile2Path = null!;
 
         [SetUp]
-        public void SetUp()
+        public void Setup()
         {
-            var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
-            _logger = loggerFactory.CreateLogger<PromptHelperTests>();
+            _mockLogger = new Mock<ILogger>();
+            _tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(_tempDirectory);
+
+            // Create test files
+            _testFile1Path = Path.Combine(_tempDirectory, "test1.txt");
+            _testFile2Path = Path.Combine(_tempDirectory, "test2.md");
+            
+            File.WriteAllText(_testFile1Path, "This is test file 1 content");
+            File.WriteAllText(_testFile2Path, "# Test File 2\nThis is markdown content");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(_tempDirectory))
+            {
+                Directory.Delete(_tempDirectory, true);
+            }
         }
 
         [Test]
-        public async Task ExpandRelativeFileLinksAsync_StandaloneUsage_WorksCorrectly()
+        public async Task ExpandRelativeFileLinksAsync_WithInlineLink_ExpandsCorrectly()
         {
             // Arrange
-            var testDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-            Directory.CreateDirectory(testDir);
+            var text = "Check out [test file](test1.txt) for details.";
+            
+            // Act
+            var result = await PromptHelper.ExpandRelativeFileLinksAsync(text, _tempDirectory, _mockLogger.Object);
+            
+            // Assert
+            Assert.That(result, Does.Contain("This is test file 1 content"));
+            Assert.That(result, Does.Contain("## Referenced File: test file (test1.txt)"));
+        }
 
-            try
-            {
-                var docsFile = Path.Combine(testDir, "sample-docs.md");
-                var docsContent = @"# Test Documentation
+        [Test]
+        public async Task ExpandRelativeFileLinksAsync_WithReferenceLink_ExpandsCorrectly()
+        {
+            // Arrange
+            var text = @"Check out [test file][testref] for details.
 
-This is a sample documentation file that can be referenced from prompts.
+[testref]: test1.txt";
+            
+            // Act
+            var result = await PromptHelper.ExpandRelativeFileLinksAsync(text, _tempDirectory, _mockLogger.Object);
+            
+            // Assert
+            Assert.That(result, Does.Contain("This is test file 1 content"));
+            Assert.That(result, Does.Contain("## Referenced File: test file (test1.txt)"));
+        }
 
-## Example Code
+        [Test]
+        public async Task ExpandRelativeFileLinksAsync_WithHttpUrl_SkipsExpansion()
+        {
+            // Arrange
+            var text = "Visit [Microsoft](https://microsoft.com) for more info.";
+            
+            // Act
+            var result = await PromptHelper.ExpandRelativeFileLinksAsync(text, _tempDirectory, _mockLogger.Object);
+            
+            // Assert
+            Assert.That(result, Is.EqualTo(text)); // Should be unchanged
+            Assert.That(result, Does.Not.Contain("## Referenced File:"));
+        }
 
-```csharp
-public async Task<string> SampleMethod()
-{
-    return ""Hello from sample!"";
-}
-```
+        [Test]
+        public async Task ExpandRelativeFileLinksAsync_WithHttpsUrl_SkipsExpansion()
+        {
+            // Arrange
+            var text = "Visit [Google](http://google.com) for search.";
+            
+            // Act
+            var result = await PromptHelper.ExpandRelativeFileLinksAsync(text, _tempDirectory, _mockLogger.Object);
+            
+            // Assert
+            Assert.That(result, Is.EqualTo(text)); // Should be unchanged
+            Assert.That(result, Does.Not.Contain("## Referenced File:"));
+        }
 
-## Best Practices
+        [Test]
+        public async Task ExpandRelativeFileLinksAsync_WithAnchorLink_SkipsExpansion()
+        {
+            // Arrange
+            var text = "See [section below](#important-section) for details.";
+            
+            // Act
+            var result = await PromptHelper.ExpandRelativeFileLinksAsync(text, _tempDirectory, _mockLogger.Object);
+            
+            // Assert
+            Assert.That(result, Is.EqualTo(text)); // Should be unchanged
+            Assert.That(result, Does.Not.Contain("## Referenced File:"));
+        }
 
-- Always use async/await for file operations
-- Include proper error handling
-- Use cancellation tokens for long-running operations";
+        [Test]
+        public async Task ExpandRelativeFileLinksAsync_WithNonExistentFile_LogsWarningAndSkips()
+        {
+            // Arrange
+            var text = "Check [missing file](nonexistent.txt) here.";
+            
+            // Act
+            var result = await PromptHelper.ExpandRelativeFileLinksAsync(text, _tempDirectory, _mockLogger.Object);
+            
+            // Assert
+            Assert.That(result, Is.EqualTo(text)); // Should be unchanged
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Referenced file not found")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
 
-                var promptFile = Path.Combine(testDir, "test-prompt.md");
-                var promptContent = @"Generate a comprehensive sample that demonstrates Azure Blob Storage operations.
-
-Please refer to [Sample Documentation](sample-docs.md) for coding best practices.
-
-The sample should include:
-- Upload operations
-- Download operations  
-- Error handling";
-
-                await File.WriteAllTextAsync(docsFile, docsContent);
-                await File.WriteAllTextAsync(promptFile, promptContent);
-
-                var prompt = await File.ReadAllTextAsync(promptFile);
-
-                // Act
-                var expandedPrompt = await PromptHelper.ExpandRelativeFileLinksAsync(prompt, testDir, _logger);
-
-                // Assert
-                Assert.That(expandedPrompt, Contains.Substring("## Referenced File: Sample Documentation (sample-docs.md)"));
-                Assert.That(expandedPrompt, Contains.Substring("Always use async/await for file operations"));
-                Assert.That(expandedPrompt, Does.Not.Contain("[Sample Documentation](sample-docs.md)"));
-            }
-            finally
-            {
-                if (Directory.Exists(testDir))
-                {
-                    Directory.Delete(testDir, true);
-                }
-            }
+        [Test]
+        public async Task ExpandRelativeFileLinksAsync_WithAbsolutePath_ExpandsCorrectly()
+        {
+            // Arrange
+            var text = $"Check [absolute file]({_testFile1Path}) for details.";
+            
+            // Act
+            var result = await PromptHelper.ExpandRelativeFileLinksAsync(text, _tempDirectory, _mockLogger.Object);
+            
+            // Assert
+            Assert.That(result, Does.Contain("This is test file 1 content"));
+            Assert.That(result, Does.Contain($"## Referenced File: absolute file ({_testFile1Path})"));
         }
 
         [Test]
         public async Task ExpandRelativeFileLinksAsync_WithMultipleLinks_ExpandsAll()
         {
-            // Arrange  
-            var testDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-            Directory.CreateDirectory(testDir);
+            // Arrange
+            var text = "See [file 1](test1.txt) and [file 2](test2.md) for info.";
+            
+            // Act
+            var result = await PromptHelper.ExpandRelativeFileLinksAsync(text, _tempDirectory, _mockLogger.Object);
+            
+            // Assert
+            Assert.That(result, Does.Contain("This is test file 1 content"));
+            Assert.That(result, Does.Contain("This is markdown content"));
+            Assert.That(result, Does.Contain("## Referenced File: file 1 (test1.txt)"));
+            Assert.That(result, Does.Contain("## Referenced File: file 2 (test2.md)"));
+        }
 
-            try
+        [Test]
+        public async Task ExpandRelativeFileLinksAsync_WithMixedLinkTypes_ExpandsOnlyLocalFiles()
+        {
+            // Arrange
+            var text = @"Check [local file](test1.txt), visit [website](https://example.com), and see [anchor](#section).";
+            
+            // Act
+            var result = await PromptHelper.ExpandRelativeFileLinksAsync(text, _tempDirectory, _mockLogger.Object);
+            
+            // Assert
+            Assert.That(result, Does.Contain("This is test file 1 content"));
+            Assert.That(result, Does.Contain("[website](https://example.com)")); // Should remain unchanged
+            Assert.That(result, Does.Contain("[anchor](#section)")); // Should remain unchanged
+        }
+
+        [Test]
+        public async Task ExpandRelativeFileLinksAsync_WithEmptyText_ReturnsEmpty()
+        {
+            // Arrange
+            var text = "";
+            
+            // Act
+            var result = await PromptHelper.ExpandRelativeFileLinksAsync(text, _tempDirectory, _mockLogger.Object);
+            
+            // Assert
+            Assert.That(result, Is.EqualTo(text));
+        }
+
+        [Test]
+        public async Task ExpandRelativeFileLinksAsync_WithNullText_ReturnsNull()
+        {
+            // Arrange
+            string? text = null;
+            
+            // Act
+            var result = await PromptHelper.ExpandRelativeFileLinksAsync(text!, _tempDirectory, _mockLogger.Object);
+            
+            // Assert
+            Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public async Task ExpandRelativeFileLinksAsync_WithNoLinks_ReturnsUnchanged()
+        {
+            // Arrange
+            var text = "This is just plain text with no links at all.";
+            
+            // Act
+            var result = await PromptHelper.ExpandRelativeFileLinksAsync(text, _tempDirectory, _mockLogger.Object);
+            
+            // Assert
+            Assert.That(result, Is.EqualTo(text));
+        }
+
+        [Test]
+        public async Task ExpandRelativeFileLinksAsync_WithReferenceWithoutDefinition_LogsWarningAndSkips()
+        {
+            // Arrange
+            var text = "Check [missing ref][undefined] for details.";
+            
+            // Act
+            var result = await PromptHelper.ExpandRelativeFileLinksAsync(text, _tempDirectory, _mockLogger.Object);
+            
+            // Assert
+            Assert.That(result, Is.EqualTo(text)); // Should be unchanged
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Reference definition not found")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task ExpandRelativeFileLinksAsync_WithMultipleReferences_ExpandsAll()
+        {
+            // Arrange
+            var text = @"Check [file 1][ref1] and [file 2][ref2].
+
+[ref1]: test1.txt
+[ref2]: test2.md";
+            
+            // Act
+            var result = await PromptHelper.ExpandRelativeFileLinksAsync(text, _tempDirectory, _mockLogger.Object);
+            
+            // Assert
+            Assert.That(result, Does.Contain("This is test file 1 content"));
+            Assert.That(result, Does.Contain("This is markdown content"));
+            Assert.That(result, Does.Contain("## Referenced File: file 1 (test1.txt)"));
+            Assert.That(result, Does.Contain("## Referenced File: file 2 (test2.md)"));
+        }
+
+        [Test]
+        public async Task ExpandRelativeFileLinksAsync_WithDuplicateFileReferences_ExpandsOnlyOnce()
+        {
+            // Arrange
+            var text = "See [first ref](test1.txt) and [second ref](test1.txt).";
+            
+            // Act
+            var result = await PromptHelper.ExpandRelativeFileLinksAsync(text, _tempDirectory, _mockLogger.Object);
+            
+            // Assert
+            // The implementation prevents duplicate file expansion for performance,
+            // so the same file should only be expanded once even if referenced multiple times
+            var contentOccurrences = CountOccurrences(result, "This is test file 1 content");
+            Assert.That(contentOccurrences, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task ExpandRelativeFileLinksAsync_WithCaseInsensitiveReferences_Works()
+        {
+            // Arrange - Test case sensitivity with different files to avoid duplicate prevention
+            var text = @"Check [test1][ref].
+
+[ref]: test1.txt";
+            
+            // Act
+            var result = await PromptHelper.ExpandRelativeFileLinksAsync(text, _tempDirectory, _mockLogger.Object);
+            
+            // Assert
+            Assert.That(result, Does.Contain("This is test file 1 content"));
+        }
+
+        [Test]
+        public async Task ExpandRelativeFileLinksAsync_WithCaseInsensitiveReferencesUppercase_Works()
+        {
+            // Arrange - Test case sensitivity with uppercase reference
+            var text = @"Check [test2][REF].
+
+[REF]: test2.md";
+            
+            // Act
+            var result = await PromptHelper.ExpandRelativeFileLinksAsync(text, _tempDirectory, _mockLogger.Object);
+            
+            // Assert
+            Assert.That(result, Does.Contain("This is markdown content"));
+        }
+
+        [TestCase("[](test1.txt)")] // Empty link text - should not match
+        [TestCase("[text]()")] // Empty path - should not match  
+        [TestCase("[][]")] // Empty reference - should not match
+        public async Task ExpandRelativeFileLinksAsync_WithInvalidLinkFormats_DoesNotMatch(string invalidLink)
+        {
+            // Arrange
+            var text = $"Check {invalidLink} for details.";
+            
+            // Act
+            var result = await PromptHelper.ExpandRelativeFileLinksAsync(text, _tempDirectory, _mockLogger.Object);
+            
+            // Assert
+            Assert.That(result, Is.EqualTo(text)); // Should be unchanged
+            Assert.That(result, Does.Not.Contain("## Referenced File:"));
+        }
+
+
+        [Test]
+        public async Task ExpandRelativeFileLinksAsync_WithLargeFile_SkipsAndLogsWarning()
+        {
+            // Arrange
+            var largeFilePath = Path.Combine(_tempDirectory, "large.txt");
+            // Create a file larger than 1MB (1024 * 1024 bytes)
+            var largeContent = new string('A', 1024 * 1024 + 1);
+            File.WriteAllText(largeFilePath, largeContent);
+            
+            var text = "Check [large file](large.txt) for details.";
+            
+            // Act
+            var result = await PromptHelper.ExpandRelativeFileLinksAsync(text, _tempDirectory, _mockLogger.Object);
+            
+            // Assert
+            Assert.That(result, Is.EqualTo(text)); // Should be unchanged
+            Assert.That(result, Does.Not.Contain("## Referenced File:"));
+            
+            // Verify warning was logged
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("is too large")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task ExpandRelativeFileLinksAsync_WithFileAtSizeLimit_ProcessesSuccessfully()
+        {
+            // Arrange
+            var limitFilePath = Path.Combine(_tempDirectory, "limit.txt");
+            // Create a file exactly at the 1MB limit
+            var limitContent = new string('B', 1024 * 1024);
+            File.WriteAllText(limitFilePath, limitContent);
+            
+            var text = "Check [limit file](limit.txt) for details.";
+            
+            // Act
+            var result = await PromptHelper.ExpandRelativeFileLinksAsync(text, _tempDirectory, _mockLogger.Object);
+            
+            // Assert
+            Assert.That(result, Does.Contain(limitContent));
+            Assert.That(result, Does.Contain("## Referenced File: limit file (limit.txt)"));
+        }
+
+        private static int CountOccurrences(string text, string substring)
+        {
+            int count = 0;
+            int index = 0;
+            while ((index = text.IndexOf(substring, index, StringComparison.Ordinal)) != -1)
             {
-                var file1 = Path.Combine(testDir, "doc1.md");
-                var file2 = Path.Combine(testDir, "doc2.md");
-                await File.WriteAllTextAsync(file1, "Content from doc1");
-                await File.WriteAllTextAsync(file2, "Content from doc2");
-
-                var prompt = "See [Doc 1](doc1.md) and [Doc 2](doc2.md) for details.";
-
-                // Act
-                var result = await PromptHelper.ExpandRelativeFileLinksAsync(prompt, testDir, _logger);
-
-                // Assert
-                Assert.That(result, Contains.Substring("Content from doc1"));
-                Assert.That(result, Contains.Substring("Content from doc2"));
-                Assert.That(result, Contains.Substring("## Referenced File: Doc 1 (doc1.md)"));
-                Assert.That(result, Contains.Substring("## Referenced File: Doc 2 (doc2.md)"));
+                count++;
+                index += substring.Length;
             }
-            finally
-            {
-                if (Directory.Exists(testDir))
-                {
-                    Directory.Delete(testDir, true);
-                }
-            }
+            return count;
         }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/PromptHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/PromptHelperTests.cs
@@ -1,0 +1,116 @@
+using Azure.Sdk.Tools.Cli.Helpers;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.Cli.Tests.Helpers
+{
+    [TestFixture]
+    public class PromptHelperTests
+    {
+        private ILogger _logger;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+            _logger = loggerFactory.CreateLogger<PromptHelperTests>();
+        }
+
+        [Test]
+        public async Task ExpandRelativeFileLinksAsync_StandaloneUsage_WorksCorrectly()
+        {
+            // Arrange
+            var testDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(testDir);
+
+            try
+            {
+                var docsFile = Path.Combine(testDir, "sample-docs.md");
+                var docsContent = @"# Test Documentation
+
+This is a sample documentation file that can be referenced from prompts.
+
+## Example Code
+
+```csharp
+public async Task<string> SampleMethod()
+{
+    return ""Hello from sample!"";
+}
+```
+
+## Best Practices
+
+- Always use async/await for file operations
+- Include proper error handling
+- Use cancellation tokens for long-running operations";
+
+                var promptFile = Path.Combine(testDir, "test-prompt.md");
+                var promptContent = @"Generate a comprehensive sample that demonstrates Azure Blob Storage operations.
+
+Please refer to [Sample Documentation](sample-docs.md) for coding best practices.
+
+The sample should include:
+- Upload operations
+- Download operations  
+- Error handling";
+
+                await File.WriteAllTextAsync(docsFile, docsContent);
+                await File.WriteAllTextAsync(promptFile, promptContent);
+
+                var prompt = await File.ReadAllTextAsync(promptFile);
+
+                // Act
+                var expandedPrompt = await PromptHelper.ExpandRelativeFileLinksAsync(prompt, testDir, _logger);
+
+                // Assert
+                Assert.That(expandedPrompt, Contains.Substring("## Referenced File: Sample Documentation (sample-docs.md)"));
+                Assert.That(expandedPrompt, Contains.Substring("Always use async/await for file operations"));
+                Assert.That(expandedPrompt, Does.Not.Contain("[Sample Documentation](sample-docs.md)"));
+            }
+            finally
+            {
+                if (Directory.Exists(testDir))
+                {
+                    Directory.Delete(testDir, true);
+                }
+            }
+        }
+
+        [Test]
+        public async Task ExpandRelativeFileLinksAsync_WithMultipleLinks_ExpandsAll()
+        {
+            // Arrange  
+            var testDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(testDir);
+
+            try
+            {
+                var file1 = Path.Combine(testDir, "doc1.md");
+                var file2 = Path.Combine(testDir, "doc2.md");
+                await File.WriteAllTextAsync(file1, "Content from doc1");
+                await File.WriteAllTextAsync(file2, "Content from doc2");
+
+                var prompt = "See [Doc 1](doc1.md) and [Doc 2](doc2.md) for details.";
+
+                // Act
+                var result = await PromptHelper.ExpandRelativeFileLinksAsync(prompt, testDir, _logger);
+
+                // Assert
+                Assert.That(result, Contains.Substring("Content from doc1"));
+                Assert.That(result, Contains.Substring("Content from doc2"));
+                Assert.That(result, Contains.Substring("## Referenced File: Doc 1 (doc1.md)"));
+                Assert.That(result, Contains.Substring("## Referenced File: Doc 2 (doc2.md)"));
+            }
+            finally
+            {
+                if (Directory.Exists(testDir))
+                {
+                    Directory.Delete(testDir, true);
+                }
+            }
+        }
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features Added
 
+- Sample generator: Add support for user-defined additional context
+- Sample generator: Add support for input prompts with local links
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/PromptHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/PromptHelper.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Sdk.Tools.Cli.Helpers
+{
+    /// <summary>
+    /// Helper class for processing and manipulating prompt content.
+    /// </summary>
+    public static class PromptHelper
+    {
+        /// <summary>
+        /// Expands relative file links in markdown-style text by inlining their content.
+        /// Supports links in the format [text](relative/path/to/file.ext)
+        /// </summary>
+        /// <param name="text">The text containing potential file links</param>
+        /// <param name="basePath">The base directory to resolve relative paths from</param>
+        /// <param name="logger">Logger for debug and warning messages</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Text with file links expanded to include their content</returns>
+        public static async Task<string> ExpandRelativeFileLinksAsync(string text, string basePath, ILogger logger, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return text;
+            }
+
+            // Regex to match markdown links: [text](path)
+            var linkPattern = @"\[([^\]]*)\]\(([^)]+)\)";
+            var regex = new System.Text.RegularExpressions.Regex(linkPattern);
+            
+            var matches = regex.Matches(text);
+            if (matches.Count == 0)
+            {
+                return text;
+            }
+
+            var result = text;
+            var expandedFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase); // Track to prevent infinite loops
+
+            logger.LogDebug("Found {linkCount} potential file links in prompt", matches.Count);
+
+            // Process matches in reverse order to maintain string positions
+            for (int i = matches.Count - 1; i >= 0; i--)
+            {
+                var match = matches[i];
+                var linkText = match.Groups[1].Value;
+                var linkPath = match.Groups[2].Value.Trim();
+
+                // Skip if it looks like a URL (starts with http/https)
+                if (linkPath.StartsWith("http://", StringComparison.OrdinalIgnoreCase) || 
+                    linkPath.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                // Skip anchors within the same document
+                if (linkPath.StartsWith("#"))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    // Resolve relative path
+                    string fullPath;
+                    if (Path.IsPathRooted(linkPath))
+                    {
+                        fullPath = linkPath;
+                    }
+                    else
+                    {
+                        fullPath = Path.GetFullPath(Path.Combine(basePath, linkPath));
+                    }
+
+                    // Check if file exists and we haven't already processed it
+                    if (File.Exists(fullPath) && !expandedFiles.Contains(fullPath))
+                    {
+                        expandedFiles.Add(fullPath);
+                        logger.LogDebug("Expanding file link: {linkPath} -> {fullPath}", linkPath, fullPath);
+
+                        var fileContent = await File.ReadAllTextAsync(fullPath, ct);
+                        
+                        // Create expanded content with clear boundaries
+                        var expandedContent = $@"
+
+## Referenced File: {linkText} ({linkPath})
+
+```
+{fileContent}
+```
+
+";
+
+                        // Replace the link with the expanded content
+                        result = result.Substring(0, match.Index) + expandedContent + result.Substring(match.Index + match.Length);
+                    }
+                    else if (!File.Exists(fullPath))
+                    {
+                        logger.LogWarning("Referenced file not found: {linkPath} (resolved to {fullPath})", linkPath, fullPath);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Failed to expand file link: {linkPath}", linkPath);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/PromptHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/PromptHelper.cs
@@ -56,7 +56,7 @@ namespace Azure.Sdk.Tools.Cli.Helpers
             var result = text;
             var expandedFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase); // Track to prevent infinite loops
 
-            logger.LogDebug($"Found {matches.Count} potential file links in prompt");
+            logger.LogDebug("Found {linkCount} potential file links in prompt", matches.Count);
             // Process matches in reverse order to maintain string positions
             for (int i = matches.Count - 1; i >= 0; i--)
             {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Samples/SampleGeneration/DotNetSampleLanguageContext.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Samples/SampleGeneration/DotNetSampleLanguageContext.cs
@@ -59,10 +59,5 @@ namespace Azure.Template.Tests.Samples
     }
 }";
 
-    public override Task<string> GetClientLibrarySourceCodeAsync(string packagePath, int totalBudget, int perFileLimit, CancellationToken ct = default)
-    {
-        var provider = new DotNetSourceInputProvider();
-        var inputs = provider.Create(packagePath);
-        return FileHelper.LoadFilesAsync(inputs, packagePath, totalBudget, perFileLimit, GetSourcePriority, ct);
-    }
+    protected override ILanguageSourceInputProvider GetSourceInputProvider() => new DotNetSourceInputProvider();
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Samples/SampleGeneration/GoSampleLanguageContext.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Samples/SampleGeneration/GoSampleLanguageContext.cs
@@ -183,10 +183,5 @@ func Example_audioTranslation() {
 	fmt.Fprintf(os.Stderr, ""Translated text: %s\n"", resp.Text)
 }
 ";
-	public override Task<string> GetClientLibrarySourceCodeAsync(string packagePath, int totalBudget, int perFileLimit, CancellationToken ct = default)
-	{
-		var provider = new GoSourceInputProvider();
-		var inputs = provider.Create(packagePath);
-		return FileHelper.LoadFilesAsync(inputs, packagePath, totalBudget, perFileLimit, GetSourcePriority, ct);
-	}
+	protected override ILanguageSourceInputProvider GetSourceInputProvider() => new GoSourceInputProvider();
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Samples/SampleGeneration/JavaSampleLanguageContext.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Samples/SampleGeneration/JavaSampleLanguageContext.cs
@@ -110,10 +110,5 @@ public class HelloWorld {
     }
 }
 ";
-    public override Task<string> GetClientLibrarySourceCodeAsync(string packagePath, int totalBudget, int perFileLimit, CancellationToken ct = default)
-    {
-        var provider = new JavaSourceInputProvider();
-        var inputs = provider.Create(packagePath);
-        return FileHelper.LoadFilesAsync(inputs, packagePath, totalBudget, perFileLimit, GetSourcePriority, ct);
-    }
+    protected override ILanguageSourceInputProvider GetSourceInputProvider() => new JavaSourceInputProvider();
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Samples/SampleGeneration/PythonSampleLanguageContext.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Samples/SampleGeneration/PythonSampleLanguageContext.cs
@@ -104,10 +104,5 @@ client.begin_delete_key(rsa_key.name)
 print(f""Deleted key '{ec_key.name}'"")
 print(f""Deleted key '{rsa_key.name}'"")
 ";
-    public override Task<string> GetClientLibrarySourceCodeAsync(string packagePath, int totalBudget, int perFileLimit, CancellationToken ct = default)
-    {
-        var provider = new PythonSourceInputProvider();
-        var inputs = provider.Create(packagePath);
-        return FileHelper.LoadFilesAsync(inputs, packagePath, totalBudget, perFileLimit, GetSourcePriority, ct);
-    }
+    protected override ILanguageSourceInputProvider GetSourceInputProvider() => new PythonSourceInputProvider();
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Samples/SampleGeneration/SampleLanguageContext.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Samples/SampleGeneration/SampleLanguageContext.cs
@@ -49,14 +49,13 @@ public abstract class SampleLanguageContext
     /// <returns>Concatenated structured context string.</returns>
     public virtual async Task<string> LoadContextAsync(IEnumerable<string> paths, int totalBudget, int perFileLimit, CancellationToken ct = default)
     {
-        var pathList = paths.ToList();
-        if (pathList.Count == 0)
+        if (!paths.Any())
         {
             throw new ArgumentException("At least one path must be provided", nameof(paths));
         }
 
-        var packagePath = pathList[0]; // First path is the package path
-        var additionalPaths = pathList.Skip(1); // Remaining paths are additional context
+        var packagePath = paths.First(); // First path is the package path
+        var additionalPaths = paths.Skip(1); // Remaining paths are additional context
 
         var sourceInputProvider = GetSourceInputProvider();
         var sourceInputs = sourceInputProvider.Create(packagePath).ToList();
@@ -68,7 +67,7 @@ public abstract class SampleLanguageContext
             {
                 var fullPath = Path.GetFullPath(path.Trim());
                 sourceInputs.Add(new SourceInput(fullPath, 
-                    IncludeExtensions: Array.Empty<string>(), // Include all files for additional context
+                    IncludeExtensions: Array.Empty<string>(),
                     ExcludeGlobPatterns: Array.Empty<string>()));
             }
         }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Samples/SampleGeneration/SampleLanguageContext.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Samples/SampleGeneration/SampleLanguageContext.cs
@@ -40,14 +40,49 @@ public abstract class SampleLanguageContext
         GetLanguageSpecificInstructions() + GetSampleExample();
 
     /// <summary>
-    /// Loads source code context for the client library to aid sample generation.
+    /// Loads context for sample generation from the specified paths.
     /// </summary>
-    /// <param name="packagePath">Root path to the language-specific package.</param>
+    /// <param name="paths">Paths to include in the context loading. First path is treated as the package path.</param>
     /// <param name="totalBudget">Maximum aggregate characters for all source files.</param>
     /// <param name="perFileLimit">Maximum characters per individual file before truncation.</param>
     /// <param name="ct">Cancellation token applied to file reads.</param>
-    /// <returns>Concatenated structured source context string.</returns>
-    public abstract Task<string> GetClientLibrarySourceCodeAsync(string packagePath, int totalBudget, int perFileLimit, CancellationToken ct = default);
+    /// <returns>Concatenated structured context string.</returns>
+    public virtual async Task<string> LoadContextAsync(IEnumerable<string> paths, int totalBudget, int perFileLimit, CancellationToken ct = default)
+    {
+        var pathList = paths.ToList();
+        if (pathList.Count == 0)
+        {
+            throw new ArgumentException("At least one path must be provided", nameof(paths));
+        }
+
+        var packagePath = pathList[0]; // First path is the package path
+        var additionalPaths = pathList.Skip(1); // Remaining paths are additional context
+
+        var sourceInputProvider = GetSourceInputProvider();
+        var sourceInputs = sourceInputProvider.Create(packagePath).ToList();
+        
+        // Add additional paths as SourceInput entries
+        foreach (var path in additionalPaths)
+        {
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                var fullPath = Path.GetFullPath(path.Trim());
+                sourceInputs.Add(new SourceInput(fullPath, 
+                    IncludeExtensions: Array.Empty<string>(), // Include all files for additional context
+                    ExcludeGlobPatterns: Array.Empty<string>()));
+            }
+        }
+        
+        return await FileHelper.LoadFilesAsync(sourceInputs, packagePath, totalBudget, perFileLimit, GetSourcePriority, ct);
+    }
+
+    /// <summary>
+    /// Gets the source input provider for this language. Override in derived classes to provide language-specific providers.
+    /// </summary>
+    protected virtual ILanguageSourceInputProvider GetSourceInputProvider()
+    {
+        throw new NotImplementedException($"Language '{Language}' must override GetSourceInputProvider() method.");
+    }
 
     /// <summary>
     /// Shared priority calculator for source inputs. Languages may override if needed, but most use the

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Samples/SampleGeneration/TypeScriptSampleLanguageContext.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Samples/SampleGeneration/TypeScriptSampleLanguageContext.cs
@@ -47,10 +47,5 @@ async function main(): Promise<void> {
 main().catch((err) => {
   console.error(""The sample encountered an error:"", err);
 });";
-    public override Task<string> GetClientLibrarySourceCodeAsync(string packagePath, int totalBudget, int perFileLimit, CancellationToken ct = default)
-    {
-        var provider = new TypeScriptSourceInputProvider();
-        var inputs = provider.Create(packagePath);
-        return FileHelper.LoadFilesAsync(inputs, packagePath, totalBudget, perFileLimit, GetSourcePriority, ct);
-    }
+    protected override ILanguageSourceInputProvider GetSourceInputProvider() => new TypeScriptSourceInputProvider();
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Samples/SampleGeneratorTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Samples/SampleGeneratorTool.cs
@@ -50,12 +50,20 @@ namespace Azure.Sdk.Tools.Cli.Tools.Samples
             Required = false
         };
 
+        private readonly Option<string[]> extraContextOption = new("--extra-context")
+        {
+            Description = "Path to a file or folder containing additional context to include in the prompt. Can be specified multiple times.",
+            Required = false,
+            AllowMultipleArgumentsPerToken = true
+        };
+
         protected override Command GetCommand() => new("generate", "Generates sample files")
         {
             SharedOptions.PackagePath,
             promptOption,
             overwriteOption,
-            modelOption
+            modelOption,
+            extraContextOption
         };
 
         public override async Task<CommandResponse> HandleCommand(ParseResult parseResult, CancellationToken ct)
@@ -79,6 +87,9 @@ namespace Azure.Sdk.Tools.Cli.Tools.Samples
                         {
                             logger.LogInformation("Loading prompt content from file: {promptFile}", fullPath);
                             prompt = await File.ReadAllTextAsync(fullPath, ct);
+                            
+                            // Expand any relative file links in the loaded prompt
+                            prompt = await PromptHelper.ExpandRelativeFileLinksAsync(prompt, Path.GetDirectoryName(fullPath)!, logger, ct);
                         }
                     }
                 }
@@ -88,13 +99,19 @@ namespace Azure.Sdk.Tools.Cli.Tools.Samples
                     prompt = rawPrompt; // fallback
                 }
             }
+            else
+            {
+                // For direct text prompts, expand any relative file links using current directory as base
+                prompt = await PromptHelper.ExpandRelativeFileLinksAsync(rawPrompt, Directory.GetCurrentDirectory(), logger, ct);
+            }
             string packagePath = parseResult.GetValue(SharedOptions.PackagePath) ?? ".";
             bool overwrite = parseResult.GetValue(overwriteOption);
             var model = parseResult.GetValue(modelOption);
+            var extraContextPaths = parseResult.GetValue(extraContextOption);
 
             try
             {
-                await GenerateSampleAsync(prompt, packagePath, overwrite, model, ct);
+                await GenerateSampleAsync(prompt, packagePath, overwrite, model, extraContextPaths, ct);
                 return new DefaultCommandResponse { Message = "Sample generation completed successfully" };
             }
             catch (ArgumentException ex)
@@ -109,7 +126,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Samples
             }
         }
 
-        private async Task GenerateSampleAsync(string prompt, string packagePath, bool overwrite, string model, CancellationToken ct)
+        private async Task GenerateSampleAsync(string prompt, string packagePath, bool overwrite, string model, string[]? extraContextPaths, CancellationToken ct)
         {
             IPackageInfoHelper? helper = await packageInfoResolver.Resolve(packagePath, ct) ?? throw new ArgumentException("Unable to determine language for package (resolver returned null). Ensure repository structure and Language-Settings.ps1 are correct.");
             var packageInfo = await helper.ResolvePackageInfo(packagePath, ct);
@@ -124,10 +141,25 @@ namespace Azure.Sdk.Tools.Cli.Tools.Samples
             logger.LogDebug("Package info: {packageName} at {repoRoot}", packageInfo.PackageName, packageInfo.RepoRoot);
             logger.LogDebug("Samples directory: {outputDirectory}", resolvedOutputDirectory);
 
-            var sourceContext = await sampleContext.GetClientLibrarySourceCodeAsync(packageInfo.PackagePath, totalBudget: 3000000, perFileLimit: 50000, ct);
-            logger.LogDebug("Loaded source context: {length} characters", sourceContext.Length);
+            var allPaths = new List<string> { packageInfo.PackagePath };
+            if (extraContextPaths != null && extraContextPaths.Length > 0)
+            {
+                foreach (var extraContextPath in extraContextPaths)
+                {
+                    if (!string.IsNullOrWhiteSpace(extraContextPath))
+                    {
+                        var fullPath = Path.GetFullPath(extraContextPath.Trim());
+                        allPaths.Add(fullPath);
+                        logger.LogDebug("Will include extra context from path: {path}", fullPath);
+                    }
+                }
+            }
 
-            if (string.IsNullOrWhiteSpace(sourceContext))
+            var context = await sampleContext.LoadContextAsync(allPaths, 4000000, 50000, ct);
+            
+            logger.LogDebug("Loaded context: {length} characters", context.Length);
+
+            if (string.IsNullOrWhiteSpace(context))
             {
                 throw new InvalidOperationException($"No source code content could be loaded from the package path '{packageInfo.PackagePath}'. Please verify the path contains valid source files for language '{language}'.");
             }
@@ -142,13 +174,12 @@ Generate samples for the {packageInfo.PackageName} client library in {language} 
 Scenarios description:
 {prompt}
 
-<source_context>
-{sourceContext}
-</source_context>
+<context>
+{context}
+</context>
 
 ";
-            logger.LogDebug("Enhanced prompt prepared with {contextLength} characters of source context", sourceContext.Length);
-
+            logger.LogDebug("Enhanced prompt prepared with {contextLength} characters of context", context.Length);
             logger.LogDebug("Starting microagent with model: {model}", model);
             logger.LogDebug("Enhanced prompt length: {promptLength} characters", enhancedPrompt.Length);
 


### PR DESCRIPTION
Adds support for
- `--extra-context <path to file or folder>` that adds more context to the sample generation context
- parsing of relative links in input prompts and inline the content in there. This parsing happens at the top level only and doesn't happen in nested files.