### PR TITLE
[tsp-client] Update output-dir processing

### DIFF
--- a/tools/tsp-client/src/index.ts
+++ b/tools/tsp-client/src/index.ts
@@ -32,7 +32,12 @@ function commandPreamble(argv: any) {
 
 /** Ensure the output directory exists and allow interactive users to confirm or override the value. */
 export function resolveOutputDir(argv: any): string {
-  let outputDir = resolvePath(process.cwd(), argv["output-dir"]);
+  let outputDir;
+  if (argv["output-dir"] === undefined) {
+    outputDir = process.cwd();
+  } else {
+    outputDir = resolvePath(process.cwd(), argv["output-dir"]);
+  }
   const usePrompt = argv["prompt"];
 
   let useOutputDir;
@@ -73,7 +78,7 @@ const parser = yargs(hideBin(process.argv))
     alias: "o",
     type: "string",
     description: "Specify an alternate output directory for the generated files.",
-    default: ".",
+    default: undefined,
   })
   .option("no-prompt", {
     alias: "y",


### PR DESCRIPTION
Fix output-dir processing by defaulting the value to undefined unless otherwise specified. There should be no behavioral change due to this update, due to the change to defaulting to undefined, if `--output-dir` isn't passed tsp-client will still resolve it to the cwd(), otherwise the value will be resolved in relation to the cwd() same as before. 