### PR TITLE
Updated telemetry data for the generation tool

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Improved error message when GitHub authentication fails to include GitHub CLI installation and authentication instructions
+- Added TypeSpecProject to the telemetry data for the `azsdk_package_generate_code` tool
 
 ### Breaking Changes
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageOperationResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageOperationResponse.cs
@@ -75,8 +75,9 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses.Package
         /// <param name="packageInfo">Optional package information to include in the response.</param>
         /// <param name="nextSteps">Optional next steps to include in the response. If null, standard failure next steps will be used.</param>
         /// <param name="sdkRepoName">Optional SDK repository name to include in the response.</param>
+        /// <param name="typespecProjectPath">Optional TypeSpec project path to include in the response.</param>
         /// <returns>A PackageOperationResponse indicating failure.</returns>
-        public static PackageOperationResponse CreateFailure(string message, PackageInfo? packageInfo = null, string[]? nextSteps = null, string? sdkRepoName = null)
+        public static PackageOperationResponse CreateFailure(string message, PackageInfo? packageInfo = null, string[]? nextSteps = null, string? sdkRepoName = null, string? typespecProjectPath = null)
         {
             return new PackageOperationResponse
             {
@@ -86,7 +87,8 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses.Package
                 PackageType = packageInfo?.SdkType ?? SdkType.Unknown,
                 Result = "failed",
                 NextSteps = nextSteps?.ToList() ?? StandardFailureNextSteps.ToList(),
-                SdkRepoName = sdkRepoName ?? string.Empty
+                SdkRepoName = sdkRepoName ?? string.Empty,
+                TypeSpecProject = typespecProjectPath ?? string.Empty
             };
         }
 
@@ -98,8 +100,9 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses.Package
         /// <param name="nextSteps">Optional next steps to include in the response.</param>
         /// <param name="result">Optional result status to include in the response.</param>
         /// <param name="sdkRepoName">Optional SDK repository name to include in the response.</param>
+        /// <param name="typespecProjectPath">Optional TypeSpec project path to include in the response.</param>
         /// <returns>A PackageOperationResponse indicating success.</returns>
-        public static PackageOperationResponse CreateSuccess(string message, PackageInfo? packageInfo = null, string[]? nextSteps = null, string? result = "succeeded", string? sdkRepoName = null)
+        public static PackageOperationResponse CreateSuccess(string message, PackageInfo? packageInfo = null, string[]? nextSteps = null, string? result = "succeeded", string? sdkRepoName = null, string? typespecProjectPath = null)
         {
             return new PackageOperationResponse
             {
@@ -110,7 +113,8 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses.Package
                 Language = packageInfo?.Language ?? SdkLanguage.Unknown,
                 PackageType = packageInfo?.SdkType ?? SdkType.Unknown,
                 NextSteps = nextSteps?.ToList() ?? [],
-                SdkRepoName = sdkRepoName ?? string.Empty
+                SdkRepoName = sdkRepoName ?? string.Empty,
+                TypeSpecProject = typespecProjectPath ?? string.Empty
             };
         }
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkGenerationTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkGenerationTool.cs
@@ -100,18 +100,22 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
                     string sdkRepoName = gitHelper.GetRepoName(tspLocationPath);
                     logger.LogInformation("SDK Repository Name: {SdkRepoName}", sdkRepoName);
                     
+                    string typeSpecProjectPath = GetTypeSpecProjectPathFromTspLocation(tspLocationPath);
+                    logger.LogInformation("TypeSpec Project Path from tsp-location.yaml: {TypeSpecProjectPath}", typeSpecProjectPath);
+
                     // Run tsp-client update using the existing tsp-location.yaml
                     var tspResult = await tspClientHelper.UpdateGenerationAsync(tspLocationPath, tspLocationDirectory, ct: ct);
                     
                     if (!tspResult.IsSuccessful)
                     {
-                        return PackageOperationResponse.CreateFailure(tspResult.ResponseError, sdkRepoName: sdkRepoName);
+                        return PackageOperationResponse.CreateFailure(tspResult.ResponseError, sdkRepoName: sdkRepoName, typespecProjectPath: typeSpecProjectPath);
                     }
                     
                     return PackageOperationResponse.CreateSuccess(
                         $"SDK re-generation completed successfully using tsp-location.yaml.",
                         nextSteps: ["If the SDK is not Python, build the code"],
-                        sdkRepoName: sdkRepoName
+                        sdkRepoName: sdkRepoName,
+                        typespecProjectPath: typeSpecProjectPath
                     );
                 }
 
