### PR TITLE
Remove repo configs from evals

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/ChatMessageHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/ChatMessageHelper.cs
@@ -85,11 +85,11 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
             };
         }
 
-        public static async Task<ScenarioData> LoadScenarioFromPrompt(string prompt, IEnumerable<string> tools)
+        public static ScenarioData LoadScenarioFromPrompt(string prompt, IEnumerable<string> tools)
         {
             var history = new List<ChatMessage>
             {
-                new ChatMessage(ChatRole.System, await LLMSystemInstructions.BuildLLMInstructions())
+                new ChatMessage(ChatRole.System, LLMSystemInstructions.BuildLLMInstructions())
             };
             var nextMessage = new ChatMessage(ChatRole.User, prompt);
             var toolCalls = ToolMocks.ToolMocks.GetToolMocks(tools);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/LLMSystemInstructions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/LLMSystemInstructions.cs
@@ -18,7 +18,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
             var linkRegex = new Regex(@"\[([^\]]+)\]\(([^)]+\.instructions\.md)\)", RegexOptions.IgnoreCase);
 
             var matches = linkRegex.Matches(copilotInstructions);
-            var instruction = matches
+            var instructions = matches
                 .Select(match => GetMentionedInstructions(match.Groups[2].Value));
             
             var builder = new StringBuilder(copilotInstructions);
@@ -44,8 +44,13 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
             instructionRelativePath = instructionRelativePath.Replace('\\', '/');
             var instructionUri = new Uri(Path.Combine(copilotBaseDirectory, instructionRelativePath));
             string instructionPath = Path.GetFullPath(instructionUri.LocalPath);
-            return File.ReadAllText(instructionPath);
 
+            if(!Path.Exists(instructionPath))
+            {
+                throw new FileNotFoundException($"Could not find instruction file mentioned inside of copilot instructions at path: {instructionPath}");
+            }
+
+            return File.ReadAllText(instructionPath);
         }
 
         private static readonly string DefaultToolInstructions =

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/LLMSystemInstructions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/LLMSystemInstructions.cs
@@ -7,24 +7,22 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
 {
     public static class LLMSystemInstructions
     {
-        private static string CopilotRepositoryPath => ".github\\copilot-instructions.md";
-
-        public static async Task<string> BuildLLMInstructions()
+        public static string BuildLLMInstructions()
         {
             var toolInstructions = DefaultToolInstructions;
-            toolInstructions += $"<instructions>{await LoadInstructions()}</instructions";
+            toolInstructions += $"<instructions>{LoadInstructions()}</instructions";
             return toolInstructions;
         }
 
-        private static async Task<string> LoadInstructions()
+        private static string LoadInstructions()
         {
-            var copilotInstructions = await GetCopilotInstructions();
+            var copilotInstructions = GetCopilotInstructions();
             var linkRegex = new Regex(@"\[([^\]]+)\]\(([^)]+\.instructions\.md)\)", RegexOptions.IgnoreCase);
 
             var matches = linkRegex.Matches(copilotInstructions);
             var instructionTasks = matches
                 .Select(match => GetMentionedInstructions(match.Groups[2].Value));
-            var instructions = await Task.WhenAll(instructionTasks);
+            var instructions =  instructionTasks;
             
             var builder = new StringBuilder(copilotInstructions);
             foreach (var instruction in instructions)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/LLMSystemInstructions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/LLMSystemInstructions.cs
@@ -35,41 +35,22 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
             return builder.ToString();
         }
 
-        private static async Task<string> GetCopilotInstructions()
+        private static string GetCopilotInstructions()
         {
-            if (!string.IsNullOrEmpty(TestSetup.GetCopilotInstructionsPath))
-            {
-                return File.ReadAllText(TestSetup.GetCopilotInstructionsPath!);
-            }
-            else
-            {
-                var logger = new LoggerFactory().CreateLogger<GitHubService>();
-                var githubService = new GitHubService(logger);
-                var copilotInstructions = await githubService.GetContentsSingleAsync(TestSetup.GetRepoOwner!, TestSetup.GetRepoName!, CopilotRepositoryPath);
-                return copilotInstructions.Content;
-            }
+            return File.ReadAllText(TestSetup.GetCopilotInstructionsPath!);
         }
 
-        private static async Task<string> GetMentionedInstructions(string instructionRelativePath)
+        private static string GetMentionedInstructions(string instructionRelativePath)
         {
-            if (!string.IsNullOrEmpty(TestSetup.GetCopilotInstructionsPath))
-            {
-                var copilotBaseDirectory = Path.GetDirectoryName(TestSetup.GetCopilotInstructionsPath!)!;
+
+            var copilotBaseDirectory = Path.GetDirectoryName(TestSetup.GetCopilotInstructionsPath!)!;
                 
-                // Normalize the path
-                instructionRelativePath = instructionRelativePath.Replace('\\', '/');
-                var instructionUri = new Uri(Path.Combine(copilotBaseDirectory, instructionRelativePath));
-                string instructionPath = Path.GetFullPath(instructionUri.LocalPath);
-                return File.ReadAllText(instructionPath);
-            }
-            else
-            {
-                string instructionPath = Path.Combine(instructionRelativePath.Substring(3));
-                var logger = new LoggerFactory().CreateLogger<GitHubService>();
-                var githubService = new GitHubService(logger);
-                var instructions = await githubService.GetContentsSingleAsync(TestSetup.GetRepoOwner!, TestSetup.GetRepoName!, instructionPath);
-                return instructions.Content;
-            }
+            // Normalize the path
+            instructionRelativePath = instructionRelativePath.Replace('\\', '/');
+            var instructionUri = new Uri(Path.Combine(copilotBaseDirectory, instructionRelativePath));
+            string instructionPath = Path.GetFullPath(instructionUri.LocalPath);
+            return File.ReadAllText(instructionPath);
+
         }
 
         private static readonly string DefaultToolInstructions =

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/LLMSystemInstructions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/LLMSystemInstructions.cs
@@ -1,7 +1,5 @@
 using System.Text;
 using System.Text.RegularExpressions;
-using Azure.Sdk.Tools.Cli.Services;
-using Microsoft.Extensions.Logging;
 
 namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/LLMSystemInstructions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/LLMSystemInstructions.cs
@@ -18,9 +18,8 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
             var linkRegex = new Regex(@"\[([^\]]+)\]\(([^)]+\.instructions\.md)\)", RegexOptions.IgnoreCase);
 
             var matches = linkRegex.Matches(copilotInstructions);
-            var instructionTasks = matches
+            var instruction = matches
                 .Select(match => GetMentionedInstructions(match.Groups[2].Value));
-            var instructions =  instructionTasks;
             
             var builder = new StringBuilder(copilotInstructions);
             foreach (var instruction in instructions)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/SerializationHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/SerializationHelper.cs
@@ -31,7 +31,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
             // For some reason above method will give all the messages user role. It still does the heavy lifting so I'll keep it and just change the roles. 
             var fixedChatMessages = ChatMessageHelper.EnsureChatMessageRole(translatedChatMessages, chatMessages);
 
-            await RebuildAttachmentsInChatMessagesAsync(fixedChatMessages);
+            RebuildAttachmentsInChatMessagesAsync(fixedChatMessages);
 
             return ChatMessageHelper.ParseChatMessagesIntoScenarioData(fixedChatMessages);
         }
@@ -41,7 +41,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
         /// with files from the configured instruction directories.
         /// </summary>
         /// <param name="chatMessages">The chat messages to process</param>
-        public static async Task RebuildAttachmentsInChatMessagesAsync(List<ChatMessage> chatMessages)
+        public static void RebuildAttachmentsInChatMessagesAsync(List<ChatMessage> chatMessages)
         {
             // Only process the first message (typically the system message)
             if (chatMessages.Count == 0)
@@ -53,14 +53,14 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
             var firstMessage = chatMessages[0];
             if (firstMessage.Contents[0] is TextContent textContent && !string.IsNullOrEmpty(textContent.Text))
             {
-                textContent.Text = await RebuildAttachmentsInTextAsync(textContent.Text);
+                textContent.Text = RebuildAttachmentsInTextAsync(textContent.Text);
             }
         }
 
         /// <summary>
         /// Rebuilds attachment sections in text content by loading files from instruction directories.
         /// </summary>
-        private static async Task<string> RebuildAttachmentsInTextAsync(string text)
+        private static string RebuildAttachmentsInTextAsync(string text)
         {
             // Find the last <instructions>...</instructions> block
             var instructionsPattern = @"<instructions>.*?</instructions>";
@@ -73,7 +73,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
                 var lastMatch = matches[matches.Count - 1];
 
                 // Get the new instructions content
-                var newInstructions = await LLMSystemInstructions.BuildLLMInstructions();
+                var newInstructions = LLMSystemInstructions.BuildLLMInstructions();
 
                 // Replace the last instructions block
                 var newInstructionsBlock = $"<instructions>{newInstructions}</instructions>";

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/TestSetup.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/TestSetup.cs
@@ -18,7 +18,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
             Environment.GetEnvironmentVariable("AZURE_OPENAI_MODEL_DEPLOYMENT_NAME")
             ?? throw new InvalidOperationException("AZURE_OPENAI_MODEL_DEPLOYMENT_NAME environment variable is required");
         
-        private static readonly bool UseMCPRelease = bool.Parse(Environment.GetEnvironmentVariable("USE_MCP_RELEASE")) ?? false;
+        private static readonly bool UseMCPRelease = bool.TryParse(Environment.GetEnvironmentVariable("USE_MCP_RELEASE"), out var result) && result;
         private static readonly string relativePathToCli = @"../../../../../tools/azsdk-cli/Azure.Sdk.Tools.Cli";
         private static readonly string localMcpPowershellScriptPath = @"../../../../../eng/common/mcp/azure-sdk-mcp.ps1";
         public static string? GetCopilotInstructionsPath => Environment.GetEnvironmentVariable("COPILOT_INSTRUCTIONS_PATH");
@@ -100,6 +100,11 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
             {
                 throw new InvalidOperationException(
                     "Invalid environment configuration: COPILOT_INSTRUCTIONS_PATH must be provided.");
+            }
+
+            if(!Path.Exists(GetCopilotInstructionsPath))
+            {
+                throw new FileNotFoundException($"Could not find copilot instructions file at path: {GetCopilotInstructionsPath}");
             }
         }
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/TestSetup.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/TestSetup.cs
@@ -19,8 +19,6 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
             ?? throw new InvalidOperationException("AZURE_OPENAI_MODEL_DEPLOYMENT_NAME environment variable is required");
         
         private static readonly string relativePathToCli = @"../../../../../tools/azsdk-cli/Azure.Sdk.Tools.Cli";
-        public static string? GetRepoName => Environment.GetEnvironmentVariable("COPILOT_INSTRUCTIONS_REPOSITORY_NAME");
-        public static string? GetRepoOwner => Environment.GetEnvironmentVariable("COPILOT_INSTRUCTIONS_REPOSITORY_OWNER");
         public static string? GetCopilotInstructionsPath => Environment.GetEnvironmentVariable("COPILOT_INSTRUCTIONS_PATH");
         public static ChatCompletion GetChatCompletion(IChatClient chatClient, IMcpClient mcpClient) => new ChatCompletion(chatClient, mcpClient);
 
@@ -81,30 +79,11 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
 
         public static void ValidateCopilotEnvironmentConfiguration()
         {
-            var repoName = GetRepoName;
-            var repoOwner = GetRepoOwner;
-            var copilotInstructionsPath = GetCopilotInstructionsPath;
-            bool hasRepoName = !string.IsNullOrEmpty(repoName);
-            bool hasRepoOwner = !string.IsNullOrEmpty(repoOwner);
-            bool hasCopilotPath = !string.IsNullOrEmpty(copilotInstructionsPath);
-
-            // Check if both repo name and owner are provided
-            bool hasRepoInfo = hasRepoName && hasRepoOwner;
-
             // Validate that we have at least one valid configuration
-            if (!hasRepoInfo && !hasCopilotPath)
+            if (string.IsNullOrEmpty(GetCopilotInstructionsPath))
             {
                 throw new InvalidOperationException(
-                    "Invalid environment configuration: Either both COPILOT_INSTRUCTIONS_REPOSITORY_NAME and " +
-                    "COPILOT_INSTRUCTIONS_REPOSITORY_OWNER must be provided, OR COPILOT_INSTRUCTIONS_PATH must be provided.");
-            }
-
-            // If repo info is partially provided, it's also an error
-            if (hasRepoOwner ^ hasRepoName)
-            {
-                throw new InvalidOperationException(
-                    "Invalid repository configuration: Both COPILOT_INSTRUCTIONS_REPOSITORY_NAME and " +
-                    "COPILOT_INSTRUCTIONS_REPOSITORY_OWNER must be provided together.");
+                    "Invalid environment configuration: COPILOT_INSTRUCTIONS_PATH must be provided.");
             }
         }
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/TestSetup.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/TestSetup.cs
@@ -20,7 +20,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
         
         private static readonly bool UseMCPRelease = bool.Parse(Environment.GetEnvironmentVariable("USE_MCP_RELEASE")) ?? false;
         private static readonly string relativePathToCli = @"../../../../../tools/azsdk-cli/Azure.Sdk.Tools.Cli";
