### PR TITLE
add reference doc for adding client customizations in TypeSpec

### DIFF
--- a/eng/common/knowledge/customizing-client-tsp.md
+++ b/eng/common/knowledge/customizing-client-tsp.md
@@ -227,7 +227,7 @@ interface Users {
 
 // Language-specific names
 @@clientName(foo, "pythonicFoo", "python")
-@@clientName(foo, "csharpicFoo", "csharp")
+@@clientName(foo, "CSharpFoo", "csharp")
 ```
 
 ### @clientNamespace
@@ -247,7 +247,7 @@ interface Users {
 ### @clientInitialization
 
 **Purpose**: Add custom parameters to client initialization.
-**Important**: When `@clientInitialization` references a model defined in `client.tsp`, a file-level namespace (e.g. `namespace ClientCustomizations;`) should be added if one does not exist.
+**Important**: When `@clientInitialization` references a model defined in `client.tsp`, add a file-level namespace (e.g. `namespace ClientCustomizations;`) if one does not exist.
 **Syntax**: `@clientInitialization(options: ClientInitializationOptions, scope?: string)`
 **Usage**:
 
@@ -384,7 +384,7 @@ op myOperationCustom(options: MyOperationOptions): void;
 - Mix `@clientLocation` with `@client`/`@operationGroup`
 - Over-customize - prefer defaults when possible
 - Use legacy decorators for new services
-- Rename without considering breaking changes
+- Rename without considering the impact on breaking changes
 - Forget to specify scope for language-specific customizations
 
 ## Common Scenarios


### PR DESCRIPTION
Part of https://github.com/Azure/azure-sdk-tools/pull/12577

This provides a knowledge base on the types of TypeSpec client customizations are allowed, what their purpose is, and how to apply them.

Once this is merged, it can be referenced by copilot instructions, chatmodes, custom agents or prompts.

### Testing

I've tested this with modified copilot-instructions in the azure-rest-api-specs repo (added section below in `Follow-up`) using claude sonnet 4 as the model.

#### SDK build failures
I primarily tested the .NET local sdk generation and local sdk build MCP flows with copilot from the azure-rest-api-specs repo. .NET has code analysis tools that give feedback such as model names being too generic, names that don't follow conventions, etc.

(Thank you @radhgupta for help identifying examples to test!) 

Prior to these changes, I saw a mix of unwanted behavior when copilot encountered these errors:
- changing model names in `main.tsp` directly, which impacts all languages and swaggers
- changing the generated SDK code directly
- making up tspconfig.yaml rules to create model name mappings
- Applied .NET-specific customization to all languages

After these changes, I reliably saw copilot correctly identify that a client customization should be used. It created a `client.tsp` file if it didn't already exist, and applied the correct scoping to the customizations. It also automatically reran the sdk generate and build commands to verify the errors were fixed.

#### Conversational feedback
I also tested various prompts to rename models and split clients based on our documentation, as well as some real API view feedback seen in the wild. (Thank you @swathipil for help identifying API view feedback!)

For example, copilot was able to take this feedback and apply the correct customization:
> Azure.AI.Projects.AIProjectConnectionEntraIDCredential: "ID is cased "Id" in .NET"

Without these changes, copilot updated the client customizations, but also updated the original model in `main.tsp` file for good measure 😓 

### Follow-up

The copilot-instructions.md in `azure-rest-api-specs` will be updated to include a new section under `SDK generation from TypeSpec`:

```md
## SDK customizations in TypeSpec projects

TypeSpec supports making client-specific customizations to a TypeSpec project to change how an SDK is generated. When making client-specific changes, read the [typespec client customizations reference](../knowledge/customizing-client-tsp.md) to understand the types of customizations supported and how to apply them.
```