@@ -132,19 +136,20 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
 
             // white spaces will be added by agent when it's a URL
             tspConfigPath = tspConfigPath.Trim();
+            string typespecProjectPath = GetTypeSpecProjectRelativePath(tspConfigPath);
 
             // Validate inputs
             logger.LogInformation("Generating SDK at repo: {LocalSdkRepoPath}", localSdkRepoPath);
             if (string.IsNullOrEmpty(localSdkRepoPath) || !Directory.Exists(localSdkRepoPath))
             {
-                return PackageOperationResponse.CreateFailure($"The directory for the local sdk repo does not provide or exist at the specified path: {localSdkRepoPath}. Prompt user to clone the matched SDK repository users want to generate SDK against.");
+                return PackageOperationResponse.CreateFailure($"The directory for the local sdk repo does not provide or exist at the specified path: {localSdkRepoPath}. Prompt user to clone the matched SDK repository users want to generate SDK against.", typespecProjectPath: typespecProjectPath);
             }
 
             // Get the generate script path
             string sdkRepoRoot = gitHelper.DiscoverRepoRoot(localSdkRepoPath);
             if (string.IsNullOrEmpty(sdkRepoRoot))
             {
-                return PackageOperationResponse.CreateFailure($"Failed to discover local sdk repo with path: {localSdkRepoPath}.");
+                return PackageOperationResponse.CreateFailure($"Failed to discover local sdk repo with path: {localSdkRepoPath}.", typespecProjectPath: typespecProjectPath);
             }
 
             string sdkRepoName = gitHelper.GetRepoName(sdkRepoRoot);
@@ -153,7 +158,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
                 // Validate arguments for local tspconfig.yaml case
                 if (!File.Exists(tspConfigPath))
                 {
-                    return PackageOperationResponse.CreateFailure($"The 'tspconfig.yaml' file does not exist at the specified path: {tspConfigPath}. Prompt user to clone the azure-rest-api-specs repository locally if it does not have a local copy.", sdkRepoName: sdkRepoName);
+                    return PackageOperationResponse.CreateFailure($"The 'tspconfig.yaml' file does not exist at the specified path: {tspConfigPath}. Prompt user to clone the azure-rest-api-specs repository locally if it does not have a local copy.", sdkRepoName: sdkRepoName, typespecProjectPath: typespecProjectPath);
                 }
                 specRepoFullName = await gitHelper.GetRepoFullNameAsync(tspConfigPath, findUpstreamParent: false);
             }
@@ -163,7 +168,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
                 logger.LogInformation("Remote 'tspconfig.yaml' URL detected: {TspConfigPath}.", tspConfigPath);
                 if (!IsValidRemoteGitHubUrlWithCommit(tspConfigPath))
                 {
-                    return PackageOperationResponse.CreateFailure($"Invalid remote GitHub URL with commit: {tspConfigPath}. The URL must include a valid commit SHA. Example: https://github.com/Azure/azure-rest-api-specs/blob/dee71463cbde1d416c47cf544e34f7966a94ddcb/specification/contosowidgetmanager/Contoso.Management/tspconfig.yaml", sdkRepoName: sdkRepoName);
+                    return PackageOperationResponse.CreateFailure($"Invalid remote GitHub URL with commit: {tspConfigPath}. The URL must include a valid commit SHA. Example: https://github.com/Azure/azure-rest-api-specs/blob/dee71463cbde1d416c47cf544e34f7966a94ddcb/specification/contosowidgetmanager/Contoso.Management/tspconfig.yaml", sdkRepoName: sdkRepoName, typespecProjectPath: typespecProjectPath);
                 }
             }
 
