### PR TITLE
[AVC] Changed run_evals signature to make -p flag truly optional

### DIFF
--- a/packages/python-packages/apiview-copilot/cli.py
+++ b/packages/python-packages/apiview-copilot/cli.py
@@ -180,10 +180,12 @@ def _local_review(
     reviewer.close()
 
 
-def run_evals(test_paths: list[str] = [], num_runs: int = 1, save: bool = False, use_recording: bool = False):
+def run_evals(test_paths: list[str] = None, num_runs: int = 1, save: bool = False, use_recording: bool = False):
     """
     Runs the specified test case(s).
     """
+    if test_paths is None:
+        test_paths = []
     from evals._discovery import discover_targets
     from evals._runner import EvaluationRunner
 


### PR DESCRIPTION
# Running all tests

### Before
`python cli.py eval run -p`

### After
`python cli.py eval run`

## Cause
`-p` was required even with no value passed because `run_evals()` did not provide a default argument for what's supposed to be an optional one.