### PR TITLE
Fix property name for skipVerifyChangeLog

### DIFF
--- a/eng/common/scripts/Verify-ChangeLogs.ps1
+++ b/eng/common/scripts/Verify-ChangeLogs.ps1
@@ -11,7 +11,7 @@ Set-StrictMode -Version 3
 
 function ShouldVerifyChangeLog ($PkgArtifactDetails) {
   if ($PkgArtifactDetails) {
-    if ($PkgArtifactDetails.PSobject.Properties.Name -contains "skipVerifyChangeLog") {
+    if ($PkgArtifactDetails.PSObject.Properties.Name -contains "skipVerifyChangeLog") {
       if ($PkgArtifactDetails.skipVerifyChangeLog) {
         return $false
       }


### PR DESCRIPTION
Fixed the issue in reading the value of the flag.
```
Verify-ChangeLogs.ps1: /mnt/vss/_work/_temp/17a29e1b-bdc2-4d26-84d2-7ebf3ef22ead.ps1:3
Line |
   3 |  . '/mnt/vss/_work/1/s/eng/common/scripts/Verify-ChangeLogs.ps1' -Pack …
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot bind argument to parameter 'ChangeLogLocation' because it is an
     | empty string.

```