@@ -191,13 +196,14 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
 
             if (!tspResult.IsSuccessful)
             {
-                return PackageOperationResponse.CreateFailure(tspResult.ResponseError, sdkRepoName: sdkRepoName);
+                return PackageOperationResponse.CreateFailure(tspResult.ResponseError, sdkRepoName: sdkRepoName, typespecProjectPath: typespecProjectPath);
             }
 
             return PackageOperationResponse.CreateSuccess(
                 $"SDK generation completed successfully using tspconfig.yaml.",
                 nextSteps: ["If the SDK is not Python, build the code"],
-                sdkRepoName: sdkRepoName
+                sdkRepoName: sdkRepoName,
+                typespecProjectPath: typespecProjectPath
             );
         }
 
@@ -236,6 +242,62 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
             }
 
             return false;
+        }
+
+        // Get the TypeSpec project relative path from tspConfigPath (local path or remote URL)
+        // Returns the path starting from "specification/..." or empty string if not found
+        private string GetTypeSpecProjectRelativePath(string tspConfigPath)
+        {
+            if (string.IsNullOrEmpty(tspConfigPath))
+            {
+                return string.Empty;
+            }
+
+            // Normalize path separators for cross-platform compatibility
+            var normalizedPath = tspConfigPath.Replace("\\", "/");
+
+            // Case-insensitive search for "specification" to handle different OS conventions
+            int specIndex = normalizedPath.IndexOf("specification", StringComparison.OrdinalIgnoreCase);
+            if (specIndex < 0)
+            {
+                return string.Empty;
+            }
+
+            var relativePath = normalizedPath[specIndex..];
+
+            // Remove tspconfig.yaml filename if present to get the project directory path
+            if (relativePath.EndsWith("/tspconfig.yaml", StringComparison.OrdinalIgnoreCase))
+            {
+                relativePath = relativePath[..^"/tspconfig.yaml".Length];
+            }
+
+            return relativePath;
+        }
+
+        // Get the 'directory' value from a tsp-location.yaml file
+        // Returns the directory path or empty string if not found
+        private string GetTypeSpecProjectPathFromTspLocation(string tspLocationPath)
+        {
+            try
+            {
+                var lines = File.ReadAllLines(tspLocationPath);
+                foreach (var line in lines)
+                {
+                    var trimmedLine = line.Trim();
+                    if (trimmedLine.StartsWith("directory:", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // Extract the value after "directory:"
+                        var value = trimmedLine["directory:".Length..].Trim();
+                        return value;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to read tsp-location.yaml file: {TspLocationPath}", tspLocationPath);
+            }
+
+            return string.Empty;
         }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkGenerationTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkGenerationTool.cs
@@ -284,10 +284,17 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
                 foreach (var line in lines)
                 {
                     var trimmedLine = line.Trim();
+                    
+                    // Skip empty lines and comments
+                    if (string.IsNullOrEmpty(trimmedLine) || trimmedLine.StartsWith('#'))
+                    {
+                        continue;
+                    }
+                    
                     if (trimmedLine.StartsWith("directory:", StringComparison.OrdinalIgnoreCase))
                     {
-                        // Extract the value after "directory:"
-                        var value = trimmedLine["directory:".Length..].Trim();
+                        // Extract the value after "directory:" and trim quotes if present
+                        var value = trimmedLine["directory:".Length..].Trim().Trim('"', '\'');
                         return value;
                     }
                 }


### PR DESCRIPTION
Resolved https://github.com/Azure/azure-sdk-tools/issues/13186

**Key Changes**:
- set `TypeSpecProject` for the generation tool in both scenarios using either the `tspconfig.yaml` or the `tsp-location.yaml`


**Test Screenshots**:
- using local `tspconfig.yaml`

<img width="880" height="749" alt="image" src="https://github.com/user-attachments/assets/d3dba4bb-7cf8-4ca1-9709-1f55ba36bb53" />

- using remote `tspconfig.yaml`

<img width="880" height="584" alt="image" src="https://github.com/user-attachments/assets/7112c6ec-9c5d-4fa8-b6d8-813bd1933212" />


- using `tsp-location.yaml`

<img width="824" height="790" alt="image" src="https://github.com/user-attachments/assets/12b6e818-793d-4869-a451-1439008ad1ce" />
