### PR TITLE
Reorganize tool namespaces & tests

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/APIView/ApiViewReviewToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/APIView/ApiViewReviewToolTests.cs
@@ -4,7 +4,7 @@ using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 using Azure.Sdk.Tools.Cli.Tools.APIView;
 using Moq;
 
-namespace Azure.Sdk.Tools.Cli.Tests.Tools;
+namespace Azure.Sdk.Tools.Cli.Tests.Tools.APIView;
 
 [TestFixture]
 public class ApiViewReviewToolTests

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Config/CodeownersToolsTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Config/CodeownersToolsTests.cs
@@ -7,8 +7,10 @@ using Azure.Sdk.Tools.Cli.Models.Responses;
 using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 using Azure.Sdk.Tools.Cli.Tests.Mocks.Services;
 using Azure.Sdk.Tools.Cli.Tools.EngSys;
+using Azure.Sdk.Tools.Cli.Tools.Config;
 using Azure.Sdk.Tools.Cli.Configuration;
-namespace Azure.Sdk.Tools.Cli.Tests.Tools
+
+namespace Azure.Sdk.Tools.Cli.Tests.Tools.Config
 {
     [TestFixture]
     public class CodeownersToolsTests

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Example/ExampleToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Example/ExampleToolTests.cs
@@ -12,7 +12,7 @@ using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 using Azure.Sdk.Tools.Cli.Tools.Example;
 using Azure.Sdk.Tools.Cli.Models.Responses.Package;
 
-namespace Azure.Sdk.Tools.Cli.Tests.Tools;
+namespace Azure.Sdk.Tools.Cli.Tests.Tools.Example;
 
 internal class ExampleToolTests
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Example/HelloWorldToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Example/HelloWorldToolTests.cs
@@ -5,7 +5,7 @@ using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 using Azure.Sdk.Tools.Cli.Tools.Example;
 using Azure.Sdk.Tools.Cli.Helpers;
 
-namespace Azure.Sdk.Tools.Cli.Tests.Tools;
+namespace Azure.Sdk.Tools.Cli.Tests.Tools.Example;
 
 internal class HelloWorldToolTests
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackageCheckToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackageCheckToolTests.cs
@@ -9,7 +9,7 @@ using Azure.Sdk.Tools.Cli.Tools.Package;
 using Microsoft.Extensions.Logging;
 using Moq;
 
-namespace Azure.Sdk.Tools.Cli.Tests.Tools
+namespace Azure.Sdk.Tools.Cli.Tests.Tools.Package
 {
     [TestFixture]
     public class PackageCheckToolTests

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/Samples/SampleTranslatorToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/Samples/SampleTranslatorToolTests.cs
@@ -10,7 +10,7 @@ using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 using Azure.Sdk.Tools.Cli.Tools.Package.Samples;
 using Moq;
 
-namespace Azure.Sdk.Tools.Cli.Tests.Tools.Samples;
+namespace Azure.Sdk.Tools.Cli.Tests.Tools.Package.Samples;
 
 [TestFixture]
 public class SampleTranslatorToolTests

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/SdkReleaseToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/SdkReleaseToolTests.cs
@@ -7,7 +7,7 @@ using Azure.Sdk.Tools.Cli.Tools.Package;
 using Azure.Sdk.Tools.Cli.Models.Responses.Package;
 using Azure.Sdk.Tools.Cli.Models;
 
-namespace Azure.Sdk.Tools.Cli.Tests.Tools
+namespace Azure.Sdk.Tools.Cli.Tests.Tools.Package
 {
     internal class SdkReleaseToolTests
     {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanManualTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanManualTests.cs
@@ -12,7 +12,7 @@ using Azure.Sdk.Tools.Cli.Tools.ReleasePlan;
 using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Helpers;
 using Moq;
 
-namespace Azure.Sdk.Tools.Cli.Tests.Tools
+namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
 {
     internal class ReleasePlanManualTests
     {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
@@ -7,7 +7,7 @@ using Azure.Sdk.Tools.Cli.Tools.ReleasePlan;
 using System.Text.Json;
 using Azure.Sdk.Tools.Cli.Models;
 
-namespace Azure.Sdk.Tools.Cli.Tests.Tools
+namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
 {
     internal class ReleasePlanToolTests
     {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/SpecWorkFlowToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/SpecWorkFlowToolTests.cs
@@ -8,7 +8,7 @@ using Microsoft.TeamFoundation.Build.WebApi;
 using Moq;
 using Octokit;
 
-namespace Azure.Sdk.Tools.Cli.Tests.Tools
+namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
 {
     [TestFixture]
     internal class SpecWorkflowToolTests

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/CustomizedCodeUpdateToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/CustomizedCodeUpdateToolTests.cs
@@ -6,9 +6,10 @@ using Azure.Sdk.Tools.Cli.Services.Languages;
 using Moq;
 using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Tools.TypeSpec;
 
 
-namespace Azure.Sdk.Tools.Cli.Tests.Tools.CustomizedCodeUpdateTool;
+namespace Azure.Sdk.Tools.Cli.Tests.Tools.Typespec;
 
 [TestFixture]
 public class CustomizedCodeUpdateToolAutoTests
@@ -88,7 +89,7 @@ public class CustomizedCodeUpdateToolAutoTests
         gitHelper.Setup(g => g.DiscoverRepoRoot(It.IsAny<string>())).Returns("/mock/repo/root");
         specGenSdkConfigHelper.Setup(s => s.GetConfigurationAsync(It.IsAny<string>(), It.IsAny<SpecGenSdkConfigType>()))
             .ReturnsAsync((SpecGenSdkConfigContentType.Unknown, string.Empty));
-        var tool = new Azure.Sdk.Tools.Cli.Tools.CustomizedCodeUpdateTool(new NullLogger<Azure.Sdk.Tools.Cli.Tools.CustomizedCodeUpdateTool>(), [svc], gitHelper.Object, tsp, specGenSdkConfigHelper.Object);
+        var tool = new CustomizedCodeUpdateTool(new NullLogger<CustomizedCodeUpdateTool>(), [svc], gitHelper.Object, tsp, specGenSdkConfigHelper.Object);
         var pkg = CreateTempPackageDir();
         var run = await tool.UpdateAsync("0123456789abcdef0123456789abcdef01234567", packagePath: pkg, ct: CancellationToken.None);
         Assert.That(run.ErrorCode, Is.Null, "Should complete successfully without errors");
@@ -107,7 +108,7 @@ public class CustomizedCodeUpdateToolAutoTests
         gitHelper.Setup(g => g.DiscoverRepoRoot(It.IsAny<string>())).Returns("/mock/repo/root");
         specGenSdkConfigHelper.Setup(s => s.GetConfigurationAsync(It.IsAny<string>(), It.IsAny<SpecGenSdkConfigType>()))
             .ReturnsAsync((SpecGenSdkConfigContentType.Unknown, string.Empty));
-        var tool = new Azure.Sdk.Tools.Cli.Tools.CustomizedCodeUpdateTool(new NullLogger<Azure.Sdk.Tools.Cli.Tools.CustomizedCodeUpdateTool>(), [svc], gitHelper.Object, tsp, specGenSdkConfigHelper.Object);
+        var tool = new CustomizedCodeUpdateTool(new NullLogger<CustomizedCodeUpdateTool>(), [svc], gitHelper.Object, tsp, specGenSdkConfigHelper.Object);
         var pkg = CreateTempPackageDir();
         // Create a mock customization directory
         Directory.CreateDirectory(Path.Combine(pkg, "customization"));
@@ -128,7 +129,7 @@ public class CustomizedCodeUpdateToolAutoTests
         gitHelper.Setup(g => g.DiscoverRepoRoot(It.IsAny<string>())).Returns("/mock/repo/root");
         specGenSdkConfigHelper.Setup(s => s.GetConfigurationAsync(It.IsAny<string>(), It.IsAny<SpecGenSdkConfigType>()))
             .ReturnsAsync((SpecGenSdkConfigContentType.Unknown, string.Empty));
-        var tool = new Azure.Sdk.Tools.Cli.Tools.CustomizedCodeUpdateTool(new NullLogger<Azure.Sdk.Tools.Cli.Tools.CustomizedCodeUpdateTool>(), [svc], gitHelper.Object, tsp, specGenSdkConfigHelper.Object);
+        var tool = new CustomizedCodeUpdateTool(new NullLogger<CustomizedCodeUpdateTool>(), [svc], gitHelper.Object, tsp, specGenSdkConfigHelper.Object);
         var pkg = CreateTempPackageDir();
         // Create a mock customization directory to trigger patch application
         Directory.CreateDirectory(Path.Combine(pkg, "customization"));

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/CustomizedCodeUpdateToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/CustomizedCodeUpdateToolTests.cs
@@ -9,7 +9,7 @@ using Azure.Sdk.Tools.Cli.Services;
 using Azure.Sdk.Tools.Cli.Tools.TypeSpec;
 
 
-namespace Azure.Sdk.Tools.Cli.Tests.Tools.Typespec;
+namespace Azure.Sdk.Tools.Cli.Tests.Tools.TypeSpec;
 
 [TestFixture]
 public class CustomizedCodeUpdateToolAutoTests

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/TspConvertToolTest.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/TspConvertToolTest.cs
@@ -5,7 +5,7 @@ using Azure.Sdk.Tools.Cli.Tools.TypeSpec;
 using Moq;
 using Azure.Sdk.Tools.Cli.Helpers;
 
-namespace Azure.Sdk.Tools.Cli.Tests.Tools
+namespace Azure.Sdk.Tools.Cli.Tests.Tools.Typespec
 {
     public class TspConvertToolTests
     {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/TspConvertToolTest.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/TspConvertToolTest.cs
@@ -5,7 +5,7 @@ using Azure.Sdk.Tools.Cli.Tools.TypeSpec;
 using Moq;
 using Azure.Sdk.Tools.Cli.Helpers;
 
-namespace Azure.Sdk.Tools.Cli.Tests.Tools.Typespec
+namespace Azure.Sdk.Tools.Cli.Tests.Tools.TypeSpec
 {
     public class TspConvertToolTests
     {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/TspInitToolTest.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/TspInitToolTest.cs
@@ -6,7 +6,7 @@ using Moq;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 
-namespace Azure.Sdk.Tools.Cli.Tests.Tools.Typespec
+namespace Azure.Sdk.Tools.Cli.Tests.Tools.TypeSpec
 {
     public class TspInitToolTests
     {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/TspInitToolTest.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/TspInitToolTest.cs
@@ -6,7 +6,7 @@ using Moq;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 
-namespace Azure.Sdk.Tools.Cli.Tests.Tools
+namespace Azure.Sdk.Tools.Cli.Tests.Tools.Typespec
 {
     public class TspInitToolTests
     {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/CommandRunner.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/CommandRunner.cs
@@ -3,7 +3,7 @@ using System.CommandLine.Help;
 using Azure.Sdk.Tools.Cli.Commands.HostServer;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Telemetry;
-using Azure.Sdk.Tools.Cli.Tools;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 
 namespace Azure.Sdk.Tools.Cli.Commands
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedOptions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedOptions.cs
@@ -11,6 +11,7 @@ using Azure.Sdk.Tools.Cli.Tools.Verify;
 using Azure.Sdk.Tools.Cli.Tools.APIView;
 using Azure.Sdk.Tools.Cli.Tools.Package.Samples;
 using Azure.Sdk.Tools.Cli.Tools.Core;
+using Azure.Sdk.Tools.Cli.Tools.Config;
 
 namespace Azure.Sdk.Tools.Cli.Commands
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
@@ -12,7 +12,7 @@ using Azure.Sdk.Tools.Cli.Extensions;
 using Azure.Sdk.Tools.Cli.Microagents;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Telemetry;
-using Azure.Sdk.Tools.Cli.Tools;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 using Azure.Sdk.Tools.Cli.Services.APIView;
 using Azure.Sdk.Tools.Cli.Services.Languages;
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/APIView/APIViewReviewTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/APIView/APIViewReviewTool.cs
@@ -5,6 +5,7 @@ using Azure.Sdk.Tools.Cli.Commands;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Models.Responses;
 using Azure.Sdk.Tools.Cli.Services.APIView;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 using ModelContextProtocol.Server;
 
 namespace Azure.Sdk.Tools.Cli.Tools.APIView;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
@@ -13,8 +13,9 @@ using Azure.Sdk.Tools.CodeownersUtils.Editing;
 using Azure.Sdk.Tools.CodeownersUtils.Parsing;
 using Azure.Sdk.Tools.Cli.Configuration;
 using Azure.Sdk.Tools.Cli.Models.Responses;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 
-namespace Azure.Sdk.Tools.Cli.Tools.EngSys
+namespace Azure.Sdk.Tools.Cli.Tools.Config
 {
     [Description("Validate and manipulate GitHub codeowners")]
     [McpServerToolType]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/GitHubLabelsTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/GitHubLabelsTool.cs
@@ -9,9 +9,10 @@ using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Models.Responses;
 using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 
 
-namespace Azure.Sdk.Tools.Cli.Tools.GitHub
+namespace Azure.Sdk.Tools.Cli.Tools.Config
 {
     [McpServerToolType, Description("Tools for working with GitHub labels for services")]
     public class GitHubLabelsTool(

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Core/InstrumentedTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Core/InstrumentedTool.cs
@@ -7,7 +7,7 @@ using ModelContextProtocol.Server;
 using Azure.Sdk.Tools.Cli.Telemetry;
 using static Azure.Sdk.Tools.Cli.Telemetry.TelemetryConstants;
 
-namespace Azure.Sdk.Tools.Cli.Tools;
+namespace Azure.Sdk.Tools.Cli.Tools.Core;
 
 public class InstrumentedTool(
     ITelemetryService telemetryService,

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Core/MCPMultiCommandTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Core/MCPMultiCommandTool.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 using System.CommandLine;
 
-namespace Azure.Sdk.Tools.Cli.Tools;
+namespace Azure.Sdk.Tools.Cli.Tools.Core;
 
 public abstract class MCPMultiCommandTool : MCPToolBase
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Core/MCPNoCommandTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Core/MCPNoCommandTool.cs
@@ -4,7 +4,7 @@ using System.CommandLine;
 using System.CommandLine.Parsing;
 using Azure.Sdk.Tools.Cli.Models;
 
-namespace Azure.Sdk.Tools.Cli.Tools;
+namespace Azure.Sdk.Tools.Cli.Tools.Core;
 
 public abstract class MCPNoCommandTool : MCPToolBase
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Core/MCPTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Core/MCPTool.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 using System.CommandLine;
 
-namespace Azure.Sdk.Tools.Cli.Tools;
+namespace Azure.Sdk.Tools.Cli.Tools.Core;
 
 public abstract class MCPTool : MCPToolBase
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Core/MCPToolBase.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Core/MCPToolBase.cs
@@ -12,7 +12,7 @@ using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Telemetry;
 using static Azure.Sdk.Tools.Cli.Telemetry.TelemetryConstants;
 
-namespace Azure.Sdk.Tools.Cli.Tools;
+namespace Azure.Sdk.Tools.Cli.Tools.Core;
 
 /// <summary>
 /// This is the base class defining how an MCP enabled tool will interface with the server.

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/EngSys/Cleanup/CleanupTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/EngSys/Cleanup/CleanupTool.cs
@@ -7,6 +7,7 @@ using Azure.Sdk.Tools.Cli.Services;
 using ModelContextProtocol.Server;
 using Azure.Sdk.Tools.Cli.Commands;
 using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 
 namespace Azure.Sdk.Tools.Cli.Tools.EngSys;
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/EngSys/LogAnalysisTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/EngSys/LogAnalysisTool.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using Azure.Sdk.Tools.Cli.Commands;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 using ModelContextProtocol.Server;
 
 namespace Azure.Sdk.Tools.Cli.Tools.EngSys;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/EngSys/TestAnalysisTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/EngSys/TestAnalysisTool.cs
@@ -8,6 +8,7 @@ using Azure.Sdk.Tools.Cli.Tools.Pipeline;
 using Azure.Sdk.Tools.Cli.Services;
 using ModelContextProtocol.Server;
 using Azure.Sdk.Tools.Cli.Commands;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 
 namespace Azure.Sdk.Tools.Cli.Tools.EngSys;
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Example/ExampleTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Example/ExampleTool.cs
@@ -10,6 +10,7 @@ using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Services;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Microagents;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 
 namespace Azure.Sdk.Tools.Cli.Tools.Example;
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Example/HelloWorldTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Example/HelloWorldTool.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using Azure.Sdk.Tools.Cli.Commands;
 using ModelContextProtocol.Server;
 using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 
 namespace Azure.Sdk.Tools.Cli.Tools.Example
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Example/Quokka.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Example/Quokka.cs
@@ -5,6 +5,7 @@ using System.CommandLine.Parsing;
 using System.Reflection;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 
 // Just a lil easter egg :)
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/GitHub/PullRequestTools.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/GitHub/PullRequestTools.cs
@@ -7,6 +7,7 @@ using Azure.Sdk.Tools.Cli.Commands;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Services;
 using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 
 namespace Azure.Sdk.Tools.Cli.Tools.GitHub
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/ReadMeGeneratorTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/ReadMeGeneratorTool.cs
@@ -9,6 +9,7 @@ using Azure.Sdk.Tools.Cli.Configuration;
 using Azure.Sdk.Tools.Cli.Microagents;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Prompts.Templates;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 
 namespace Azure.Sdk.Tools.Cli.Tools.Package
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkGenerationTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkGenerationTool.cs
@@ -6,6 +6,7 @@ using Azure.Sdk.Tools.Cli.Commands;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Models.Responses.Package;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 
 namespace Azure.Sdk.Tools.Cli.Tools.Package
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkReleaseTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkReleaseTool.cs
@@ -8,6 +8,7 @@ using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Models.Responses.Package;
 using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 
 namespace Azure.Sdk.Tools.Cli.Tools.Package
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineAnalysisTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineAnalysisTool.cs
@@ -17,6 +17,7 @@ using Azure.Sdk.Tools.Cli.Configuration;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 
 namespace Azure.Sdk.Tools.Cli.Tools.Pipeline;
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineTestsTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineTestsTool.cs
@@ -12,6 +12,7 @@ using Azure.Sdk.Tools.Cli.Commands;
 using Azure.Sdk.Tools.Cli.Configuration;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 
 namespace Azure.Sdk.Tools.Cli.Tools.Pipeline;
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineTool.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using Azure.Sdk.Tools.Cli.Commands;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 using ModelContextProtocol.Server;
 
 namespace Azure.Sdk.Tools.Cli.Tools.Pipeline

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -11,6 +11,7 @@ using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Models.Responses.ReleasePlan;
 using Azure.Sdk.Tools.Cli.Models.Responses.ReleasePlanList;
 using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 using ModelContextProtocol.Server;
 using Octokit;
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/SpecWorkFlowTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/SpecWorkFlowTool.cs
@@ -10,6 +10,7 @@ using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Services;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Models.Responses.ReleasePlan;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 
 namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/CustomizedCodeUpdateTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/CustomizedCodeUpdateTool.cs
@@ -10,7 +10,7 @@ using Azure.Sdk.Tools.Cli.Services.Languages;
 using Azure.Sdk.Tools.Cli.Tools.Core;
 using ModelContextProtocol.Server;
 
-namespace Azure.Sdk.Tools.Cli.Tools;
+namespace Azure.Sdk.Tools.Cli.Tools.TypeSpec;
 
 [McpServerToolType, Description("Update customized SDK code after TypeSpec regeneration: creates a new generation, provides intelligent analysis and recommendations for updating customization code.")]
 public class CustomizedCodeUpdateTool: LanguageMcpTool

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/SpecCommonTools.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/SpecCommonTools.cs
@@ -8,6 +8,7 @@ using ModelContextProtocol.Server;
 using Azure.Sdk.Tools.Cli.Commands;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 
 namespace Azure.Sdk.Tools.Cli.Tools.TypeSpec
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/SpecValidationTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/SpecValidationTool.cs
@@ -12,6 +12,7 @@ using Azure.Sdk.Tools.Cli.Commands;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Models.Responses.TypeSpec;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 
 namespace Azure.Sdk.Tools.Cli.Tools.TypeSpec
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/TspConvertTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/TspConvertTool.cs
@@ -8,6 +8,7 @@ using Azure.Sdk.Tools.Cli.Commands;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Models.Responses.TypeSpec;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 
 namespace Azure.Sdk.Tools.Cli.Tools.TypeSpec
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/TspInitTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/TspInitTool.cs
@@ -8,6 +8,7 @@ using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Commands;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Models.Responses.TypeSpec;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 
 namespace Azure.Sdk.Tools.Cli.Tools.TypeSpec
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/TypeSpecPublicRepoValidationTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/TypeSpecPublicRepoValidationTool.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using Azure.Sdk.Tools.Cli.Commands;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Tools.Core;
 using ModelContextProtocol.Server;
 
 namespace Azure.Sdk.Tools.Cli.Tools.TypeSpec


### PR DESCRIPTION
- Restructured `azsdk-cli\Azure.Sdk.Tools.Cli.Tests\Tools` to match the folder structure of `azsdk-cli\Azure.Sdk.Tools.Cli\Tools`
- Aligned namespaces with their folder path

This PR isn’t critical; it’s just an organizational idea I wanted to share.