### PR TITLE
[azsdk-cli, go] Some fixes to make the pkg validate tool a bit more useful

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Models/Responses/Package/PackageCheckResponseTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Models/Responses/Package/PackageCheckResponseTests.cs
@@ -1,0 +1,53 @@
+using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Models.Responses.Package;
+
+namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages;
+
+[TestFixture]
+public class PackageCheckResponseTests
+{
+    [Test]
+    public void TestInitWithMultiple()
+    {
+        var resp = new PackageCheckResponse([
+            CreateProcessResult(1001, "output", "error")
+        ]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(resp.CheckStatusDetails, Is.EqualTo(
+                // NOTE: the "output\nerror\n" is just how the ProcessResult class handles stdout and stderr being added, it's not part of the formatting in PackageCheckResponse.
+                $"output{Environment.NewLine}error{Environment.NewLine}" + Environment.NewLine));
+            Assert.That(resp.ExitCode, Is.EqualTo(1001));
+        });
+
+        resp = new PackageCheckResponse([
+            // NOTE: the "output\nerror\n" is just how the ProcessResult class handles stdout and stderr being added, it's not part of the formatting in PackageCheckResponse.
+            CreateProcessResult(0, "first-output", "first-error"),
+            CreateProcessResult(1001, "last-output", "last-error")
+        ]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(resp.CheckStatusDetails, Is.EqualTo(
+                $"first-output{Environment.NewLine}first-error{Environment.NewLine}" + Environment.NewLine +
+                $"last-output{Environment.NewLine}last-error{Environment.NewLine}" + Environment.NewLine));
+
+            // last exit code wins.
+            Assert.That(resp.ExitCode, Is.EqualTo(1001));
+        });
+    }
+
+    private static ProcessResult CreateProcessResult(int exitCode, string stdout, string stderr)
+    {
+        var pr = new ProcessResult
+        {
+            ExitCode = exitCode
+        };
+
+        pr.AppendStdout(stdout);
+        pr.AppendStderr(stderr);
+
+        return pr;
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Models/Responses/Package/PackageCheckResponseTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Models/Responses/Package/PackageCheckResponseTests.cs
@@ -7,9 +7,51 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages;
 public class PackageCheckResponseTests
 {
     [Test]
-    public void TestInitWithMultiple()
+    public void TestConstructorMultipleResponses_Validation()
     {
-        var resp = new PackageCheckResponse([
+        var notUsed = new ProcessResult();
+
+        var ex = Assert.Throws<ArgumentException>(() => new PackageCheckResponse("", Models.SdkLanguage.Go, [notUsed]));
+        Assert.That(ex.ParamName, Is.EqualTo("packageName"));
+
+        // purposefully allowing a null
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+        ex = Assert.Throws<ArgumentNullException>(() => new PackageCheckResponse(null, Models.SdkLanguage.Go, [notUsed]));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+        Assert.That(ex.ParamName, Is.EqualTo("packageName"));
+
+        ex = Assert.Throws<ArgumentException>(() => new PackageCheckResponse("aztemplate", Models.SdkLanguage.Unknown, [notUsed]));
+        Assert.That(ex.ParamName, Is.EqualTo("language"));
+
+        ex = Assert.Throws<ArgumentException>(() => new PackageCheckResponse("aztemplate", Models.SdkLanguage.Go, []));
+        Assert.That(ex.ParamName, Is.EqualTo("processResults"));
+
+        // purposefully allowing a null
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+        ex = Assert.Throws<ArgumentNullException>(() => new PackageCheckResponse("aztemplate", Models.SdkLanguage.Go, null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+        Assert.That(ex.ParamName, Is.EqualTo("processResults"));
+    }
+
+    [Test]
+    public void TestConstructorSingleResponse_Validation()
+    {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+        ArgumentException ex = Assert.Throws<ArgumentNullException>(() => new PackageCheckResponse(null, Models.SdkLanguage.Go, 0, "", ""));
+        Assert.That(ex.ParamName, Is.EqualTo("packageName"));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+
+        ex = Assert.Throws<ArgumentException>(() => new PackageCheckResponse("", Models.SdkLanguage.Go, 0, "", ""));
+        Assert.That(ex.ParamName, Is.EqualTo("packageName"));
+
+        ex = Assert.Throws<ArgumentException>(() => new PackageCheckResponse("aztemplate", Models.SdkLanguage.Unknown, 0, "", ""));
+        Assert.That(ex.ParamName, Is.EqualTo("language"));
+    }
+
+    [Test]
+    public void TestConstructWithMultipleResponses()
+    {
+        var resp = new PackageCheckResponse("github.com/Azure/azure-sdk-for-go/sdk/template/aztemplate", Models.SdkLanguage.Go, [
             CreateProcessResult(1001, "output", "error")
         ]);
 
@@ -19,9 +61,11 @@ public class PackageCheckResponseTests
                 // NOTE: the "output\nerror\n" is just how the ProcessResult class handles stdout and stderr being added, it's not part of the formatting in PackageCheckResponse.
                 $"output{Environment.NewLine}error{Environment.NewLine}" + Environment.NewLine));
             Assert.That(resp.ExitCode, Is.EqualTo(1001));
+            Assert.That(resp.PackageName, Is.EqualTo("github.com/Azure/azure-sdk-for-go/sdk/template/aztemplate"));
+            Assert.That(resp.Language, Is.EqualTo(Models.SdkLanguage.Go));
         });
 
-        resp = new PackageCheckResponse([
+        resp = new PackageCheckResponse("github.com/Azure/azure-sdk-for-go/sdk/template/aztemplate", Models.SdkLanguage.Go, [
             // NOTE: the "output\nerror\n" is just how the ProcessResult class handles stdout and stderr being added, it's not part of the formatting in PackageCheckResponse.
             CreateProcessResult(0, "first-output", "first-error"),
             CreateProcessResult(1001, "last-output", "last-error")
@@ -35,6 +79,8 @@ public class PackageCheckResponseTests
 
             // last exit code wins.
             Assert.That(resp.ExitCode, Is.EqualTo(1001));
+            Assert.That(resp.PackageName, Is.EqualTo("github.com/Azure/azure-sdk-for-go/sdk/template/aztemplate"));
+            Assert.That(resp.Language, Is.EqualTo(Models.SdkLanguage.Go));
         });
     }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Models/Responses/Package/PackageCheckResponseTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Models/Responses/Package/PackageCheckResponseTests.cs
@@ -28,7 +28,9 @@ public class PackageCheckResponseTests
 
         // purposefully allowing a null
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-        ex = Assert.Throws<ArgumentNullException>(() => new PackageCheckResponse("aztemplate", Models.SdkLanguage.Go, null));
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
+        ex = Assert.Throws<ArgumentNullException>(() => new PackageCheckResponse("aztemplate", Models.SdkLanguage.Go, (IEnumerable<ProcessResult>)null));
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
         Assert.That(ex.ParamName, Is.EqualTo("processResults"));
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/GoLanguageServicesTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/GoLanguageServicesTests.cs
@@ -44,8 +44,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
                 Assert.Ignore("golang tooling dependencies are not installed, can't run GoLanguageSpecificChecksTests");
             }
 
-            var resp = await LangService.CreateEmptyPackage(packagePath, "github.com/Azure/azure-sdk-for-go/sdk/template/aztemplate", CancellationToken.None);
-            Assert.That(resp.ExitCode, Is.EqualTo(0));
+            await LangService.CreateEmptyPackage(packagePath, "github.com/Azure/azure-sdk-for-go/sdk/template/aztemplate", CancellationToken.None);
 
             // check that our current version of Go is new enough for these tests.
             var version = await GoLanguageService.GetGoModVersionAsync(Path.Join(packagePath, "go.mod"));

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/GoLanguageServicesTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/GoLanguageServicesTests.cs
@@ -98,9 +98,6 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
 
             resp = await LangService.BuildProject(tempDir.DirectoryPath, CancellationToken.None);
             Assert.That(resp.ExitCode, Is.EqualTo(0));
-
-            resp = await LangService.LintCode(tempDir.DirectoryPath, false, CancellationToken.None);
-            Assert.That(resp.ExitCode, Is.EqualTo(0));
         }
 
         [Test]
@@ -123,25 +120,14 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
         }
 
         [Test]
-        public async Task TestGoLanguageSpecificChecksLintErrors()
+        public async Task TestGoLanguageLinting()
         {
-            await File.WriteAllTextAsync(Path.Combine(tempDir.DirectoryPath, "main.go"), """
-                package main
+            var goRepoRoot = IgnoreTestIfRepoNotConfigured();
+            var resp = await LangService.LintCode(Path.Join(goRepoRoot, "sdk", "template", "aztemplate"));
 
-                import (
-                )
-
-                func unusedFunc() {}
-
-                func main() {
-                }
-                """);
-
-            var resp = await LangService.LintCode(tempDir.DirectoryPath, false, CancellationToken.None);
             Assert.Multiple(() =>
             {
-                Assert.That(resp.ExitCode, Is.EqualTo(1));
-                Assert.That(resp.CheckStatusDetails, Does.Contain("is unused (unused)"));
+                Assert.That(resp.ExitCode, Is.EqualTo(0));
             });
         }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageCheckResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageCheckResponse.cs
@@ -75,6 +75,12 @@ public class PackageCheckResponse : PackageResponseBase
         CheckStatusDetails = processResult.Output;
     }
 
