### PR TITLE
Set 'generateFromTypeSpec' flag with the value returned from .net script

### DIFF
--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Release
 
+## 2025-12-12 - 0.9.4
+
+- Updated 'generateFromTypeSpec' value to the result returned from the language script for .NET
+
 ## 2025-11-07 - 0.9.3
 
-- Updated SwaggerToSdkConfigSchema by introducing 'updateChangelogContentScript', 'updateCiScript', 'updateMetadataScript', and 'updateVersionScript' properties to the 'packageOptions' property. This is to support the integration with language-specific scripts.
+- Updated SwaggerToSdkConfigSchema by introducing 'updateChangelogContentScript', 'updateCiScript', 'updateMetadataScript', and 'updateVersionScript' properties to the 'packageOptions' property. This is to support the integration with language-specific scripts
 
 ## 2025-09-09 - 0.9.2
 

--- a/tools/spec-gen-sdk/package-lock.json
+++ b/tools/spec-gen-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/spec-gen-sdk",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/spec-gen-sdk",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/tools/spec-gen-sdk/package.json
+++ b/tools/spec-gen-sdk/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-tools"
   },
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "A TypeScript implementation of the API specification to SDK tool",
   "tags": [
     "spec-gen-sdk"

--- a/tools/spec-gen-sdk/src/automation/reportStatus.ts
+++ b/tools/spec-gen-sdk/src/automation/reportStatus.ts
@@ -25,9 +25,10 @@ export const generateReport = (context: WorkflowContext) => {
   let markdownContent = '';
   let message = "";
   let isTypeSpec = false;
+  let hasPkgFromTypeSpec = false;
   let generateFromTypeSpec = false;
 
-  if (context.specConfigPath && context.specConfigPath.endsWith('tspconfig.yaml')) {
+  if (!context.config.sdkName.includes('net') && context.specConfigPath && context.specConfigPath.endsWith('tspconfig.yaml')) {
     generateFromTypeSpec = true;
   }
   for (const pkg of context.handledPackages) {
@@ -79,8 +80,14 @@ export const generateReport = (context: WorkflowContext) => {
       `hasSuppressions [${hasSuppressions}] ` +
       `hasAbsentSuppressions [${hasAbsentSuppressions}]`
     );
+    hasPkgFromTypeSpec = hasPkgFromTypeSpec || isTypeSpec;
   }
 
+  // only for .NET SDK, use the flag returned from the .NET automation to mark the whole generationFromTypeSpec
+  if (context.config.sdkName.includes('net') && hasPkgFromTypeSpec) {
+    generateFromTypeSpec = true;
+  }
+ 
   if (context.config.pullNumber && markdownContent) {
     try {
       // Write a markdown file to be rendered by the Azure DevOps pipeline

--- a/tools/spec-gen-sdk/src/cli/cli.ts
+++ b/tools/spec-gen-sdk/src/cli/cli.ts
@@ -70,7 +70,7 @@ const generateSdk = async (config: SpecGenSdkCliConfig) => {
       specCommitSha: config.specCommitSha,
       specRepoHttpsUrl: config.specRepoHttpsUrl,
       pullNumber: config.prNumber,
-      sdkName: config.sdkRepoName.replace('-pr', ''),
+      sdkName: config.sdkRepoName.toLowerCase().replace('-pr', ''),
       apiVersion: config.apiVersion,
       runMode: config.runMode,
       sdkReleaseType: config.sdkReleaseType,


### PR DESCRIPTION
This is part of the work to support making `SDK Validation - .NET` required for selected services using the selected emitters.