### PR TITLE
Skip namespace approval check for mgmt plane

### DIFF
--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -283,7 +283,7 @@ function ProcessPackage($packageInfo)
                     # Check if package name is approved. Preview version cannot be released without package name approval
                     if (!$pkgNameStatus.IsApproved)
                     {
-                        if (IsApiviewStatusCheckRequired $packageInfo)
+                        if ($packageInfo.SdkType -eq "client" -and $packageInfo.IsNewSdk)
                         {
                             Write-Error $($pkgNameStatus.Details)
                             return 1


### PR DESCRIPTION
Package name approval check is not required for management plane. But a bug was introduced in https://github.com/Azure/azure-sdk-for-net/pull/43599/files and it mandated package name approval for .NET.

Fixes issue #https://github.com/Azure/azure-sdk-tools/issues/13080