### PR TITLE
Move operation status to top level tag in telelemtry

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryConstants.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryConstants.cs
@@ -36,6 +36,7 @@ internal static class TelemetryConstants
         public const string CompletionTokens = "completion_tokens";
         public const string TotalTokens = "total_tokens";
         public const string ModelsUsed = "models_used";
+        public const string OperationStatus = "operation_status";
     }
 
     internal class ActivityName

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryProcessor.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryProcessor.cs
@@ -29,6 +29,10 @@ public sealed class TelemetryProcessor : BaseProcessor<Activity>
         {
             activity.SetTag(TelemetryConstants.TagName.SdkType, sdkType);
         }
+        if (activity.GetCustomProperty(TelemetryConstants.TagName.OperationStatus) is Status operationStatus)
+        {
+            activity.SetTag(TelemetryConstants.TagName.OperationStatus, operationStatus.ToString());
+        }
 
         // TokenUsageHelper telemetry
         if (activity.GetCustomProperty(TelemetryConstants.TagName.PromptTokens) is string promptTokens)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryProcessor.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryProcessor.cs
@@ -31,7 +31,7 @@ public sealed class TelemetryProcessor : BaseProcessor<Activity>
         }
         if (activity.GetCustomProperty(TelemetryConstants.TagName.OperationStatus) is Status operationStatus)
         {
-            activity.SetTag(TelemetryConstants.TagName.OperationStatus, operationStatus.ToString());
+            activity.SetTag(TelemetryConstants.TagName.OperationStatus, operationStatus);
         }
 
         // TokenUsageHelper telemetry

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryProcessor.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryProcessor.cs
@@ -25,11 +25,11 @@ public sealed class TelemetryProcessor : BaseProcessor<Activity>
         {
             activity.SetTag(TelemetryConstants.TagName.TypeSpecProject, typeSpecProject);
         }
-        if (activity.GetCustomProperty(TelemetryConstants.TagName.SdkType) is SdkType sdkType)
+        if (activity.GetCustomProperty(TelemetryConstants.TagName.SdkType) is string sdkType)
         {
             activity.SetTag(TelemetryConstants.TagName.SdkType, sdkType);
         }
-        if (activity.GetCustomProperty(TelemetryConstants.TagName.OperationStatus) is Status operationStatus)
+        if (activity.GetCustomProperty(TelemetryConstants.TagName.OperationStatus) is string operationStatus)
         {
             activity.SetTag(TelemetryConstants.TagName.OperationStatus, operationStatus);
         }


### PR DESCRIPTION
Fixes #https://github.com/Azure/azure-sdk-tools/issues/12841

Add operation status as top level tag for each tool executed telemetry.