### PR TITLE
Upgrade MCP library to 0.5.0

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Azure.Sdk.Tools.Cli.Evaluations.csproj
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Azure.Sdk.Tools.Cli.Evaluations.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.AI.Evaluation.Reporting" Version="9.9.0" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.9.1-preview.1.25474.6" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
-    <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.4" />
+    <PackageReference Include="ModelContextProtocol" Version="0.5.0-preview.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/ChatCompletion.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/ChatCompletion.cs
@@ -5,8 +5,8 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
 {
     public class ChatCompletion
     {
-        private IChatClient _chatClient;
-        private McpClient _mcpClient;
+        private readonly IChatClient _chatClient;
+        private readonly McpClient _mcpClient;
 
         public ChatCompletion(IChatClient chatClient, McpClient mcpClient)
         {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/ChatCompletion.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/ChatCompletion.cs
@@ -6,9 +6,9 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
     public class ChatCompletion
     {
         private IChatClient _chatClient;
-        private IMcpClient _mcpClient;
+        private McpClient _mcpClient;
 
-        public ChatCompletion(IChatClient chatClient, IMcpClient mcpClient)
+        public ChatCompletion(IChatClient chatClient, McpClient mcpClient)
         {
             _chatClient = chatClient;
             _mcpClient = mcpClient;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/TestSetup.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Helpers/TestSetup.cs
@@ -22,7 +22,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
         public static string? RepositoryName => Environment.GetEnvironmentVariable("REPOSITORY_NAME");
         
         public static string? CopilotInstructionsPath => Environment.GetEnvironmentVariable("COPILOT_INSTRUCTIONS_PATH_MCP_EVALS");
-        public static ChatCompletion GetChatCompletion(IChatClient chatClient, IMcpClient mcpClient) => new ChatCompletion(chatClient, mcpClient);
+        public static ChatCompletion GetChatCompletion(IChatClient chatClient, McpClient mcpClient) => new ChatCompletion(chatClient, mcpClient);
 
         public static TokenCredential GetCredential(ILogger? logger = null)
         {
@@ -46,7 +46,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
                 .Build();
         }
 
-        public static async Task<IMcpClient> GetMcpClientAsync(ILogger? logger = null)
+        public static async Task<McpClient> GetMcpClientAsync(ILogger? logger = null)
         {
             logger?.LogDebug("Starting MCP client creation...");
             logger?.LogDebug($"Command: dotnet run --project {relativePathToCli} -- start");
@@ -56,7 +56,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
                 if (UseMCPRelease)
                 {
                     // Use MCP release
-                    return await McpClientFactory.CreateAsync(
+                    return await McpClient.CreateAsync(
                         new StdioClientTransport(
                             new()
                             {
@@ -68,7 +68,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Helpers
                 }
                 
                 // Run your local MCP server directly with dotnet run
-                var mcpClient = await McpClientFactory.CreateAsync(
+                var mcpClient = await McpClient.CreateAsync(
                     new StdioClientTransport(
                         new()
                         {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenario.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenario.cs
@@ -15,7 +15,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
     {
         // Static services shared across all tests
         protected static IChatClient? s_chatClient;
-        protected static IMcpClient? s_mcpClient;
+        protected static McpClient? s_mcpClient;
         protected static ChatCompletion? s_chatCompletion;
         protected static IEnumerable<string>? s_toolNames;
         protected static ChatConfiguration? s_chatConfig;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
@@ -39,8 +39,8 @@
     <PackageReference Include="Azure.Identity" Version="1.14.2" />
     <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
     <PackageReference Include="Octokit" Version="14.0.0" />
-    <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.4" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.1.0-preview.11" />
+    <PackageReference Include="ModelContextProtocol" Version="0.5.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.5.0-preview.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.3" />

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Core/InstrumentedTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Core/InstrumentedTool.cs
@@ -9,16 +9,28 @@ using static Azure.Sdk.Tools.Cli.Telemetry.TelemetryConstants;
 
 namespace Azure.Sdk.Tools.Cli.Tools.Core;
 
-public class InstrumentedTool(
-    ITelemetryService telemetryService,
-    ILogger logger,
-    McpServerTool innerTool
-) : DelegatingMcpServerTool(innerTool)
+public class InstrumentedTool : DelegatingMcpServerTool
 {
+    private readonly ITelemetryService telemetryService;
+    private readonly ILogger logger;
+    private readonly McpServerTool innerTool;
     private readonly JsonSerializerOptions serializerOptions = new()
     {
         WriteIndented = false,
     };
+
+    public InstrumentedTool(
+        ITelemetryService telemetryService,
+        ILogger logger,
+        McpServerTool innerTool
+    ) : base(innerTool)
+    {
+        this.telemetryService = telemetryService;
+        this.logger = logger;
+        this.innerTool = innerTool;
+    }
+
+    public override IReadOnlyList<object> Metadata => innerTool.Metadata;
 
     public override async ValueTask<CallToolResult> InvokeAsync(RequestContext<CallToolRequestParams> request, CancellationToken ct = default)
     {


### PR DESCRIPTION
PR contains changes to upgrade MCP protocol lib and changes in instrumentation tool to support implementing Metadata getter (a requirement in new lib when inheriting delegate mcp tool class).