+    public PackageCheckResponse(string packageName, SdkLanguage language, ProcessResult processResult) : base(packageName, language)
+    {
+        ExitCode = processResult.ExitCode;
+        CheckStatusDetails = processResult.Output;
+    }
+
     protected override string Format()
     {
         StringBuilder output = new();

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageCheckResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageCheckResponse.cs
@@ -28,15 +28,34 @@ public class PackageCheckResponse : PackageResponseBase
         }
     }
 
+    public PackageCheckResponse(string packageName, SdkLanguage language, int exitCode, string checkStatusDetails, string error = null)
+        : base(packageName, language)
+    {
+        ExitCode = exitCode;
+        CheckStatusDetails = checkStatusDetails;
+        if (!string.IsNullOrEmpty(error))
+        {
+            ResponseError = error;
+        }
+    }
+
     /// <summary>
     /// Combines multiple <see cref="ProcessResult"/> instances into a single response.
     /// </summary>
-    /// <param name="processResults">Results to combine.
-    /// <see cref="ExitCode"/> is set to the last result's exit code
-    /// <see cref="CheckStatusDetails"/> is set to the concatenated output from all results.
-    /// </param>
-    public PackageCheckResponse(IEnumerable<ProcessResult> processResults)
+    /// <param name="packageName">Name of the package being checked.</param>
+    /// <param name="language">The SDK language of the package.</param>
+    /// <param name="processResults">Results to combine. <see cref="ExitCode"/> is set to the last result's exit code and
+    /// <see cref="CheckStatusDetails"/> is set to the concatenated output from all results.</param>
+    public PackageCheckResponse(string packageName, SdkLanguage language, IEnumerable<ProcessResult> processResults)
+        : base(packageName, language)
     {
+        ArgumentNullException.ThrowIfNull(processResults, nameof(processResults));
+
+        if (!processResults.Any())
+        {
+            throw new ArgumentException("processResults cannot be empty or null", nameof(processResults));
+        }
+
         var output = new StringBuilder();
 
         foreach (var pr in processResults)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageCheckResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageCheckResponse.cs
@@ -28,6 +28,28 @@ public class PackageCheckResponse : PackageResponseBase
         }
     }
 
