### PR TITLE
[azsdk-cli, go] Fixing a few more Go issues, and adding in a few more convenience funcs.

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/PackageInfoContractTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/PackageInfoContractTests.cs
@@ -75,7 +75,7 @@ public class PackageInfoContractTests
         var repoRoot = gitHelper.DiscoverRepoRoot(packagePath);
         var scriptsDir = Path.Combine(repoRoot, "eng", "scripts");
         Directory.CreateDirectory(scriptsDir);
-        
+
         // Create a minimal Python script that outputs the package info
         var scriptContent = $@"#!/usr/bin/env python
 import sys
@@ -98,11 +98,11 @@ print(f'{{package_name}} {{version}} True {{package_path}} ')
   "name": "@azure/{{packageName}}",
   "version": "{{version}}",
   "sdk-type": "{{sdkType switch
-    {
-        SdkType.Dataplane => "client",
-        SdkType.Management => "mgmt",
-        _ => ""
-    }}}" 
+        {
+            SdkType.Dataplane => "client",
+            SdkType.Management => "mgmt",
+            _ => ""
+        }}}" 
 }
 """);
     }
@@ -197,7 +197,7 @@ print(f'{{package_name}} {{version}} True {{package_path}} ')
         var info = await helper.GetPackageInfo(pkgPath);
         Assert.That(info.PackageVersion, Is.EqualTo(expectedVersion));
     }
-    
+
     [Test]
     [TestCase(SdkLanguage.JavaScript, SdkType.Dataplane)]
     [TestCase(SdkLanguage.JavaScript, SdkType.Management)]
@@ -237,7 +237,7 @@ print(f'{{package_name}} {{version}} True {{package_path}} ')
         SdkLanguage.Java => new JavaLanguageService(processHelper, gitHelper, new Mock<IMavenHelper>().Object, microAgentMock, new TestLogger<JavaLanguageService>(), commonValidationHelper, Mock.Of<IFileHelper>()),
         SdkLanguage.Python => new PythonLanguageService(processHelper, pythonHelper, npxHelper, gitHelper, new TestLogger<PythonLanguageService>(), commonValidationHelper, Mock.Of<IFileHelper>()),
         SdkLanguage.JavaScript => new JavaScriptLanguageService(processHelper, npxHelper, gitHelper, new TestLogger<JavaScriptLanguageService>(), commonValidationHelper, Mock.Of<IFileHelper>()),
-        SdkLanguage.Go => new GoLanguageService(processHelper, gitHelper, new TestLogger<GoLanguageService>(), commonValidationHelper, Mock.Of<IFileHelper>()),
+        SdkLanguage.Go => new GoLanguageService(processHelper, powershellHelper, gitHelper, new TestLogger<GoLanguageService>(), commonValidationHelper, Mock.Of<IFileHelper>()),
         _ => throw new ArgumentException($"Unsupported language '{language}'", nameof(language))
     };
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/GoLanguageServicesTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/GoLanguageServicesTests.cs
@@ -93,7 +93,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
             Assert.Multiple(() =>
             {
                 Assert.That(resp.ExitCode, Is.EqualTo(0));
-                Assert.That(resp.PackageName, Is.EqualTo("github.com/Azure/azure-sdk-for-go/sdk/template/aztemplate"));
+                Assert.That(resp.PackageName, Is.EqualTo("sdk/template/aztemplate"));
                 Assert.That(resp.Language, Is.EqualTo(SdkLanguage.Go));
             });
 
@@ -144,18 +144,9 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
             Assert.Multiple(() =>
             {
                 Assert.That(resp.ExitCode, Is.EqualTo(0));
-                Assert.That(resp.PackageName, Is.EqualTo("github.com/Azure/azure-sdk-for-go/sdk/template/aztemplate"));
+                Assert.That(resp.PackageName, Is.EqualTo("sdk/template/aztemplate"));
                 Assert.That(resp.Language, Is.EqualTo(SdkLanguage.Go));
             });
-        }
-
-        [Test]
-        public async Task TestGetSDKPackageName()
-        {
-            Assert.That(
-                await GoLanguageService.GetGoModuleName(packagePath),
-                Is.EqualTo("github.com/Azure/azure-sdk-for-go/sdk/template/aztemplate")
-            );
         }
 
         [Test]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/GoLanguageServicesTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/GoLanguageServicesTests.cs
@@ -19,8 +19,6 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
 
         private GoLanguageService LangService { get; set; } = null!;
 
-        private Mock<IGitHelper> GitHelperMock { get; set; }
-
         private readonly Version goMinimumVersion = Version.Parse("1.24");
 
         [SetUp]
@@ -258,6 +256,13 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
             File.WriteAllText(goModPath, "there's no version in here!");
 
             Assert.ThrowsAsync(typeof(Exception), async () => await GoLanguageService.GetGoModVersionAsync(goModPath));
+        }
+
+        [Test]
+        public async Task TestGetSubPath()
+        {
+            var subPath = await LangService.GetSubPath(packagePath);
+            Assert.That(subPath, Is.EqualTo("sdk/template/aztemplate"));
         }
 
         /// <summary>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/SdkBuildToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/SdkBuildToolTests.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using Moq;
 using Azure.Sdk.Tools.Cli.Helpers;
-using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
-using Azure.Sdk.Tools.Cli.Tools.Package;
+using Azure.Sdk.Tools.Cli.Microagents;
 using Azure.Sdk.Tools.Cli.Services;
 using Azure.Sdk.Tools.Cli.Services.Languages;
-using Azure.Sdk.Tools.Cli.Microagents;
+using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
+using Azure.Sdk.Tools.Cli.Tools.Package;
+using Moq;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Tools.Package;
 
@@ -61,7 +61,7 @@ public class SdkBuildToolTests
             new PythonLanguageService(_mockProcessHelper.Object, _mockPythonHelper.Object, _mockNpxHelper.Object, _mockGitHelper.Object, languageLogger, _commonValidationHelpers.Object, Mock.Of<IFileHelper>()),
             new JavaLanguageService(_mockProcessHelper.Object, _mockGitHelper.Object, new Mock<IMavenHelper>().Object, mockMicrohostAgent.Object, languageLogger, _commonValidationHelpers.Object, Mock.Of<IFileHelper>()),
             new JavaScriptLanguageService(_mockProcessHelper.Object, _mockNpxHelper.Object, _mockGitHelper.Object, languageLogger, _commonValidationHelpers.Object, Mock.Of<IFileHelper>()),
-            new GoLanguageService(_mockProcessHelper.Object, _mockGitHelper.Object, languageLogger, _commonValidationHelpers.Object, Mock.Of<IFileHelper>()),
+            new GoLanguageService(_mockProcessHelper.Object, _mockPowerShellHelper.Object, _mockGitHelper.Object, languageLogger, _commonValidationHelpers.Object, Mock.Of<IFileHelper>()),
             new DotnetLanguageService(_mockProcessHelper.Object, _mockPowerShellHelper.Object, _mockGitHelper.Object, languageLogger, _commonValidationHelpers.Object, Mock.Of<IFileHelper>())
         ];
 
@@ -109,15 +109,15 @@ public class SdkBuildToolTests
         // Arrange - create a test directory structure
         var projectDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "project");
         Directory.CreateDirectory(projectDir);
-        
+
         // Save the current directory
         var originalDir = Directory.GetCurrentDirectory();
-        
+
         try
         {
             // Change to the temp directory
             Directory.SetCurrentDirectory(_tempDirectory.DirectoryPath);
-            
+
             // Mock GitHelper for the resolved path
             _mockGitHelper
                 .Setup(x => x.DiscoverRepoRoot(projectDir))

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Verify/VerifySetupToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Verify/VerifySetupToolTests.cs
@@ -64,7 +64,7 @@ internal class VerifySetupToolTests
             new PythonLanguageService(mockProcessHelper.Object, mockPythonHelper.Object, _mockNpxHelper.Object, _mockGitHelper.Object, _languageLogger, _commonValidationHelpers.Object, Mock.Of<IFileHelper>()),
             new JavaLanguageService(mockProcessHelper.Object, _mockGitHelper.Object, new Mock<IMavenHelper>().Object, _mockMicrohostAgent.Object, _languageLogger, _commonValidationHelpers.Object, Mock.Of<IFileHelper>()),
             new JavaScriptLanguageService(mockProcessHelper.Object, _mockNpxHelper.Object, _mockGitHelper.Object, _languageLogger, _commonValidationHelpers.Object, Mock.Of<IFileHelper>()),
-            new GoLanguageService(mockProcessHelper.Object, _mockGitHelper.Object, _languageLogger, _commonValidationHelpers.Object, Mock.Of<IFileHelper>()),
+            new GoLanguageService(mockProcessHelper.Object, _mockPowerShellHelper.Object, _mockGitHelper.Object, _languageLogger, _commonValidationHelpers.Object, Mock.Of<IFileHelper>()),
             new DotnetLanguageService(mockProcessHelper.Object, _mockPowerShellHelper.Object, _mockGitHelper.Object, _languageLogger, _commonValidationHelpers.Object, Mock.Of<IFileHelper>())
         ];
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Process/Options/ProcessOptions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Process/Options/ProcessOptions.cs
@@ -48,6 +48,21 @@ public class ProcessOptions : IProcessOptions
         TimeSpan? timeout = null
     ) : this(command, args, command, args, logOutputStream, workingDirectory, timeout) { }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProcessOptions"/> class that uses the same command-line arguments on both platforms.
+    /// See <see cref="ProcessOptions(string, string[], string, string[], bool, string?, TimeSpan?)"/> to pass different arguments 
+    /// for each platform.
+    /// </summary>
+    public ProcessOptions(
+        string unixCommand,
+        string windowsCommand,
+        string[] args,
+        bool logOutputStream = true,
+        string? workingDirectory = null,
+        TimeSpan? timeout = null)
+        : this(unixCommand, args, windowsCommand, args, logOutputStream, workingDirectory, timeout)
+    { }
+
     public ProcessOptions(
         string unixCommand,
         string[] unixArgs,

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Process/ProcessResult.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Process/ProcessResult.cs
@@ -22,4 +22,11 @@ public class ProcessResult
     {
         OutputDetails.Add((StdioLevel.StandardError, line));
     }
+
+    /// <summary>
+    /// Extracts only stdout. For both stdout and stderr, interleaved, see <see cref="Output"/>
+    /// </summary>
+    public string Stdout => string.Join(
+        Environment.NewLine,
+        OutputDetails.Where(x => x.Item1 == StdioLevel.StandardOutput).Select(x => x.Item2));
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageResponseBase.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageResponseBase.cs
@@ -27,9 +27,15 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses.Package
                 _language = value;
             }
         }
+
+        /// <summary>
+        /// The package name, within the package ecosystem (ie: azure-core, @azure/core, etc..). 
+        /// Go uses the sub-path as the package name (sdk/azcore, sdk/resourcemanager/msi/armmsi).
+        /// </summary>
         [Telemetry]
         [JsonPropertyName("package_name")]
         public string? PackageName { get; set; }
+
         [JsonPropertyName("package_display_name")]
         public string? DisplayName { get; set; }
         [JsonPropertyName("version")]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/GoLanguageService.Checks.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/GoLanguageService.Checks.cs
@@ -16,8 +16,8 @@ public partial class GoLanguageService : LanguageService
     {
         try
         {
-            var compilerExists = (await processHelper.Run(new ProcessOptions(goUnix, ["version"], goWin, ["version"]), ct)).ExitCode == 0;
-            var linterExists = (await processHelper.Run(new ProcessOptions(golangciLintUnix, ["--version"], golangciLintWin, ["--version"]), ct)).ExitCode == 0;
+            var compilerExists = (await processHelper.Run(new ProcessOptions(goUnix, goWin, ["version"]), ct)).ExitCode == 0;
+            var linterExists = (await processHelper.Run(new ProcessOptions(golangciLintUnix, golangciLintWin, ["--version"]), ct)).ExitCode == 0;
 
             var tempFilePath = Path.GetTempFileName();
             bool formatterExists = false;
@@ -25,10 +25,7 @@ public partial class GoLanguageService : LanguageService
             try
             {
                 await File.WriteAllTextAsync(tempFilePath, "package main", ct);
-                var gofmtOptions = new ProcessOptions(
-                    unixCommand: gofmtUnix, unixArgs: [tempFilePath],
-                    windowsCommand: gofmtWin, windowsArgs: [tempFilePath]
-                );
+                var gofmtOptions = new ProcessOptions(gofmtUnix, gofmtWin, [tempFilePath]);
                 formatterExists = (await processHelper.Run(gofmtOptions, ct)).ExitCode == 0;
             }
             finally
@@ -47,7 +44,7 @@ public partial class GoLanguageService : LanguageService
 
     public async Task CreateEmptyPackage(string packagePath, string moduleName, CancellationToken ct)
     {
-        var result = await processHelper.Run(new ProcessOptions(goUnix, ["mod", "init", moduleName], goWin, ["mod", "init", moduleName], workingDirectory: packagePath), ct);
+        var result = await processHelper.Run(new ProcessOptions(goUnix, goWin, ["mod", "init", moduleName], workingDirectory: packagePath), ct);
 
         if (result.ExitCode != 0)
         {
@@ -64,7 +61,7 @@ public partial class GoLanguageService : LanguageService
 
         try
         {
-            packageName = await GetSDKPackageName(packagePath, ct);
+            packageName = await GetGoModuleName(packagePath, ct);
         }
         catch (Exception ex)
         {
@@ -95,7 +92,7 @@ public partial class GoLanguageService : LanguageService
                 }
 
                 // Update all dependencies to the latest first
-                var updateResult = await processHelper.Run(new ProcessOptions(goUnix, [.. goGetArgs], goWin, [.. goGetArgs], workingDirectory: goModDir), ct);
+                var updateResult = await processHelper.Run(new ProcessOptions(goUnix, goWin, [.. goGetArgs], workingDirectory: goModDir), ct);
                 results.Add(updateResult);
 
                 if (updateResult.ExitCode != 0)
@@ -104,7 +101,7 @@ public partial class GoLanguageService : LanguageService
                 }
 
                 // Now tidy, to cleanup any deps that aren't needed
-                var tidyResult = await processHelper.Run(new ProcessOptions(goUnix, ["mod", "tidy"], goWin, ["mod", "tidy"], workingDirectory: goModDir), ct);
+                var tidyResult = await processHelper.Run(new ProcessOptions(goUnix, goWin, ["mod", "tidy"], workingDirectory: goModDir), ct);
                 results.Add(tidyResult);
 
                 if (tidyResult.ExitCode != 0)
@@ -126,13 +123,9 @@ public partial class GoLanguageService : LanguageService
     {
         try
         {
-            var result = await processHelper.Run(new ProcessOptions(
-                gofmtUnix, ["-w", "."],
-                gofmtWin, ["-w", "."],
-                workingDirectory: packagePath
-            ), ct);
+            var result = await processHelper.Run(new ProcessOptions(gofmtUnix, gofmtWin, ["-w", "."], workingDirectory: packagePath), ct);
 
-            var packageName = await GetSDKPackageName(packagePath, ct);
+            var packageName = await GetGoModuleName(packagePath, ct);
             return new PackageCheckResponse(packageName, Models.SdkLanguage.Go, result);
         }
         catch (Exception ex)
@@ -146,17 +139,32 @@ public partial class GoLanguageService : LanguageService
     {
         try
         {
+            var processResults = new List<ProcessResult>();
+
+            // run the standard golangci-lint
             var repoRoot = gitHelper.DiscoverRepoRoot(packagePath);
+            var packageName = await GetGoModuleName(packagePath, ct);
+            var result = await processHelper.Run(new ProcessOptions(golangciLintUnix, golangciLintWin, ["run", "--config", Path.Join(repoRoot, "eng", ".golangci.yml")], workingDirectory: packagePath), ct);
+            processResults.Add(result);
 
-            string[] runArgs = [
-                "run",
-                "--config",
-                Path.Join(repoRoot, "eng", ".golangci.yml")
-            ];
+            if (result.ExitCode != 0)
+            {
+                return new PackageCheckResponse(packageName, Models.SdkLanguage.Go, processResults);
+            }
 
-            var packageName = await GetSDKPackageName(packagePath, ct);
-            var result = await processHelper.Run(new ProcessOptions(golangciLintUnix, runArgs, golangciLintWin, runArgs, workingDirectory: packagePath), ct);
-            return new PackageCheckResponse(packageName, Models.SdkLanguage.Go, result);
+            // check for copyright headers
+            var powershellOptions = new PowershellOptions(
+                Path.Join(repoRoot, "eng", "scripts", "copyright-header-check.ps1"),
+                ["-Packages", packagePath]
+            );
+
+            var results = await powershellHelper.Run(powershellOptions, ct);
+            processResults.Add(result);
+
+            return new PackageCheckResponse(
+                packageName,
+                Models.SdkLanguage.Go,
+                processResults);
         }
         catch (Exception ex)
         {
@@ -169,8 +177,8 @@ public partial class GoLanguageService : LanguageService
     {
         try
         {
-            var packageName = await GetSDKPackageName(packagePath, ct);
-            var result = await processHelper.Run(new ProcessOptions(goUnix, ["build"], goWin, ["build"], workingDirectory: packagePath), ct);
+            var packageName = await GetGoModuleName(packagePath, ct);
+            var result = await processHelper.Run(new ProcessOptions(goUnix, goWin, ["build"], workingDirectory: packagePath), ct);
             return new PackageCheckResponse(packageName, Models.SdkLanguage.Go, result);
         }
         catch (Exception ex)
@@ -180,7 +188,12 @@ public partial class GoLanguageService : LanguageService
         }
     }
 
-    public static async Task<string> GetSDKPackageName(string packagePath, CancellationToken cancellationToken = default)
+    /// <summary>
+    /// Gets the full go module name for a package path, by reading go.mod
+    /// </summary>
+    /// <param name="packagePath">A full path to a package folder (eg: [gitroot]/sdk/messaging/azservicebus)</param>
+    /// <returns>The full go module name (ex: github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus)</returns>
+    public static async Task<string> GetGoModuleName(string packagePath, CancellationToken cancellationToken = default)
     {
         var text = await File.ReadAllTextAsync(Path.Join(packagePath, "go.mod"), cancellationToken);
 
@@ -194,6 +207,30 @@ public partial class GoLanguageService : LanguageService
         return m.Groups[1].Value;
     }
 
+
+    /// <summary>
+    /// Gets the sub path, for the package, that most SDK scripts expect for -PackageName.
+    /// </summary>
+    /// <param name="gitRepoPath">The full path to the git repository</param>
+    /// <param name="packagePath">The full path to the package</param>
+    /// <returns>The sub-path (ex: sdk/messaging/azservicebus)</returns>
+    public async Task<string> GetSubPath(string packagePath, CancellationToken cancellationToken = default)
+    {
+        var gitRepoPath = gitHelper.DiscoverRepoRoot(packagePath);
+
+        if (!gitRepoPath.EndsWith(Path.DirectorySeparatorChar))
+        {
+            gitRepoPath += Path.DirectorySeparatorChar;
+        }
+
+        // ex: sdk/messaging/azservicebus/
+        var relativePath = packagePath.Replace(gitRepoPath, "");
+        // Ensure forward slashes for Go package names and remove trailing slash
+        var packageName = relativePath.Replace(Path.DirectorySeparatorChar, '/');
+
+        return await Task.FromResult(packageName.TrimEnd('/'));
+    }
+
     public override async Task<PackageCheckResponse> UpdateSnippets(string packagePath, bool fixCheckErrors = false, CancellationToken cancellationToken = default)
     {
         return await Task.FromResult(new PackageCheckResponse());
@@ -201,15 +238,15 @@ public partial class GoLanguageService : LanguageService
 
     public override async Task<PackageCheckResponse> ValidateChangelog(string packagePath, bool fixCheckErrors = false, CancellationToken cancellationToken = default)
     {
-        var packageName = await GetSDKPackageName(packagePath, cancellationToken);
-        return await commonValidationHelpers.ValidateChangelog(packageName, packagePath, fixCheckErrors, cancellationToken);
+        var packageSubPath = await GetSubPath(packagePath, cancellationToken);
+        return await commonValidationHelpers.ValidateChangelog(packageSubPath, packagePath, fixCheckErrors, cancellationToken);
     }
 
     public override async Task<TestRunResponse> RunAllTests(string packagePath, CancellationToken ct = default)
     {
         try
         {
-            var result = await processHelper.Run(new ProcessOptions(goUnix, ["test", "-v", "-timeout", "1h", "./..."], goWin, ["test", "-v", "-timeout", "1h", "./..."], workingDirectory: packagePath), ct);
+            var result = await processHelper.Run(new ProcessOptions(goUnix, goWin, ["test", "-v", "-timeout", "1h", "./..."], workingDirectory: packagePath), ct);
             return new TestRunResponse(result);
         }
         catch (Exception ex)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/GoLanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/GoLanguageService.cs
@@ -14,12 +14,14 @@ public partial class GoLanguageService : LanguageService
 {
     public GoLanguageService(
         IProcessHelper processHelper,
+        IPowershellHelper powershellHelper,
         IGitHelper gitHelper,
         ILogger<LanguageService> logger,
         ICommonValidationHelpers commonValidationHelpers,
         IFileHelper fileHelper)
     {
         base.processHelper = processHelper;
+        this.powershellHelper = powershellHelper;
         base.gitHelper = gitHelper;
         base.logger = logger;
         base.commonValidationHelpers = commonValidationHelpers;
@@ -32,6 +34,7 @@ public partial class GoLanguageService : LanguageService
     private readonly string gofmtWin = "gofmt.exe";
     private readonly string golangciLintUnix = "golangci-lint";
     private readonly string golangciLintWin = "golangci-lint.exe";
+    private readonly IPowershellHelper powershellHelper;
 
     public override SdkLanguage Language { get; } = SdkLanguage.Go;
 
@@ -40,80 +43,69 @@ public partial class GoLanguageService : LanguageService
         var repoRoot = gitHelper.DiscoverRepoRoot(packagePath);
         var sdkRoot = Path.Combine(repoRoot, "sdk");
         var fullPath = RealPath.GetRealPath(packagePath);
+        var commonPS1 = Path.Join(repoRoot, "eng", "common", "scripts", "common.ps1");
+
+        // The powershell outputs this:
+        // {
+        //   "Name": "sdk/messaging/azservicebus",
+        //   "Version": "1.10.1-beta.1",
+        //   "DirectoryPath": "../sdk/messaging/azservicebus",
+        //   "ServiceDirectory": "messaging/azservicebus",
+        //   "ReadMePath": "../sdk/messaging/azservicebus/README.md",
+        //   "ChangeLogPath": "../sdk/messaging/azservicebus/CHANGELOG.md",
+        //   "SdkType": "client",
+        //   "IsNewSdk": true,
+        //   "ReleaseStatus": "Unreleased",
+        //   "IncludedForValidation": false,
+        //   "CIParameters": {
+        //     "CIMatrixConfigs": []
+        //   },
+        //   "VersionFile": "/home/ripark/src/az/sdk/messaging/azservicebus/internal/constants.go",
+        //   "ModuleName": "azservicebus"
+        // }
+        logger.LogDebug("Resolving Go package info for path: {packagePath}", packagePath);
+        string[] args = [$". {commonPS1}; Get-GoModuleProperties('{packagePath}') | ConvertTo-Json"];
+        var processResult = await processHelper.Run(new PowershellOptions(args, workingDirectory: repoRoot), ct);
+
+        if (processResult.ExitCode != 0)
+        {
+            throw new Exception($"Failed to extract package properties for {packagePath}: {processResult.Output}");
+        }
+
+        GoModulePropertiesPowershell goModuleProperties;
 
         try
         {
-            var commonPS1 = Path.Join(repoRoot, "eng", "common", "scripts", "common.ps1");
-
-            // The powershell outputs this:
-            // {
-            //   "Name": "sdk/messaging/azservicebus",
-            //   "Version": "1.10.1-beta.1",
-            //   "DirectoryPath": "../sdk/messaging/azservicebus",
-            //   "ServiceDirectory": "messaging/azservicebus",
-            //   "ReadMePath": "../sdk/messaging/azservicebus/README.md",
-            //   "ChangeLogPath": "../sdk/messaging/azservicebus/CHANGELOG.md",
-            //   "SdkType": "client",
-            //   "IsNewSdk": true,
-            //   "ReleaseStatus": "Unreleased",
-            //   "IncludedForValidation": false,
-            //   "CIParameters": {
-            //     "CIMatrixConfigs": []
-            //   },
-            //   "VersionFile": "/home/ripark/src/az/sdk/messaging/azservicebus/internal/constants.go",
-            //   "ModuleName": "azservicebus"
-            // }
-            logger.LogDebug("Resolving Go package info for path: {packagePath}", packagePath);
-            string[] args = [$". {commonPS1}; Get-GoModuleProperties('{packagePath}') | ConvertTo-Json"];
-            var processResult = await processHelper.Run(new PowershellOptions(args, workingDirectory: repoRoot), ct);
-
-            if (processResult.ExitCode != 0)
-            {
-                throw new Exception($"Failed to extract package properties for {packagePath}: {processResult.Output}");
-            }
-
-            var goModuleProperties = JsonSerializer.Deserialize<GoModulePropertiesPowershell>(processResult.Output)
-                ?? throw new Exception($"Failed to deserialize results from Get-GoModuleProperties");
-
-            var sdkType = goModuleProperties.SdkType switch
-            {
-                "mgmt" => SdkType.Management,
-                "client" => SdkType.Dataplane,
-                _ => SdkType.Unknown,
-            };
-
-            var model = new PackageInfo
-            {
-                PackagePath = fullPath,
-                RepoRoot = repoRoot,
-                RelativePath = Path.GetRelativePath(sdkRoot, fullPath).TrimStart(Path.DirectorySeparatorChar),
-                PackageName = goModuleProperties.Name,
-                PackageVersion = goModuleProperties.Version,
-                ServiceName = Path.GetFileName(Path.GetDirectoryName(fullPath)) ?? string.Empty,
-                SdkType = sdkType,
-                Language = SdkLanguage.Go,
-                SamplesDirectory = fullPath
-            };
-
-            logger.LogDebug("Resolved Go package: {packageName} v{packageVersion}", model.PackageName ?? "(unknown)", model.PackageVersion ?? "(unknown)");
-            return model;
+            goModuleProperties = JsonSerializer.Deserialize<GoModulePropertiesPowershell>(processResult.Stdout)
+                ?? throw new Exception($"Failed to deserialize results from Get-GoModuleProperties.");
         }
         catch (Exception ex)
         {
-            logger.LogDebug(ex, "Exception thrown when trying to get package properties for {Path}", packagePath);
-            return new PackageInfo()
-            {
-                PackagePath = fullPath,
-                RepoRoot = repoRoot,
-                RelativePath = Path.GetRelativePath(sdkRoot, fullPath).TrimStart(Path.DirectorySeparatorChar),
-                PackageName = null,
-                PackageVersion = null,
-                ServiceName = Path.GetFileName(Path.GetDirectoryName(fullPath)) ?? string.Empty,
-                SdkType = SdkType.Unknown,
-                Language = SdkLanguage.Go,
-                SamplesDirectory = fullPath
-            };
+            throw new Exception($"Failed to deserialized JSON output '{processResult.Stdout}'", ex);
         }
+
+        var sdkType = goModuleProperties.SdkType switch
+        {
+            "mgmt" => SdkType.Management,
+            "client" => SdkType.Dataplane,
+            _ => SdkType.Unknown,
+        };
+
+        var model = new PackageInfo
+        {
+            PackagePath = fullPath,
+            RepoRoot = repoRoot,
+            RelativePath = Path.GetRelativePath(sdkRoot, fullPath).TrimStart(Path.DirectorySeparatorChar),
+            PackageName = goModuleProperties.Name,
+            PackageVersion = goModuleProperties.Version,
+            ServiceName = Path.GetFileName(Path.GetDirectoryName(fullPath)) ?? string.Empty,
+            SdkType = sdkType,
+            Language = SdkLanguage.Go,
+            SamplesDirectory = fullPath
+        };
+
+        logger.LogDebug("Resolved Go package: {packageName} v{packageVersion}", model.PackageName ?? "(unknown)", model.PackageVersion ?? "(unknown)");
+        return model;
     }
 
     public override List<SetupRequirements.Requirement> GetRequirements(string packagePath, Dictionary<string, List<SetupRequirements.Requirement>> categories, CancellationToken ct = default)


### PR DESCRIPTION
- Fixing a bug in the Go changelog command that was passing the wrong value (path instead of module name!)
- Fixed an issue in GetPackageProperties() where we'd also try to parse stderr output, which is never a good idea.
- Added copyright header validation into the Lint() step.

Other small QoL stuff:
- Added a constructor to ProcessOptions that lets you use a win/unix command with the _same_ args, which is the common case for me.
- Added a "Stdout" property to ProcessResult which only extracts Stdout (unlike Output, which has both stderr and stdout)

Fixes #11399