### PR TITLE
[azsdkcli] case insensitivity in Scanpath

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugs Fixed
 
+- Fixed case insensitivity with ward ScanPaths in package validation readme tool
+
 ### Other Changes
 
 ## 0.5.11 (2026-01-05)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CommonLanguageHelpers.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CommonLanguageHelpers.cs
@@ -116,9 +116,9 @@ public class CommonValidationHelpers : ICommonValidationHelpers
 
             if (processResult.ExitCode != 0)
             {
-                _logger.LogWarning("Readme validation failed. Exit Code: {ExitCode}, Output: {Output}, Error: {Error}",
-                    processResult.ExitCode, processResult.Output, processResult.Error);
-                return new PackageCheckResponse(processResult.ExitCode, processResult.Output, processResult.Error);
+                _logger.LogWarning("Changelog validation failed. Exit Code: {ExitCode}, Output: {Output}",
+                    processResult.ExitCode, processResult.Output);
+                return new PackageCheckResponse(processResult.ExitCode, "", processResult.Output);
             }
 
             return new PackageCheckResponse(processResult);
@@ -177,9 +177,9 @@ public class CommonValidationHelpers : ICommonValidationHelpers
 
             if (processResult.ExitCode != 0)
             {
-                _logger.LogWarning("Readme validation failed. Exit Code: {ExitCode}, Output: {Output}, Error: {Error}",
-                    processResult.ExitCode, processResult.Output, processResult.Error);
-                return new PackageCheckResponse(processResult.ExitCode, processResult.Output, processResult.Error);
+                _logger.LogWarning("Readme validation failed. Exit Code: {ExitCode}, Output: {Output}",
+                    processResult.ExitCode, processResult.Output);
+                return new PackageCheckResponse(processResult.ExitCode, "", processResult.Output);
             }
 
             return new PackageCheckResponse(processResult);
@@ -242,9 +242,9 @@ public class CommonValidationHelpers : ICommonValidationHelpers
 
             if (processResult.ExitCode != 0)
             {
-                _logger.LogWarning("Spelling check failed. Exit Code: {ExitCode}, Output: {Output}, Error: {Error}",
-                    processResult.ExitCode, processResult.Output, processResult.Error);
-                return new PackageCheckResponse(processResult.ExitCode, processResult.Output, processResult.Error);
+                _logger.LogWarning("Spelling check failed. Exit Code: {ExitCode}, Output: {Output}",
+                    processResult.ExitCode, processResult.Output);
+                return new PackageCheckResponse(processResult.ExitCode, "", processResult.Output);
             }
 
             return new PackageCheckResponse(processResult);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CommonLanguageHelpers.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CommonLanguageHelpers.cs
@@ -118,7 +118,7 @@ public class CommonValidationHelpers : ICommonValidationHelpers
             {
                 _logger.LogWarning("Changelog validation failed. Exit Code: {ExitCode}, Output: {Output}",
                     processResult.ExitCode, processResult.Output);
-                return new PackageCheckResponse(processResult.ExitCode, "", processResult.Output);
+                return new PackageCheckResponse(processResult.ExitCode, processResult.Output, "Changelog validation failed.");
             }
 
             return new PackageCheckResponse(processResult);
@@ -179,7 +179,7 @@ public class CommonValidationHelpers : ICommonValidationHelpers
             {
                 _logger.LogWarning("Readme validation failed. Exit Code: {ExitCode}, Output: {Output}",
                     processResult.ExitCode, processResult.Output);
-                return new PackageCheckResponse(processResult.ExitCode, "", processResult.Output);
+                return new PackageCheckResponse(processResult.ExitCode, processResult.Output, "Readme validation failed.");
             }
 
             return new PackageCheckResponse(processResult);
@@ -244,7 +244,7 @@ public class CommonValidationHelpers : ICommonValidationHelpers
             {
                 _logger.LogWarning("Spelling check failed. Exit Code: {ExitCode}, Output: {Output}",
                     processResult.ExitCode, processResult.Output);
-                return new PackageCheckResponse(processResult.ExitCode, "", processResult.Output);
+                return new PackageCheckResponse(processResult.ExitCode, processResult.Output, "Spelling check failed.");
             }
 
             return new PackageCheckResponse(processResult);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CommonLanguageHelpers.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CommonLanguageHelpers.cs
