### PR TITLE
[azsdk-cli] Remove sha from --version

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
@@ -14,6 +14,7 @@
     <AssemblyName>azsdk</AssemblyName>
     <VersionPrefix>0.5.10</VersionPrefix>
     <VersionSuffix></VersionSuffix>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <!-- Package metadata -->
     <PackageReleaseNotes>See CHANGELOG.md for release notes</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/Azure/azure-sdk-tools</RepositoryUrl>


### PR DESCRIPTION
[azsdk-cli] Remove sha from --version

before

```
$ azsdk --version
0.5.10+8d5da4b2fefb1ebbb890cafe5128b4afdd3d46e8
```

after
```
$ azsdk --version
0.5.10
```