### PR TITLE
Enforced an array for single element

### DIFF
--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -370,11 +370,11 @@ elseif ($ArtifactList -and $ArtifactList.Count -gt 0) {
         }
     }
 }
-elseif ($PackageInfoFiles -and @($PackageInfoFiles).Count -gt 0) {
+elseif ($PackageInfoFiles -and $PackageInfoFiles.Count -gt 0) {
     # Lowest Priority: Direct PackageInfoFiles (new method)
-    Write-Host "Using PackageInfoFiles parameter with $(@($PackageInfoFiles).Count) files"
+    Write-Host "Using PackageInfoFiles parameter with $($PackageInfoFiles.Count) files"
     # Filter out empty strings or whitespace-only entries
-    $ProcessedPackageInfoFiles = @($PackageInfoFiles) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    $ProcessedPackageInfoFiles = @($PackageInfoFiles | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
 }
 else {
     Write-Error "No package information provided. Please provide either 'PackageName', 'ArtifactList', or 'PackageInfoFiles' parameters."

--- a/eng/common/scripts/Validate-All-Packages.ps1
+++ b/eng/common/scripts/Validate-All-Packages.ps1
@@ -278,11 +278,11 @@ if ($ArtifactList -and $ArtifactList.Count -gt 0)
         }
     }
 }
-elseif ($PackageInfoFiles -and @($PackageInfoFiles).Count -gt 0) {
+elseif ($PackageInfoFiles -and $PackageInfoFiles.Count -gt 0) {
     # Direct PackageInfoFiles (new method)
-    Write-Host "Using PackageInfoFiles parameter with $(@($PackageInfoFiles).Count) files"
+    Write-Host "Using PackageInfoFiles parameter with $($PackageInfoFiles.Count) files"
     # Filter out empty strings or whitespace-only entries
-    $ProcessedPackageInfoFiles = @($PackageInfoFiles) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    $ProcessedPackageInfoFiles = @($PackageInfoFiles | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
 }
 
 # Validate that we have package info files to process


### PR DESCRIPTION
Fixed an error when the package info contains only one element:
```
Create-APIReview.ps1: /mnt/vss/_work/_temp/1862e026-04da-4159-8c2d-108d3d9519b9.ps1:3
Line |
   3 |  . '/mnt/vss/_work/1/s/eng/common/scripts/Create-APIReview.ps1' -Packa …
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | The property 'Count' cannot be found on this object. Verify that the
     | property exists.
```

[Test Run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5605535&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=f4db5e16-d7b0-5b31-442e-4686e619d115)
