### PR TITLE
Updated CLI name for build and generate tools

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/SdkBuildToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/SdkBuildToolTests.cs
@@ -149,7 +149,7 @@ public class SdkBuildToolTests
         var result = await _tool.BuildSdkAsync(_tempDirectory.DirectoryPath);
 
         // Assert
-        Assert.That(result.ResponseErrors?.First(), Does.Contain("Failed to get build configuration"));
+        Assert.That(result.ResponseErrors?.First(), Does.Contain("Neither 'packageOptions/buildScript/command' nor 'packageOptions/buildScript/path' found in configuration"));
     }
 
     [Test]
@@ -171,7 +171,7 @@ public class SdkBuildToolTests
         var result = await _tool.BuildSdkAsync(_tempDirectory.DirectoryPath);
 
         // Assert
-        Assert.That(result.ResponseErrors?.First(), Does.Contain("Failed to get build configuration"));
+        Assert.That(result.ResponseErrors?.First(), Does.Contain("Error parsing JSON configuration: Invalid JSON"));
     }
 
     #endregion

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/SdkBuildToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/SdkBuildToolTests.cs
@@ -110,7 +110,7 @@ public class SdkBuildToolTests
         var result = await _tool.BuildSdkAsync(pythonProjectPath);
 
         // Assert
-        Assert.That(result.Result, Is.EqualTo("succeeded"));
+        Assert.That(result.Result, Is.EqualTo("noop"));
         Assert.That(result.Message, Does.Contain("Python SDK project detected"));
         Assert.That(result.Message, Does.Contain("Skipping build step"));
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkBuildTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkBuildTool.cs
@@ -103,7 +103,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
                     };
                     
                     // Create and execute process options for the build script
-                    var processOptions = this.specGenSdkConfigHelper.CreateProcessOptions(configContentType, configValue, sdkRepoRoot, packagePath, scriptParameters);
+                    var processOptions = this.specGenSdkConfigHelper.CreateProcessOptions(configContentType, configValue, sdkRepoRoot, packagePath, scriptParameters, CommandTimeoutInMinutes);
                     if (processOptions != null)
                     {
                         return await this.specGenSdkConfigHelper.ExecuteProcessAsync(processOptions, ct, packageInfo, "Build completed successfully.");

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkBuildTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkBuildTool.cs
@@ -88,7 +88,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
                 if (sdkRepoName.Contains(AzureSdkForPythonRepoName, StringComparison.OrdinalIgnoreCase))
                 {
                     logger.LogInformation("Python SDK project detected. Skipping build step as Python SDKs do not require a build process.");
-                    return PackageOperationResponse.CreateSuccess("Python SDK project detected. Skipping build step as Python SDKs do not require a build process.", packageInfo);
+                    return PackageOperationResponse.CreateSuccess("Python SDK project detected. Skipping build step as Python SDKs do not require a build process.", packageInfo, result: "noop");
                 }
 
                 var (configContentType, configValue) = await this.specGenSdkConfigHelper.GetConfigurationAsync(sdkRepoRoot, SpecGenSdkConfigType.Build);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkBuildTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkBuildTool.cs
@@ -31,7 +31,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
             this.specGenSdkConfigHelper = specGenSdkConfigHelper;
         }
 
-        public override CommandGroup[] CommandHierarchy { get; set; } = [SharedCommandGroups.Package, SharedCommandGroups.SourceCode];
+        public override CommandGroup[] CommandHierarchy { get; set; } = [SharedCommandGroups.Package];
 
         // Command names
         private const string BuildSdkCommandName = "build";
@@ -91,91 +91,30 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
                     return PackageOperationResponse.CreateSuccess("Python SDK project detected. Skipping build step as Python SDKs do not require a build process.", packageInfo);
                 }
 
-                // Get the build configuration (command or script path)
-                ProcessOptions options;
-                try
+                var (configContentType, configValue) = await this.specGenSdkConfigHelper.GetConfigurationAsync(sdkRepoRoot, SpecGenSdkConfigType.Build);
+                if (configContentType != SpecGenSdkConfigContentType.Unknown && !string.IsNullOrEmpty(configValue))
                 {
-                    options = await CreateProcessOptions(sdkRepoRoot, packagePath);
-                }
-                catch (Exception ex)
-                {
-                    return PackageOperationResponse.CreateFailure($"Failed to get build configuration: {ex.Message}", packageInfo);
-                }
+                    logger.LogInformation("Found valid configuration for build process. Executing configured script...");
 
-                // Run the build script or command
-                logger.LogInformation("Executing build process...");
-                var buildResult = await processHelper.Run(options, ct);
-                var trimmedBuildResult = (buildResult.Output ?? string.Empty).Trim();
-                if (buildResult.ExitCode != 0)
-                {
-                    return PackageOperationResponse.CreateFailure($"Build process failed with exit code {buildResult.ExitCode}. Output:\n{trimmedBuildResult}", packageInfo);
+                    // Prepare script parameters
+                    var scriptParameters = new Dictionary<string, string>
+                    {
+                        { "PackagePath", packagePath }
+                    };
+                    
+                    // Create and execute process options for the build script
+                    var processOptions = this.specGenSdkConfigHelper.CreateProcessOptions(configContentType, configValue, sdkRepoRoot, packagePath, scriptParameters);
+                    if (processOptions != null)
+                    {
+                        return await this.specGenSdkConfigHelper.ExecuteProcessAsync(processOptions, ct, packageInfo, "Build completed successfully.");
+                    }
                 }
