### PR TITLE
verify prompts eval fix

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_CreateReleasePlan.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_CreateReleasePlan.cs
@@ -12,7 +12,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
         public async Task Evaluate_CreateReleasePlan()
         {
             // randomized service/product id
-            const string prompt = "Create a release plan for the Contoso Widget Manager, no need to get it afterwords only create and setup has already been verified. Here is all the context you need: TypeSpec project located at \"c:\\Users\\juanospina\\source\\repos\\azure-rest-api-specs\\specification\\contosowidgetmanager\\Contoso.WidgetManager\". Use service tree ID \"a7f2b8e4-9c1d-4a3e-b6f9-2d8e5a7c3b1f\", product tree ID \"f1a8c5d2-6e4b-4f7a-9c2d-8b5e1f3a6c9e\", target release timeline \"December 2025\", API version \"2022-11-01-preview\", SDK release type \"beta\", and link it to the spec pull request \"https://github.com/Azure/azure-rest-api-specs/pull/38387\".";
+            const string prompt = "Create a release plan for the Contoso Widget Manager, no need to get it afterwards only create. Do not verify my setup, I've already verified it. Here is all the context you need: TypeSpec project located at \"c:\\Users\\juanospina\\source\\repos\\azure-rest-api-specs\\specification\\contosowidgetmanager\\Contoso.WidgetManager\". Use service tree ID \"a7f2b8e4-9c1d-4a3e-b6f9-2d8e5a7c3b1f\", product tree ID \"f1a8c5d2-6e4b-4f7a-9c2d-8b5e1f3a6c9e\", target release timeline \"December 2025\", API version \"2022-11-01-preview\", SDK release type \"beta\", and link it to the spec pull request \"https://github.com/Azure/azure-rest-api-specs/pull/38387\".";
             string[] expectedTools =
             [
                 "azsdk_create_release_plan"

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_CreateReleasePlan.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_CreateReleasePlan.cs
@@ -12,7 +12,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
         public async Task Evaluate_CreateReleasePlan()
         {
             // randomized service/product id
-            const string prompt = "Create a release plan for the Contoso Widget Manager, no need to get it afterwords only create. Here is all the context you need: TypeSpec project located at \"c:\\Users\\juanospina\\source\\repos\\azure-rest-api-specs\\specification\\contosowidgetmanager\\Contoso.WidgetManager\". Use service tree ID \"a7f2b8e4-9c1d-4a3e-b6f9-2d8e5a7c3b1f\", product tree ID \"f1a8c5d2-6e4b-4f7a-9c2d-8b5e1f3a6c9e\", target release timeline \"December 2025\", API version \"2022-11-01-preview\", SDK release type \"beta\", and link it to the spec pull request \"https://github.com/Azure/azure-rest-api-specs/pull/38387\".";
+            const string prompt = "Create a release plan for the Contoso Widget Manager, no need to get it afterwords only create and setup has already been verified. Here is all the context you need: TypeSpec project located at \"c:\\Users\\juanospina\\source\\repos\\azure-rest-api-specs\\specification\\contosowidgetmanager\\Contoso.WidgetManager\". Use service tree ID \"a7f2b8e4-9c1d-4a3e-b6f9-2d8e5a7c3b1f\", product tree ID \"f1a8c5d2-6e4b-4f7a-9c2d-8b5e1f3a6c9e\", target release timeline \"December 2025\", API version \"2022-11-01-preview\", SDK release type \"beta\", and link it to the spec pull request \"https://github.com/Azure/azure-rest-api-specs/pull/38387\".";
             string[] expectedTools =
             [
                 "azsdk_create_release_plan"

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_GetPullRequestLinkForCurrentBranch.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_GetPullRequestLinkForCurrentBranch.cs
@@ -11,7 +11,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
         [Test]
         public async Task Evaluate_GetPullRequestLinkForCurrentBranch()
         {
-            const string prompt = "What's the status of the spec PR in my current branch? Only check the status once and the setup has already been verified. Path to my repository root: C:\\Users\\juanospina\\source\\repos\\azure-rest-api-specs";
+            const string prompt = "What's the status of the spec PR in my current branch? Only check the status once. Do not verify my setup, I've already verified it. Path to my repository root: C:\\Users\\juanospina\\source\\repos\\azure-rest-api-specs";
             string[] expectedTools =
             [
                 "azsdk_get_pull_request_link_for_current_branch",

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_GetPullRequestLinkForCurrentBranch.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_GetPullRequestLinkForCurrentBranch.cs
@@ -11,7 +11,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
         [Test]
         public async Task Evaluate_GetPullRequestLinkForCurrentBranch()
         {
-            const string prompt = "What's the status of the spec PR in my current branch? Only check the status once. Path to my repository root: C:\\Users\\juanospina\\source\\repos\\azure-rest-api-specs";
+            const string prompt = "What's the status of the spec PR in my current branch? Only check the status once setup has already been verified. Path to my repository root: C:\\Users\\juanospina\\source\\repos\\azure-rest-api-specs";
             string[] expectedTools =
             [
                 "azsdk_get_pull_request_link_for_current_branch",

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_GetPullRequestLinkForCurrentBranch.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_GetPullRequestLinkForCurrentBranch.cs
@@ -11,7 +11,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
         [Test]
         public async Task Evaluate_GetPullRequestLinkForCurrentBranch()
         {
-            const string prompt = "What's the status of the spec PR in my current branch? Only check the status once setup has already been verified. Path to my repository root: C:\\Users\\juanospina\\source\\repos\\azure-rest-api-specs";
+            const string prompt = "What's the status of the spec PR in my current branch? Only check the status once and the setup has already been verified. Path to my repository root: C:\\Users\\juanospina\\source\\repos\\azure-rest-api-specs";
             string[] expectedTools =
             [
                 "azsdk_get_pull_request_link_for_current_branch",

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_ValidateTypespec.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_ValidateTypespec.cs
@@ -11,10 +11,9 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
         [Test]
         public async Task Evaluate_ValidateTypespec()
         {
-            const string prompt = "Validate my typespec project. It is already confirmed we are in a public repository. The path to my typespec is C:\\Users\\juanospina\\source\\repos\\azure-rest-api-specs\\specification\\contosowidgetmanager\\Contoso.WidgetManager\\main.tsp.";
+            const string prompt = "Validate my typespec project. It is already confirmed we are in a public repository. Do not verify my setup, I've already verified it. The path to my typespec is C:\\Users\\juanospina\\source\\repos\\azure-rest-api-specs\\specification\\contosowidgetmanager\\Contoso.WidgetManager\\main.tsp.";
             string[] expectedTools =
             [
-                "azsdk_verify_setup",
                 "azsdk_run_typespec_validation",
             ];
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_ValidateTypespec.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_ValidateTypespec.cs
@@ -14,6 +14,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
             const string prompt = "Validate my typespec project. It is already confirmed we are in a public repository. The path to my typespec is C:\\Users\\juanospina\\source\\repos\\azure-rest-api-specs\\specification\\contosowidgetmanager\\Contoso.WidgetManager\\main.tsp.";
             string[] expectedTools =
             [
+                "azsdk_verify_setup",
                 "azsdk_run_typespec_validation",
             ];
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_ValidateTypespec.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/Evaluate_ValidateTypespec.cs
@@ -11,9 +11,10 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
         [Test]
         public async Task Evaluate_ValidateTypespec()
         {
-            const string prompt = "Validate my typespec project. It is already confirmed we are in a public repository. Do not verify my setup, I've already verified it. The path to my typespec is C:\\Users\\juanospina\\source\\repos\\azure-rest-api-specs\\specification\\contosowidgetmanager\\Contoso.WidgetManager\\main.tsp.";
+            const string prompt = "Validate my typespec project. It is already confirmed we are in a public repository. The path to my typespec is C:\\Users\\juanospina\\source\\repos\\azure-rest-api-specs\\specification\\contosowidgetmanager\\Contoso.WidgetManager\\main.tsp.";
             string[] expectedTools =
             [
+                "azsdk_verify_setup",
                 "azsdk_run_typespec_validation",
             ];
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/ToolMocks/ToolMocks.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/ToolMocks/ToolMocks.cs
@@ -26,6 +26,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.ToolMocks
                 new GetPullRequestLinkForCurrentBranch(),
                 new CreatePullRequest(),
                 new CreateReleasePlan(),
+                new VerifySetup(),
             };
 
             foreach (var mock in mockInstances)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/ToolMocks/VerifySetup.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/ToolMocks/VerifySetup.cs
@@ -30,7 +30,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.ToolMocks
                         ToolName,
                         new Dictionary<string, object?>
                         {
-                            { "packagePath", "C:/azure-rest-api-specs" },
+                            { "packagePath", "C:\\azure-rest-api-specs" },
                         }
                     )
                 ]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/ToolMocks/VerifySetup.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/ToolMocks/VerifySetup.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.AI;
+
+namespace Azure.Sdk.Tools.Cli.Evaluations.ToolMocks
+{
+    public class VerifySetup : IToolMock
+    {
+        public string ToolName => "azsdk_verify_setup";
+        public string CallId => "tooluse_l1vP7afmgopmnhgmgv";
+        private string ToolResult => """{"results":[],"operation_status":"Succeeded"}""";
+        public ChatMessage GetMockResponse(string callid)
+        {
+            return new ChatMessage(
+                ChatRole.Tool,
+                [
+                    new FunctionResultContent(
+                        callid,
+                        ToolResult
+                    )
+                ]
+            );
+        }
+
+        public ChatMessage GetMockCall()
+        {
+            return new ChatMessage(
+                ChatRole.Assistant,
+                [
+                    new FunctionCallContent(
+                        CallId,
+                        ToolName,
+                        new Dictionary<string, object?>
+                        {
+                            { "packagePath", "C:/azure-rest-api-specs" },
+                        }
+                    )
+                ]
+            );
+        }
+    }
+}


### PR DESCRIPTION
- Fix evals for verify setup change
- Mocked the new tool and expect it to be called before verifying the type spec.
- Other scenarios added in context to avoid running it. 