-        private static readonly string localMcpPowershellScriptPath = @"../../../../..//eng/common/mcp/azure-sdk-mcp.ps1";
+        private static readonly string localMcpPowershellScriptPath = @"../../../../../eng/common/mcp/azure-sdk-mcp.ps1";
         public static string? GetCopilotInstructionsPath => Environment.GetEnvironmentVariable("COPILOT_INSTRUCTIONS_PATH");
         public static ChatCompletion GetChatCompletion(IChatClient chatClient, IMcpClient mcpClient) => new ChatCompletion(chatClient, mcpClient);
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_CreateReleasePlan.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_CreateReleasePlan.cs
@@ -19,7 +19,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
             ];
 
             // Build scenario data
-            var scenarioData = await ChatMessageHelper.LoadScenarioFromPrompt(prompt, expectedTools);
+            var scenarioData = ChatMessageHelper.LoadScenarioFromPrompt(prompt, expectedTools);
             var expectedToolResults = ChatMessageHelper.GetExpectedToolsByName(scenarioData.ExpectedOutcome, s_toolNames!);
 
             // External construction of evaluation context

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_GetPullRequestLinkForCurrentBranch.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_GetPullRequestLinkForCurrentBranch.cs
@@ -18,7 +18,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
             ];
 
             // Build scenario data
