### PR TITLE
examples-automation, run samples publish on js

### DIFF
--- a/tools/azure-rest-api-specs-examples-automation/js/main.py
+++ b/tools/azure-rest-api-specs-examples-automation/js/main.py
@@ -11,6 +11,7 @@ from typing import List
 from enum import Enum
 import importlib.util
 
+from tools import publish_samples
 from models import JsExample, JsLintResult
 from lint import JsLint
 
@@ -381,6 +382,10 @@ def main():
     sample_version = get_sample_version(release.version)
 
     module_relative_path_local = get_module_relative_path(sdk_name, package_type, sdk_path)
+
+    # call "npx dev-tool samples publish"
+    publish_samples(sdk_path, module_relative_path_local)
+
     js_examples_relative_path = path.join(module_relative_path_local, "samples", sample_version, "javascript")
     js_examples_path = path.join(sdk_path, js_examples_relative_path)
 

--- a/tools/azure-rest-api-specs-examples-automation/js/tools.py
+++ b/tools/azure-rest-api-specs-examples-automation/js/tools.py
@@ -1,0 +1,24 @@
+import os
+import platform
+import subprocess
+import logging
+from typing import List
+
+
+OS_WINDOWS = platform.system().lower() == "windows"
+
+
+def check_call(cmd: List[str], work_dir: str):
+    logging.info("Command line: " + " ".join(cmd))
+    subprocess.check_call(cmd, cwd=work_dir)
+
+
+def publish_samples(sdk_path: str, module_relative_path: str):
+    pnpm_cmd = "pnpm" + (".cmd" if OS_WINDOWS else "")
+    npx_cmd = "npx" + (".cmd" if OS_WINDOWS else "")
+
+    cmd = [pnpm_cmd, "install"]
+    check_call(cmd, sdk_path)
+
+    cmd = [npx_cmd, "dev-tool", "samples", "publish"]
+    check_call(cmd, os.path.join(sdk_path, module_relative_path))

--- a/tools/azure-rest-api-specs-examples-automation/js/tools_test.py
+++ b/tools/azure-rest-api-specs-examples-automation/js/tools_test.py
@@ -1,0 +1,13 @@
+import unittest
+
+from tools import publish_samples
+
+
+class TestTools(unittest.TestCase):
+
+    @unittest.skip("require a local clone of https://github.com/Azure/azure-sdk-for-js")
+    def test_publish_samples(self):
+        sdk_path = "c:/github/azure-sdk-for-js"
+        module_relative_path = "sdk/advisor/arm-advisor"
+
+        publish_samples(sdk_path, module_relative_path)


### PR DESCRIPTION
link https://github.com/Azure/azure-sdk-for-js/issues/36757#issuecomment-3600264034

For JS, automation will call `pnpm install` then `npx dev-tool samples publish` to generate the JS samples in runtime.