### PR TITLE
[APIView] Agent comments reply should be AIGenerated

### DIFF
--- a/src/dotnet/APIView/APIViewUnitTests/CommentsManagerTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/CommentsManagerTests.cs
@@ -167,6 +167,11 @@ public class CommentsManagerTests
         commentsRepoMock.Setup(r => r.GetCommentsAsync("review1", "el1"))
             .ReturnsAsync(new List<CommentItemModel> { comment });
 
+        CommentItemModel capturedAgentComment = null;
+        commentsRepoMock.Setup(r => r.UpsertCommentAsync(It.IsAny<CommentItemModel>()))
+            .Callback<CommentItemModel>(c => capturedAgentComment = c)
+            .Returns(Task.CompletedTask);
+
         CommentUpdatesDto commentUpdate = null;
         string calledMethod = string.Empty;
         hubContextMock.Setup(g =>
@@ -182,6 +187,8 @@ public class CommentsManagerTests
 
         Assert.Equal("ReceiveCommentUpdates", calledMethod);
         Assert.Equal("review1", commentUpdate.ReviewId);
+        Assert.NotNull(capturedAgentComment);
+        Assert.Equal(CommentSource.AIGenerated, capturedAgentComment.CommentSource);
     }
 
     #region ToggleVoteAsync Tests

--- a/src/dotnet/APIView/APIViewWeb/Managers/CommentsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/CommentsManager.cs
@@ -313,7 +313,7 @@ namespace APIViewWeb.Managers
             }
         }
 
-        private async Task AddAgentComment (CommentItemModel comment, string response)
+        private async Task AddAgentComment(CommentItemModel comment, string response)
         {
             var commentResult = new CommentItemModel
             {
@@ -325,7 +325,8 @@ namespace APIViewWeb.Managers
                 ResolutionLocked = false,
                 CreatedBy = ApiViewConstants.AzureSdkBotName,
                 CreatedOn = DateTime.UtcNow,
-                CommentType = CommentType.APIRevision
+                CommentType = CommentType.APIRevision,
+                CommentSource = CommentSource.AIGenerated
             };
 
             await _commentsRepository.UpsertCommentAsync(commentResult);


### PR DESCRIPTION
This a small fix in where I realized that the replies were not tagged as AIGenerated
<img width="770" height="149" alt="image" src="https://github.com/user-attachments/assets/2f89dd78-7973-4c93-a763-7f812c85aa92" />


where it should look like 
<img width="780" height="131" alt="image" src="https://github.com/user-attachments/assets/52748ff2-ee4e-4ffe-a404-d3b1cd5e5891" />