-
-                logger.LogInformation("Build process execution completed");
-                return PackageOperationResponse.CreateSuccess($"Build completed successfully. Output:\n{trimmedBuildResult}", packageInfo);
+                return PackageOperationResponse.CreateFailure("No build configuration found or failed to preprare the build command", packageInfo, nextSteps: ["Ensure the SDK repository has a valid 'buildScript' configuration in eng/swagger_to_sdk_config.json", "Resolve any issues reported in the build log", "Re-run the tool"]);
             }
             catch (Exception ex)
             {
                 logger.LogError(ex, "Error occurred while building SDK");
-                return PackageOperationResponse.CreateFailure($"An error occurred: {ex.Message}");
-            }
-        }
-
-        // Create process options for building the SDK based on configuration
-        private async Task<ProcessOptions> CreateProcessOptions(string sdkRepoRoot, string packagePath)
-        {
-            var (configType, configValue) = await specGenSdkConfigHelper.GetConfigurationAsync(sdkRepoRoot, SpecGenSdkConfigType.Build);
-
-            if (configType == SpecGenSdkConfigContentType.Command)
-            {
-                // Execute as command
-                var variables = new Dictionary<string, string>
-                {
-                    { "packagePath", packagePath }
-                };
-
-                var substitutedCommand = specGenSdkConfigHelper.SubstituteCommandVariables(configValue, variables);
-                logger.LogInformation("Executing build command: {SubstitutedCommand}", substitutedCommand);
-
-                var commandParts = specGenSdkConfigHelper.ParseCommand(substitutedCommand);
-                if (commandParts.Length == 0)
-                {
-                    throw new InvalidOperationException($"Invalid build command: {substitutedCommand}");
-                }
-
-                return new ProcessOptions(
-                    commandParts[0],
-                    commandParts.Skip(1).ToArray(),
-                    logOutputStream: true,
-                    workingDirectory: packagePath,
-                    timeout: TimeSpan.FromMinutes(CommandTimeoutInMinutes)
-                );
-            }
-            else // BuildConfigType.ScriptPath
-            {
-                // Execute as script file
-                // Always resolve relative paths against sdkRepoRoot, then normalize
-                var fullBuildScriptPath = Path.IsPathRooted(configValue)
-                    ? configValue
-                    : Path.Combine(sdkRepoRoot, configValue);
-
-                // Normalize the final path
-                fullBuildScriptPath = Path.GetFullPath(fullBuildScriptPath);
-
-                if (!File.Exists(fullBuildScriptPath))
-                {
-                    throw new FileNotFoundException($"Build script not found at: {fullBuildScriptPath}");
-                }
-
-                logger.LogInformation("Executing build script file: {BuildScriptPath}", fullBuildScriptPath);
-
-                return new PowershellOptions(
-                    fullBuildScriptPath,
-                    ["-PackagePath", packagePath],
-                    logOutputStream: true,
-                    workingDirectory: sdkRepoRoot,
-                    timeout: TimeSpan.FromMinutes(CommandTimeoutInMinutes)
-                );
+                return PackageOperationResponse.CreateFailure($"An error occurred: {ex.Message}", nextSteps: ["Check the build logs for details about the error", "Resolve the issue", "Re-run the tool"]);
             }
         }
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkBuildTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkBuildTool.cs
@@ -109,7 +109,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
                         return await this.specGenSdkConfigHelper.ExecuteProcessAsync(processOptions, ct, packageInfo, "Build completed successfully.");
                     }
                 }
-                return PackageOperationResponse.CreateFailure("No build configuration found or failed to preprare the build command", packageInfo, nextSteps: ["Ensure the SDK repository has a valid 'buildScript' configuration in eng/swagger_to_sdk_config.json", "Resolve any issues reported in the build log", "Re-run the tool"]);
+                return PackageOperationResponse.CreateFailure("No build configuration found or failed to prepare the build command", packageInfo, nextSteps: ["Ensure the SDK repository has a valid 'buildScript' configuration in eng/swagger_to_sdk_config.json", "Resolve any issues reported in the build log", "Re-run the tool"]);
             }
             catch (Exception ex)
             {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkGenerationTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkGenerationTool.cs
@@ -17,7 +17,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
         INpxHelper npxHelper
     ) : MCPTool
     {
-        public override CommandGroup[] CommandHierarchy { get; set; } = [SharedCommandGroups.Package, SharedCommandGroups.SourceCode];
+        public override CommandGroup[] CommandHierarchy { get; set; } = [SharedCommandGroups.Package];
 
         // Command names
         private const string GenerateSdkCommandName = "generate";


### PR DESCRIPTION
Changes Overview
- Removed 'source-code' from the CLI name
- Used the common methods from the `SpecGenSdkConfigHelper` class