### PR TITLE
[APIView] Lighter color for Dark/Polarized Enums

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Client/css/shared/theme-colors.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/shared/theme-colors.scss
@@ -160,7 +160,7 @@
     --code-color: #db3984;
     --code-comment: green;
     --literal-color: #008509;
-    --enum-color: #8700BD;
+    --enum-color: #BB86FC;
     --hidden-api-filter: brightness(60%) saturate(60%);
     --java-doc-color: #629755;
     --java-comment-color: #808080;
@@ -271,7 +271,7 @@
     --name-color: #{$base-text-color};
     --code-color: #db3984;
     --literal-color: #008509;
-    --enum-color: #8700BD;
+    --enum-color: #BB86FC;
     --hidden-api-filter: brightness(60%) saturate(60%);
     --code-comment: #8a9898;
     --java-doc-color: #629755;


### PR DESCRIPTION
Fixes #13583.

<img width="468" height="262" alt="image" src="https://github.com/user-attachments/assets/8ade9624-78e9-4a77-8212-65250a7096e5" />
