### PR TITLE
Add concurrency control to GitHub Event Processor workflow

### DIFF
--- a/.github/workflows/event-processor.yml
+++ b/.github/workflows/event-processor.yml
@@ -16,6 +16,11 @@ on:
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
 permissions: {}
 
+# Ensure only one event processor runs at a time for a given PR/Issue to avoid duplicate processing
+concurrency:
+  group: event-processor-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   # This event requires the Azure CLI to get the LABEL_SERVICE_API_KEY from the vault.
   # Because the azure/login step adds time costly pre/post Az CLI commands to any every job


### PR DESCRIPTION
This change adds workflow-level concurrency control to the GitHub Event Processor workflow.

By grouping executions per issue or pull request and canceling in-progress runs, this prevents overlapping processing of the same resource, reduces duplicate comments and artifacts, and improves runner efficiency without altering existing behavior.
