### PR TITLE
CLI command to mark package as released in release plan

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
@@ -127,6 +127,12 @@ namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
             var releasePlans = new List<ReleasePlanWorkItem>();
             return Task.FromResult(releasePlans);
         }
+
+        Task<List<ReleasePlanWorkItem>> IDevOpsService.GetReleasePlansForPackageAsync(string packageName, string language, bool isTestReleasePlan)
+        {
+            var releasePlans = new List<ReleasePlanWorkItem>();
+            return Task.FromResult(releasePlans);
+        }
         
         Task<ReleasePlanWorkItem> IDevOpsService.GetReleasePlanForWorkItemAsync(int workItemId)
         {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/PackageReleaseStatusToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/PackageReleaseStatusToolTests.cs
@@ -1,0 +1,474 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.AzureDevOps;
+using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
+using Azure.Sdk.Tools.Cli.Tools.ReleasePlan;
+using Moq;
+
+namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
+{
+    [TestFixture]
+    internal class PackageReleaseStatusToolTests
+    {
+        private Mock<IDevOpsService> mockDevOpsService;
+        private TestLogger<PackageReleaseStatusTool> logger;
+        private PackageReleaseStatusTool packageReleaseStatusTool;
+
+        [SetUp]
+        public void Setup()
+        {
+            mockDevOpsService = new Mock<IDevOpsService>();
+            logger = new TestLogger<PackageReleaseStatusTool>();
+            packageReleaseStatusTool = new PackageReleaseStatusTool(mockDevOpsService.Object, logger);
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_WithNullPackageName_ReturnsError()
+        {
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus(null!, "python", "Released");
+
+            // Assert
+            Assert.That(result.ResponseError, Does.Contain("Package name cannot be null or empty"));
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_WithEmptyPackageName_ReturnsError()
+        {
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("", "python", "Released");
+
+            // Assert
+            Assert.That(result.ResponseError, Does.Contain("Package name cannot be null or empty"));
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_WithWhitespacePackageName_ReturnsError()
+        {
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("   ", "python", "Released");
+
+            // Assert
+            Assert.That(result.ResponseError, Does.Contain("Package name cannot be null or empty"));
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_WithNullLanguage_ReturnsError()
+        {
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", null!, "Released");
+
+            // Assert
+            Assert.That(result.ResponseError, Does.Contain("Language cannot be null or empty"));
+            Assert.That(result.PackageName, Is.EqualTo("azure-test-package"));
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_WithEmptyLanguage_ReturnsError()
+        {
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "", "Released");
+
+            // Assert
+            Assert.That(result.ResponseError, Does.Contain("Language cannot be null or empty"));
+            Assert.That(result.PackageName, Is.EqualTo("azure-test-package"));
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_WithWhitespaceLanguage_ReturnsError()
+        {
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "   ", "Released");
+
+            // Assert
+            Assert.That(result.ResponseError, Does.Contain("Language cannot be null or empty"));
+        }
+
+        [TestCase("rust")]
+        [TestCase("swift")]
+        [TestCase("cpp")]
+        [TestCase("invalid-language")]
+        public async Task UpdatePackageReleaseStatus_WithUnsupportedLanguage_ReturnsError(string language)
+        {
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", language, "Released");
+
+            // Assert
+            Assert.That(result.ResponseError, Does.Contain($"Language '{language}' is not supported"));
+            Assert.That(result.ResponseError, Does.Contain("Supported languages:"));
+        }
+
+        [TestCase("python")]
+        [TestCase(".net")]
+        [TestCase("javascript")]
+        [TestCase("java")]
+        [TestCase("go")]
+        [TestCase("Python")]
+        [TestCase(".NET")]
+        [TestCase("JavaScript")]
+        [TestCase("Java")]
+        [TestCase("Go")]
+        public async Task UpdatePackageReleaseStatus_WithSupportedLanguage_NoReleasePlansFound_ReturnsError(string language)
+        {
+            // Arrange
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem>());
+
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", language, "Released");
+
+            // Assert
+            Assert.That(result.ResponseError, Does.Contain("No in-progress release plans found"));
+            Assert.That(result.ResponseError, Does.Contain("azure-test-package"));
+            Assert.That(result.ReleaseStatus, Is.EqualTo("Released"));
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_WithSingleReleasePlan_UpdatesSuccessfully()
+        {
+            // Arrange
+            var releasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 12345,
+                ReleasePlanId = 100,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo
+                    {
+                        Language = "python",
+                        PackageName = "azure-test-package",
+                        PullRequestStatus = "InProgress"
+                    }
+                }
+            };
+
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync("azure-test-package", "python", It.IsAny<bool>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem> { releasePlan });
+
+            mockDevOpsService
+                .Setup(x => x.UpdateWorkItemAsync(12345, It.IsAny<Dictionary<string, string>>()))
+                .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
+
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released");
+
+            // Assert
+            Assert.That(result.ResponseError, Is.Null);
+            Assert.That(result.ReleaseStatus, Is.EqualTo("Released"));
+            Assert.That(result.PackageName, Is.EqualTo("azure-test-package"));
+
+            mockDevOpsService.Verify(
+                x => x.UpdateWorkItemAsync(12345, It.Is<Dictionary<string, string>>(d => 
+                    d.ContainsKey("Custom.ReleaseStatusForPython") && d["Custom.ReleaseStatusForPython"] == "Released")),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_WithMultipleReleasePlans_SelectsMergedPullRequest()
+        {
+            // Arrange
+            var releasePlanWithMergedPR = new ReleasePlanWorkItem
+            {
+                WorkItemId = 11111,
+                ReleasePlanId = 101,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo
+                    {
+                        Language = "python",
+                        PackageName = "azure-test-package",
+                        PullRequestStatus = "Merged"
+                    }
+                }
+            };
+
+            var releasePlanWithOpenPR = new ReleasePlanWorkItem
+            {
+                WorkItemId = 22222,
+                ReleasePlanId = 102,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo
+                    {
+                        Language = "python",
+                        PackageName = "azure-test-package",
+                        PullRequestStatus = "Open"
+                    }
+                }
+            };
+
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync("azure-test-package", "python", It.IsAny<bool>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem> { releasePlanWithOpenPR, releasePlanWithMergedPR });
+
+            mockDevOpsService
+                .Setup(x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>()))
+                .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 11111 });
+
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released");
+
+            // Assert
+            Assert.That(result.ResponseError, Is.Null);
+            Assert.That(result.ReleaseStatus, Is.EqualTo("Released"));
+
+            // Verify the one with merged PR was selected (work item 11111)
+            mockDevOpsService.Verify(
+                x => x.UpdateWorkItemAsync(11111, It.IsAny<Dictionary<string, string>>()),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_WithMultipleReleasePlans_NoMergedPR_SelectsFirst()
+        {
+            // Arrange
+            var firstReleasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 11111,
+                ReleasePlanId = 101,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo
+                    {
+                        Language = "python",
+                        PackageName = "azure-test-package",
+                        PullRequestStatus = "Open"
+                    }
+                }
+            };
+
+            var secondReleasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 22222,
+                ReleasePlanId = 102,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo
+                    {
+                        Language = "python",
+                        PackageName = "azure-test-package",
+                        PullRequestStatus = "InProgress"
+                    }
+                }
+            };
+
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync("azure-test-package", "python", It.IsAny<bool>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem> { firstReleasePlan, secondReleasePlan });
+
+            mockDevOpsService
+                .Setup(x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>()))
+                .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 11111 });
+
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released");
+
+            // Assert
+            Assert.That(result.ResponseError, Is.Null);
+
+            // Verify the first one was selected (work item 11111)
+            mockDevOpsService.Verify(
+                x => x.UpdateWorkItemAsync(11111, It.IsAny<Dictionary<string, string>>()),
+                Times.Once);
+        }
+
+        [TestCase("python", "Custom.ReleaseStatusForPython")]
+        [TestCase(".net", "Custom.ReleaseStatusForDotnet")]
+        [TestCase("javascript", "Custom.ReleaseStatusForJavaScript")]
+        [TestCase("java", "Custom.ReleaseStatusForJava")]
+        [TestCase("go", "Custom.ReleaseStatusForGo")]
+        public async Task UpdatePackageReleaseStatus_UsesCorrectFieldNameForLanguage(string language, string expectedFieldName)
+        {
+            // Arrange
+            var releasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 12345,
+                ReleasePlanId = 100,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo
+                    {
+                        Language = language,
+                        PackageName = "azure-test-package",
+                        PullRequestStatus = "InProgress"
+                    }
+                }
+            };
+
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem> { releasePlan });
+
+            mockDevOpsService
+                .Setup(x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>()))
+                .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
+
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", language, "Released");
+
+            // Assert
+            Assert.That(result.ResponseError, Is.Null);
+
+            mockDevOpsService.Verify(
+                x => x.UpdateWorkItemAsync(12345, It.Is<Dictionary<string, string>>(d => d.ContainsKey(expectedFieldName))),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_WithCustomReleaseStatus_UsesProvidedStatus()
+        {
+            // Arrange
+            var releasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 12345,
+                ReleasePlanId = 100,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo
+                    {
+                        Language = "python",
+                        PackageName = "azure-test-package",
+                        PullRequestStatus = "Merged"
+                    }
+                }
+            };
+
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync("azure-test-package", "python", It.IsAny<bool>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem> { releasePlan });
+
+            mockDevOpsService
+                .Setup(x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>()))
+                .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
+
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Pending");
+
+            // Assert
+            Assert.That(result.ResponseError, Is.Null);
+            Assert.That(result.ReleaseStatus, Is.EqualTo("Pending"));
+            mockDevOpsService.Verify(
+                x => x.UpdateWorkItemAsync(12345, It.Is<Dictionary<string, string>>(d => 
+                    d["Custom.ReleaseStatusForPython"] == "Pending")),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_WhenDevOpsServiceThrowsException_ReturnsError()
+        {
+            // Arrange
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+                .ThrowsAsync(new Exception("DevOps service error"));
+
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released");
+
+            // Assert
+            Assert.That(result.ResponseError, Does.Contain("Failed to update release status"));
+            Assert.That(result.ResponseError, Does.Contain("DevOps service error"));
+            Assert.That(result.PackageName, Is.EqualTo("azure-test-package"));
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_WhenUpdateWorkItemThrowsException_ReturnsError()
+        {
+            // Arrange
+            var releasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 12345,
+                ReleasePlanId = 100,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo
+                    {
+                        Language = "python",
+                        PackageName = "azure-test-package",
+                        PullRequestStatus = "Merged"
+                    }
+                }
+            };
+
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem> { releasePlan });
+
+            mockDevOpsService
+                .Setup(x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>()))
+                .ThrowsAsync(new Exception("Failed to update work item"));
+
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released");
+
+            // Assert
+            Assert.That(result.ResponseError, Does.Contain("Failed to update release status"));
+            Assert.That(result.ResponseError, Does.Contain("Failed to update work item"));
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_SetsCorrectLanguageOnResponse()
+        {
+            // Arrange
+            var releasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 12345,
+                ReleasePlanId = 100,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo
+                    {
+                        Language = "java",
+                        PackageName = "com.azure.test",
+                        PullRequestStatus = "Merged"
+                    }
+                }
+            };
+
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync("com.azure.test", "java", It.IsAny<bool>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem> { releasePlan });
+
+            mockDevOpsService
+                .Setup(x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>()))
+                .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
+
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("com.azure.test", "java", "Released");
+
+            // Assert
+            Assert.That(result.ResponseError, Is.Null);
+            Assert.That(result.Language, Is.EqualTo(SdkLanguage.Java));
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_WhenNoMatchingReleasePlanFound_ReturnsErrorWithPackageAndLanguage()
+        {
+            // Arrange
+            var packageName = "azure-nonexistent-package";
+            var language = "python";
+
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync(packageName, language, It.IsAny<bool>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem>());
+
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus(packageName, language, "Released");
+
+            // Assert
+            Assert.That(result.ResponseError, Is.Not.Null);
+            Assert.That(result.ResponseError, Does.Contain("No in-progress release plans found"));
+            Assert.That(result.ResponseError, Does.Contain(packageName));
+            Assert.That(result.ResponseError, Does.Contain(language));
+            Assert.That(result.ReleaseStatus, Is.EqualTo("Released"));
+
+            // Verify UpdateWorkItemAsync was never called since no release plan was found
+            mockDevOpsService.Verify(
+                x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>()),
+                Times.Never);
+        }
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added a new CLI command to update the package release status in release plan.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedCommandGroups.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedCommandGroups.cs
@@ -52,6 +52,11 @@ namespace Azure.Sdk.Tools.Cli.Commands
             Description: "Test operations for SDK packages"
         );
 
