### PR TITLE
[API View] Fix real-time UI updates

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Managers/CommentsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/CommentsManager.cs
@@ -618,7 +618,8 @@ namespace APIViewWeb.Managers
                     CommentId = comment.Id,
                     ReviewId = comment.ReviewId,
                     ElementId = comment.ElementId,
-                    NodeId = comment.ElementId
+                    NodeId = comment.ElementId,
+                    Comment = comment
                 });
         }
 
@@ -664,7 +665,8 @@ namespace APIViewWeb.Managers
                         CommentId = comment.Id,
                         ReviewId = comment.ReviewId,
                         ElementId = comment.ElementId,
-                        NodeId = comment.ElementId
+                        NodeId = comment.ElementId,
+                        Comment = comment
                     });
             }
         }

--- a/src/dotnet/APIView/APIViewWeb/Startup.cs
+++ b/src/dotnet/APIView/APIViewWeb/Startup.cs
@@ -324,6 +324,8 @@ namespace APIViewWeb
             services.AddSignalR(options => {
                 options.EnableDetailedErrors = true;
                 options.MaximumReceiveMessageSize =  1024 * 1024;
+            }).AddJsonProtocol(options => {
+                options.PayloadSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
             });
             services.AddSwaggerGen(options =>
             {

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.ts
@@ -68,7 +68,7 @@ export class CodePanelComponent implements OnChanges{
 
   menuItemsLineActions: MenuItem[] = [];
 
-  constructor(private changeDetectorRef: ChangeDetectorRef, private commentsService: CommentsService, 
+  constructor(private changeDetectorRef: ChangeDetectorRef, private commentsService: CommentsService,
     private signalRService: SignalRService, private route: ActivatedRoute, private router: Router,
     private messageService: MessageService, private elementRef: ElementRef<HTMLElement>) { }
 
@@ -403,12 +403,17 @@ export class CodePanelComponent implements OnChanges{
     }
       
     await this.codePanelRowSource?.adapter?.relax();
-    await this.codePanelRowSource?.adapter?.update({
-      predicate: ({ $index, data, element}) => {
+    await this.codePanelRowSource?.adapter?.fix({
+      updater: ({ data, element }) => {
         if (data.nodeIdHashed === updateData.nodeIdHashed && data.type === updateData.type) {
-          return updateData;
+          if (updateData.type === CodePanelRowDatatype.CommentThread) {
+            if (data.associatedRowPositionInGroup === updateData.associatedRowPositionInGroup) {
+              Object.assign(data, updateData);
+            }
+          } else {
+            Object.assign(data, updateData);
+          }
         }
-        return true;
       }
     });
   }

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/shared/comment-thread/comment-thread.component.html
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/shared/comment-thread/comment-thread.component.html
@@ -144,7 +144,7 @@
         </div>
         <app-editor editorId="replyEditor" [(content)]="codePanelRowData!.draftCommentText" [style]="{ width: '100%'}"></app-editor>
         <div class="btn-group mt-2" role="group" aria-label="Comment Action Buttons">
-            <button type="button" class="btn btn-sm btn-outline-success editor-action-btn submit" [disabled]="codePanelRowData!.draftCommentText.length === 0" (click)="saveCommentAction($event)">Add comment</button>  
+            <button type="button" class="btn btn-sm btn-outline-success editor-action-btn submit" [disabled]="!codePanelRowData!.draftCommentText || codePanelRowData!.draftCommentText.length === 0" (click)="saveCommentAction($event)">Add comment</button>  
             <button type="button" class="btn btn-sm btn-outline-danger editor-action-btn" (click)="cancelCommentAction($event)">Cancel</button>
             <button 
                 type="button" 
@@ -166,7 +166,7 @@
             <img [alt]="userProfile?.userName" src="https://github.com/{{ userProfile?.userName }}.png?size=40" width="40" height="40" class="user-avartar mx-4"/>
             <button type="button" style="flex-grow: 1;" class="btn btn-sm border text-muted text-start me-4 reply-button" (click)="showReplyEditor($event)">Reply...</button>
         </div>
-        <button *ngIf="codePanelRowData!.comments?.length! > 0" type="button" (click)="handleThreadResolutionButtonClick(resolveThreadButtonText)" class="btn btn-outline-secondary comment-action-btn btn-sm mx-2">{{resolveThreadButtonText}} Conversation</button>
+        <button *ngIf="codePanelRowData!.comments?.length! > 0" type="button" (click)="handleThreadResolutionButtonClick(codePanelRowData!.isResolvedCommentThread ? 'Unresolve' : 'Resolve')" class="btn btn-outline-secondary comment-action-btn btn-sm mx-2">{{codePanelRowData!.isResolvedCommentThread ? 'Unresolve' : 'Resolve'}} Conversation</button>
     </div>
 </div>
 <div *ngIf="instanceLocation === 'code-panel' && !isThreadCollapsed && (!codePanelRowData!.isResolvedCommentThread || threadResolvedAndExpanded)" class="btn-group-vertical comment-thread-navigation ms-2 {{ floatItemEnd }}" role="group" aria-label="Comment Navigation Button">

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/shared/comment-thread/comment-thread.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/shared/comment-thread/comment-thread.component.ts
@@ -302,6 +302,9 @@ export class CommentThreadComponent {
   }
 
   showReplyEditor(event: Event) {
+    if (this.codePanelRowData!.draftCommentText === undefined) {
+      this.codePanelRowData!.draftCommentText = '';
+    }
     this.codePanelRowData!.showReplyTextBox = true;
   }
 


### PR DESCRIPTION
### Summary
Fixes three UI bugs in the APIView SPA related to real-time updates and component rendering.

### Fixes

1. **Reply editor renders incorrectly on first click** - Initialize `draftCommentText` when undefined (data from server isn't instantiated with class defaults)

2. **Resolve/Unresolve button text doesn't update in real-time** - Compute button text directly from `isResolvedCommentThread` instead of cached property

3. **SignalR vote updates not reflecting in UI** - Add camelCase JSON serialization to SignalR, include full Comment object in vote messages, and fix virtual scroller updates with proper object references

### Root Cause
These issues happened after consolidating SignalR calls to the backend (previously duplicated in both backend and frontend). This is a cleaner pattern, but the signals were not using the same format, causing messages to be improperly received.

On top of that on this pull request https://github.com/Azure/azure-sdk-tools/pull/13021 I changed how we were updating the new information, which caused issues. And didn't validate adding a new comment! it wasn't the best pr :(

### Note on Testing
These issues were validated locally but didn't surface during initial testing. There have been past issues where the ClientSPA doesn't fully rebuild, resulting in partial testing of changes. Will perform more complete UX validations going forward.

