### PR TITLE
[APIView] Preserve CrossLanguageMetadata when sandboxing pipeline updates CodeFile

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -713,6 +713,15 @@ namespace APIViewWeb.Managers
                     var apiRevision = await _apiRevisionsRepository.GetAPIRevisionAsync(apiRevisionId: apiRevisionId);
                     if (apiRevision != null)
                     {
+                        if (codeFile.CrossLanguageMetadata == null)
+                        {
+                            CodeFile existingCodeFile = await _codeFileRepository.GetCodeFileFromStorageAsync(apiRevisionId, apiRevision.Files.Single().FileId);
+                            if (existingCodeFile?.CrossLanguageMetadata != null)
+                            {
+                                codeFile.CrossLanguageMetadata = existingCodeFile.CrossLanguageMetadata;
+                            }
+                        }
+
                         await _codeFileRepository.UpsertCodeFileAsync(apiRevisionId, apiRevision.Files.Single().FileId, codeFile);
                         var file = apiRevision.Files.FirstOrDefault();
                         file.VersionString = codeFile.VersionString;


### PR DESCRIPTION
closes https://github.com/Azure/azure-sdk-tools/issues/13143

Fixes the issue where `CrossLanguageMetadata` is lost when the sandboxing pipeline regenerates a CodeFile.

**Changes:**
- Modified `UpdateAPIRevisionCodeFileAsync` to check if the incoming CodeFile has `CrossLanguageMetadata`
- If not, retrieves and preserves the existing metadata from blob storage before upserting