### PR TITLE
Remove redundant usage of SpecProjectPath

### DIFF
--- a/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
+++ b/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
@@ -517,7 +517,6 @@ function CreateOrUpdatePackageWorkItem($lang, $pkg, $verMajorMinor, $existingIte
   $pkgType = $pkg.Type
   $pkgNewLibrary = $pkg.New
   $pkgRepoPath = $pkg.RepoPath
-  $specProjectPath = $pkg.SpecProjectPath
   $serviceName = $pkg.ServiceName
   $title = $lang + " - " + $pkg.DisplayName + " - " + $verMajorMinor
 


### PR DESCRIPTION
Fixes pipeline issue in https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5632907&view=results

Example run: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5633202&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e&t=15f816d9-f3e4-52e0-476c-2b3a3fc03171