### PR TITLE
Add #Requires statement to common.ps1

### DIFF
--- a/eng/common/scripts/common.ps1
+++ b/eng/common/scripts/common.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.0
 # cSpell:ignore Apireview
 # cSpell:ignore Onboarded
 $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot .. .. ..)


### PR DESCRIPTION
Setting baseline supported powershell version for most of eng/common to 7.0