### PR TITLE
Fix mcp tool naming convention analyzer to handle variable references

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Analyzer/README.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Analyzer/README.md
@@ -192,9 +192,9 @@ Methods with the `[McpServerTool]` attribute must specify a Name property.
 `snake_case` style naming is required for MCP server tool names.
 
 **Valid examples:**
-- `[McpServerTool(Name = "hello_world")]`
-- `[McpServerTool(Name = "test_tool")]`
-- `[McpServerTool(Name = "api_validator")]`
+- `[McpServerTool(Name = "azsdk_hello_world")]`
+- `[McpServerTool(Name = "azsdk_test_tool")]`
+- `[McpServerTool(Name = "azsdk_api_validator")]`
 
 **Invalid examples:**
 - `[McpServerTool(Name = "helloWorld")]` - camelCase


### PR DESCRIPTION
A recent change was made to use variable references for mcp tool names in order to support the tools list command. The analyzer only worked against string literals, so this update fixes the analyzer to process variable references as well to enforce naming conventions.

CC @smw-ms @praveenkuttappan 