### PR TITLE
[azsdk-cli] Sanitize paths in telemetry

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/TelemetryPathSanitizerTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/TelemetryPathSanitizerTests.cs
@@ -5,16 +5,25 @@ namespace Azure.Sdk.Tools.Cli.Tests.Helpers;
 
 public class TelemetryPathSanitizerTests
 {
-    [TestCase("specification/service", "[PATH REDACTED]/specification/service")]
-    [TestCase("azure-rest-api-specs/specification/service", "[PATH REDACTED]/azure-rest-api-specs/specification/service")]
+    [TestCase("azure-rest-api-specs/specification/service", "azure-rest-api-specs/specification/service")]
     [TestCase("/azure-rest-api-specs/specification/service", "[PATH REDACTED]/azure-rest-api-specs/specification/service")]
     [TestCase("/Users/ben/specification/service", "[PATH REDACTED]/specification/service")]
-    [TestCase(@"C:\Users\ben\sdk\azure-sdk-for-net\sdk\storage", @"[PATH REDACTED]\azure-sdk-for-net\sdk\storage")]
-    [TestCase("C:/Users/ben/sdk/azure-sdk-for-net/sdk/storage", "[PATH REDACTED]/azure-sdk-for-net/sdk/storage")]
-    [TestCase("/home/ben/sdk/azure-sdk-for-net/sdk/storage", "[PATH REDACTED]/azure-sdk-for-net/sdk/storage")]
-    [TestCase("/home/ben/sdk/azure-sdk-for-go/sdk/resourcemanager/advisor/armadvisor", "[PATH REDACTED]/azure-sdk-for-go/sdk/resourcemanager/advisor/armadvisor")]
+    [TestCase(@"C:\Users\ben\sdk\azure-sdk-for-net\sdk\storage", @"[PATH REDACTED]\sdk\azure-sdk-for-net\sdk\storage")]
+    [TestCase("C:/Users/ben/repos/azure-sdk-for-net/sdk/storage", "[PATH REDACTED]/azure-sdk-for-net/sdk/storage")]
+    [TestCase("/home/ben/repos/azure-sdk-for-net/sdk/storage", "[PATH REDACTED]/azure-sdk-for-net/sdk/storage")]
     [TestCase("~/specification/service", "[PATH REDACTED]/specification/service")]
     public void Sanitize_PreservesAllowlistedSegments(string input, string expected)
+    {
+        var sanitized = TelemetryPathSanitizer.Sanitize(input);
+
+        Assert.That(sanitized, Is.EqualTo(expected));
+    }
+
+    [TestCase("sdk/resourcemanager/advisor/armadvisor", "sdk/resourcemanager/advisor/armadvisor")]
+    [TestCase("github.com/Azure/azure-sdk-for-go/sdk/azcore", "github.com/Azure/azure-sdk-for-go/sdk/azcore")]
+    [TestCase("@azure/storage-blob", "@azure/storage-blob")]
+    [TestCase("@azure-rest/core-client", "@azure-rest/core-client")]
+    public void Sanitize_PreservesAllowlistedSegmentsForPackageNamingConventions(string input, string expected)
     {
         var sanitized = TelemetryPathSanitizer.Sanitize(input);
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/TelemetryPathSanitizerTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/TelemetryPathSanitizerTests.cs
@@ -1,0 +1,80 @@
+using Azure.Sdk.Tools.Cli.Telemetry;
+using NUnit.Framework;
+
+namespace Azure.Sdk.Tools.Cli.Tests.Helpers;
+
+public class TelemetryPathSanitizerTests
+{
+    [TestCase("specification/service", "[PATH REDACTED]/specification/service")]
+    [TestCase("azure-rest-api-specs/specification/service", "[PATH REDACTED]/azure-rest-api-specs/specification/service")]
+    [TestCase("/Users/ben/specification/service", "[PATH REDACTED]/specification/service")]
+    [TestCase(@"C:\Users\ben\azure-sdk-for-net\sdk\storage", @"[PATH REDACTED]\azure-sdk-for-net\sdk\storage")]
+    public void Sanitize_PreservesAllowlistedSegments(string input, string expected)
+    {
+        var sanitized = TelemetryPathSanitizer.Sanitize(input);
+
+        Assert.That(sanitized, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void Sanitize_RedactsNonAllowlistedPath()
+    {
+        var input = "/Users/ben/private/file.txt";
+
+        var sanitized = TelemetryPathSanitizer.Sanitize(input);
+
+        Assert.That(sanitized, Is.EqualTo(TelemetryPathSanitizer.Redacted));
+    }
+
+    [Test]
+    public void Sanitize_DoesNotChangeUrls()
+    {
+        var input = "https://example.com/specification/service";
+
+        var sanitized = TelemetryPathSanitizer.Sanitize(input);
+
+        Assert.That(sanitized, Is.EqualTo(input));
+    }
+
+    [Test]
+    public void Sanitize_PreservesPunctuationAroundPaths()
+    {
+        var input = "Failed to open /Users/ben/private/file.txt, please retry.";
+
+        var sanitized = TelemetryPathSanitizer.Sanitize(input);
+
+        Assert.That(sanitized, Is.EqualTo($"Failed to open {TelemetryPathSanitizer.Redacted}, please retry."));
+    }
+
+    [Test]
+    public void Sanitize_UsesKnownRootPrefix()
+    {
+        TelemetryPathSanitizer.AddKnownRoot("/repo/root");
+        var input = "/repo/root/specification/service";
+
+        var sanitized = TelemetryPathSanitizer.Sanitize(input);
+
+        Assert.That(sanitized, Is.EqualTo("[PATH REDACTED]/specification/service"));
+    }
+
+    [Test]
+    public void Sanitize_UsesDynamicAllowlistedSegment()
+    {
+        TelemetryPathSanitizer.AddAllowlistedSegment("custom-repo");
+        var input = "/tmp/custom-repo/src/file.cs";
+
+        var sanitized = TelemetryPathSanitizer.Sanitize(input);
+
+        Assert.That(sanitized, Is.EqualTo("[PATH REDACTED]/custom-repo/src/file.cs"));
+    }
+
+    [Test]
+    public void Sanitize_IgnoresJsonEscapeSequences()
+    {
+        var input = "{\"message\":\"RESPONDING TO \\u0027foo\\u0027 with SUCCESS: 0\",\"duration\":1}";
+
+        var sanitized = TelemetryPathSanitizer.Sanitize(input);
+
+        Assert.That(sanitized, Is.EqualTo(input));
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/TelemetryPathSanitizerTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/TelemetryPathSanitizerTests.cs
@@ -12,6 +12,7 @@ public class TelemetryPathSanitizerTests
     [TestCase(@"C:\Users\ben\sdk\azure-sdk-for-net\sdk\storage", @"[PATH REDACTED]\azure-sdk-for-net\sdk\storage")]
     [TestCase("C:/Users/ben/sdk/azure-sdk-for-net/sdk/storage", "[PATH REDACTED]/azure-sdk-for-net/sdk/storage")]
     [TestCase("/home/ben/sdk/azure-sdk-for-net/sdk/storage", "[PATH REDACTED]/azure-sdk-for-net/sdk/storage")]
+    [TestCase("/home/ben/sdk/azure-sdk-for-go/sdk/resourcemanager/advisor/armadvisor", "[PATH REDACTED]/azure-sdk-for-go/sdk/resourcemanager/advisor/armadvisor")]
     [TestCase("~/specification/service", "[PATH REDACTED]/specification/service")]
     public void Sanitize_PreservesAllowlistedSegments(string input, string expected)
     {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Telemetry/TelemetryExceptionHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Telemetry/TelemetryExceptionHelperTests.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics;
+using Azure.Sdk.Tools.Cli.Telemetry;
+using NUnit.Framework;
+
+namespace Azure.Sdk.Tools.Cli.Tests.Telemetry;
+
+public class TelemetryExceptionHelperTests
+{
+    [Test]
+    public void AddSanitizedException_RedactsPathsIncludingInnerExceptions()
+    {
+        using var activity = new Activity("test");
+        activity.Start();
+
+        var inner = new InvalidOperationException("Inner at /Users/ben/private/inner.txt");
+        var ex = new Exception("Outer at /Users/ben/private/outer.txt", inner);
+
+        TelemetryExceptionHelper.AddSanitizedException(activity, ex);
+
+        var exceptionEvent = activity.Events.Single(e => e.Name == "exception");
+        var tags = exceptionEvent.Tags.ToDictionary(t => t.Key, t => t.Value?.ToString());
+
+        Assert.That(tags["exception.message"], Does.Contain(TelemetryPathSanitizer.Redacted));
+        Assert.That(tags["exception.inner"], Does.Contain(TelemetryPathSanitizer.Redacted));
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryExceptionHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryExceptionHelper.cs
@@ -4,7 +4,7 @@
 using System.Diagnostics;
 namespace Azure.Sdk.Tools.Cli.Telemetry;
 
-internal static class TelemetryExceptionHelper
+public static class TelemetryExceptionHelper
 {
     public static void AddSanitizedException(Activity? activity, Exception ex)
     {
@@ -24,6 +24,42 @@ internal static class TelemetryExceptionHelper
             tags["exception.stacktrace"] = TelemetryPathSanitizer.Sanitize(ex.StackTrace);
         }
 
+        var innerDetails = BuildInnerExceptionDetails(ex.InnerException);
+        if (!string.IsNullOrEmpty(innerDetails))
+        {
+            tags["exception.inner"] = innerDetails;
+        }
+
         activity.AddEvent(new ActivityEvent("exception", default, tags));
+    }
+
+    private static string BuildInnerExceptionDetails(Exception? ex)
+    {
+        if (ex == null)
+        {
+            return string.Empty;
+        }
+
+        var parts = new List<string>();
+        var current = ex;
+        var depth = 0;
+        while (current != null && depth < 5)
+        {
+            var message = TelemetryPathSanitizer.Sanitize(current.Message ?? string.Empty);
+            if (!string.IsNullOrEmpty(message))
+            {
+                parts.Add($"Message: {message}");
+            }
+
+            if (!string.IsNullOrEmpty(current.StackTrace))
+            {
+                parts.Add($"StackTrace: {TelemetryPathSanitizer.Sanitize(current.StackTrace)}");
+            }
+
+            current = current.InnerException;
+            depth++;
+        }
+
+        return string.Join(" | ", parts);
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryExceptionHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryExceptionHelper.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+namespace Azure.Sdk.Tools.Cli.Telemetry;
+
+internal static class TelemetryExceptionHelper
+{
+    public static void AddSanitizedException(Activity? activity, Exception ex)
+    {
+        if (activity == null)
+        {
+            return;
+        }
+
+        var tags = new ActivityTagsCollection
+        {
+            ["exception.type"] = ex.GetType().FullName,
+            ["exception.message"] = TelemetryPathSanitizer.Sanitize(ex.Message ?? string.Empty),
+        };
+
+        if (!string.IsNullOrEmpty(ex.StackTrace))
+        {
+            tags["exception.stacktrace"] = TelemetryPathSanitizer.Sanitize(ex.StackTrace);
+        }
+
+        activity.AddEvent(new ActivityEvent("exception", default, tags));
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryPathSanitizer.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryPathSanitizer.cs
@@ -29,7 +29,7 @@ public static class TelemetryPathSanitizer
         "@azure-rest",
     ];
 
-    private const string AzureSdkPrefix = "azure-sdk-";
+    private const string AzurePrefix = "azure";
 
     private static readonly ConcurrentDictionary<string, byte> KnownRoots =
         new(StringComparer.OrdinalIgnoreCase);
@@ -63,7 +63,7 @@ public static class TelemetryPathSanitizer
         }
 
         AllowlistedSegmentSet.TryAdd(segment, 0);
-        if (segment.StartsWith(AzureSdkPrefix, StringComparison.OrdinalIgnoreCase))
+        if (segment.StartsWith(AzurePrefix, StringComparison.OrdinalIgnoreCase))
         {
             KnownRoots.TryAdd(segment, 0);
         }
@@ -346,7 +346,7 @@ public static class TelemetryPathSanitizer
 
     private static bool IsAllowlistedSegment(string segment)
     {
-        if (segment.StartsWith(AzureSdkPrefix, StringComparison.OrdinalIgnoreCase))
+        if (segment.StartsWith(AzurePrefix, StringComparison.OrdinalIgnoreCase))
         {
             return true;
         }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryPathSanitizer.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryPathSanitizer.cs
@@ -52,12 +52,12 @@ public static class TelemetryPathSanitizer
         {
             return;
         }
-        if (segment.StartsWith(AzureSdkPrefix, StringComparison.OrdinalIgnoreCase))
-        {
-            return;
-        }
 
         AllowlistedSegmentSet.TryAdd(segment, 0);
+        if (segment.StartsWith(AzureSdkPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            KnownRoots.TryAdd(segment, 0);
+        }
     }
 
     public static string Sanitize(string input)
@@ -290,12 +290,13 @@ public static class TelemetryPathSanitizer
                     return $"{Redacted}{sep}{root}{remainder}";
                 }
 
-                if (remainder[0] != '/' && remainder[0] != '\\')
+                var trimmedRemainder = remainder.TrimStart('/', '\\');
+                if (string.IsNullOrEmpty(trimmedRemainder))
                 {
-                    return $"{Redacted}{sep}{remainder}";
+                    return Redacted + sep;
                 }
 
-                return Redacted + remainder;
+                return $"{Redacted}{sep}{trimmedRemainder}";
             }
         }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryPathSanitizer.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Telemetry/TelemetryPathSanitizer.cs
@@ -1,0 +1,355 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+using System.Text;
+
+namespace Azure.Sdk.Tools.Cli.Telemetry;
+
+// Paths in telemetry can contain usernames and other identifying information.
+// We want to redact this info but keep the child segments of paths that are
+// relevant for correlating per-package usage of this tool, based on known
+// directory prefixes or names that correspond to our repositories.
+public static class TelemetryPathSanitizer
+{
+    public const string Redacted = "[PATH REDACTED]";
+
+    private static readonly string[] AllowlistedSegments =
+    [
+        "azure-rest-api-specs",
+        "specification",
+    ];
+
+    private const string AzureSdkPrefix = "azure-sdk-";
+
+    private static readonly ConcurrentDictionary<string, byte> KnownRoots =
+        new(StringComparer.OrdinalIgnoreCase);
+    private static readonly ConcurrentDictionary<string, byte> AllowlistedSegmentSet =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    static TelemetryPathSanitizer()
+    {
+        foreach (var segment in AllowlistedSegments)
+        {
+            KnownRoots.TryAdd(segment, 0);
+            AllowlistedSegmentSet.TryAdd(segment, 0);
+        }
+    }
+
+    public static void AddKnownRoot(string root)
+    {
+        if (string.IsNullOrWhiteSpace(root))
+        {
+            return;
+        }
+
+        KnownRoots.TryAdd(root, 0);
+    }
+
+    public static void AddAllowlistedSegment(string segment)
+    {
+        if (string.IsNullOrWhiteSpace(segment))
+        {
+            return;
+        }
+        if (segment.StartsWith(AzureSdkPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        AllowlistedSegmentSet.TryAdd(segment, 0);
+    }
+
+    public static string Sanitize(string input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            return input;
+        }
+
+        if (!MayContainPath(input))
+        {
+            return input;
+        }
+
+        var sb = new StringBuilder(input.Length);
+        int index = 0;
+        while (index < input.Length)
+        {
+            if (IsTokenBoundary(input, index))
+            {
+                int end = FindTokenEnd(input, index);
+                if (end > index)
+                {
+                    var token = input.Substring(index, end - index);
+                    var sanitized = SanitizeToken(token);
+                    sb.Append(sanitized);
+                    index = end;
+                    continue;
+                }
+            }
+
+            sb.Append(input[index]);
+            index++;
+        }
+
+        return sb.ToString();
+    }
+
+    private static bool MayContainPath(string input)
+    {
+        return ContainsPathSeparator(input);
+    }
+
+    private static bool IsTokenBoundary(string input, int index)
+    {
+        return index == 0 || IsTerminator(input[index - 1]);
+    }
+
+    private static int FindTokenEnd(string input, int start)
+    {
+        int idx = start;
+        while (idx < input.Length && !IsTerminator(input[idx]))
+        {
+            idx++;
+        }
+        return idx;
+    }
+
+    private static bool IsTerminator(char value)
+    {
+        return char.IsWhiteSpace(value) || value is '"' or '\'' or '<' or '>' or '(' or ')' or '[' or ']' or '{' or '}' or ',' or ';';
+    }
+
+    private static string SanitizeToken(string token)
+    {
+        var coreStart = 0;
+        var coreEnd = token.Length;
+
+        while (coreStart < coreEnd && IsWrapper(token[coreStart]))
+        {
+            coreStart++;
+        }
+
+        while (coreEnd > coreStart && IsWrapper(token[coreEnd - 1]))
+        {
+            coreEnd--;
+        }
+
+        var core = token.Substring(coreStart, coreEnd - coreStart);
+        if (!LooksLikePath(core))
+        {
+            return token;
+        }
+
+        var sanitizedCore = SanitizePathCore(core);
+        if (sanitizedCore == core)
+        {
+            return token;
+        }
+
+        return token.Substring(0, coreStart) + sanitizedCore + token.Substring(coreEnd);
+    }
+
+    private static bool IsWrapper(char value)
+    {
+        return value is '"' or '\'' or '<' or '>' or '(' or ')' or '[' or ']' or '{' or '}' or ',' or '.';
+    }
+
+    private static bool LooksLikePath(string token)
+    {
+        if (string.IsNullOrEmpty(token))
+        {
+            return false;
+        }
+
+        if (token.Contains("://", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (ContainsPathSeparator(token))
+        {
+            return true;
+        }
+
+        return IsDriveLetterPath(token) || IsTildePath(token);
+    }
+
+    private static bool ContainsPathSeparator(string input)
+    {
+        return TryFindSeparator(input, out _);
+    }
+
+    private static char GetSeparator(string input)
+    {
+        return TryFindSeparator(input, out var separator) ? separator : '/';
+    }
+
+    private static bool TryFindSeparator(string input, out char separator)
+    {
+        // Treat real path separators as signals while skipping JSON escape sequences like \uXXXX or \".
+        var hasBackslash = false;
+        for (int i = 0; i < input.Length; i++)
+        {
+            var c = input[i];
+            if (c == '/')
+            {
+                separator = '/';
+                return true;
+            }
+
+            if (c != '\\')
+            {
+                continue;
+            }
+
+            if (i + 1 >= input.Length)
+            {
+                continue;
+            }
+
+            var next = input[i + 1];
+            if (next == '\\' || next == '/')
+            {
+                if (next == '/')
+                {
+                    separator = '/';
+                    return true;
+                }
+
+                hasBackslash = true;
+                i++;
+                continue;
+            }
+
+            if (next == 'u' && i + 5 < input.Length)
+            {
+                if (IsHex(input[i + 2]) && IsHex(input[i + 3]) && IsHex(input[i + 4]) && IsHex(input[i + 5]))
+                {
+                    i += 5;
+                    continue;
+                }
+            }
+
+            if (next is '"' or '\\' or '/' or 'b' or 'f' or 'n' or 'r' or 't')
+            {
+                i++;
+                continue;
+            }
+
+            hasBackslash = true;
+        }
+
+        if (hasBackslash)
+        {
+            separator = '\\';
+            return true;
+        }
+
+        separator = '/';
+        return false;
+    }
+
+    private static bool IsHex(char value)
+    {
+        return (value >= '0' && value <= '9')
+            || (value >= 'a' && value <= 'f')
+            || (value >= 'A' && value <= 'F');
+    }
+
+    private static bool IsDriveLetterPath(string token)
+    {
+        return token.Length >= 3
+            && char.IsLetter(token[0])
+            && token[1] == ':'
+            && (token[2] == '\\' || token[2] == '/');
+    }
+
+    private static bool IsTildePath(string token)
+    {
+        return token.Length >= 2 && token[0] == '~' && (token[1] == '\\' || token[1] == '/');
+    }
+
+    private static string SanitizePathCore(string token)
+    {
+        foreach (var root in KnownRoots.Keys)
+        {
+            if (token.StartsWith(root, StringComparison.OrdinalIgnoreCase))
+            {
+                var remainder = token.Substring(root.Length);
+                if (string.IsNullOrEmpty(remainder))
+                {
+                    var rootSeparator = GetSeparator(token);
+                    return IsAllowlistedSegment(root) ? $"{Redacted}{rootSeparator}{root}" : Redacted;
+                }
+
+                var sep = GetSeparator(token);
+                if (IsAllowlistedSegment(root) && (remainder[0] == '/' || remainder[0] == '\\'))
+                {
+                    return $"{Redacted}{sep}{root}{remainder}";
+                }
+
+                if (remainder[0] != '/' && remainder[0] != '\\')
+                {
+                    return $"{Redacted}{sep}{remainder}";
+                }
+
+                return Redacted + remainder;
+            }
+        }
+
+        var sepChar = GetSeparator(token);
+        var trimmed = token;
+        if (token.StartsWith(@"\\", StringComparison.Ordinal))
+        {
+            trimmed = token[2..];
+        }
+        else if (IsDriveLetterPath(token))
+        {
+            trimmed = token[3..];
+        }
+        else if (IsTildePath(token))
+        {
+            trimmed = token[2..];
+        }
+        else if (token.StartsWith("/", StringComparison.Ordinal))
+        {
+            trimmed = token[1..];
+        }
+
+        var segments = trimmed.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
+        var allowedIndex = FindAllowlistedSegmentIndex(segments);
+        if (allowedIndex >= 0)
+        {
+            var kept = string.Join(sepChar, segments.Skip(allowedIndex));
+            return string.IsNullOrEmpty(kept) ? Redacted : $"{Redacted}{sepChar}{kept}";
+        }
+
+        return Redacted;
+    }
+
+    private static int FindAllowlistedSegmentIndex(string[] segments)
+    {
+        for (int i = 0; i < segments.Length; i++)
+        {
+            var segment = segments[i];
+            if (IsAllowlistedSegment(segment))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static bool IsAllowlistedSegment(string segment)
+    {
+        if (segment.StartsWith(AzureSdkPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return AllowlistedSegmentSet.ContainsKey(segment);
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Core/InstrumentedTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Core/InstrumentedTool.cs
@@ -69,7 +69,7 @@ public class InstrumentedTool : DelegatingMcpServerTool
         }
         catch (Exception ex)
         {
-            activity?.AddException(ex);
+            TelemetryExceptionHelper.AddSanitizedException(activity, ex);
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             throw;
         }
@@ -122,7 +122,7 @@ public class InstrumentedTool : DelegatingMcpServerTool
         }
         catch (JsonException ex)
         {
-            activity?.AddException(ex);
+            TelemetryExceptionHelper.AddSanitizedException(activity, ex);
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             logger.LogError(ex, "Failed to deserialize contentBlock.Text for telemetry properties");
         }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Core/MCPToolBase.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Core/MCPToolBase.cs
@@ -67,7 +67,7 @@ public abstract class MCPToolBase
         }
         catch (Exception ex)
         {
-            activity?.AddException(ex);
+            TelemetryExceptionHelper.AddSanitizedException(activity, ex);
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             throw;
         }


### PR DESCRIPTION
We don't want paths containing usernames to show up in our telemetry data, for example @chrisradek:

<img width="668" height="80" alt="image" src="https://github.com/user-attachments/assets/be492088-e64f-4e42-9054-28bccc42dd50" />

These can show up anywhere: process output, exceptions, custom tags we set in tools, etc.

Right now this takes a brute force approach and analyzes every activity tag for a path-like pattern and redacts it. We keep the child segments of paths after well-known directory names like repository so that we can still do package usage correlation (e.g. `/home/ben/azure-sdk-for-python/sdk/foo` becomes `[PATH REDACTED]/azure-sdk-for-python/sdk/foo`. Additionally other components like the git helper can add to the dir name allowlist, for example when we call `DiscoverRepoRoot` that will update that root dir so we don't exclude workspaces where the name doesn't match the github remote.

I anticipate this sanitization infra will also be extended to process additional types of patterns in the future.