### PR TITLE
[APIView] Fix: Show decorators in Changed types only diff view when related method has changes

### DIFF
--- a/src/dotnet/APIView/ClientSPA/src/app/_workers/apitree-builder.worker.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_workers/apitree-builder.worker.ts
@@ -88,7 +88,7 @@ function buildCodePanelRows(nodeIdHashed: string, navigationTree: NavigationTree
   if (node.relatedNodeIdHash && !node.isNodeWithDiff && !node.isNodeWithDiffInDescendants && apiTreeBuilderData?.diffStyle == TREE_DIFF_STYLE)
   {
     let relatedNode = codePanelData?.nodeMetaData[node.relatedNodeIdHash]!;
-    if (!relatedNode.isNodeWithDiff && !node.isNodeWithDiffInDescendants && !visibleNodes.has(node.relatedNodeIdHash))
+    if (!relatedNode.isNodeWithDiff && !relatedNode.isNodeWithDiffInDescendants && !visibleNodes.has(node.relatedNodeIdHash))
     {
       return;
     }


### PR DESCRIPTION
fixes: https://github.com/Azure/azure-sdk-tools/issues/12272

In "Changed types only" diff view, decorators like `@overload` were not appearing even when their associated method had changes in descendants (e.g., parameter modifications). This caused confusion as users thought decorators were missing from the diff.

Changed the condition in apitree-builder.worker.ts to check relatedNode.isNodeWithDiffInDescendants so that decorators appear when their related method (or its children) have changes.

## UI
<img width="2058" height="1015" alt="image" src="https://github.com/user-attachments/assets/73d29cfa-8c4b-4aac-b256-c7c3a4fd6f67" />