-            var scenarioData = await ChatMessageHelper.LoadScenarioFromPrompt(prompt, expectedTools);
+            var scenarioData = ChatMessageHelper.LoadScenarioFromPrompt(prompt, expectedTools);
             var expectedToolResults = ChatMessageHelper.GetExpectedToolsByName(scenarioData.ExpectedOutcome, s_toolNames!);
 
             // External construction of evaluation context

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_ValidateTypespec.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_ValidateTypespec.cs
@@ -18,7 +18,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
             ];
 
             // Build scenario data from prompt
-            var scenarioData = await ChatMessageHelper.LoadScenarioFromPrompt(prompt, expectedTools);
+            var scenarioData = ChatMessageHelper.LoadScenarioFromPrompt(prompt, expectedTools);
             var expectedToolResults = ChatMessageHelper.GetExpectedToolsByName(scenarioData.ExpectedOutcome, s_toolNames!);
 
             // External contexts (no deep input checking for this one)

--- a/tools/azsdk-cli/run-ai-eval.yml
+++ b/tools/azsdk-cli/run-ai-eval.yml
@@ -47,8 +47,6 @@ jobs:
         DOTNET_MULTILEVEL_LOOKUP: 0
         AZURE_OPENAI_MODEL_DEPLOYMENT_NAME: ${{ parameters.Model }}
         AZURE_OPENAI_ENDPOINT: ${{ parameters.OpenAIEndPoint }}
-        COPILOT_INSTRUCTIONS_REPOSITORY_NAME: ${{ parameters.RepoName }}
-        COPILOT_INSTRUCTIONS_REPOSITORY_OWNER: ${{ parameters.RepoOwner }}
         COPILOT_INSTRUCTIONS_PATH: $(System.DefaultWorkingDirectory)/${{ parameters.RepoName }}/.github/copilot-instructions.md
 
     - task: PublishTestResults@2


### PR DESCRIPTION
- Removed the repository configuration to use GitHub octokit as it is no longer needed. 
- Resolves #12784
- Added in an extra configuration for which MCP to run. Latest on main when triggered by release that way we have the right version. To run the MCP through the script you would pass in false and it would run the MCP in the script. 
- Also resolves #12783