### PR TITLE
Update work item parent method in DevOps service 

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AzureDevOps/EpicWorkItem.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AzureDevOps/EpicWorkItem.cs
@@ -4,7 +4,7 @@ using Azure.Sdk.Tools.Cli.Attributes;
 
 namespace Azure.Sdk.Tools.Cli.Models.AzureDevOps
 {
-    public class ServiceWorkItem : WorkItemBase
+    public class EpicWorkItem : WorkItemBase
     {
         [FieldName("Custom.PackageDisplayName")]
         public string PackageDisplayName { get; set; } = string.Empty;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AzureDevOps/PackageWorkItem.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AzureDevOps/PackageWorkItem.cs
@@ -4,7 +4,7 @@ using Azure.Sdk.Tools.Cli.Attributes;
 
 namespace Azure.Sdk.Tools.Cli.Models.AzureDevOps
 {
-    public class ProductWorkItem : WorkItemBase
+    public class PackageWorkItem : WorkItemBase
     {
         [FieldName("Custom.Language")]
         public string Language { get; set; } = string.Empty;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AzureDevOps/WorkItemBase.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AzureDevOps/WorkItemBase.cs
@@ -25,6 +25,9 @@ namespace Azure.Sdk.Tools.Cli.Models.AzureDevOps
         [FieldName("System.Title")]
         public string Title { get; set; } = string.Empty;
 
+        [FieldName("System.Parent")]
+        public int ParentId { get; set; }
+
         public string Description { get; set; } = string.Empty;
 
         public string Status { get; set; } = string.Empty;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AzureDevOps/WorkItemBase.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AzureDevOps/WorkItemBase.cs
@@ -26,7 +26,7 @@ namespace Azure.Sdk.Tools.Cli.Models.AzureDevOps
         public string Title { get; set; } = string.Empty;
 
         [FieldName("System.Parent")]
-        public int ParentId { get; set; }
+        public int ParentId { get; set; } = 0;
 
         public string Description { get; set; } = string.Empty;
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -1384,7 +1384,7 @@ namespace Azure.Sdk.Tools.Cli.Services
 
         public async Task UpdateWorkItemParentAsync(WorkItemBase child, WorkItemBase parent)
         {
-            if (child.WorkItemId == parent.WorkItemId)
+            if (child.ParentId == parent.WorkItemId)
             {
                 return; // already the parent
             }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -509,17 +509,13 @@ namespace Azure.Sdk.Tools.Cli.Services
             }
 
             var targetRelation = workItem.Relations.FirstOrDefault(r =>
-                r.Rel.Equals(relationTypeSystemName, StringComparison.OrdinalIgnoreCase)
+                r.Rel.Equals(relationTypeSystemName, StringComparison.OrdinalIgnoreCase) &&
+                r.Url.Equals(targetWorkItem.Url, StringComparison.OrdinalIgnoreCase)
             );
 
             if (targetRelation == null)
             {
                 throw new Exception($"Relation of type '{relationType}' to target work item ID {targetId} not found in work item {id}.");
-            }
-
-            if (targetRelation.Url != targetWorkItem.Url)
-            {
-                throw new Exception($"Relation of type '{relationType}' does not point to target work item ID {targetId} in work item {id}.");
             }
 
             var patchDocument = new Microsoft.VisualStudio.Services.WebApi.Patch.Json.JsonPatchDocument();

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -1386,9 +1386,12 @@ namespace Azure.Sdk.Tools.Cli.Services
             }
 
             // Remove existing parent link
-            // Child must have existing parent link or remove work item relation will fail.
-            await RemoveWorkItemRelationAsync(child.WorkItemId, "Parent", child.ParentId);
-
+            // Child must have existing parent link
+            if (child.ParentId != 0)
+            {
+                await RemoveWorkItemRelationAsync(child.WorkItemId, "Parent", child.ParentId);
+            }
+            
             await CreateWorkItemRelationAsync(child.WorkItemId, "Parent", parent.WorkItemId);
         }
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -1390,7 +1390,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             }
 
             // Remove existing parent link
-            // Child must have existing parent link or remove work item relation will fail. 
+            // Child must have existing parent link or remove work item relation will fail.
             await RemoveWorkItemRelationAsync(child.WorkItemId, "Parent", child.ParentId);
 
             await CreateWorkItemRelationAsync(child.WorkItemId, "Parent", parent.WorkItemId);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -1386,7 +1386,7 @@ namespace Azure.Sdk.Tools.Cli.Services
         {
             if (child.WorkItemId == parent.WorkItemId)
             {
-                return; //already the parent
+                return; // already the parent
             }
 
             // Remove existing parent link

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -1382,7 +1382,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             return workItem;
         }
 
-        public async Task UpdateWorkItemParentAsync(WorkItemBase child, WorkItemBase parent)
+        private async Task UpdateWorkItemParentAsync(WorkItemBase child, WorkItemBase parent)
         {
             if (child.ParentId == parent.WorkItemId)
             {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -450,7 +450,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             {
                 var targetWorkItem = await connection.GetWorkItemClient().GetWorkItemAsync(targetId.Value);
 
-                // Query should only come up with one work item
+                // Ensure the target work item exists before creating the relation
                 if (targetWorkItem == null)
                 {
                     throw new Exception($"Work item with ID {targetId} does not exist.");


### PR DESCRIPTION
- Resolves #13659
- Added `UpdateWorkItemParentAsync` which updates the parent which the child work item is pointing to. 
- Added 'RemoveWorkItemRelationAsync` to remove the previous parent of the child work item. Can also be useful when removing relations elsewhere. 
- Renamed `ProductWorkItem` to `PackageWorkItem` because I realized that in the powershell the fields were actually for creating a Package Work Item. Product and Service have identical fields so might rename `ServiceWorkItem`
- Powershell equivalent can be found here:
https://github.com/Azure/azure-sdk-tools/blob/be21153dc65cb65fe291036234290643b36c5b09/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1#L346