### PR TITLE
Added update-changelog-content tool

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/ChangelogContentUpdateToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/ChangelogContentUpdateToolTests.cs
@@ -1,0 +1,379 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Moq;
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
+using Azure.Sdk.Tools.Cli.Tools.Package;
+using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.Responses.Package;
+using Azure.Sdk.Tools.Cli.Extensions;
+using Microsoft.Extensions.Logging;
+using Azure.Sdk.Tools.Cli.Services.Languages;
+
+namespace Azure.Sdk.Tools.Cli.Tests.Tools.Package;
+
+[TestFixture]
+public class ChangelogContentUpdateToolTests
+{
+    #region Test Constants
+
+    private const string TestPackagePath = "/test/package/path";
+    private const string TestRepoRoot = "/test/repo/root";
+    private const string TestConfigValue = "test-config-value";
+    private const string TestSuccessMessage = "Changelog content is updated.";
+    private const string TestErrorMessage = "Test error message";
+
+    // Error message patterns
+    private const string EmptyPackagePathError = "Package path is required and cannot be empty.";
+    private const string PackageNotFoundError = "Package path does not exist: ";
+    private const string RepoRootNotFoundError = "Unable to find git repository root from the provided package path.";
+
+    #endregion
+
+    private ChangelogContentUpdateTool _tool;
+    private Mock<IGitHelper> _mockGitHelper;
+    private Mock<ISpecGenSdkConfigHelper> _mockSpecGenSdkConfigHelper;
+    private Mock<LanguageService> _mockLanguageService;
+    private TestLogger<ChangelogContentUpdateTool> _logger;
+    private TempDirectory _tempDirectory;
+    private PackageInfo _testPackageInfo;
+    private List<LanguageService> _languageServices;
+    private PackageOperationResponse _successResponse;
+    private PackageOperationResponse _failureResponse;
+
+    [SetUp]
+    public void Setup()
+    {
+        // Create mocks
+        _mockGitHelper = new Mock<IGitHelper>();
+        _mockSpecGenSdkConfigHelper = new Mock<ISpecGenSdkConfigHelper>();
+        _logger = new TestLogger<ChangelogContentUpdateTool>();
+
+        _mockLanguageService = new Mock<LanguageService>();
+
+        // Create temp directory for tests
+        _tempDirectory = TempDirectory.Create("ChangelogContentUpdateToolTests");
+
+        // Setup test data FIRST before setting up mocks that use it
+        _testPackageInfo = new PackageInfo
+        {
+            PackagePath = TestPackagePath,
+            RepoRoot = TestRepoRoot,
+            RelativePath = "test/relative/path",
+            PackageName = "test-package",
+            ServiceName = "test-service",
+            PackageVersion = "1.0.0",
+            SamplesDirectory = "/test/samples",
+            Language = SdkLanguage.DotNet,
+            SdkType = SdkType.Management  // Changed to Management for script execution tests
+        };
+
+        // Setup language service to return test package info
+        _mockLanguageService.Setup(x => x.GetPackageInfo(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_testPackageInfo);
+        _mockLanguageService.Setup(x => x.Language).Returns(SdkLanguage.DotNet);
+        _languageServices = new List<LanguageService> { _mockLanguageService.Object };
+
+        _successResponse = new PackageOperationResponse
+        {
+            Result = "succeeded",
+            Message = TestSuccessMessage,
+            PackageName = _testPackageInfo.PackageName,
+            Language = _testPackageInfo.Language,
+            PackageType = _testPackageInfo.SdkType
+        };
+
+        _failureResponse = new PackageOperationResponse
+        {
+            ResponseErrors = [TestErrorMessage],
+            Result = "failed",
+            PackageName = string.Empty,
+            Language = SdkLanguage.Unknown,
+            PackageType = SdkType.Unknown
+        };
+
+        // Create the tool instance
+        _tool = new ChangelogContentUpdateTool(
+            _mockGitHelper.Object,
+            _logger,
+            _languageServices,
+            _mockSpecGenSdkConfigHelper.Object
+        );
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _tempDirectory.Dispose();
+    }
+
+    #region Constructor Tests
+
+    [Test]
+    public void Constructor_WithValidParameters_ShouldCreateInstance()
+    {
+        // Act & Assert
+        Assert.That(_tool, Is.Not.Null);
+        Assert.That(_tool.GetType().Name, Is.EqualTo("ChangelogContentUpdateTool"));
+    }
+
+    #endregion
+
+    #region UpdateChangelogContentAsync Tests
+
+    [Test]
+    public async Task UpdateChangelogContentAsync_WithNullPackagePath_ShouldReturnFailure()
+    {
+        // Act
+        var result = await _tool.UpdateChangelogContentAsync(null!, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.Result, Is.EqualTo("failed"));
+        Assert.That(result.ResponseErrors.FirstOrDefault(), Is.EqualTo(EmptyPackagePathError));
+    }
+
+    [Test]
+    public async Task UpdateChangelogContentAsync_WithEmptyPackagePath_ShouldReturnFailure()
+    {
+        // Act
+        var result = await _tool.UpdateChangelogContentAsync(string.Empty, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.Result, Is.EqualTo("failed"));
+        Assert.That(result.ResponseErrors.FirstOrDefault(), Is.EqualTo(EmptyPackagePathError));
+    }
+
+    [Test]
+    public async Task UpdateChangelogContentAsync_WithNonExistentPackagePath_ShouldReturnFailure()
+    {
+        // Arrange
+        var nonExistentPath = "/non/existent/path";
+        var expectedError = $"{PackageNotFoundError}{nonExistentPath}";
+
+        // Act
+        var result = await _tool.UpdateChangelogContentAsync(nonExistentPath, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.Result, Is.EqualTo("failed"));
+        Assert.That(result.ResponseErrors.FirstOrDefault(), Is.EqualTo(expectedError));
+    }
+
+    [Test]
+    public async Task UpdateChangelogContentAsync_WithValidPath_WhenRepoRootNotFound_ShouldReturnFailure()
+    {
+        // Arrange
+        var testPath = _tempDirectory.DirectoryPath;
+        _mockGitHelper.Setup(x => x.DiscoverRepoRoot(testPath)).Returns((string?)null!);
+
+        // Act
+        var result = await _tool.UpdateChangelogContentAsync(testPath, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.Result, Is.EqualTo("failed"));
+        Assert.That(result.ResponseErrors.FirstOrDefault(), Is.EqualTo(RepoRootNotFoundError));
+    }
+
+    [Test]
+    public async Task UpdateChangelogContentAsync_WithConfigurationFound_ShouldExecuteScript()
+    {
+        // Arrange
+        var testPath = _tempDirectory.DirectoryPath;
+        _mockGitHelper.Setup(x => x.DiscoverRepoRoot(testPath)).Returns(TestRepoRoot);
+        _mockGitHelper.Setup(x => x.GetRepoName(testPath)).Returns("azure-sdk-for-net");
+        _mockSpecGenSdkConfigHelper.Setup(x => x.GetConfigurationAsync(TestRepoRoot, SpecGenSdkConfigType.UpdateChangelogContent))
+            .ReturnsAsync((SpecGenSdkConfigContentType.Command, TestConfigValue));
+
+        var mockProcessOptions = new ProcessOptions("echo", ["test"]);
+        _mockSpecGenSdkConfigHelper.Setup(x => x.CreateProcessOptions(
+            SpecGenSdkConfigContentType.Command,
+            TestConfigValue,
+            TestRepoRoot,
+            testPath,
+            It.IsAny<Dictionary<string, string>>(),
+            It.IsAny<int>()))
+            .Returns(mockProcessOptions);
+
+        _mockSpecGenSdkConfigHelper.Setup(x => x.ExecuteProcessAsync(
+            It.IsAny<ProcessOptions>(),
+            It.IsAny<CancellationToken>(),
+            It.IsAny<PackageInfo>(),
+            It.IsAny<string>(),
+            It.IsAny<string[]>()))
+            .ReturnsAsync(PackageOperationResponse.CreateSuccess("Success", null));
+
+        // Act
+        var result = await _tool.UpdateChangelogContentAsync(testPath, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.OperationStatus, Is.EqualTo(Status.Succeeded));
+        _mockSpecGenSdkConfigHelper.Verify(x => x.CreateProcessOptions(
+            SpecGenSdkConfigContentType.Command,
+            TestConfigValue,
+            TestRepoRoot,
+            testPath,
+            It.IsAny<Dictionary<string, string>>(),
+            It.IsAny<int>()), Times.Once);
+        _mockSpecGenSdkConfigHelper.Verify(x => x.ExecuteProcessAsync(
+            It.IsAny<ProcessOptions>(),
+            It.IsAny<CancellationToken>(),
+            It.IsAny<PackageInfo>(),
+            It.IsAny<string>(),
+            It.IsAny<string[]>()), Times.Once);
+    }
+
+    [Test]
+    public async Task UpdateChangelogContentAsync_WithConfigurationFound_WhenProcessOptionsNull_ShouldFallbackToLanguageService()
+    {
+        // Arrange
+        var testPath = _tempDirectory.DirectoryPath;
+        _mockGitHelper.Setup(x => x.DiscoverRepoRoot(testPath)).Returns(TestRepoRoot);
+        _mockGitHelper.Setup(x => x.GetRepoName(testPath)).Returns("azure-sdk-for-net");
+        _mockSpecGenSdkConfigHelper.Setup(x => x.GetConfigurationAsync(TestRepoRoot, SpecGenSdkConfigType.UpdateChangelogContent))
+            .ReturnsAsync((SpecGenSdkConfigContentType.Command, TestConfigValue));
+
+        _mockSpecGenSdkConfigHelper.Setup(x => x.CreateProcessOptions(
+            It.IsAny<SpecGenSdkConfigContentType>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<Dictionary<string, string>>(),
+            It.IsAny<int>()))
+            .Returns((ProcessOptions)null!);
+
+        _mockLanguageService.Setup(x => x.UpdateChangelogContentAsync(testPath, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_successResponse);
+
+        // Act
+        var result = await _tool.UpdateChangelogContentAsync(testPath, CancellationToken.None);
+
+        // Assert
+        Assert.That(result, Is.EqualTo(_successResponse));
+        _mockLanguageService.Verify(x => x.UpdateChangelogContentAsync(testPath, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task UpdateChangelogContentAsync_WithoutConfiguration_ShouldUseLanguageService()
+    {
+        // Arrange
+        var testPath = _tempDirectory.DirectoryPath;
+        _mockGitHelper.Setup(x => x.DiscoverRepoRoot(testPath)).Returns(TestRepoRoot);
+        _mockGitHelper.Setup(x => x.GetRepoName(testPath)).Returns("azure-sdk-for-net");
+        _mockSpecGenSdkConfigHelper.Setup(x => x.GetConfigurationAsync(TestRepoRoot, SpecGenSdkConfigType.UpdateChangelogContent))
+            .ReturnsAsync((SpecGenSdkConfigContentType.Unknown, string.Empty));
+
+        _mockLanguageService.Setup(x => x.UpdateChangelogContentAsync(testPath, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_successResponse);
+
+        // Act
+        var result = await _tool.UpdateChangelogContentAsync(testPath, CancellationToken.None);
+
+        // Assert
+        Assert.That(result, Is.EqualTo(_successResponse));
+        _mockLanguageService.Verify(x => x.UpdateChangelogContentAsync(testPath, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task UpdateChangelogContentAsync_WhenExceptionThrown_ShouldReturnFailure()
+    {
+        // Arrange
+        var testPath = _tempDirectory.DirectoryPath;
+        var expectedException = new InvalidOperationException("Test exception");
+        var expectedErrorMessage = $"An error occurred: {expectedException.Message}";
+
+        _mockGitHelper.Setup(x => x.DiscoverRepoRoot(testPath)).Throws(expectedException);
+
+        // Act
+        var result = await _tool.UpdateChangelogContentAsync(testPath, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.Result, Is.EqualTo("failed"));
+        Assert.That(result.ResponseErrors.FirstOrDefault(), Is.EqualTo(expectedErrorMessage));
+    }
+
+    [Test]
+    public async Task UpdateChangelogContentAsync_WithCancellationToken_ShouldPassTokenToServices()
+    {
+        // Arrange
+        var testPath = _tempDirectory.DirectoryPath;
+        var cancellationToken = new CancellationToken();
+        
+        _mockGitHelper.Setup(x => x.DiscoverRepoRoot(testPath)).Returns(TestRepoRoot);
+        _mockGitHelper.Setup(x => x.GetRepoName(testPath)).Returns("azure-sdk-for-net");
+        _mockSpecGenSdkConfigHelper.Setup(x => x.GetConfigurationAsync(TestRepoRoot, SpecGenSdkConfigType.UpdateChangelogContent))
+            .ReturnsAsync((SpecGenSdkConfigContentType.Unknown, string.Empty));
+
+        _mockLanguageService.Setup(x => x.UpdateChangelogContentAsync(testPath, cancellationToken))
+            .ReturnsAsync(_successResponse);
+
+        // Act
+        var result = await _tool.UpdateChangelogContentAsync(testPath, cancellationToken);
+
+        // Assert
+        Assert.That(result, Is.EqualTo(_successResponse));
+        _mockLanguageService.Verify(x => x.UpdateChangelogContentAsync(testPath, cancellationToken), Times.Once);
+    }
+
+    #endregion
+
+    #region Integration Tests
+
+    [Test]
+    public async Task UpdateChangelogContentAsync_IntegrationTest_WithScriptConfiguration()
+    {
+        // Arrange
+        var testPath = _tempDirectory.DirectoryPath;
+        var scriptContent = "echo 'Updating changelog content'";
+        
+        _mockGitHelper.Setup(x => x.DiscoverRepoRoot(testPath)).Returns(TestRepoRoot);
+        _mockGitHelper.Setup(x => x.GetRepoName(testPath)).Returns("azure-sdk-for-net");
+        _mockSpecGenSdkConfigHelper.Setup(x => x.GetConfigurationAsync(TestRepoRoot, SpecGenSdkConfigType.UpdateChangelogContent))
+            .ReturnsAsync((SpecGenSdkConfigContentType.Command, scriptContent));
+
+        var processOptions = new ProcessOptions("echo", ["test"]);
+        _mockSpecGenSdkConfigHelper.Setup(x => x.CreateProcessOptions(
+            SpecGenSdkConfigContentType.Command,
+            scriptContent,
+            TestRepoRoot,
+            testPath,
+            It.Is<Dictionary<string, string>>(d => 
+                d["SdkRepoPath"] == TestRepoRoot && 
+                d["PackagePath"] == testPath),
+            It.IsAny<int>()))
+            .Returns(processOptions);
+
+        _mockSpecGenSdkConfigHelper.Setup(x => x.ExecuteProcessAsync(
+            It.IsAny<ProcessOptions>(),
+            It.IsAny<CancellationToken>(),
+            It.IsAny<PackageInfo>(),
+            It.IsAny<string>(),
+            It.IsAny<string[]>()))
+            .ReturnsAsync(PackageOperationResponse.CreateSuccess("Success", null));
+
+        // Act
+        var result = await _tool.UpdateChangelogContentAsync(testPath, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.OperationStatus, Is.EqualTo(Status.Succeeded));
+        
+        // Verify the complete flow
+        _mockSpecGenSdkConfigHelper.Verify(x => x.GetConfigurationAsync(TestRepoRoot, SpecGenSdkConfigType.UpdateChangelogContent), Times.Once);
+        _mockSpecGenSdkConfigHelper.Verify(x => x.CreateProcessOptions(
+            SpecGenSdkConfigContentType.Command,
+            scriptContent,
+            TestRepoRoot,
+            testPath,
+            It.IsAny<Dictionary<string, string>>(),
+            It.IsAny<int>()), Times.Once);
+        _mockSpecGenSdkConfigHelper.Verify(x => x.ExecuteProcessAsync(
+            It.IsAny<ProcessOptions>(),
+            It.IsAny<CancellationToken>(),
+            It.IsAny<PackageInfo>(),
+            It.IsAny<string>(),
+            It.IsAny<string[]>()), Times.Once);
+    }
+
+    #endregion
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedOptions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedOptions.cs
@@ -31,6 +31,7 @@ namespace Azure.Sdk.Tools.Cli.Commands
             typeof(SdkBuildTool),
             typeof(SdkGenerationTool),
             typeof(MetadataUpdateTool),
+            typeof(ChangelogContentUpdateTool),
             typeof(SdkReleaseTool),
             typeof(SpecCommonTools),
             typeof(PullRequestTools),

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageOperationResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageOperationResponse.cs
@@ -86,12 +86,13 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses.Package
         /// <param name="message">The success message to include in the response.</param>
         /// <param name="packageInfo">Optional package information to include in the response.</param>
         /// <param name="nextSteps">Optional next steps to include in the response.</param>
+        /// <param name="result">Optional result status to include in the response.</param>
         /// <returns>A PackageOperationResponse indicating success.</returns>
-        public static PackageOperationResponse CreateSuccess(string message, PackageInfo? packageInfo = null, string[]? nextSteps = null)
+        public static PackageOperationResponse CreateSuccess(string message, PackageInfo? packageInfo = null, string[]? nextSteps = null, string? result = "succeeded")
         {
             return new PackageOperationResponse
             {
-                Result = "succeeded",
+                Result = result,
                 Message = message,
                 PackageName = packageInfo?.PackageName ?? string.Empty,
                 Language = packageInfo?.Language ?? SdkLanguage.Unknown,

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/LanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/LanguageService.cs
@@ -231,7 +231,8 @@ namespace Azure.Sdk.Tools.Cli.Services.Languages
         /// <returns>A response indicating the result of the metadata update operation.</returns>
         public virtual Task<PackageOperationResponse> UpdateMetadataAsync(string packagePath, CancellationToken ct)
         {
-            return Task.FromResult(PackageOperationResponse.CreateSuccess("This is not an applicable operation for this language."));
+            this.logger.LogInformation("No language-specific package metadata update implementation found for package path: {packagePath}.", packagePath);
+            return Task.FromResult(PackageOperationResponse.CreateSuccess("No package metadata updates need to be performed.", nextSteps: ["Update the version when preparing for a release"]));
         }
 
         /// <summary>
@@ -242,7 +243,15 @@ namespace Azure.Sdk.Tools.Cli.Services.Languages
         /// <returns>A response indicating the result of the changelog update operation.</returns>
         public virtual Task<PackageOperationResponse> UpdateChangelogContentAsync(string packagePath, CancellationToken ct)
         {
-            return Task.FromResult(PackageOperationResponse.CreateSuccess("This is not an applicable operation for this language."));
+            return Task.FromResult(
+                PackageOperationResponse.CreateSuccess(
+                    "Data-plane changelog untouched; manual edits required.",
+                    nextSteps: [
+                        "Summarize version updates under 'Features Added', 'Breaking Changes', 'Bug Fixes', and 'Other Changes'",
+                        "Refer to this documentation: https://eng.ms/docs/products/azure-developer-experience/develop/sdk-release/sdk-release-prerequisites",
+                        "Update package metadata after the changelog content has been updated"
+                        ],
+                    result: "noop"));
         }
 
         /// <summary>
@@ -253,7 +262,8 @@ namespace Azure.Sdk.Tools.Cli.Services.Languages
         /// <returns>A response indicating the result of the version update operation.</returns>
         public virtual Task<PackageOperationResponse> UpdateVersionAsync(string packagePath, CancellationToken ct)
         {
-            return Task.FromResult(PackageOperationResponse.CreateSuccess("This is not an applicable operation for this language."));
+            this.logger.LogInformation("No language-specific package version update implementation found for package path: {packagePath}.", packagePath);
+            return Task.FromResult(PackageOperationResponse.CreateSuccess("No package version updates need to be performed."));
         }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/LanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/LanguageService.cs
@@ -245,7 +245,7 @@ namespace Azure.Sdk.Tools.Cli.Services.Languages
         {
             return Task.FromResult(
                 PackageOperationResponse.CreateSuccess(
-                    "Data-plane changelog untouched; manual edits required.",
+                    "Changelog untouched; manual edits required.",
                     nextSteps: [
                         "Summarize version updates under 'Features Added', 'Breaking Changes', 'Bug Fixes', and 'Other Changes'",
                         "Refer to this documentation: https://eng.ms/docs/products/azure-developer-experience/develop/sdk-release/sdk-release-prerequisites",

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/ChangelogContentUpdateTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/ChangelogContentUpdateTool.cs
@@ -82,7 +82,7 @@ public class ChangelogContentUpdateTool : LanguageMcpTool
             var languageService = GetLanguageService(packagePath);
             if (languageService == null)
             {
-                return PackageOperationResponse.CreateFailure("Tooling error: unable to determine language service for the specified package path.", nextSteps: ["Create an issue at the https://github.com/Azure/azure-sdk-tools/issues/new?", "contact the Azure SDK team for assistance."]);
+                return PackageOperationResponse.CreateFailure("Tooling error: unable to determine language service for the specified package path.", nextSteps: ["Create an issue at the https://github.com/Azure/azure-sdk-tools/issues/new", "contact the Azure SDK team for assistance."]);
             }
 
             // Check for package type
@@ -111,8 +111,8 @@ public class ChangelogContentUpdateTool : LanguageMcpTool
                 }
             }
 
-            // Run default logic for data-plane packages
-            logger.LogInformation("Running default logic to update changelog content for the data-plane package...");
+            // Run default logic to update changelog content
+            logger.LogInformation("Running default logic to update changelog content for the package...");
             return await languageService.UpdateChangelogContentAsync(packagePath, ct);
         }
         catch (Exception ex)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/ChangelogContentUpdateTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/ChangelogContentUpdateTool.cs
@@ -1,0 +1,124 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.ComponentModel;
+using Azure.Sdk.Tools.Cli.Commands;
+using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.Responses.Package;
+using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Services.Languages;
+using Azure.Sdk.Tools.Cli.Tools.Core;
+using ModelContextProtocol.Server;
+
+namespace Azure.Sdk.Tools.Cli.Tools.Package;
+
+/// <summary>
+/// Tool for updating changelog content in Azure SDK packages.
+/// Supports running configured script or built-in code for update flows.
+/// </summary>
+[McpServerToolType, Description("This type contains the tools to update changelog content for Azure SDK packages.")]
+public class ChangelogContentUpdateTool : LanguageMcpTool
+{
+    private readonly ISpecGenSdkConfigHelper _specGenSdkConfigHelper;
+
+    public ChangelogContentUpdateTool(
+        IGitHelper gitHelper,
+        ILogger<ChangelogContentUpdateTool> logger,
+        IEnumerable<LanguageService> languageServices,
+        ISpecGenSdkConfigHelper specGenSdkConfigHelper): base(languageServices, gitHelper, logger)
+    {
+        _specGenSdkConfigHelper = specGenSdkConfigHelper;
+    }
+
+    public override CommandGroup[] CommandHierarchy { get; set; } = [SharedCommandGroups.Package];
+
+    private const string UpdateChangelogContentCommandName = "update-changelog-content";
+
+    protected override Command GetCommand() =>
+        new(UpdateChangelogContentCommandName, "Updates changelog content for Azure SDK packages.") { SharedOptions.PackagePath };
+
+    public override async Task<CommandResponse> HandleCommand(ParseResult parseResult, CancellationToken ct)
+    {
+        var packagePath = parseResult.GetValue(SharedOptions.PackagePath);
+        return await UpdateChangelogContentAsync(packagePath, ct);
+    }
+
+    /// <summary>
+    /// Updates the changelog content for a specified package.
+    /// For management-plane packages: invokes changelog update script.
+    /// For data-plane packages: returns guidance for manual editing.
+    /// </summary>
+    /// <param name="packagePath">The absolute path to the package directory.</param>
+    /// <param name="ct">Cancellation token for the operation.</param>
+    /// <returns>A response indicating the result of the changelog update operation.</returns>
+    [McpServerTool(Name = "azsdk_package_update_changelog_content"), Description("Updates the changelog content for a specified package.")]
+    public async Task<PackageOperationResponse> UpdateChangelogContentAsync(
+        [Description("The absolute path to the package directory.")] string packagePath,
+        CancellationToken ct)
+    {
+        try
+        {
+            logger.LogInformation("Updating changelog content for package at: {packagePath}", packagePath);
+
+            // Validate package path
+            if (string.IsNullOrWhiteSpace(packagePath))
+            {
+                return PackageOperationResponse.CreateFailure("Package path is required and cannot be empty.");
+            }
+
+            if (!Directory.Exists(packagePath))
+            {
+                return PackageOperationResponse.CreateFailure($"Package path does not exist: {packagePath}");
+            }
+
+            // Discover the repository root
+            var sdkRepoRoot = gitHelper.DiscoverRepoRoot(packagePath);
+            if (sdkRepoRoot == null)
+            {
+                return PackageOperationResponse.CreateFailure("Unable to find git repository root from the provided package path.");
+            }
+
+            logger.LogInformation("Repository root discovered: {SdkRepoRoot}", sdkRepoRoot);
+            var languageService = GetLanguageService(packagePath);
+            if (languageService == null)
+            {
+                return PackageOperationResponse.CreateFailure("Tooling error: unable to determine language service for the specified package path.", nextSteps: ["Create an issue at the https://github.com/Azure/azure-sdk-tools/issues/new?", "contact the Azure SDK team for assistance."]);
+            }
+
+            // Check for package type
+            var packageInfo = await languageService.GetPackageInfo(packagePath, ct);
+            if (packageInfo?.SdkType == SdkType.Management)
+            {
+                // For management-plane packages, execute configured changelog update script
+                var (configContentType, configValue) = await _specGenSdkConfigHelper.GetConfigurationAsync(sdkRepoRoot, SpecGenSdkConfigType.UpdateChangelogContent);
+                if (configContentType != SpecGenSdkConfigContentType.Unknown && !string.IsNullOrEmpty(configValue))
+                {
+                    logger.LogInformation("Found valid configuration for updating changelog content. Executing configured script...");
+
+                    // Prepare script parameters
+                    var scriptParameters = new Dictionary<string, string>
+                    {
+                        { "SdkRepoPath", sdkRepoRoot },
+                        { "PackagePath", packagePath }
+                    };
+                    
+                    // Create and execute process options for the update-changelog-content script
+                    var processOptions = _specGenSdkConfigHelper.CreateProcessOptions(configContentType, configValue, sdkRepoRoot, packagePath, scriptParameters);
+                    if (processOptions != null)
+                    {
+                        return await _specGenSdkConfigHelper.ExecuteProcessAsync(processOptions, ct, packageInfo, "Changelog content is updated.", ["Review the changelog for accuracy and completeness", "Update metadata for the package"]);
+                    }
+                }
+            }
+
+            // Run default logic for data-plane packages
+            logger.LogInformation("Running default logic to update changelog content for the data-plane package...");
+            return await languageService.UpdateChangelogContentAsync(packagePath, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error occurred while updating changelog content for package: {PackagePath}", packagePath);
+            return PackageOperationResponse.CreateFailure($"An error occurred: {ex.Message}", nextSteps: ["Check the running logs for details about the error", "resolve the issue", "re-run the tool"]);
+        }
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/MetadataUpdateTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/MetadataUpdateTool.cs
@@ -23,7 +23,7 @@ public class MetadataUpdateTool : LanguageMcpTool
 
     public MetadataUpdateTool(
         IGitHelper gitHelper,
-        ILogger<LanguageMcpTool> logger,
+        ILogger<MetadataUpdateTool> logger,
         IEnumerable<LanguageService> languageServices,
         ISpecGenSdkConfigHelper specGenSdkConfigHelper): base(languageServices, gitHelper, logger)
     {
@@ -56,6 +56,8 @@ public class MetadataUpdateTool : LanguageMcpTool
     {
         try
         {
+            logger.LogInformation("Updating package metadata content for package at: {packagePath}", packagePath);
+
             // Validate package path
             if (string.IsNullOrWhiteSpace(packagePath))
             {
@@ -78,8 +80,9 @@ public class MetadataUpdateTool : LanguageMcpTool
             var languageService = GetLanguageService(packagePath);
             if (languageService == null)
             {
-                return PackageOperationResponse.CreateFailure("Unable to determine language service for the specified package path.");
+                return PackageOperationResponse.CreateFailure("Tooling error: unable to determine language service for the specified package path.", nextSteps: ["Create an issue at the https://github.com/Azure/azure-sdk-tools/issues/new?", "contact the Azure SDK team for assistance."]);
             }
+
             var (configContentType, configValue) = await _specGenSdkConfigHelper.GetConfigurationAsync(sdkRepoRoot, SpecGenSdkConfigType.UpdateMetadata);
             if (configContentType != SpecGenSdkConfigContentType.Unknown && !string.IsNullOrEmpty(configValue))
             {
@@ -97,7 +100,7 @@ public class MetadataUpdateTool : LanguageMcpTool
                 if (processOptions != null)
                 {
                     var packageInfo = await languageService.GetPackageInfo(packagePath, ct);
-                    return await _specGenSdkConfigHelper.ExecuteProcessAsync(processOptions, ct, packageInfo, "Package metadata content is updated.", ["Update the version if it's a release."]);
+                    return await _specGenSdkConfigHelper.ExecuteProcessAsync(processOptions, ct, packageInfo, "Package metadata content is updated.", ["Update the version when preparing for a release."]);
                 }
             }
 
@@ -108,7 +111,7 @@ public class MetadataUpdateTool : LanguageMcpTool
         catch (Exception ex)
         {
             logger.LogError(ex, "Error occurred while updating package metadata for package: {PackagePath}", packagePath);
-            return PackageOperationResponse.CreateFailure($"An error occurred: {ex.Message}");
+            return PackageOperationResponse.CreateFailure($"An error occurred: {ex.Message}", nextSteps: ["Check the running logs for details about the error", "resolve the issue", "re-run the tool"]);
         }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/MetadataUpdateTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/MetadataUpdateTool.cs
@@ -80,7 +80,7 @@ public class MetadataUpdateTool : LanguageMcpTool
             var languageService = GetLanguageService(packagePath);
             if (languageService == null)
             {
-                return PackageOperationResponse.CreateFailure("Tooling error: unable to determine language service for the specified package path.", nextSteps: ["Create an issue at the https://github.com/Azure/azure-sdk-tools/issues/new?", "contact the Azure SDK team for assistance."]);
+                return PackageOperationResponse.CreateFailure("Tooling error: unable to determine language service for the specified package path.", nextSteps: ["Create an issue at the https://github.com/Azure/azure-sdk-tools/issues/new", "contact the Azure SDK team for assistance."]);
             }
 
             var (configContentType, configValue) = await _specGenSdkConfigHelper.GetConfigurationAsync(sdkRepoRoot, SpecGenSdkConfigType.UpdateMetadata);

--- a/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
+++ b/tools/azsdk-cli/docs/specs/6-package-updater.spec.md
@@ -126,7 +126,7 @@ The three tools are intentionally small, composable units. Each emits a machine-
 
 Name (CLI): `azsdk package update-changelog-content`
 
-Name (MCP): `azsdk_package_update_changelog-content`
+Name (MCP): `azsdk_package_update_changelog_content`
 
 Purpose: Ensure changelog is auto-generated and has an entry for the upcoming release (management-plane) or provide guidance (data-plane) where manual editing is expected. This tool only modifies changelog content and does not change release date or version numbers.
 
@@ -359,8 +359,8 @@ Update the package at /home/dev/sdk/healthdataaiservices/Azure.ResourceManager.H
 **Expected Agent Activity:**
 
 1. Run changelog update.
-2. Run version update with inferred `--release-type stable`.
-3. Run metadata update (README, API export, formatting if needed) and summarize JSON results.
+2. Run metadata update (pom.xml, _metadata.json, API export, etc.) and summarize JSON results.
+3. Run version update with inferred `--release-type stable`.
 
 ### Scenario 2: Update Version for Stable Release (Data-Plane)
 


### PR DESCRIPTION
This is [the design spec](https://github.com/Azure/azure-sdk-tools/blob/main/tools/azsdk-cli/docs/specs/6-package-updater.spec.md)

Overview of the logic:
- for mgmt-plane package, run update-changelog-content script
- for data-plane package, return 'noop'
