### PR TITLE
[Service Label] Add service label: Speech Transcription

### DIFF
--- a/tools/github/data/common-labels.csv
+++ b/tools/github/data/common-labels.csv
@@ -235,6 +235,7 @@ Service Bus,,e99695
 Service Fabric,,e99695
 Service Map,,e99695
 SignalR,,e99695
+Speech Transcription,,e99695
 Storage,"Storage Service (Queues, Blobs, Files)",e99695
 Storsimple,,e99695
 Stream Analytics,,e99695


### PR DESCRIPTION
This PR adds the service label 'Speech Transcription' to the repository. Documentation link: https://azure.microsoft.com/products/ai-services/ai-speech