+        public static readonly CommandGroup ReleasePlan = new(
+           Verb: "release-plan",
+           Description: "Manage release plans in Azure DevOps"
+       );
+
         public static readonly CommandGroup TypeSpec = new(
             Verb: "tsp",
             Description: "Commands for setting up or working with TypeSpec projects",

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedOptions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedOptions.cs
@@ -30,6 +30,7 @@ namespace Azure.Sdk.Tools.Cli.Commands
             typeof(SampleGeneratorTool),
             typeof(SampleTranslatorTool),
             typeof(ReleasePlanTool),
+            typeof(PackageReleaseStatusTool),
             typeof(SpecWorkflowTool),
             typeof(SdkBuildTool),
             typeof(SdkGenerationTool),

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ReleasePlan/ReleaseStatusUpdateResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ReleasePlan/ReleaseStatusUpdateResponse.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace Azure.Sdk.Tools.Cli.Models.Responses.ReleasePlan
+{
+    /// <summary>
+    /// Response model for release status update operations.
+    /// </summary>
+    public class ReleaseStatusUpdateResponse : ReleasePlanBaseResponse
+    {
+        [JsonPropertyName("release_status")]
+        public string ReleaseStatus { get; set; } = string.Empty;
+
+        [JsonPropertyName("language")]
+        public SdkLanguage Language { get; set; } = SdkLanguage.Unknown;
+
+        [JsonPropertyName("release_plan_id")]
+        public int ReleasePlanId { get; set; }
+
+        [JsonPropertyName("package_name")]
+        public string PackageName { get; set; } = string.Empty;
+
+        public void SetLanguage(string language)
+        {
+            Language = SdkLanguageHelpers.GetSdkLanguage(language);
+        }
+        protected override string Format()
+        {
+            var result = new StringBuilder();
+            if (!string.IsNullOrEmpty(ReleaseStatus))
+            {
+                result.AppendLine($"Release Status: {ReleaseStatus}");
+            }
+            if (!string.IsNullOrEmpty(PackageName))
+            {
+                result.AppendLine($"Package Name: {PackageName}");
+            }
+            if (Language != SdkLanguage.Unknown)
+            {
+                result.AppendLine($"Language: {Language}");
+            }
+            if (ReleasePlanId > 0)
+            {
+                result.AppendLine($"Release Plan ID: {ReleasePlanId}");
+            }
+            return result.ToString();
+        }
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -93,6 +93,7 @@ namespace Azure.Sdk.Tools.Cli.Services
         public Task<ReleasePlanWorkItem> GetReleasePlanForWorkItemAsync(int workItemId);
         public Task<ReleasePlanWorkItem> GetReleasePlanAsync(string pullRequestUrl);
         public Task<List<ReleasePlanWorkItem>> GetReleasePlansForProductAsync(string productTreeId, string specApiVersion, string sdkReleaseType, bool isTestReleasePlan = false);
+        public Task<List<ReleasePlanWorkItem>> GetReleasePlansForPackageAsync(string packageName, string language, bool isTestReleasePlan = false);
         public Task<WorkItem> CreateReleasePlanWorkItemAsync(ReleasePlanWorkItem releasePlan);
         public Task<Build> RunSDKGenerationPipelineAsync(string apiSpecBranchRef, string typespecProjectRoot, string apiVersion, string sdkReleaseType, string language, int workItemId, string sdkRepoBranch = "");
         public Task<Build> GetPipelineRunAsync(int buildId);
@@ -214,6 +215,40 @@ namespace Azure.Sdk.Tools.Cli.Services
             {
                 logger.LogError(ex, "Failed to get release plans for product id {productTreeId}", productTreeId);
                 throw new Exception($"Failed to get release plans for product id {productTreeId}. Error: {ex.Message}");
+            }
+        }
+
+        public async Task<List<ReleasePlanWorkItem>> GetReleasePlansForPackageAsync(string packageName, string language, bool isTestReleasePlan = false)
+        {
+            try
+            {
+                var languageId = MapLanguageToId(language);
+                var escapedPackageName = packageName?.Replace("'", "''");
+                var query = $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{Constants.AZURE_SDK_DEVOPS_RELEASE_PROJECT}'";
+                query += $" AND [System.Tags] {(isTestReleasePlan ? "CONTAINS" : "NOT CONTAINS")} '{RELEASE_PLANER_APP_TEST}'";
+                query += $" AND [Custom.{languageId}PackageName] = '{escapedPackageName}'";
+                query += " AND [System.WorkItemType] = 'Release Plan'";
+                query += " AND [System.State] = 'In Progress'";
+                var releasePlanWorkItems = await FetchWorkItemsAsync(query);
+                if (releasePlanWorkItems.Count == 0)
+                {
+                    logger.LogInformation("No in-progress release plans found for package {packageName} in {language}", packageName, language);
+                    return [];
+                }
+
+                var releasePlans = new List<ReleasePlanWorkItem>();
+                foreach (var workItem in releasePlanWorkItems)
+                {
+                    var releasePlan = await MapWorkItemToReleasePlanAsync(workItem);
+                    releasePlans.Add(releasePlan);
+                }
+
+                return releasePlans;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to get release plans for package {packageName} in {language}", packageName, language);
+                throw new Exception($"Failed to get release plans for package {packageName} in {language}. Error: {ex.Message}", ex);
             }
         }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/PackageReleaseStatusTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/PackageReleaseStatusTool.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.CommandLine;
+using System.ComponentModel;
+using Azure.Sdk.Tools.Cli.Commands;
+using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.Responses.ReleasePlan;
+using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Tools.Core;
+using ModelContextProtocol.Server;
+
+namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
+{
+    [Description("Tool to update SDK package release status in the release plan")]
+    [McpServerToolType]
+    public class PackageReleaseStatusTool(
+        IDevOpsService devOpsService,
+        ILogger<PackageReleaseStatusTool> logger
+    ) : MCPTool
+    {
+        public override CommandGroup[] CommandHierarchy { get; set; } = [SharedCommandGroups.ReleasePlan];
+
+        // Commands
+        private const string updateReleaseStatusCommandName = "update-release-status";
+
+        // Options
+        private readonly Option<string> packageNameOpt = new("--package-name", "-p")
+        {
+            Description = "SDK package name",
+            Required = true,
+        };
+
+        private readonly Option<string> languageOpt = new("--language", "-l")
+        {
+            Description = "SDK language (e.g., .NET, Java, JavaScript, Python, Go)",
+            Required = true,
+        };
+
+        private readonly Option<string> releaseStatusOpt = new("--status", "-s")
+        {
+            Description = "Release status (e.g., Released, Pending)",
+            Required = false,
+            DefaultValueFactory = _ => "Released"
+        };
+
+        protected override Command GetCommand() =>
+            new McpCommand(updateReleaseStatusCommandName, "Update package release status in the release plan")
+            {
+                packageNameOpt, languageOpt, releaseStatusOpt
+            };
+
+
+        public override async Task<CommandResponse> HandleCommand(ParseResult parseResult, CancellationToken ct)
+        {
+            var commandParser = parseResult;
+            var command = commandParser.CommandResult.Command.Name;
+            switch (command)
+            {
+                case updateReleaseStatusCommandName:
+                    var packageName = commandParser.GetValue(packageNameOpt);
+                    var language = commandParser.GetValue(languageOpt);
+                    var releaseStatus = commandParser.GetValue(releaseStatusOpt);
+                    return await UpdatePackageReleaseStatus(packageName, language, releaseStatus);
+
+                default:
+                    logger.LogError("Unknown command: {command}", command);
+                    return new DefaultCommandResponse { ResponseError = $"Unknown command: '{command}'" };
+            }
+        }
+
+        public async Task<ReleaseStatusUpdateResponse> UpdatePackageReleaseStatus(string packageName, string language, string releaseStatus)
+        {
+            try
+            {
+                // Validate inputs
+                if (string.IsNullOrWhiteSpace(packageName))
+                {
+                    return new ReleaseStatusUpdateResponse { ResponseError = "Package name cannot be null or empty." };
+                }
+                if (string.IsNullOrWhiteSpace(language))
+                {
+                    return new ReleaseStatusUpdateResponse { PackageName = packageName, ResponseError = "Language cannot be null or empty." };
+                }
+
+                var response = new ReleaseStatusUpdateResponse()
+                {
+                    PackageName = packageName,
+                    Language = SdkLanguageHelpers.GetSdkLanguage(language),
+                    ReleaseStatus = releaseStatus
+                };
+
+                if (!ReleasePlanTool.SUPPORTED_LANGUAGES.Contains(language.ToLower()))
+                {
+                    response.ResponseError = $"Language '{language}' is not supported. Supported languages: {string.Join(", ", ReleasePlanTool.SUPPORTED_LANGUAGES)}";
+                    return response;
+                }
+                
+                logger.LogInformation("Searching for in-progress release plans with package {packageName} for {language}", packageName, language);
+                bool isAgentTesting = bool.TryParse(Environment.GetEnvironmentVariable("AZSDKTOOLS_AGENT_TESTING"), out var result) && result;
+                // Find all release plans in "In Progress" status with the given package name
+                var releasePlans = await devOpsService.GetReleasePlansForPackageAsync(packageName, language, isAgentTesting);
+                if (releasePlans.Count == 0)
+                {
+                    response.ResponseError = $"No in-progress release plans found for package '{packageName}' in language '{language}'.";
+                    return response;
+                }
+
+                // If there are multiple release plans, prioritize the one with a merged pull request for the package
+                var releasePlan = releasePlans[0];
+                if (releasePlans.Count > 1)
+                {
+                    logger.LogInformation("Multiple active release plans are found for '{packageName}' in language '{language}'", packageName, language);
+                    var releasePlanWithPrMerged = releasePlans.FirstOrDefault(rp => rp.SDKInfo.Any(s => s.PackageName.Equals(packageName) && s.PullRequestStatus.Equals("Merged")));
+                    if (releasePlanWithPrMerged != null)
+                    {
+                        logger.LogInformation("Selected first release plan {releasePlanId} with pull request as merged.", releasePlanWithPrMerged.ReleasePlanId);
+                        releasePlan = releasePlanWithPrMerged;
+                    }
+                    else
+                    {
+                        logger.LogInformation("No release plan with merged pull request status found. Defaulting to first release plan {releasePlanId}.", releasePlan.ReleasePlanId);
+                    }
+                }
+                else
+                {
+                    logger.LogInformation("Found release plan work item {workItemId} for package {packageName} in language {language}", releasePlan.WorkItemId, packageName, language);
+                }
+
+                response.ReleasePlanId = releasePlan.ReleasePlanId;
+                logger.LogInformation("Updating release status for package {packageName} in release plan work item {workItemId}", packageName, releasePlan.WorkItemId);
+
+                // Update the release status for the specific language
+                var fieldsToUpdate = new Dictionary<string, string>
+                {
+                    { $"Custom.ReleaseStatusFor{DevOpsService.MapLanguageToId(language)}", releaseStatus }
+                };
+
+                await devOpsService.UpdateWorkItemAsync(releasePlan.WorkItemId, fieldsToUpdate);
+                logger.LogInformation("Successfully updated release status for package {packageName} in release plan {workItemId}", packageName, releasePlan.WorkItemId);
+                response.ReleaseStatus = releaseStatus;
+                return response;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to update release status for package {packageName}", packageName);
+                return new ReleaseStatusUpdateResponse { PackageName = packageName, ResponseError = $"Failed to update release status: {ex.Message}" };
+            }
+        }
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -32,7 +32,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
         HttpClient httpClient
     ) : MCPMultiCommandTool
     {
-        public override CommandGroup[] CommandHierarchy { get; set; } = [new("release-plan", "Manage release plans in AzureDevops")];
+        public override CommandGroup[] CommandHierarchy { get; set; } = [SharedCommandGroups.ReleasePlan];
 
         // Commands
         private const string getReleasePlanDetailsCommandName = "get";


### PR DESCRIPTION
This PR adds a new CLI command to update package release status in release plan. This will also get pushed to telemetry by command line telemetry.

This CLI command will be used in place of current powershell script in release pipeline to mark a package as released.