### PR TITLE
Add support for System.ClientModel.ClientSettings in AZC0007 and new AZC0021 analyzer

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0021Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0021Tests.cs
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Xunit;
+using Verifier = Azure.ClientSdk.Analyzers.Tests.AzureAnalyzerVerifier<Azure.ClientSdk.Analyzers.ClientConstructorAnalyzer>;
+
+namespace Azure.ClientSdk.Analyzers.Tests
+{
+    public class AZC0021Tests
+    {
+        [Fact]
+        public async Task AZC0021ProducedForClientSettingsWithOtherParameters()
+        {
+            const string code = @"
+namespace System.ClientModel
+{
+    public class ClientSettings {}
+}
+
+namespace RandomNamespace
+{
+    public class SomeClientSettings : System.ClientModel.ClientSettings {}
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public {|AZC0021:SomeClient|}(string connectionString, SomeClientSettings settings) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact]
+        public async Task AZC0021ProducedForClientSettingsWithMultipleOtherParameters()
+        {
+            const string code = @"
+namespace System.ClientModel
+{
+    public class ClientSettings {}
+}
+
+namespace RandomNamespace
+{
+    using System;
+    using Azure;
+
+    public class SomeClientSettings : System.ClientModel.ClientSettings {}
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public {|AZC0021:SomeClient|}(Uri endpoint, AzureKeyCredential credential, SomeClientSettings settings) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact]
+        public async Task AZC0021NotProducedForClientSettingsAsOnlyParameter()
+        {
+            const string code = @"
+namespace System.ClientModel
+{
+    public class ClientSettings {}
+}
+
+namespace RandomNamespace
+{
+    public class SomeClientSettings : System.ClientModel.ClientSettings {}
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public SomeClient(SomeClientSettings settings) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact]
+        public async Task AZC0021NotProducedForNonClientSettingsWithMultipleParameters()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using Azure.Core;
+
+    public class SomeClientOptions : ClientOptions {}
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public SomeClient(string connectionString) {}
+        public SomeClient(string connectionString, SomeClientOptions options) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact]
+        public async Task AZC0021ProducedForClientSettingsInMiddlePosition()
+        {
+            const string code = @"
+namespace System.ClientModel
+{
+    public class ClientSettings {}
+}
+
+namespace RandomNamespace
+{
+    public class SomeClientSettings : System.ClientModel.ClientSettings {}
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public {|AZC0021:SomeClient|}(SomeClientSettings settings, string connectionString) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
@@ -134,6 +134,15 @@ namespace Azure.ClientSdk.Analyzers
             DiagnosticCategory.Usage,
             DiagnosticSeverity.Warning, true);
 
+        public static DiagnosticDescriptor AZC0021 = new DiagnosticDescriptor(
+            nameof(AZC0021),
+            "ClientSettings constructor parameters should not be combined with other parameters",
+            "A constructor with a ClientSettings-derived parameter should only take that single parameter",
+            DiagnosticCategory.Usage,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true
+        );
+
         public static readonly DiagnosticDescriptor AZC0030 = new DiagnosticDescriptor(
             nameof(AZC0030),
             "Improper model name suffix",

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/SymbolAnalyzerBase.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/SymbolAnalyzerBase.cs
@@ -11,6 +11,7 @@ namespace Azure.ClientSdk.Analyzers
         private const string ClientOptionsSuffix = "ClientOptions";
         private const string ClientsOptionsSuffix = "ClientsOptions";
         private const string AzureCoreClientOptions = "Azure.Core.ClientOptions";
+        private const string SystemClientModelClientSettings = "System.ClientModel.ClientSettings";
 
         public abstract SymbolKind[] SymbolKinds { get; }
         public abstract void Analyze(ISymbolAnalysisContext context);
@@ -51,6 +52,29 @@ namespace Azure.ClientSdk.Analyzers
                 if ($"{fullName}".Equals(AzureCoreClientOptions))
                 {
                     return typeSymbol.Name.EndsWith(ClientOptionsSuffix) || typeSymbol.Name.EndsWith(ClientsOptionsSuffix);
+                }
+
+                baseType = baseType.BaseType;
+            }
+
+            return false;
+        }
+
+        protected bool IsClientSettingsType(ITypeSymbol typeSymbol)
+        {
+            if (typeSymbol.TypeKind != TypeKind.Class || typeSymbol.DeclaredAccessibility != Accessibility.Public)
+            {
+                return false;
+            }
+            
+            ITypeSymbol baseType = typeSymbol.BaseType;
+            while (baseType != null) 
+            {
+                // validate if the base type is System.ClientModel.ClientSettings
+                var fullName = $"{baseType.ContainingNamespace.GetFullNamespaceName()}.{baseType.Name}";
+                if ($"{fullName}".Equals(SystemClientModelClientSettings))
+                {
+                    return true;
                 }
 
                 baseType = baseType.BaseType;


### PR DESCRIPTION
## Description

This PR adds support for the new System.ClientModel.ClientSettings pattern introduced in https://github.com/Azure/azure-sdk-for-net/pull/55034.

## Changes

### New Analyzer: AZC0021
- Enforces that ClientSettings parameters must always be the only parameter in a constructor
- Triggers when any parameter deriving from System.ClientModel.ClientSettings is combined with other parameters

### Updated Analyzer: AZC0007
- Now allows constructors with a single ClientSettings parameter without requiring a ClientOptions overload
- This is the new pattern for System.ClientModel-based clients

### Implementation Details
- Added IsClientSettingsType() helper method in SymbolAnalyzerBase.cs to detect types deriving from System.ClientModel.ClientSettings
- Updated ClientConstructorAnalyzer to handle the new pattern
- Added comprehensive test coverage (12 new tests)

## Test Coverage

### AZC0007 Tests (6 new tests)
1. Client with parameterless ctor + single ClientSettings ctor (passes)
2. Client with only ClientSettings ctor and no parameterless ctor (triggers AZC0005)
3. Client with ClientSettings and other proper overloads (passes)
4. Client with ClientSettings but missing options overload on non-settings ctors (triggers AZC0007)
5. Multiple different ClientSettings overloads (passes)
6. Settings parameter not deriving from ClientSettings (triggers AZC0007)

### AZC0021 Tests (5 new tests)
1. ClientSettings combined with one other parameter (triggers AZC0021)
2. ClientSettings combined with multiple parameters (triggers AZC0021)
3. Solo ClientSettings parameter (passes)
4. Non-ClientSettings with multiple parameters (passes)
5. ClientSettings in middle position (triggers AZC0021)

## Test Results
✅ All 848 analyzer tests passing (12 new tests added)

## Key Behavior
- Constructors with a solo ClientSettings parameter don't require a ClientOptions overload
- ClientSettings must ALWAYS be the only parameter (enforced by AZC0021)
- ClientSettings parameters must derive from System.ClientModel.ClientSettings
- Parameterless constructor still required (AZC0005)
- Other constructors still require ClientOptions overloads (AZC0007)