### PR TITLE
Auto documentation job after publishing package

### DIFF
--- a/tools/azsdk-cli/auto-documentation.yml
+++ b/tools/azsdk-cli/auto-documentation.yml
@@ -6,6 +6,7 @@ parameters:
 jobs:
   - job: UpdateMCPDocumentation
     displayName: 'Update MCP Tools Documentation'
+    dependsOn: PostPackagePublish
     pool:
       name: $(LINUXPOOL)
       image: $(LINUXVMIMAGE)


### PR DESCRIPTION
- Added a depends on `PostPackagePublish` for the auto documentation job so that it installs the correct version of the azsdk cli.
- Should also resolve the empty PR title since it happens after the increment package PR is created.
- Resolves #13472 