### PR TITLE
Fixing a bug where "go get" can auto-update the go version directive, which can break tooling

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/GoLanguageServicesTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/GoLanguageServicesTests.cs
@@ -226,7 +226,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
                 )
                 """);
 
-            File.WriteAllText(Path.Join(tempFolder.DirectoryPath, "main.go"), @"""
+            File.WriteAllText(Path.Join(tempFolder.DirectoryPath, "main.go"), """
                 package main
 
                 import (

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/GoLanguageServicesTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/GoLanguageServicesTests.cs
@@ -246,6 +246,16 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
             Assert.That(version, Is.EqualTo(Version.Parse("1.23.0")));
         }
 
+        [Test]
+        public void TestGetGoModVersionAsync()
+        {
+            using var tempDir = TempDirectory.Create("go_mod_test");
+            var goModPath = Path.Join(tempDir.DirectoryPath, "go.mod");
+            File.WriteAllText(goModPath, "there's no version in here!");
+
+            Assert.ThrowsAsync(typeof(Exception), async () => await GoLanguageService.GetGoModVersionAsync(goModPath));
+        }
+
         /// <summary>
         /// Ignores the test if you don't have a path to a real Go repo configured.
         /// </summary>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/GoLanguageService.Checks.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/GoLanguageService.Checks.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models.Responses.Package;
 
@@ -9,16 +10,32 @@ namespace Azure.Sdk.Tools.Cli.Services.Languages;
 /// </summary>
 public partial class GoLanguageService : LanguageService
 {
-
     #region Go specific functions, not part of the LanguageRepoService
 
     public async Task<bool> CheckDependencies(CancellationToken ct)
     {
         try
         {
-            var compilerExists = (await processHelper.Run(new ProcessOptions(compilerName, ["version"], compilerNameWindows, ["version"]), ct)).ExitCode == 0;
-            var linterExists = (await processHelper.Run(new ProcessOptions(linterName, ["--version"], linterNameWindows, ["--version"]), ct)).ExitCode == 0;
-            var formatterExists = (await processHelper.Run(new ProcessOptions("echo", ["package main", "|", formatterName]), ct)).ExitCode == 0;
+            var compilerExists = (await processHelper.Run(new ProcessOptions(goUnix, ["version"], goWin, ["version"]), ct)).ExitCode == 0;
+            var linterExists = (await processHelper.Run(new ProcessOptions(golangciLintUnix, ["--version"], golangciLintWin, ["--version"]), ct)).ExitCode == 0;
+
+            var tempFilePath = Path.GetTempFileName();
+            bool formatterExists = false;
+
+            try
+            {
+                await File.WriteAllTextAsync(tempFilePath, "package main", ct);
+                var gofmtOptions = new ProcessOptions(
+                    unixCommand: gofmtUnix, unixArgs: [tempFilePath],
+                    windowsCommand: gofmtWin, windowsArgs: [tempFilePath]
+                );
+                formatterExists = (await processHelper.Run(gofmtOptions, ct)).ExitCode == 0;
+            }
+            finally
+            {
+                File.Delete(tempFilePath);
+            }
+
             return compilerExists && linterExists && formatterExists;
         }
         catch (Exception ex)
@@ -32,7 +49,7 @@ public partial class GoLanguageService : LanguageService
     {
         try
         {
-            var result = await processHelper.Run(new ProcessOptions(compilerName, ["mod", "init", moduleName], compilerNameWindows, ["mod", "init", moduleName], workingDirectory: packagePath), ct);
+            var result = await processHelper.Run(new ProcessOptions(goUnix, ["mod", "init", moduleName], goWin, ["mod", "init", moduleName], workingDirectory: packagePath), ct);
             return new PackageCheckResponse(result);
         }
         catch (Exception ex)
@@ -48,15 +65,26 @@ public partial class GoLanguageService : LanguageService
     {
         try
         {
+            var goGetArgs = new List<string>(["get", "-u", "all"]);
+            var goModVersion = await GetGoModVersionAsync(Path.Join(packagePath, "go.mod"), ct);
+
+            if (goModVersion.Major == 1 && goModVersion.Minor == 23)
+            {
+                // For compatibility, we'll ensure that the toolchain/go-version does not upgrade for modules 
+                // that are still set at 1.23. See this issue for some context:
+                //   https://github.com/Azure/azure-sdk-for-go/issues/25407
+                goGetArgs.AddRange(["toolchain@none", "go@1.23.0"]);
+            }
+
             // Update all dependencies to the latest first
-            var updateResult = await processHelper.Run(new ProcessOptions(compilerName, ["get", "-u", "all"], compilerNameWindows, ["get", "-u", "all"], workingDirectory: packagePath), ct);
+            var updateResult = await processHelper.Run(new ProcessOptions(goUnix, [.. goGetArgs], goWin, [.. goGetArgs], workingDirectory: packagePath), ct);
             if (updateResult.ExitCode != 0)
             {
                 return new PackageCheckResponse(updateResult);
             }
 
             // Now tidy, to cleanup any deps that aren't needed
-            var tidyResult = await processHelper.Run(new ProcessOptions(compilerName, ["mod", "tidy"], compilerNameWindows, ["mod", "tidy"], workingDirectory: packagePath), ct);
+            var tidyResult = await processHelper.Run(new ProcessOptions(goUnix, ["mod", "tidy"], goWin, ["mod", "tidy"], workingDirectory: packagePath), ct);
             return new PackageCheckResponse(tidyResult);
         }
         catch (Exception ex)
@@ -70,8 +98,8 @@ public partial class GoLanguageService : LanguageService
         try
         {
             var result = await processHelper.Run(new ProcessOptions(
-                formatterName, ["-w", "."],
-                formatterNameWindows, ["-w", "."],
+                gofmtUnix, ["-w", "."],
+                gofmtWin, ["-w", "."],
                 workingDirectory: packagePath
             ), ct);
             return new PackageCheckResponse(result);
@@ -87,7 +115,7 @@ public partial class GoLanguageService : LanguageService
     {
         try
         {
-            var result = await processHelper.Run(new ProcessOptions(linterName, ["run"], linterNameWindows, ["run"], workingDirectory: packagePath), ct);
+            var result = await processHelper.Run(new ProcessOptions(golangciLintUnix, ["run"], golangciLintWin, ["run"], workingDirectory: packagePath), ct);
             return new PackageCheckResponse(result);
         }
         catch (Exception ex)
@@ -101,7 +129,7 @@ public partial class GoLanguageService : LanguageService
     {
         try
         {
-            var result = await processHelper.Run(new ProcessOptions(compilerName, ["build"], compilerNameWindows, ["build"], workingDirectory: packagePath), ct);
+            var result = await processHelper.Run(new ProcessOptions(goUnix, ["build"], goWin, ["build"], workingDirectory: packagePath), ct);
             return new PackageCheckResponse(result);
         }
         catch (Exception ex)
@@ -141,7 +169,7 @@ public partial class GoLanguageService : LanguageService
     {
         try
         {
-            var result = await processHelper.Run(new ProcessOptions(compilerName, ["test", "-v", "-timeout", "1h", "./..."], compilerNameWindows, ["test", "-v", "-timeout", "1h", "./..."], workingDirectory: packagePath), ct);
+            var result = await processHelper.Run(new ProcessOptions(goUnix, ["test", "-v", "-timeout", "1h", "./..."], goWin, ["test", "-v", "-timeout", "1h", "./..."], workingDirectory: packagePath), ct);
             return result.ExitCode == 0;
         }
         catch (Exception ex)
@@ -150,5 +178,31 @@ public partial class GoLanguageService : LanguageService
             return false;
         }
     }
+
+    /// <summary>
+    /// Gets the version specified by the go version directive in the go.mod file.
+    /// </summary>
+    /// <param name="goModPath">Path to a go.mod file</param>
+    /// <param name="ct"></param>
+    /// <returns></returns>
+    /// <exception cref="Exception"></exception>
+    public static async Task<Version> GetGoModVersionAsync(string goModPath, CancellationToken ct = default)
+    {
+        var text = await File.ReadAllTextAsync(goModPath, ct);
+
+        var match = GoModVersionRegex().Match(text)
+            ?? throw new Exception($"{goModPath} doesn't contain a valid go version");
+
+        return Version.Parse(match.Groups[1].Value);
+    }
+
+    /// <summary>
+    /// Captures the go version directive in a go.mod file
+    /// </summary>
+    /// <remarks>
+    /// Ex: "go 1.24.0", "go 1.23", etc...
+    /// </remarks>
+    [GeneratedRegex(@"^go (1\.\d+(?:\.\d+|$))", RegexOptions.Multiline)]
+    private static partial Regex GoModVersionRegex();
 }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/GoLanguageService.Checks.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/GoLanguageService.Checks.cs
@@ -188,8 +188,12 @@ public partial class GoLanguageService : LanguageService
     {
         var text = await File.ReadAllTextAsync(goModPath, ct);
 
-        var match = GoModVersionRegex().Match(text)
-            ?? throw new Exception($"{goModPath} doesn't contain a valid go version");
+        var match = GoModVersionRegex().Match(text);
+
+        if (!match.Success)
+        {
+            throw new Exception($"{goModPath} doesn't contain a go version directive");
+        }
 
         return Version.Parse(match.Groups[1].Value);
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/GoLanguageService.Checks.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/GoLanguageService.Checks.cs
@@ -184,8 +184,6 @@ public partial class GoLanguageService : LanguageService
     /// </summary>
     /// <param name="goModPath">Path to a go.mod file</param>
     /// <param name="ct"></param>
-    /// <returns></returns>
-    /// <exception cref="Exception"></exception>
     public static async Task<Version> GetGoModVersionAsync(string goModPath, CancellationToken ct = default)
     {
         var text = await File.ReadAllTextAsync(goModPath, ct);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/GoLanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/GoLanguageService.cs
@@ -24,12 +24,13 @@ public partial class GoLanguageService : LanguageService
         base.commonValidationHelpers = commonValidationHelpers;
     }
 
-    private readonly string compilerName = "go";
-    private readonly string compilerNameWindows = "go.exe";
-    private readonly string formatterName = "goimports";
-    private readonly string formatterNameWindows = "gofmt.exe";
-    private readonly string linterName = "golangci-lint";
-    private readonly string linterNameWindows = "golangci-lint.exe";
+    private readonly string goUnix = "go";
+    private readonly string goWin = "go.exe";
+    private readonly string gofmtUnix = "gofmt";
+    private readonly string gofmtWin = "gofmt.exe";
+    private readonly string golangciLintUnix = "golangci-lint";
+    private readonly string golangciLintWin = "golangci-lint.exe";
+
     public override SdkLanguage Language { get; } = SdkLanguage.Go;
 
     public override async Task<PackageInfo> GetPackageInfo(string packagePath, CancellationToken ct = default)
@@ -112,7 +113,6 @@ public partial class GoLanguageService : LanguageService
             };
         }
     }
-
 
     public override List<SetupRequirements.Requirement> GetRequirements(string packagePath, Dictionary<string, List<SetupRequirements.Requirement>> categories, CancellationToken ct = default)
     {


### PR DESCRIPTION
Don't auto-upgrade the Go version directive for older modules. We're in a transition state, and that would break areas that aren't ready yet.

Also, some small fixes:
- Use gofmt, instead of goimports. gofmt is included with the Go compiler. In the future it'd be nice to allow them to choose, but this is the standard setup on CI.
- Rename all the constants to make it more obvious which one is Unix, and which is Windows.
- Fix some checks so their cross-platform-ness is explicit, even though they would have worked fine since the .exe suffix is implicit on Windows.