@@ -150,11 +150,19 @@ public class CommonValidationHelpers : ICommonValidationHelpers
                 return new PackageCheckResponse(1, "", $"Doc settings file not found at expected location: {settingsPath}");
             }
 
+            // Normalize both package path for Scan Paths
+            var normalizedPackagePath = Path.GetFullPath(packagePath);
+            // Ensure drive letter is uppercase on Windows for consistency
+            if (Path.IsPathRooted(normalizedPackagePath) && normalizedPackagePath.Length >= 2 && normalizedPackagePath[1] == ':')
+            {
+                normalizedPackagePath = char.ToUpperInvariant(normalizedPackagePath[0]) + normalizedPackagePath.Substring(1);
+            }
+            
             var command = "pwsh";
             var args = new[] {
                 "-File", scriptPath,
                 "-SettingsPath", settingsPath,
-                "-ScanPaths", packagePath,
+                "-ScanPaths", normalizedPackagePath,
             };
 
             var timeout = TimeSpan.FromMinutes(10);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CommonLanguageHelpers.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CommonLanguageHelpers.cs
@@ -153,9 +153,7 @@ public class CommonValidationHelpers : ICommonValidationHelpers
             // TODO: investigate doc-warden code, this normalizes package path for Scan Paths
             var normalizedPackagePath = Path.GetFullPath(packagePath);
             // Ensure drive letter is uppercase on Windows for consistency
-            if (OperatingSystem.IsWindows() && 
-                Path.IsPathRooted(normalizedPackagePath) && 
-                normalizedPackagePath.Length >= 2)
+            if (OperatingSystem.IsWindows() && normalizedPackagePath.Length >= 2)
             {
                 normalizedPackagePath = char.ToUpperInvariant(normalizedPackagePath[0]) + normalizedPackagePath.Substring(1);
             }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CommonLanguageHelpers.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CommonLanguageHelpers.cs
@@ -150,9 +150,9 @@ public class CommonValidationHelpers : ICommonValidationHelpers
                 return new PackageCheckResponse(1, "", $"Doc settings file not found at expected location: {settingsPath}");
             }
 
-            // Normalize both package path for Scan Paths
+            // Normalize package path for Scan Paths
             var normalizedPackagePath = Path.GetFullPath(packagePath);
-            // Ensure drive letter is uppercase on Windows for consistency
+            // Ensure drive letter is uppercase on Windows
             if (Path.IsPathRooted(normalizedPackagePath) && normalizedPackagePath.Length >= 2 && normalizedPackagePath[1] == ':')
             {
                 normalizedPackagePath = char.ToUpperInvariant(normalizedPackagePath[0]) + normalizedPackagePath.Substring(1);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CommonLanguageHelpers.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CommonLanguageHelpers.cs
@@ -114,6 +114,13 @@ public class CommonValidationHelpers : ICommonValidationHelpers
             var timeout = TimeSpan.FromMinutes(5);
             var processResult = await _processHelper.Run(new(command, args, timeout: timeout, workingDirectory: packagePath), ct);
 
+            if (processResult.ExitCode != 0)
+            {
+                _logger.LogWarning("Readme validation failed. Exit Code: {ExitCode}, Output: {Output}, Error: {Error}",
+                    processResult.ExitCode, processResult.Output, processResult.Error);
+                return new PackageCheckResponse(processResult.ExitCode, processResult.Output, processResult.Error);
+            }
+
             return new PackageCheckResponse(processResult);
         }
         catch (Exception ex)
@@ -167,6 +174,13 @@ public class CommonValidationHelpers : ICommonValidationHelpers
 
             var timeout = TimeSpan.FromMinutes(10);
             var processResult = await _processHelper.Run(new(command, args, timeout: timeout, workingDirectory: packagePath), ct);
