### PR TITLE
Add options metadata to list command output

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ToolListResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ToolListResponse.cs
@@ -44,16 +44,16 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses
             sb.AppendLine(
                 $"{("Name").PadRight(nameWidth)}{sep}" +
                 $"{("Command").PadRight(cmdWidth)}{sep}" +
-                $"{("Description").PadRight(descWidth)}{sep}" +
-                $"{("Options").PadRight(optsWidth)}"
+                $"{("Options").PadRight(optsWidth)}{sep}" +
+                $"{("Description").PadRight(descWidth)}"
             );
 
             // --- Underline ---
             sb.AppendLine(
                 $"{new string('-', nameWidth)}{sep}" +
                 $"{new string('-', cmdWidth)}{sep}" +
-                $"{new string('-', descWidth)}{sep}" +
-                $"{new string('-', optsWidth)}"
+                $"{new string('-', optsWidth)}{sep}" +
+                $"{new string('-', descWidth)}"
             );
 
             // --- Rows ---
@@ -66,13 +66,20 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses
                 string cmdCell = (tool?.CommandLine ?? string.Empty).PadRight(cmdWidth);
                 string descCell = (tool?.Description ?? string.Empty).PadRight(descWidth);
 
+                var horizontalLine =
+                    $"{new string('-', nameWidth)}{sep}" +
+                    $"{new string('-', cmdWidth)}{sep}" +
+                    $"{new string('-', optsWidth)}{sep}" +
+                    $"{new string('-', descWidth)}";
+
                 if (optionLines.Count == 0)
                 {
-                    sb.AppendLine($"{nameCell}{sep}{cmdCell}{sep}{descCell}{sep}{string.Empty.PadRight(optsWidth)}");
+                    sb.AppendLine($"{nameCell}{sep}{cmdCell}{sep}{string.Empty.PadRight(optsWidth)}{sep}{descCell}");
+                    sb.AppendLine(horizontalLine);
                     continue;
                 }
 
-                sb.AppendLine($"{nameCell}{sep}{cmdCell}{sep}{descCell}{sep}{optionLines[0].PadRight(optsWidth)}");
+                sb.AppendLine($"{nameCell}{sep}{cmdCell}{sep}{optionLines[0].PadRight(optsWidth)}{sep}{descCell}");
 
                 // Continuation lines: only Options column, blanks elsewhere
                 for (int i = 1; i < optionLines.Count; i++)
@@ -80,17 +87,11 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses
                     sb.AppendLine(
                         $"{string.Empty.PadRight(nameWidth)}{sep}" +
                         $"{string.Empty.PadRight(cmdWidth)}{sep}" +
-                        $"{string.Empty.PadRight(descWidth)}{sep}" +
-                        $"{optionLines[i].PadRight(optsWidth)}"
+                        $"{optionLines[i].PadRight(optsWidth)}{sep}" +
+                        $"{string.Empty.PadRight(descWidth)}"
                     );
                 }
-
-                    sb.AppendLine(
-                        new string('-', nameWidth) + sep +
-                        new string('-', cmdWidth) + sep + 
-                        new string('-', descWidth)+ sep +
-                        new string('-', optsWidth)
-                    );
+                sb.AppendLine(horizontalLine);
             }
             return sb.ToString();
         }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ToolListResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ToolListResponse.cs
@@ -16,22 +16,81 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses
                 return sb.ToString();
             }
             sb.AppendLine("Available Tools:");
+
+            static List<string> OptionsToLines(ToolInfo t)
+            {
+                if (t?.Options == null || t.Options.Count == 0) { return new List<string>(); }
+                return t.Options.Select(o =>
+                    $"Name: {o.Name} | Type: {o.Type} | Required: {(o.Required ? "Yes" : "No")}"
+                ).ToList();
+            }
+
             // Calculate max widths for each column
             int nameWidth = Tools.Max(t => t.McpToolName?.Length ?? 0);
             int cmdWidth = Tools.Max(t => t.CommandLine?.Length ?? 0);
             int descWidth = Tools.Max(t => t.Description?.Length ?? 0);
+
+            int optsWidth = Math.Max(
+                Tools.SelectMany(t => OptionsToLines(t))
+                     .DefaultIfEmpty(string.Empty)
+                     .Max(line => line?.Length ?? 0),
+                "Options".Length);
             nameWidth = Math.Max(nameWidth, "Name".Length);
             cmdWidth = Math.Max(cmdWidth, "Command".Length);
             descWidth = Math.Max(descWidth, "Description".Length);
 
-            // Header
-            sb.AppendLine($"| {"Name".PadRight(nameWidth)} | {"Command".PadRight(cmdWidth)} | {"Description".PadRight(descWidth)} |");
-            sb.AppendLine($"|-{new string('-', nameWidth)}-|-{new string('-', cmdWidth)}-|-{new string('-', descWidth)}-|");
+            const string sep = " | ";
+            // --- Header ---
+            sb.AppendLine(
+                $"{("Name").PadRight(nameWidth)}{sep}" +
+                $"{("Command").PadRight(cmdWidth)}{sep}" +
+                $"{("Description").PadRight(descWidth)}{sep}" +
+                $"{("Options").PadRight(optsWidth)}"
+            );
 
