### PR TITLE
`test-proxy` is invoked with `DOTNET_ROOT` set

### DIFF
--- a/eng/common/testproxy/test-proxy-standalone-tool.yml
+++ b/eng/common/testproxy/test-proxy-standalone-tool.yml
@@ -74,6 +74,9 @@ steps:
 
     # nohup does NOT continue beyond the current session if you use it within powershell
     - bash: |
+        if [[ "$(uname)" == "Darwin" ]]; then
+          export DOTNET_ROOT="$HOME/.dotnet"
+        fi
         echo "nohup $(PROXY_EXE) 1>${{ parameters.rootFolder }}/test-proxy.log 2>${{ parameters.rootFolder }}/test-proxy-error.log &"
         nohup $(PROXY_EXE) 1>${{ parameters.rootFolder }}/test-proxy.log 2>${{ parameters.rootFolder }}/test-proxy-error.log &
 
@@ -86,7 +89,6 @@ steps:
       workingDirectory: "${{ parameters.rootFolder }}"
       env:
         DOTNET_ROLL_FORWARD: 'Major'
-        DOTNET_ROOT: $(HOME)/.dotnet
 
     - pwsh: |
         for ($i = 0; $i -lt 10; $i++) {

--- a/eng/common/testproxy/test-proxy-tool.yml
+++ b/eng/common/testproxy/test-proxy-tool.yml
@@ -87,6 +87,9 @@ steps:
 
     # nohup does NOT continue beyond the current session if you use it within powershell
     - bash: |
+        if [[ "$(uname)" == "Darwin" ]]; then
+          export DOTNET_ROOT="$HOME/.dotnet"
+        fi
         nohup $(Build.BinariesDirectory)/test-proxy/test-proxy 1>${{ parameters.rootFolder }}/test-proxy.log 2>${{ parameters.rootFolder }}/test-proxy-error.log &
 
         echo $! > $(Build.SourcesDirectory)/test-proxy.pid
@@ -98,7 +101,6 @@ steps:
       workingDirectory: "${{ parameters.rootFolder }}"
       env:
         DOTNET_ROLL_FORWARD: 'Major'
-        DOTNET_ROOT: $(HOME)/.dotnet
 
     - pwsh: |
         for ($i = 0; $i -lt 10; $i++) {


### PR DESCRIPTION
[addressing these failures](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5747960&view=logs&j=4292103c-0b16-5791-49d4-677847b591ee&t=b1997528-b260-523b-b97d-be9f4a4d58e4)

Failure is due to this change: https://github.com/actions/runner-images/issues/13470

And weird interactions with just the mac agent. I'm just setting DOTNET_ROOT. All of the correct sdks are installed and available.

[Verification run](https://dev.azure.com/azure-sdk/playground/_build/results?buildId=5748648&view=logs&j=0071ed8d-8ceb-5123-3717-45f96b7d3294&t=5656edd4-58b2-5eb5-ccda-d32c9a3ae8f1)