### PR TITLE
[APIView]  Fix navigation panel not showing removed namespaces in diff view

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Helpers/CodeFileHelpers.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/CodeFileHelpers.cs
@@ -211,9 +211,7 @@ namespace APIViewWeb.Helpers
         private static NavigationTreeNode CreateNavigationNode(ReviewLine reviewLine, string nodeIdHashed)
         {
             NavigationTreeNode navTreeNode = null;
-            //Generate navigation node only from active revision
-            if (!reviewLine.IsActiveRevisionLine)
-                return navTreeNode;
+            // Generate navigation node for both active revision lines and removed lines (from diff revision)
             var navToken = reviewLine.Tokens.FirstOrDefault(t => !string.IsNullOrEmpty(t.NavigationDisplayName));
             if (navToken != null && reviewLine.IsHidden != true)
             {


### PR DESCRIPTION
fixes: https://github.com/Azure/azure-sdk-tools/issues/13000

When comparing API revisions in diff view, namespaces that were **removed** (exist in older revision but not in newer) were not appearing in the left navigation panel. This caused child items like methods and classes to appear as top-level elements instead of being nested under their parent namespace.

### Root Cause

In `CreateNavigationNode()`, navigation tree nodes were only created for active revision lines. When a namespace only exists in the diff (older) revision, it was being skipped, so no navigation node was created for it. This meant removed namespaces couldn't appear in the navigation panel even though they were rendered correctly in the code panel.


### Fix
<img width="1872" height="1086" alt="image" src="https://github.com/user-attachments/assets/3a071ad2-2c61-4b92-a208-269c8cab11e4" />
