### PR TITLE
Remove Azure/azure-powershell-pr from SDKPrivate

### DIFF
--- a/eng/pipelines/branch-cleanup.yml
+++ b/eng/pipelines/branch-cleanup.yml
@@ -30,7 +30,6 @@ parameters:
 - name: SDKPrivate
   type: object
   default:
-    - Azure/azure-powershell-pr
     - Azure/azure-sdk-for-go-pr
     - Azure/azure-sdk-for-java-pr
     - Azure/azure-sdk-for-js-pr


### PR DESCRIPTION
Removed 'Azure/azure-powershell-pr' from SDKPrivate default values.