+    /// <summary>
+    /// Combines multiple <see cref="ProcessResult"/> instances into a single response.
+    /// </summary>
+    /// <param name="processResults">Results to combine.
+    /// <see cref="ExitCode"/> is set to the last result's exit code
+    /// <see cref="CheckStatusDetails"/> is set to the concatenated output from all results.
+    /// </param>
+    public PackageCheckResponse(IEnumerable<ProcessResult> processResults)
+    {
+        var output = new StringBuilder();
+
+        foreach (var pr in processResults)
+        {
+            ExitCode = pr.ExitCode;
+
+            output.AppendLine(pr.Output);
+            output.AppendLine();
+        }
+
+        CheckStatusDetails = output.ToString();
+    }
+
     public PackageCheckResponse(ProcessResult processResult)
     {
         ExitCode = processResult.ExitCode;
@@ -36,7 +58,7 @@ public class PackageCheckResponse : PackageResponseBase
 
     protected override string Format()
     {
-        StringBuilder output = new ();
+        StringBuilder output = new();
         output.Append($"Check status: {CheckStatusDetails}");
         output.Append($"Language: {Language}");
         output.Append($"Package PackageName: {PackageName}");

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageResponseBase.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageResponseBase.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 using System.Text.Json.Serialization;
 using Azure.Sdk.Tools.Cli.Attributes;
-using Azure.Sdk.Tools.Cli.Services.Languages;
 
 namespace Azure.Sdk.Tools.Cli.Models.Responses.Package
 {
@@ -44,6 +43,26 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses.Package
         [JsonPropertyName("sdk_repo")]
         public string? SdkRepoName { get; set; }
 
+        public PackageResponseBase() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PackageResponseBase"/> class with the specified
+        /// SDK language and package name.
+        /// </summary>
+        /// <param name="packageName">The package identifier or name.</param>
+        /// <param name="language">The SDK language for the package.</param>
+        public PackageResponseBase(string packageName, SdkLanguage language)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(packageName, nameof(packageName));
+
+            if (language == SdkLanguage.Unknown)
+            {
+                throw new ArgumentException($"language cannot be {SdkLanguage.Unknown}", nameof(language));
+            }
+
+            PackageName = packageName;
+            Language = language;
+        }
 
         public void SetLanguage(string language)
         {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/GoLanguageService.Checks.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/GoLanguageService.Checks.cs
@@ -45,7 +45,7 @@ public partial class GoLanguageService : LanguageService
         }
     }
 
-    public async void CreateEmptyPackage(string packagePath, string moduleName, CancellationToken ct)
+    public async Task CreateEmptyPackage(string packagePath, string moduleName, CancellationToken ct)
     {
         var result = await processHelper.Run(new ProcessOptions(goUnix, ["mod", "init", moduleName], goWin, ["mod", "init", moduleName], workingDirectory: packagePath), ct);
 


### PR DESCRIPTION
- Search, recursively, for go.mod files. This helps in the 'azcore' case where we have some perf tests in a sub-folder.
- Use the repo configured golangci-lint configuration file when linting
- Added in a convenience method for PackageCheckResult that can handle multiple ProcessResults.
- Parsing the go.mod file to get the actual package name instead of guessing using file system paths
- Adding some convenience constructors to make sure we're always sending package name and the language.

Related to https://github.com/Azure/azure-sdk-tools/issues/11399
