### PR TITLE
Add Evaluator for tool description similarity

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Evaluators/ToolDescriptionSimilarityEvaluator.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Evaluators/ToolDescriptionSimilarityEvaluator.cs
@@ -1,9 +1,8 @@
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.AI.Evaluation;
 using Azure.Sdk.Tools.Cli.Evaluations.Models;
+using Azure.Sdk.Tools.Cli.Evaluations.Helpers;
 using Azure.AI.OpenAI;
-using Azure;
-using Azure.Identity;
 
 namespace Azure.Sdk.Tools.Cli.Evaluations.Evaluators
 {
@@ -22,12 +21,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Evaluators
 
         public ToolDescriptionSimilarityEvaluator(string? azureOpenAIEndpoint = null)
         {
-            // Use environment variables or defaults
-            var endpoint = azureOpenAIEndpoint ?? 
-                Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? 
-                throw new InvalidOperationException("Azure OpenAI endpoint not configured. Set AZURE_OPENAI_ENDPOINT environment variable.");
-            
-            _openAIClient = new AzureOpenAIClient(new Uri(endpoint), new DefaultAzureCredential());
+            _openAIClient = TestSetup.GetAzureOpenAIClient();
         }
 
         public async ValueTask<EvaluationResult> EvaluateAsync(

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Evaluators/ToolDescriptionSimilarityEvaluator.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Evaluators/ToolDescriptionSimilarityEvaluator.cs
@@ -12,7 +12,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Evaluators
     public class ToolDescriptionSimilarityEvaluator : IEvaluator
     {
         public const string SimilarityMetricName = "Tool Description Similarity";
-        private const double SimilarityThreshold = 0.2; // 80% similarity threshold
+        private const double SimilarityThreshold = 0.8; // 80% similarity threshold
         
         public IReadOnlyCollection<string> EvaluationMetricNames => [SimilarityMetricName];
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Evaluators/ToolDescriptionSimilarityEvaluator.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Evaluators/ToolDescriptionSimilarityEvaluator.cs
@@ -14,7 +14,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Evaluators
     public class ToolDescriptionSimilarityEvaluator : IEvaluator
     {
         public const string SimilarityMetricName = "Tool Description Similarity";
-        private const double SimilarityThreshold = 0.85; // 85% cosine similarity threshold
+        private const double SimilarityThreshold = 0.80; // 80% cosine similarity threshold
         private readonly AzureOpenAIClient _openAIClient;
         private readonly string _embeddingModelDeployment = "text-embedding-3-large";
         
@@ -180,14 +180,14 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Evaluators
             if (metric.Value == false)
             {
                 metric.Interpretation = new EvaluationMetricInterpretation(
-                    EvaluationRating.Poor,
+                    EvaluationRating.Unacceptable,
                     failed: true,
                     reason: "Similar tool descriptions may confuse the AI agent. " + metric.Reason);
             }
             else
             {
                 metric.Interpretation = new EvaluationMetricInterpretation(
-                    EvaluationRating.Good,
+                    EvaluationRating.Exceptional,
                     reason: "Tool descriptions are sufficiently distinct. " + metric.Reason);
             }
         }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Evaluators/ToolDescriptionSimilarityEvaluator.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Evaluators/ToolDescriptionSimilarityEvaluator.cs
@@ -1,0 +1,147 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.AI.Evaluation;
+using Azure.Sdk.Tools.Cli.Evaluations.Models;
+using System.Text.RegularExpressions;
+
+namespace Azure.Sdk.Tools.Cli.Evaluations.Evaluators
+{
+    /// <summary>
+    /// Evaluates MCP tool descriptions to identify similar or duplicate descriptions
+    /// that could confuse the AI agent.
+    /// </summary>
+    public class ToolDescriptionSimilarityEvaluator : IEvaluator
+    {
+        public const string SimilarityMetricName = "Tool Description Similarity";
+        private const double SimilarityThreshold = 0.2; // 80% similarity threshold
+        
+        public IReadOnlyCollection<string> EvaluationMetricNames => [SimilarityMetricName];
+
+        public ValueTask<EvaluationResult> EvaluateAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatResponse modelResponse,
+            ChatConfiguration? chatConfiguration = null,
+            IEnumerable<EvaluationContext>? additionalContext = null,
+            CancellationToken cancellationToken = default)
+        {
+            var metric = new BooleanMetric(SimilarityMetricName);
+
+            // Get tools from additional context
+            if (additionalContext?.OfType<ToolDescriptionSimilarityEvaluatorContext>().FirstOrDefault()
+                is not ToolDescriptionSimilarityEvaluatorContext context)
+            {
+                MetricError($"A value of type {nameof(ToolDescriptionSimilarityEvaluatorContext)} was not found in the {nameof(additionalContext)} collection.", metric);
+                return new ValueTask<EvaluationResult>(new EvaluationResult(metric));
+            }
+
+            var tools = context.Tools;
+            var similarityIssues = new List<string>();
+
+            // Compare each tool description with every other tool
+            for (int i = 0; i < tools.Count; i++)
+            {
+                for (int j = i + 1; j < tools.Count; j++)
+                {
+                    var tool1 = tools[i];
+                    var tool2 = tools[j];
+
+                    var desc1 = tool1.Description ?? string.Empty;
+                    var desc2 = tool2.Description ?? string.Empty;
+
+                    // Skip empty descriptions
+                    if (string.IsNullOrWhiteSpace(desc1) || string.IsNullOrWhiteSpace(desc2))
+                    {
+                        continue;
+                    }
+
+                    var similarity = CalculateSimilarity(desc1, desc2);
+
+                    if (similarity >= SimilarityThreshold)
+                    {
+                        var issue = $"Tools '{tool1.Name}' and '{tool2.Name}' have {similarity:P0} similar descriptions:\n" +
+                                  $"  - {tool1.Name}: {desc1}\n" +
+                                  $"  - {tool2.Name}: {desc2}";
+                        similarityIssues.Add(issue);
+                        
+                        metric.AddDiagnostics(EvaluationDiagnostic.Warning(issue));
+                    }
+                    else
+                    {
+                        metric.AddDiagnostics(
+                            EvaluationDiagnostic.Informational(
+                                $"Tools '{tool1.Name}' and '{tool2.Name}' have acceptable description difference ({similarity:P0} similar)"));
+                    }
+                }
+            }
+
+            if (similarityIssues.Any())
+            {
+                metric.Value = false;
+                metric.Reason = $"Found {similarityIssues.Count} pair(s) of tools with overly similar descriptions";
+            }
+            else
+            {
+                metric.Value = true;
+                metric.Reason = $"All {tools.Count} tool descriptions are sufficiently distinct";
+            }
+
+            Interpret(metric);
+            return new ValueTask<EvaluationResult>(new EvaluationResult(metric));
+        }
+
+        /// <summary>
+        /// Calculate similarity between two strings using Jaccard similarity on word tokens
+        /// </summary>
+        private static double CalculateSimilarity(string text1, string text2)
+        {
+            // Normalize: lowercase and extract words
+            var words1 = ExtractWords(text1.ToLowerInvariant());
+            var words2 = ExtractWords(text2.ToLowerInvariant());
+
+            if (!words1.Any() || !words2.Any())
+            {
+                return 0.0;
+            }
+
+            // Calculate Jaccard similarity: |intersection| / |union|
+            var intersection = words1.Intersect(words2).Count();
+            var union = words1.Union(words2).Count();
+
+            return union > 0 ? (double)intersection / union : 0.0;
+        }
+
+        private static HashSet<string> ExtractWords(string text)
+        {
+            // Extract words (alphanumeric sequences)
+            var words = Regex.Matches(text, @"\b\w+\b")
+                             .Cast<Match>()
+                             .Select(m => m.Value)
+                             .Where(w => w.Length > 2) // Skip very short words
+                             .ToHashSet();
+            return words;
+        }
+
+        private static void Interpret(BooleanMetric metric)
+        {
+            if (metric.Value == false)
+            {
+                metric.Interpretation = new EvaluationMetricInterpretation(
+                    EvaluationRating.Poor,
+                    failed: true,
+                    reason: "Similar tool descriptions may confuse the AI agent. " + metric.Reason);
+            }
+            else
+            {
+                metric.Interpretation = new EvaluationMetricInterpretation(
+                    EvaluationRating.Good,
+                    reason: "Tool descriptions are sufficiently distinct. " + metric.Reason);
+            }
+        }
+
+        private static void MetricError(string message, BooleanMetric metric)
+        {
+            metric.AddDiagnostics(EvaluationDiagnostic.Error(message));
+            metric.Value = false;
+            Interpret(metric);
+        }
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Evaluators/ToolDescriptionSimilarityEvaluator.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Evaluators/ToolDescriptionSimilarityEvaluator.cs
@@ -177,19 +177,14 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Evaluators
 
         private static void Interpret(BooleanMetric metric)
         {
-            if (metric.Value == false)
-            {
-                metric.Interpretation = new EvaluationMetricInterpretation(
-                    EvaluationRating.Unacceptable,
-                    failed: true,
-                    reason: "Similar tool descriptions may confuse the AI agent. " + metric.Reason);
-            }
-            else
-            {
-                metric.Interpretation = new EvaluationMetricInterpretation(
-                    EvaluationRating.Exceptional,
-                    reason: "Tool descriptions are sufficiently distinct. " + metric.Reason);
-            }
+            metric.Interpretation = metric.Value == false
+            ? new EvaluationMetricInterpretation(
+                EvaluationRating.Unacceptable,
+                failed: true,
+                reason: "Similar tool descriptions may confuse the AI agent. " + metric.Reason)
+            : new EvaluationMetricInterpretation(
+                EvaluationRating.Exceptional,
+                reason: "Tool descriptions are sufficiently distinct. " + metric.Reason);
         }
 
         private static void MetricError(string message, BooleanMetric metric)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/EvaluationHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/EvaluationHelper.cs
@@ -10,13 +10,23 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
 {
     public class EvaluationHelper
     {
-        public static void ValidateToolInputsEvaluator(EvaluationResult result)
+        public static void ValidateBooleanMetricEvaluator(EvaluationResult result, string metricName)
         {
             EvaluationRating[] expectedRatings = [EvaluationRating.Good, EvaluationRating.Exceptional];
-            BooleanMetric expectedToolInput = result.Get<BooleanMetric>(ExpectedToolInputEvaluator.ExpectedToolInputMetricName);
-            expectedToolInput.Interpretation!.Failed.Should().BeFalse(because: expectedToolInput.Interpretation.Reason);
-            expectedToolInput.Interpretation.Rating.Should().BeOneOf(expectedRatings, because: expectedToolInput.Reason);
-            expectedToolInput.ContainsDiagnostics(d => d.Severity >= EvaluationDiagnosticSeverity.Warning).Should().BeFalse();
+            BooleanMetric metric = result.Get<BooleanMetric>(metricName);
+            metric.Interpretation!.Failed.Should().BeFalse(because: metric.Interpretation.Reason);
+            metric.Interpretation.Rating.Should().BeOneOf(expectedRatings, because: metric.Reason);
+            metric.ContainsDiagnostics(d => d.Severity >= EvaluationDiagnosticSeverity.Warning).Should().BeFalse();
+        }
+
+        public static void ValidateToolInputsEvaluator(EvaluationResult result)
+        {
+            ValidateBooleanMetricEvaluator(result, ExpectedToolInputEvaluator.ExpectedToolInputMetricName);
+        }
+
+        public static void ValidateToolDescriptionSimilarityEvaluator(EvaluationResult result)
+        {
+            ValidateBooleanMetricEvaluator(result, ToolDescriptionSimilarityEvaluator.SimilarityMetricName);
         }
 
         public static async Task<EvaluationResult> RunScenarioAsync(

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Models/ToolDescriptionSimilarityEvaluatorContext.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Models/ToolDescriptionSimilarityEvaluatorContext.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.AI.Evaluation;
+
+namespace Azure.Sdk.Tools.Cli.Evaluations.Models
+{
+    /// <summary>
+    /// Context for ToolDescriptionSimilarityEvaluator containing the list of tools to evaluate
+    /// </summary>
+    public class ToolDescriptionSimilarityEvaluatorContext(IReadOnlyList<AIFunction> tools)
+        : EvaluationContext(name: ToolDescriptionSimilarityContextName, content: $"{tools.Count} tools to evaluate")
+    {
+        public static string ToolDescriptionSimilarityContextName => "Tool Description Similarity";
+        public IReadOnlyList<AIFunction> Tools { get; } = tools;
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/README.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/README.md
@@ -38,6 +38,8 @@ REPOSITORY_NAME=Owner/RepoName
 COPILOT_INSTRUCTIONS_PATH_MCP_EVALS=path/to/.github/copilot-instructions.md
 ```
 
+**Note**: The Azure OpenAI endpoint must have a `text-embedding-3-large` deployment configured. This is required by the `ToolDescriptionSimilarityEvaluator` for embedding-based similarity tests. Without this deployment, the tests will fail.
+
 ### Running Evaluations
 
 ```bash

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/AzureRestApiSpecs/AzsdkTypeSpecGeneration_Step02_TypespecValidation.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/AzureRestApiSpecs/AzsdkTypeSpecGeneration_Step02_TypespecValidation.cs
@@ -20,7 +20,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
             // This test enables deeper input checking
             bool checkInputs = true;
 
-            var result = await EvaluationHelper.RunScenarioAsync(
+            var result = await EvaluationHelper.RunToolInputScenarioAsync(
                 scenarioName: this.ScenarioName,
                 scenarioData: scenarioData,
                 chatCompletion: s_chatCompletion!,

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/AzureRestApiSpecs/Evaluate_CheckSDKGenerationStatus.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/AzureRestApiSpecs/Evaluate_CheckSDKGenerationStatus.cs
@@ -20,7 +20,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
             // This test enables deeper input checking
             bool checkInputs = true;
 
-            var result = await EvaluationHelper.RunScenarioAsync(
+            var result = await EvaluationHelper.RunToolInputScenarioAsync(
                 scenarioName: this.ScenarioName,
                 scenarioData: scenarioData,
                 chatCompletion: s_chatCompletion!,

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/AzureRestApiSpecs/Evaluate_ValidateTypespec.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/AzureRestApiSpecs/Evaluate_ValidateTypespec.cs
@@ -25,7 +25,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
             // External contexts (no deep input checking for this one)
             bool checkInputs = false;
 
-            var result = await EvaluationHelper.RunScenarioAsync(
+            var result = await EvaluationHelper.RunToolInputScenarioAsync(
                 scenarioName: this.ScenarioName,
                 scenarioData: scenarioData,
                 chatCompletion: s_chatCompletion!,

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/General/Evaluate_CreateReleasePlan.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/General/Evaluate_CreateReleasePlan.cs
@@ -24,7 +24,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
             // External construction of evaluation context
             bool checkInputs = false;
 
-            var result = await EvaluationHelper.RunScenarioAsync(
+            var result = await EvaluationHelper.RunToolInputScenarioAsync(
                 scenarioName: this.ScenarioName,
                 scenarioData: scenarioData,
                 chatCompletion: s_chatCompletion!,

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/General/Evaluate_GetPullRequestLinkForCurrentBranch.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/General/Evaluate_GetPullRequestLinkForCurrentBranch.cs
@@ -23,7 +23,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
             // External construction of evaluation context
             bool checkInputs = false;
 
-            var result = await EvaluationHelper.RunScenarioAsync(
+            var result = await EvaluationHelper.RunToolInputScenarioAsync(
                 scenarioName: this.ScenarioName,
                 scenarioData: scenarioData,
                 chatCompletion: s_chatCompletion!,

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/General/Evaluate_ToolDescriptionSimilarity.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/General/Evaluate_ToolDescriptionSimilarity.cs
@@ -34,13 +34,12 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
             var evaluator = new ToolDescriptionSimilarityEvaluator(azureOpenAIEndpoint);
 
             var result = await EvaluationHelper.RunScenarioAsync(
+                messages: [],
+                response: new ChatResponse(),
                 scenarioName: this.ScenarioName,
-                scenarioData: scenarioData,
-                chatCompletion: s_chatCompletion!,
                 chatConfig: s_chatConfig!,
                 executionName: s_executionName,
                 reportingPath: ReportingPath,
-                toolNames: s_toolNames!,
                 evaluators: [evaluator],
                 enableResponseCaching: false,
                 additionalContexts: new EvaluationContext[]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/General/Evaluate_ToolDescriptionSimilarity.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/General/Evaluate_ToolDescriptionSimilarity.cs
@@ -26,6 +26,13 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
             // Get all tools from MCP server
             var tools = (await s_mcpClient!.ListToolsAsync()).ToList();
 
+            // Get Azure OpenAI configuration from environment variables
+            var azureOpenAIEndpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT");
+            // var embeddingDeployment = Environment.GetEnvironmentVariable("AZURE_OPENAI_EMBEDDING_DEPLOYMENT");
+
+            // Create evaluator with optional configuration (will use environment variables if not provided)
+            var evaluator = new ToolDescriptionSimilarityEvaluator(azureOpenAIEndpoint);
+
             var result = await EvaluationHelper.RunScenarioAsync(
                 scenarioName: this.ScenarioName,
                 scenarioData: scenarioData,
@@ -34,7 +41,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
                 executionName: s_executionName,
                 reportingPath: ReportingPath,
                 toolNames: s_toolNames!,
-                evaluators: [new ToolDescriptionSimilarityEvaluator()],
+                evaluators: [evaluator],
                 enableResponseCaching: false,
                 additionalContexts: new EvaluationContext[]
                 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/General/Evaluate_ToolDescriptionSimilarity.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/General/Evaluate_ToolDescriptionSimilarity.cs
@@ -47,26 +47,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
                     new ToolDescriptionSimilarityEvaluatorContext(tools)
                 });
 
-            // Validate the similarity check
-            var similarityMetric = result.Get<BooleanMetric>(ToolDescriptionSimilarityEvaluator.SimilarityMetricName);
-            
-            // Assert that tool descriptions are distinct
-            Assert.That(similarityMetric.Value, Is.True, 
-                $"Tool descriptions should be sufficiently distinct to avoid agent confusion. {similarityMetric.Reason}");
-            
-            // Log any warnings for review even if test passes
-            var warnings = similarityMetric.Diagnostics?
-                .Where(d => d.Severity == EvaluationDiagnosticSeverity.Warning)
-                .ToList();
-            
-            if (warnings?.Any() == true)
-            {
-                TestContext.WriteLine($"⚠️  Found {warnings.Count} tool description similarity warnings:");
-                foreach (var warning in warnings)
-                {
-                    TestContext.WriteLine($"   {warning.Message}");
-                }
-            }
+            EvaluationHelper.ValidateToolDescriptionSimilarityEvaluator(result);
         }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/General/Evaluate_ToolDescriptionSimilarity.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenarios/General/Evaluate_ToolDescriptionSimilarity.cs
@@ -1,0 +1,66 @@
+using Azure.Sdk.Tools.Cli.Evaluations.Evaluators;
+using Azure.Sdk.Tools.Cli.Evaluations.Helpers;
+using Azure.Sdk.Tools.Cli.Evaluations.Models;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.AI.Evaluation;
+using ModelContextProtocol.Client;
+using NUnit.Framework;
+
+namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
+{
+    public partial class Scenario
+    {
+        [Test]
+        public async Task Evaluate_ToolDescriptionSimilarity()
+        {
+            // This test validates that MCP tool descriptions are sufficiently distinct
+            // to avoid confusion for the AI agent
+
+            // Create a simple prompt - the actual content doesn't matter much
+            // since we're evaluating the tools themselves, not the agent's response
+            const string prompt = "List all available tools";
+
+            // Build scenario data
+            var scenarioData = ChatMessageHelper.LoadScenarioFromPrompt(prompt, []);
+
+            // Get all tools from MCP server
+            var tools = (await s_mcpClient!.ListToolsAsync()).ToList();
+
+            var result = await EvaluationHelper.RunScenarioAsync(
+                scenarioName: this.ScenarioName,
+                scenarioData: scenarioData,
+                chatCompletion: s_chatCompletion!,
+                chatConfig: s_chatConfig!,
+                executionName: s_executionName,
+                reportingPath: ReportingPath,
+                toolNames: s_toolNames!,
+                evaluators: [new ToolDescriptionSimilarityEvaluator()],
+                enableResponseCaching: false,
+                additionalContexts: new EvaluationContext[]
+                {
+                    new ToolDescriptionSimilarityEvaluatorContext(tools)
+                });
+
+            // Validate the similarity check
+            var similarityMetric = result.Get<BooleanMetric>(ToolDescriptionSimilarityEvaluator.SimilarityMetricName);
+            
+            // Assert that tool descriptions are distinct
+            Assert.That(similarityMetric.Value, Is.True, 
+                $"Tool descriptions should be sufficiently distinct to avoid agent confusion. {similarityMetric.Reason}");
+            
+            // Log any warnings for review even if test passes
+            var warnings = similarityMetric.Diagnostics?
+                .Where(d => d.Severity == EvaluationDiagnosticSeverity.Warning)
+                .ToList();
+            
+            if (warnings?.Any() == true)
+            {
+                TestContext.WriteLine($"⚠️  Found {warnings.Count} tool description similarity warnings:");
+                foreach (var warning in warnings)
+                {
+                    TestContext.WriteLine($"   {warning.Message}");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Alternate idea to this one: https://github.com/Azure/azure-sdk-tools/issues/12251

(Would want to use a better similarity score than Jaccard though) 

Eval results (80% vs 20% similarity threshold) Jaccard similarity 
[report-20251216_215343.html](https://github.com/user-attachments/files/24206295/report-20251216_215343.html)
[report-20251216_220125.html](https://github.com/user-attachments/files/24206296/report-20251216_220125.html)

Eval results - semantic similarity
[report-20251217_115731.html](https://github.com/user-attachments/files/24220858/report-20251217_115731.html) (85% threshold) 
[report-20251217_121927.html](https://github.com/user-attachments/files/24221113/report-20251217_121927.html)(80% threshold)