+
+            if (processResult.ExitCode != 0)
+            {
+                _logger.LogWarning("Readme validation failed. Exit Code: {ExitCode}, Output: {Output}, Error: {Error}",
+                    processResult.ExitCode, processResult.Output, processResult.Error);
+                return new PackageCheckResponse(processResult.ExitCode, processResult.Output, processResult.Error);
+            }
 
             return new PackageCheckResponse(processResult);
         }
@@ -224,6 +238,13 @@ public class CommonValidationHelpers : ICommonValidationHelpers
                     _logger.LogError(ex, "Error running spelling fix microagent");
                     return new PackageCheckResponse(processResult.ExitCode, processResult.Output, ex.Message);
                 }
+            }
+
+            if (processResult.ExitCode != 0)
+            {
+                _logger.LogWarning("Spelling check failed. Exit Code: {ExitCode}, Output: {Output}, Error: {Error}",
+                    processResult.ExitCode, processResult.Output, processResult.Error);
+                return new PackageCheckResponse(processResult.ExitCode, processResult.Output, processResult.Error);
             }
 
             return new PackageCheckResponse(processResult);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CommonLanguageHelpers.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CommonLanguageHelpers.cs
@@ -150,10 +150,12 @@ public class CommonValidationHelpers : ICommonValidationHelpers
                 return new PackageCheckResponse(1, "", $"Doc settings file not found at expected location: {settingsPath}");
             }
 
-            // Normalize package path for Scan Paths
+            // TODO: investigate doc-warden code, this normalizes package path for Scan Paths
             var normalizedPackagePath = Path.GetFullPath(packagePath);
-            // Ensure drive letter is uppercase on Windows
-            if (Path.IsPathRooted(normalizedPackagePath) && normalizedPackagePath.Length >= 2 && normalizedPackagePath[1] == ':')
+            // Ensure drive letter is uppercase on Windows for consistency
+            if (OperatingSystem.IsWindows() && 
+                Path.IsPathRooted(normalizedPackagePath) && 
+                normalizedPackagePath.Length >= 2)
             {
                 normalizedPackagePath = char.ToUpperInvariant(normalizedPackagePath[0]) + normalizedPackagePath.Substring(1);
             }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/GitHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/GitHelper.cs
@@ -179,8 +179,11 @@ namespace Azure.Sdk.Tools.Cli.Helpers
         /// <exception cref="InvalidOperationException">Thrown when no git repository is found at or above the specified path</exception>
         public string DiscoverRepoRoot(string pathInRepo)
         {
+            // Normalize the path to handle case insensitivity on Windows (e.g., "C:\" vs "c:\")
+            var normalizedPath = Path.GetFullPath(pathInRepo);
+            
             // Discover the repo root for this path
-            var repoPath = Repository.Discover(pathInRepo);
+            var repoPath = Repository.Discover(normalizedPath);
             if (string.IsNullOrEmpty(repoPath))
             {
                 throw new InvalidOperationException($"No git repository found at or above the path: {pathInRepo}");

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/GitHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/GitHelper.cs
@@ -179,11 +179,8 @@ namespace Azure.Sdk.Tools.Cli.Helpers
         /// <exception cref="InvalidOperationException">Thrown when no git repository is found at or above the specified path</exception>
         public string DiscoverRepoRoot(string pathInRepo)
         {
-            // Normalize the path to handle case insensitivity on Windows (e.g., "C:\" vs "c:\")
-            var normalizedPath = Path.GetFullPath(pathInRepo);
-            
             // Discover the repo root for this path
-            var repoPath = Repository.Discover(normalizedPath);
+            var repoPath = Repository.Discover(pathInRepo);
             if (string.IsNullOrEmpty(repoPath))
             {
                 throw new InvalidOperationException($"No git repository found at or above the path: {pathInRepo}");


### PR DESCRIPTION
Copilot for in some cases was passing paths with "c:\", which was then causing failures with ScanPath in readme validation --
open to suggestions on resolution here

doc-warden scanPaths are having issues with case insensitivity for some reason -> will investigate fixing there but this resolves #13426 for now