### PR TITLE
[azsdk-cli] Remove unit test warning noise

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/FileHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/FileHelperTests.cs
@@ -19,9 +19,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Helpers
         public void SetUp()
         {
             _tempDir = TempDirectory.Create("FileHelperTests");
-            
-            var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
-            _logger = loggerFactory.CreateLogger<FileHelper>();
+
+            _logger = new TestLogger<FileHelper>();
             _fileHelper = new FileHelper(_logger);
         }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Generators/SampleGeneratorToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Generators/SampleGeneratorToolTests.cs
@@ -530,17 +530,16 @@ public class SampleGeneratorToolTests
     }
 
     [Test]
-    public async Task GenerateSamples_MissingPromptOption_ShowsError()
+    public void GenerateSamples_MissingPromptOption_ShowsError()
     {
         // Arrange: create a valid package path but omit --prompt (required)
         var (_, packagePath) = CreateFakeGoPackage();
         var command = tool.GetCommandInstances().First();
 
-        // Act: invoke without required --prompt
+        // Act: parse without required --prompt
         var parseResult = command.Parse(["generate", "--package-path", packagePath]);
-        int exitCode = await parseResult.InvokeAsync();
 
         // Assert: parser/tool should fail with non-zero exit code
-        Assert.That(exitCode, Is.Not.EqualTo(0), "Expected non-zero exit code when required --prompt option is missing");
+        Assert.That(parseResult.Errors, Is.Not.Empty, "Expected parse errors when required --prompt option is missing");
     }
 }


### PR DESCRIPTION
A couple unit tests that verified expected failures were dumping out misleading log warnings to the test output. This removes those for a cleaner test report.

>   Azure.Sdk.Tools.Cli.Tests test succeeded with 2 warning(s) (4.9s)
    /home/ben/.dotnet/sdk/9.0.306/Microsoft.TestPlatform.targets(48,5): warning :
      warn: Azure.Sdk.Tools.Cli.Helpers.FileHelper[0]
            Failed to load file missing.cs: Could not find file '/tmp/FileHelperTests_bbb9d54747224860814cc16083f1b183/missing.cs'.
>
>    /home/ben/.dotnet/sdk/9.0.306/Microsoft.TestPlatform.targets(48,5): warning : Option '--prompt' is required.