### PR TITLE
Fix empty owners issue

### DIFF
--- a/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils/Parsing/CodeownersParser.cs
+++ b/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils/Parsing/CodeownersParser.cs
@@ -126,20 +126,14 @@ namespace Azure.Sdk.Tools.CodeownersUtils.Parsing
                 bool isSourcePathOwnerLine = ParsingUtils.IsSourcePathOwnerLine(line);
                 if (isSourcePathOwnerLine)
                 {
+                    codeownersEntry.PathExpression = ParsingUtils.ParseSourcePathFromLine(line);
                     codeownersEntry.SourceOwners = ParsingUtils.ParseOwnersFromLine(ownerDataUtils,
                                                                                     line,
                                                                                     true /*expand teams when parsing*/);
                     codeownersEntry.OriginalSourceOwners = ParsingUtils.ParseOwnersFromLine(ownerDataUtils,
                                                                                           line,
                                                                                           false /*do not expand teams when parsing*/);
-                    // So it's clear why this is here:
-                    // The original parser left the PathExpression empty if there were no source owners for a given path
-                    // in order to prevent matches against a PathExpression with no source owners. The same needs to be
-                    // done here for compat reasons.
-                    if (codeownersEntry.SourceOwners.Count != 0)
-                    {
-                        codeownersEntry.PathExpression = ParsingUtils.ParseSourcePathFromLine(line);
-                    }
+
                 }
                 else
                 {


### PR DESCRIPTION
We have valid reasons to empty the owners list for particular paths so the parser needs to handle that.