### PR TITLE
[js-sdk-release-tools] remove existing node_modules before restoring from backup

### DIFF
--- a/tools/js-sdk-release-tools/src/utils/backupNodeModules.ts
+++ b/tools/js-sdk-release-tools/src/utils/backupNodeModules.ts
@@ -14,14 +14,14 @@ export async function backupNodeModules(folder: string) {
 
 export async function restoreNodeModules(folder: string) {
     const nodeModulesBackupPath = path.join(folder, "node_modules_backup");
-    const nodeModulesPath = nodeModulesBackupPath.replace('_backup', '');
-    if (fs.existsSync(nodeModulesPath)) {
-        logger.info(`Remove existing '${nodeModulesPath}' first.`);
-        fs.rmSync(nodeModulesPath, { recursive: true, force: true });
-    }
     if (fs.existsSync(nodeModulesBackupPath)) {
+        const nodeModulesPath = nodeModulesBackupPath.replace('_backup', '');
+        if (fs.existsSync(nodeModulesPath)) {
+            logger.info(`Remove existing '${nodeModulesPath}' first.`);
+            fs.rmSync(nodeModulesPath, { recursive: true, force: true });
+        }
         logger.info(`Start to rename '${nodeModulesBackupPath}' to '${nodeModulesPath}'.`);
-        fs.renameSync(nodeModulesBackupPath, `${nodeModulesPath}`);
+        fs.renameSync(nodeModulesBackupPath, nodeModulesPath);
     }
     if ('/' === path.dirname(folder)) return;
     await restoreNodeModules(path.dirname(folder));


### PR DESCRIPTION
otherwise the follow error could be thrown when the directory exists

>[ERROR]: ENOTEMPTY: directory not empty, rename '/mnt/vss/_work/1/s/azure-sdk-for-js/node_modules_backup' -> '/mnt/vss/_work/1/s/azure-sdk-for-js/node_modules'