### PR TITLE
hlc to modular clean up logic

### DIFF
--- a/tools/js-sdk-release-tools/src/common/utils.ts
+++ b/tools/js-sdk-release-tools/src/common/utils.ts
@@ -468,7 +468,7 @@ export async function cleanUpPackageDirectory(
         const managementSDKType = getSDKType(packageDirectory);
         if (managementSDKType === SDKType.HighLevelClient) {
             if (pipelineRunMode) {
-                // In Release/Local modes, preserve test and assets.json, clean up everything else (src folder handled by emitter)
+                // In Release/Local modes, preserve test and assets.json, clean up everything else including src
                 logger.info(`[HighLevelClient] Cleaning up in ${runMode} mode, preserving test and assets.json for: ${packageDirectory}`);
                 await cleanUpDirectory(packageDirectory, ["test","assets.json"]);
                 return;

--- a/tools/js-sdk-release-tools/src/test/common/utils.test.ts
+++ b/tools/js-sdk-release-tools/src/test/common/utils.test.ts
@@ -227,7 +227,7 @@ describe("cleanUpPackageDirectory", () => {
     //   * Release/Local mode: Cleanup is skipped (handled by emitter)
     //   * SpecPullRequest/Batch modes: All files are cleaned up
     // - Management Plane (arm-*) HighLevelClient: 
-    //   * Release/Local mode: Preserves test and assets.json, cleans up everything else
+    //   * Release/Local mode: Preserves test and assets.json, cleans up everything else including src
     //   * SpecPullRequest/Batch modes: All files are cleaned up
     // - Management Plane (arm-*) Non-HighLevelClient: 
     //   * All modes: Cleanup is skipped (handled by emitter)


### PR DESCRIPTION
fixes https://github.com/Azure/azure-sdk-tools/issues/13611
test job: https://github.com/Azure/azure-sdk-for-js/pull/37125

<img width="1151" height="146" alt="image" src="https://github.com/user-attachments/assets/65eef2b9-e0e9-4292-a954-61887abab609" />

cleanup logic for Management Plane HighLevelClient to modular

1. In SpecPullRequest and Batch modes, clean up everything
2. In Release/Local modes, preserve test and assets.json,clean up everything
