### PR TITLE
Update Env Setup Instructions Prompt Parameters

### DIFF
--- a/eng/common/instructions/azsdk-tools/verify-setup.instructions.md
+++ b/eng/common/instructions/azsdk-tools/verify-setup.instructions.md
@@ -3,18 +3,17 @@ description: 'Verify Setup'
 ---
 
 ## Goal
-This tool verifies the developer's environment for SDK development and release tasks. It returns what requirements are missing for the specified languages and repo.
+This tool verifies the developer's environment for SDK development and release tasks. It returns what requirements are missing for the specified languages and repo, or success if all requirements are satisfied.
 
 Your goal is to identify the project repo root, and pass in the `packagePath` to the Verify Setup tool. For a language repo, pass in the language of the repo.
 
 ## Examples
 - in `azure-sdk-for-js`, run `azsdk_verify_setup` with `(langs=javascript, packagePath=<path>/azure-sdk-for-js)`.
-- in `azure-sdk-for-python`, run `azsdk_verify_setup` with `(langs=python, packagePath=<path>/azure-sdk-for-python, venvPath=<path-to-venv>)`.
 
 ## Parameter Requirements
-WHENEVER Python is included in `langs`, BEFORE RUNNING `azsdk_verify_setup`, you MUST ASK THE USER TO SPECIFY WHICH virtual environment they want to check. DO NOT ASSUME THE VENV WITHOUT ASKING THE USER. After obtaining the `venvPath`, you can run the tool.
-
-The user can specify multiple languages to check. If the user wants to check all languages, pass in ALL supported languages and STILL ASK for a `venvPath`. Passing in no languages will only check the core requirements.
+The user can specify multiple languages to check. If the user wants to check all languages, pass in ALL supported languages. Passing in no languages will only check the core requirements.
 
 ## Output
-Display results in a user-friendly and concise format, highlighting any missing dependencies that need to be addressed.
+Display results in a user-friendly and concise format, highlighting any missing dependencies that need to be addressed and how to resolve them.
+
+WHENEVER Python related requirements fail, ALWAYS ASK the user if they have set the `AZSDKTOOLS_PYTHON_VENV_PATH` system environment variable to their desired virtual environment. This tool can only check requirements in the venv path specified by that environment variable.


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-tools/pull/12817?notification_referrer_id=NT_kwDOA8F-_LQyMDMxNDcwODA4Nzo2MzAxMjYwNA#event-20895580959 removes the venvPath argument from VerifySetup and relies on user setting an env var

This updates the VerifySetup instructions prompt accordingly