### PR TITLE
Bump version to 2.15.1 for js-release-tool

### DIFF
--- a/tools/js-sdk-release-tools/package-lock.json
+++ b/tools/js-sdk-release-tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/js-sdk-release-tools",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/js-sdk-release-tools",
-      "version": "2.15.0",
+      "version": "2.15.1",
       "license": "MIT",
       "dependencies": {
         "@azure-tools/openapi-tools-common": "^1.2.2",

--- a/tools/js-sdk-release-tools/package.json
+++ b/tools/js-sdk-release-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/js-sdk-release-tools",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "",
   "files": [
     "dist"


### PR DESCRIPTION
Bump version to 2.15.1 for js-release-tool