-            // Rows
+            // --- Underline ---
+            sb.AppendLine(
+                $"{new string('-', nameWidth)}{sep}" +
+                $"{new string('-', cmdWidth)}{sep}" +
+                $"{new string('-', descWidth)}{sep}" +
+                $"{new string('-', optsWidth)}"
+            );
+
+            // --- Rows ---
             foreach (var tool in Tools)
             {
-                sb.AppendLine($"| {tool.McpToolName.PadRight(nameWidth)} | {tool.CommandLine.PadRight(cmdWidth)} | {tool.Description.PadRight(descWidth)} |");
+                var optionLines = OptionsToLines(tool);
+
+                // First line: print all columns
+                string nameCell = (tool?.McpToolName ?? string.Empty).PadRight(nameWidth);
+                string cmdCell = (tool?.CommandLine ?? string.Empty).PadRight(cmdWidth);
+                string descCell = (tool?.Description ?? string.Empty).PadRight(descWidth);
+
+                if (optionLines.Count == 0)
+                {
+                    sb.AppendLine($"{nameCell}{sep}{cmdCell}{sep}{descCell}{sep}{string.Empty.PadRight(optsWidth)}");
+                    continue;
+                }
+
+                sb.AppendLine($"{nameCell}{sep}{cmdCell}{sep}{descCell}{sep}{optionLines[0].PadRight(optsWidth)}");
+
+                // Continuation lines: only Options column, blanks elsewhere
+                for (int i = 1; i < optionLines.Count; i++)
+                {
+                    sb.AppendLine(
+                        $"{string.Empty.PadRight(nameWidth)}{sep}" +
+                        $"{string.Empty.PadRight(cmdWidth)}{sep}" +
+                        $"{string.Empty.PadRight(descWidth)}{sep}" +
+                        $"{optionLines[i].PadRight(optsWidth)}"
+                    );
+                }
+
+                    sb.AppendLine(
+                        new string('-', nameWidth) + sep +
+                        new string('-', cmdWidth) + sep + 
+                        new string('-', descWidth)+ sep +
+                        new string('-', optsWidth)
+                    );
             }
             return sb.ToString();
         }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ToolInfo.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ToolInfo.cs
@@ -4,15 +4,32 @@ namespace Azure.Sdk.Tools.Cli.Models
 {
     public class ToolInfo
     {
-        public ToolInfo(string mcpToolName, string commandLine, string description)
+        public ToolInfo(string mcpToolName, string commandLine, string description, List<OptionInfo> options = null)
         {
             McpToolName = mcpToolName;
             Description = description;
             CommandLine = commandLine;
+            Options = options ?? new List<OptionInfo>();
         }
 
         public string McpToolName { get; set; } = string.Empty;
         public string Description { get; set; } = string.Empty;
         public string CommandLine { get; set; } = string.Empty;
+        public List<OptionInfo> Options { get; set; } = [];
+    }
+
+    public class OptionInfo
+    {
+        public OptionInfo(string name, string description, string type, bool required)
+        {
+            Name = name;
+            Description = description;
+            Type = type;
+            Required = required;
+        }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string Type { get; set; }
+        public bool Required { get; set; }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Core/ListCommandTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Core/ListCommandTool.cs
@@ -67,27 +67,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Core
                 if (!tools.Any(t=> t.McpToolName == mcpTool.Name))
                 {
                     // Add new tool that does not have CLI command representation
-                    var required = new HashSet<string>();    
-                    if (mcpTool.InputSchema.TryGetProperty("required", out var reqArray))
-                    {
-                        foreach (var r in reqArray.EnumerateArray())
-                        {
-                            required.Add(r.GetString());
-                        }
-                    }
-
-                    var options = new List<OptionInfo>();
-                    var props = mcpTool.InputSchema.GetProperty("properties");
-                    foreach (var prop in props.EnumerateObject())
-                    {
-                        string name = prop.Name;
-                        string type = prop.Value.GetProperty("type").GetString() ?? "";
-                        bool isRequired = required.Contains(name);
-
-                        options.Add(new OptionInfo(name, "", type, isRequired));
-                    }
-
-                    tools.Add(new ToolInfo(mcpTool.Name, "", mcpTool.Description ?? "", options));
+                    tools.Add(new ToolInfo(mcpTool.Name, "", mcpTool.Description ?? ""));
                 }                
             }
             return tools.OrderBy(t => string.IsNullOrEmpty(t.McpToolName)).ThenBy(t => t.McpToolName).ToList();


### PR DESCRIPTION
Issue: https://github.com/Azure/azure-sdk-tools/issues/13139

New output (azsdk list -o json) : 
[output.json](https://github.com/user-attachments/files/24043975/output.json)


New output (azsdk list):
[output.txt](https://github.com/user-attachments/files/24043984/output.txt)

