### PR TITLE
LogGroupStart should have local build output

### DIFF
--- a/eng/common/scripts/logging.ps1
+++ b/eng/common/scripts/logging.ps1
@@ -94,6 +94,9 @@ function LogGroupStart() {
   elseif (Test-SupportsGitHubLogging) {
     Write-Host "::group::$args"
   }
+  else {
+    Write-Host "> $args"
+  }
 }
 
 function LogGroupEnd() {


### PR DESCRIPTION
The script call `Invoke-LoggedMsBuildCommand $command -GroupOutput` should log the command before logging its output.
When run locally, `LogGroupStart` logs nothing, so the command isn't logged.