### PR TITLE
Add support for authenticating to an Azure DevOps feed outside of organization

### DIFF
--- a/eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+++ b/eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
@@ -6,6 +6,9 @@ parameters:
   - name: CustomCondition
     type: string
     default: succeeded()
+  - name: ServiceConnection
+    type: string
+    default: ''
 
 steps:
 - pwsh: |
@@ -21,8 +24,10 @@ steps:
     $content | Out-File '${{ parameters.npmrcPath }}'
   displayName: 'Create .npmrc'
   condition: ${{ parameters.CustomCondition }}
+
 - task: npmAuthenticate@0
   displayName: Authenticate .npmrc
   condition: ${{ parameters.CustomCondition }}
   inputs:
     workingFile: ${{ parameters.npmrcPath }}
+    azureDevOpsServiceConnection: ${{ parameters.ServiceConnection }}


### PR DESCRIPTION
* Add support for authenticating to feeds in a different Azure DevOps organization
* Based on documentation from: https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/azure-artifacts/managed-identity-authentication-tasks#npmauthenticatev0