### PR TITLE
Update SDK generation as completed when SDK pull request is linked 

### DIFF
--- a/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
+++ b/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
@@ -1161,6 +1161,7 @@ function Update-PullRequestInReleasePlan($releasePlanWorkItemId, $pullRequestUrl
         $fields += "`"SDKPullRequestFor$($devopsFieldLanguage)=$pullRequestUrl`""
     }
     $fields += "`"SDKPullRequestStatusFor$($devopsFieldLanguage)=$status`""
+    $fields += "`"GenerationStatusFor$($devopsFieldLanguage)=Completed`""
 
     Write-Host "Updating release plan [$releasePlanWorkItemId] with pull request details for language [$languageName]."
     $workItem = UpdateWorkItem -id $releasePlanWorkItemId -fields $fields


### PR DESCRIPTION
Mark SDK generation task as completed in release plan work item. Release planner uses this status to identify whether pull request link has latest generated SDK or stale data(This happens when SDK generation is rerunning).

Release planner and MCP tool marks SDK generation as in progress in the work item and SDK generation pipeline will mark task as completed.