### PR TITLE
[azsdkcli] Report failure + test output when running tests

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Bugs Fixed
 
+- Fixed test failures being reported as a success to the agent.
+- Test result output is now made available to the agent.
+
 ### Other Changes
 
 ## 0.5.10 (2025-12-08)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/TestRunResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/TestRunResponse.cs
@@ -20,17 +20,14 @@ public class TestRunResponse : PackageResponseBase
         {
             ResponseError = error;
         }
-    }
-
-    public TestRunResponse(ProcessResult processResult)
-    {
-        ExitCode = processResult.ExitCode;
-        TestRunOutput = processResult.Output;
-
-        if (ExitCode != 0)
+        else if (exitCode != 0)
         {
             ResponseError = "Test run failed with a non-zero exit code";
         }
+    }
+
+    public TestRunResponse(ProcessResult processResult) : this(processResult.ExitCode, processResult.Output)
+    {
     }
 
     protected override string Format()

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/TestRunResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/TestRunResponse.cs
@@ -1,0 +1,54 @@
+using System.Text;
+using System.Text.Json.Serialization;
+using Azure.Sdk.Tools.Cli.Helpers;
+
+namespace Azure.Sdk.Tools.Cli.Models.Responses.Package;
+
+/// <summary>
+/// Response payload for package test runs with exit code and details.
+/// </summary>
+public class TestRunResponse : PackageResponseBase
+{
+    [JsonPropertyName("test_run_output")]
+    public string? TestRunOutput { get; set; }
+
+    public TestRunResponse(int exitCode, string? testRunOutput, string? error = null)
+    {
+        ExitCode = exitCode;
+        TestRunOutput = testRunOutput;
+        if (!string.IsNullOrEmpty(error))
+        {
+            ResponseError = error;
+        }
+    }
+
+    public TestRunResponse(ProcessResult processResult)
+    {
+        ExitCode = processResult.ExitCode;
+        TestRunOutput = processResult.Output;
+
+        if (ExitCode != 0)
+        {
+            ResponseError = "Test run failed with a non-zero exit code";
+        }
+    }
+
+    protected override string Format()
+    {
+        StringBuilder output = new();
+        if (!string.IsNullOrEmpty(TestRunOutput))
+        {
+            output.Append(TestRunOutput);
+        }
+        else if (!string.IsNullOrEmpty(ResponseError))
+        {
+            output.Append(ResponseError);
+        }
+        else
+        {
+            output.Append("Test run executed.");
+        }
+
+        return output.ToString();
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/DotnetLanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/DotnetLanguageService.cs
@@ -3,6 +3,7 @@
 using System.Xml.Linq;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.Responses.Package;
 
 namespace Azure.Sdk.Tools.Cli.Services.Languages;
 
@@ -208,7 +209,7 @@ public sealed partial class DotnetLanguageService: LanguageService
         }
     }
 
-    public override async Task<bool> RunAllTests(string packagePath, CancellationToken ct = default)
+    public override async Task<TestRunResponse> RunAllTests(string packagePath, CancellationToken ct = default)
     {
         var result = await processHelper.Run(new ProcessOptions(
                 command: "dotnet",
@@ -218,7 +219,7 @@ public sealed partial class DotnetLanguageService: LanguageService
             ct
         );
 
-        return result.ExitCode == 0;
+        return new TestRunResponse(result);
     }
 
     public override List<SetupRequirements.Requirement> GetRequirements(string packagePath, Dictionary<string, List<SetupRequirements.Requirement>> categories, CancellationToken ct = default)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/GoLanguageService.Checks.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/GoLanguageService.Checks.cs
@@ -165,17 +165,17 @@ public partial class GoLanguageService : LanguageService
         return await commonValidationHelpers.ValidateChangelog(packageName, packagePath, fixCheckErrors, cancellationToken);
     }
 
-    public override async Task<bool> RunAllTests(string packagePath, CancellationToken ct = default)
+    public override async Task<TestRunResponse> RunAllTests(string packagePath, CancellationToken ct = default)
     {
         try
         {
             var result = await processHelper.Run(new ProcessOptions(goUnix, ["test", "-v", "-timeout", "1h", "./..."], goWin, ["test", "-v", "-timeout", "1h", "./..."], workingDirectory: packagePath), ct);
-            return result.ExitCode == 0;
+            return new TestRunResponse(result);
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "{MethodName} failed with an exception", nameof(RunAllTests));
-            return false;
+            return new TestRunResponse(1, null, $"Running Go tests failed: {ex.Message}");
         }
     }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/JavaLanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/JavaLanguageService.cs
@@ -6,6 +6,7 @@ using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Microagents;
 using Azure.Sdk.Tools.Cli.Microagents.Tools;
 using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.Responses.Package;
 using Azure.Sdk.Tools.Cli.Prompts.Templates;
 
 namespace Azure.Sdk.Tools.Cli.Services.Languages;
@@ -219,7 +220,7 @@ public sealed partial class JavaLanguageService : LanguageService
 
     private static readonly TimeSpan TestTimeout = TimeSpan.FromMinutes(5);
 
