### PR TITLE
add func generator to index

### DIFF
--- a/tools/apiview/parsers/js-api-parser/src/tokenGenerators/index.ts
+++ b/tools/apiview/parsers/js-api-parser/src/tokenGenerators/index.ts
@@ -1,6 +1,7 @@
 import { enumTokenGenerator } from "./enum";
 import { ReviewToken } from '../models';
 import { ApiItem } from '@microsoft/api-extractor-model';
+import { functionTokenGenerator } from "./function";
 
 /**
  * Interface for token generators that create ReviewTokens from ApiItems.
@@ -23,5 +24,6 @@ export interface TokenGenerator<T extends ApiItem = ApiItem> {
 }
 
 export const generators: TokenGenerator[] = [
-    enumTokenGenerator
+    enumTokenGenerator,
+    functionTokenGenerator
 ];


### PR DESCRIPTION
This PR adds the functionTokenGenerator to the token generators registry, enabling the parser to process and generate tokens for function API items. This is part of expanding the API parser's capability to handle different API item types.

Imports functionTokenGenerator from the ./function module
Adds functionTokenGenerator to the exported generators array