### PR TITLE
Rename TspClientUpdateTool to CustomizedCodeUpdateTool

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/CustomizedCodeUpdateToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/CustomizedCodeUpdateToolTests.cs
@@ -1,5 +1,4 @@
 using Azure.Sdk.Tools.Cli.Models;
-using Azure.Sdk.Tools.Cli.Tools;
 using Microsoft.Extensions.Logging.Abstractions;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models.Responses.TypeSpec;
@@ -7,12 +6,11 @@ using Azure.Sdk.Tools.Cli.Services.Languages;
 using Moq;
 using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 using Azure.Sdk.Tools.Cli.Services;
-using Microsoft.Extensions.Logging;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Tools.CustomizedCodeUpdateTool;
 
 [TestFixture]
-public class TspClientUpdateToolAutoTests
+public class CustomizedCodeUpdateToolAutoTests
 {
     private static string CreateTempPackageDir()
     {
@@ -25,7 +23,7 @@ public class TspClientUpdateToolAutoTests
     private class MockNoChangeLanguageService : LanguageService
     {
         public override SdkLanguage Language { get; } = SdkLanguage.Java;
-        public override bool IsTspClientupdatedSupported => true;
+        public override bool IsCustomizedCodeUpdateSupported => true;
         public SdkLanguage SupportedLanguage => SdkLanguage.Java;
         public override Task<List<ApiChange>> DiffAsync(string oldGenerationPath, string newGenerationPath) => Task.FromResult(new List<ApiChange>());
         public override string? GetCustomizationRoot(string generationRoot, CancellationToken ct) => null; // No customizations found
@@ -37,7 +35,7 @@ public class TspClientUpdateToolAutoTests
     private class MockChangeLanguageService : LanguageService
     {
         public override SdkLanguage Language { get; } = SdkLanguage.Java;
-        public override bool IsTspClientupdatedSupported => true;
+        public override bool IsCustomizedCodeUpdateSupported => true;
         public SdkLanguage SupportedLanguage => SdkLanguage.Java;
         public override Task<List<ApiChange>> DiffAsync(string oldGenerationPath, string newGenerationPath)
             => Task.FromResult(new List<ApiChange> {
@@ -61,7 +59,7 @@ public class TspClientUpdateToolAutoTests
         var svc = new MockNoChangeLanguageService();
         var tsp = new MockTspHelper();
         gitHelper.Setup(g => g.GetRepoName(It.IsAny<string>())).Returns("azure-sdk-for-java");
-        var tool = new TspClientUpdateTool(new NullLogger<TspClientUpdateTool>(), [svc], gitHelper.Object, tsp);
+        var tool = new Azure.Sdk.Tools.Cli.Tools.CustomizedCodeUpdateTool(new NullLogger<Azure.Sdk.Tools.Cli.Tools.CustomizedCodeUpdateTool>(), [svc], gitHelper.Object, tsp);
         var pkg = CreateTempPackageDir();
         var run = await tool.UpdateAsync("0123456789abcdef0123456789abcdef01234567", packagePath: pkg, ct: CancellationToken.None);
         Assert.That(run.ErrorCode, Is.Null, "Should complete successfully without errors");
@@ -76,7 +74,7 @@ public class TspClientUpdateToolAutoTests
         var svc = new MockChangeLanguageService();
         var tsp = new MockTspHelper();
         gitHelper.Setup(g => g.GetRepoName(It.IsAny<string>())).Returns("azure-sdk-for-java");
-        var tool = new TspClientUpdateTool(new NullLogger<TspClientUpdateTool>(), [svc], gitHelper.Object, tsp);
+        var tool = new Azure.Sdk.Tools.Cli.Tools.CustomizedCodeUpdateTool(new NullLogger<Azure.Sdk.Tools.Cli.Tools.CustomizedCodeUpdateTool>(), [svc], gitHelper.Object, tsp);
         var pkg = CreateTempPackageDir();
         // Create a mock customization directory
         Directory.CreateDirectory(Path.Combine(pkg, "customization"));
@@ -93,7 +91,7 @@ public class TspClientUpdateToolAutoTests
         var gitHelper = new Mock<IGitHelper>();
         int calls = 0; var svc = new TestLanguageServiceFailThenFix(() => calls++);
         gitHelper.Setup(g => g.GetRepoName(It.IsAny<string>())).Returns("azure-sdk-for-java");
-        var tool = new TspClientUpdateTool(new NullLogger<TspClientUpdateTool>(), [svc], gitHelper.Object, tsp);
+        var tool = new Azure.Sdk.Tools.Cli.Tools.CustomizedCodeUpdateTool(new NullLogger<Azure.Sdk.Tools.Cli.Tools.CustomizedCodeUpdateTool>(), [svc], gitHelper.Object, tsp);
         var pkg = CreateTempPackageDir();
         // Create a mock customization directory to trigger patch application
         Directory.CreateDirectory(Path.Combine(pkg, "customization"));
@@ -106,7 +104,7 @@ public class TspClientUpdateToolAutoTests
     private class TestLanguageServiceFailThenFix: LanguageService
     {
         public override SdkLanguage Language { get; } = SdkLanguage.Java;
-        public override bool IsTspClientupdatedSupported => true;
+        public override bool IsCustomizedCodeUpdateSupported => true;
         public SdkLanguage SupportedLanguage => SdkLanguage.Java;
         private Func<int> _next;
         public TestLanguageServiceFailThenFix(Func<int> next) { _next = next; }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedOptions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedOptions.cs
@@ -40,7 +40,7 @@ namespace Azure.Sdk.Tools.Cli.Commands
             typeof(TestAnalysisTool),
             typeof(TypeSpecConvertTool),
             typeof(TypeSpecInitTool),
-            typeof(TspClientUpdateTool),
+            typeof(CustomizedCodeUpdateTool),
             typeof(TypeSpecPublicRepoValidationTool),
             typeof(VerifySetupTool),
             typeof(TestTool),

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/CustomizedCodeUpdateResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/CustomizedCodeUpdateResponse.cs
@@ -6,9 +6,9 @@ using System.Text.Json.Serialization;
 namespace Azure.Sdk.Tools.Cli.Models.Responses.Package;
 
 /// <summary>
-/// Response payload for TspClientUpdateTool MCP / CLI operations.
+/// Response payload for CustomizedCodeUpdateTool MCP / CLI operations.
 /// </summary>
-public class TspClientUpdateResponse : PackageResponseBase
+public class CustomizedCodeUpdateResponse : PackageResponseBase
 {
     [JsonPropertyName("message")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/JavaLanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/JavaLanguageService.cs
@@ -13,7 +13,7 @@ namespace Azure.Sdk.Tools.Cli.Services.Languages;
 public sealed partial class JavaLanguageService : LanguageService
 {
     public override SdkLanguage Language { get; } = SdkLanguage.Java;
-    public override bool IsTspClientupdatedSupported => true;
+    public override bool IsCustomizedCodeUpdateSupported => true;
     private readonly IMicroagentHostService microagentHost;
     private readonly IMavenHelper _mavenHelper;
     private const string CustomizationDirName = "customization";

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/LanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/LanguageService.cs
@@ -14,7 +14,7 @@ namespace Azure.Sdk.Tools.Cli.Services.Languages
         protected ICommonValidationHelpers commonValidationHelpers;
 
         public abstract SdkLanguage Language { get; }
-        public virtual bool IsTspClientupdatedSupported => false;
+        public virtual bool IsCustomizedCodeUpdateSupported => false;
 #pragma warning disable CS1998
         public async virtual Task<PackageInfo> GetPackageInfo(string packagePath, CancellationToken cancellationToken = default)
         {

--- a/tools/azsdk-cli/docs/mcp-tools.md
+++ b/tools/azsdk-cli/docs/mcp-tools.md
@@ -40,7 +40,7 @@ This document provides a comprehensive list of all MCP (Model Context Protocol) 
 | azsdk_release_sdk | Releases the specified SDK package for a language. This includes checking if the package is ready for release and triggering the release pipeline. This tool calls CheckPackageReleaseReadiness |
 | azsdk_run_generate_sdk | Generate SDK from a TypeSpec project using pipeline. |
 | azsdk_run_typespec_validation | Run TypeSpec validation. Provide absolute path to TypeSpec project root as param. This tool runs TypeSpec validation and TypeSpec configuration validation. |
-| azsdk_tsp_update | Update customized TypeSpec-generated client code |
+| azsdk_customized_code_update | Update customized TypeSpec-generated client code |
 | azsdk_typespec_check_project_in_public_repo | Check if TypeSpec project is in public spec repo. Provide absolute path to TypeSpec project root as param. |
 | azsdk_update_language_exclusion_justification | Update language exclusion justification in release plan work item. This tool is called to update justification for excluded languages in the release plan. Optionally pass a language name to explicitly request exclusion for a specific language. |
 | azsdk_update_sdk_details_in_release_plan | Update the SDK details in the release plan work item. This tool is called to update SDK language and package name in the release plan work item. sdkDetails parameter is a JSON of list of SDKInfo and each SDKInfo contains Language and PackageName as properties. |


### PR DESCRIPTION
The new name `CustomizedCodeUpdateTool` better reflects the tool's role as the central place for TypeSpec customization workflows, handling both spec-level customizations and SDK code updates as described in the enhancement specification https://github.com/Azure/azure-sdk-tools/pull/12577.

Closes #12453