### PR TITLE
Update VerifySetup Requirements for Go

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Configuration/RequirementsV1.json
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Configuration/RequirementsV1.json
@@ -74,7 +74,7 @@
             {
                 "requirement": "go",
                 "check": ["go", "version"],
-                "instructions": ["Download and install the latest Go version of the compiler on https://go.dev/dl/"]
+                "instructions": ["Download and install the latest Go version of the compiler on https://go.dev/dl/", "If using Ubuntu, run `sudo snap install go`"]
             },
             {
                 "requirement": "goimports",
@@ -87,7 +87,7 @@
                 "instructions": ["https://golangci-lint.run/docs/welcome/install/"]
             },
             {
-                "requirement": "generator",
+                "requirement": "generator >= 0.4.3",
                 "check": ["generator", "--help"],
                 "instructions": ["go install github.com/Azure/azure-sdk-for-go/eng/tools/generator@latest"]
             }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Configuration/RequirementsV1.json
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Configuration/RequirementsV1.json
@@ -88,7 +88,7 @@
             },
             {
                 "requirement": "generator >= 0.4.3",
-                "check": ["generator", "--help"],
+                "check": ["generator", "-v"],
                 "instructions": ["go install github.com/Azure/azure-sdk-for-go/eng/tools/generator@latest"]
             }
         ],


### PR DESCRIPTION
Suggest installing Go with `sudo snap` on Ubuntu - related to https://github.com/orgs/Azure/projects/865/views/21?pane=issue&itemId=140099805&issue=Azure%7Cazure-sdk-tools%7C12978 but note doesn't resolve WSL specific issues where the MCP server lacks some PATH information to detect the additional tools like generator or goimports

Closes https://github.com/Azure/azure-sdk-tools/issues/13238 by adding a minimum version check for go generator

<img width="620" height="241" alt="image" src="https://github.com/user-attachments/assets/be12285a-3a04-4dff-92a8-100a699e427c" />

<img width="705" height="538" alt="image" src="https://github.com/user-attachments/assets/f773d108-33f2-4d1e-b8e1-b5eb7b6fb138" />
