### PR TITLE
[API View] Fix Copilot Authentication - Use Delegated Permissions

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Services/CopilotAuthenticationService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Services/CopilotAuthenticationService.cs
@@ -29,7 +29,7 @@ namespace APIViewWeb.Services
                 throw new InvalidOperationException("CopilotAppId configuration is missing");
             }
 
-            var scope = $"api://{copilotAppId}/.default";
+            var scope = $"api://{copilotAppId}/user_impersonation";
             var tokenRequestContext = new TokenRequestContext([scope]);
             var token = await _credential.GetTokenAsync(tokenRequestContext, cancellationToken);
             return token.Token;


### PR DESCRIPTION
### Problem
APIView → apiview-copilot requests failing with `403 Forbidden: "Required permissions not satisfied: scopes set(), roles set()"`

### Solution
Changed authentication scope from application permissions (`.default`) to delegated permissions (`user_impersonation`):

```diff
- var scope = $"api://{copilotAppId}/.default";
+ var scope = $"api://{copilotAppId}/user_impersonation";
```

The Copilot service expects delegated scopes with user_impersonation in the token's spc claim