-    public override async Task<bool> RunAllTests(string packagePath, CancellationToken ct = default)
+    public override async Task<TestRunResponse> RunAllTests(string packagePath, CancellationToken ct = default)
     {
         logger.LogInformation("Starting test execution for Java project at: {PackagePath}", packagePath);
 
@@ -230,12 +231,12 @@ public sealed partial class JavaLanguageService : LanguageService
         if (result.ExitCode == 0)
         {
             logger.LogInformation("Test execution completed successfully");
-            return true;
+            return new TestRunResponse(result);
         }
         else
         {
             logger.LogWarning("Test execution failed with exit code {ExitCode}", result.ExitCode);
-            return false;
+            return new TestRunResponse(result);
         }
 
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/JavaScriptLanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/JavaScriptLanguageService.cs
@@ -3,6 +3,7 @@
 using System.Text.Json;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.Responses.Package;
 
 namespace Azure.Sdk.Tools.Cli.Services.Languages;
 
@@ -143,7 +144,7 @@ public sealed partial class JavaScriptLanguageService : LanguageService
         }
     }
 
-    public override async Task<bool> RunAllTests(string packagePath, CancellationToken ct = default)
+    public override async Task<TestRunResponse> RunAllTests(string packagePath, CancellationToken ct = default)
     {
         var result = await processHelper.Run(new ProcessOptions(
                 command: "npm",
@@ -153,7 +154,7 @@ public sealed partial class JavaScriptLanguageService : LanguageService
             ct
         );
 
-        return result.ExitCode == 0;
+        return new TestRunResponse(result);
     }
 
     public override List<SetupRequirements.Requirement> GetRequirements(string packagePath, Dictionary<string, List<SetupRequirements.Requirement>> categories, CancellationToken ct = default)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/LanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/LanguageService.cs
@@ -143,10 +143,10 @@ namespace Azure.Sdk.Tools.Cli.Services.Languages
         /// </summary>
         /// <param name="packagePath">The path to the package containing the tests.</param>
         /// <param name="ct">A cancellation token.</param>
-        /// <returns>True if all tests pass; otherwise, false.</returns>
-        public virtual Task<bool> RunAllTests(string packagePath, CancellationToken ct = default)
+        /// <returns>A <see cref="TestRunResponse"/> containing process output details.</returns>
+        public virtual Task<TestRunResponse> RunAllTests(string packagePath, CancellationToken ct = default)
         {
-            return Task.FromResult(true);
+            return Task.FromResult(new TestRunResponse(0, "This is not an applicable operation for this language."));
         }
 
         /// <summary>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/PythonLanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/PythonLanguageService.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.Responses.Package;
 using Azure.Sdk.Tools.Cli.Services.Languages;
 using Microsoft.Extensions.Logging;
 
@@ -121,7 +122,7 @@ private async Task<(string? Name, string? Version)> TryGetPackageInfoAsync(strin
     return (packageName, packageVersion);
 }
 
-    public override async Task<bool> RunAllTests(string packagePath, CancellationToken ct = default)
+    public override async Task<TestRunResponse> RunAllTests(string packagePath, CancellationToken ct = default)
     {
         var result = await pythonHelper.Run(new PythonOptions(
                 "pytest",
@@ -131,7 +132,7 @@ private async Task<(string? Name, string? Version)> TryGetPackageInfoAsync(strin
             ct
         );
 
-        return result.ExitCode == 0;
+        return new TestRunResponse(result);
     }
     public override List<SetupRequirements.Requirement> GetRequirements(string packagePath, Dictionary<string, List<SetupRequirements.Requirement>> categories, CancellationToken ct = default)
     {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/TestTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/TestTool.cs
@@ -10,6 +10,7 @@ using Azure.Sdk.Tools.Cli.Services;
 using Azure.Sdk.Tools.Cli.Services.Languages;
 using Azure.Sdk.Tools.Cli.Tools.Core;
 using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Models.Responses.Package;
 
 namespace Azure.Sdk.Tools.Cli.Tools.Package
 {
@@ -42,39 +43,22 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
         }
 
         [McpServerTool(Name = RunPackageTestsToolName), Description("Run tests for the specified SDK package. Provide package path.")]
-        public async Task<DefaultCommandResponse> RunPackageTests(string packagePath, CancellationToken ct = default)
+        public async Task<TestRunResponse> RunPackageTests(string packagePath, CancellationToken ct = default)
         {
             try
             {
                 logger.LogInformation("Starting tests for package at: {packagePath}", packagePath);
                 var languageService = GetLanguageService(packagePath);
-                var success = await languageService.RunAllTests(packagePath, ct);
+                var testResponse = await languageService.RunAllTests(packagePath, ct);
 
-                if (success)
-                {
-                    return new DefaultCommandResponse
-                    {
-                        ExitCode = 0,
-                        Result = $"Test run for package at '{packagePath}' completed successfully.",
-                    };
-                }
-                else
-                {
-                    return new DefaultCommandResponse
-                    {
-                        ExitCode = 1,
-                        Result = $"Test run for package at '{packagePath}' was not successful.",
-                        NextSteps = ["Analyze the test output to identify the cause of the failure."],
-                    };
-                }
+                return testResponse;
             }
             catch (Exception ex)
             {
                 logger.LogError(ex, "Unhandled exception while running package tests");
-                return new DefaultCommandResponse
+                return new TestRunResponse(exitCode: 1, testRunOutput: null, error: $"An unexpected error occurred while running package tests: {ex.Message}")
                 {
-                    ExitCode = 1,
-                    ResponseError = $"An unexpected error occurred while running package tests: {ex.Message}"
+                    NextSteps = ["Inspect the error message and attempt to resolve it"],
                 };
             }
         }


### PR DESCRIPTION
- Add TestRunResponse instead of using DefaultCommandResponse
- Make RunAllTests return TestRunResponse; this allows for providing output and next steps

Fixes #12930