### PR TITLE
Refactor tsp-client calls to use npm exec

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/SdkGenerationToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/SdkGenerationToolTests.cs
@@ -92,7 +92,7 @@ public class SdkGenerationToolTests
             TypeSpecProject = Path.GetDirectoryName(tspLocationPath)!
         };
         _mockTspClientHelper
-            .Setup(x => x.UpdateGenerationAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.UpdateGenerationAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedResult);
 
         // Act
@@ -104,7 +104,7 @@ public class SdkGenerationToolTests
         Assert.That(result.NextSteps, Is.Not.Null);
         Assert.That(result.NextSteps, Has.Count.GreaterThan(0));
         Assert.That(result.NextSteps?.First(), Does.Contain("build the code"));
-        _mockTspClientHelper.Verify(x => x.UpdateGenerationAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockTspClientHelper.Verify(x => x.UpdateGenerationAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Test]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/CustomizedCodeUpdateToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/CustomizedCodeUpdateToolTests.cs
@@ -181,10 +181,10 @@ public class CustomizedCodeUpdateToolAutoTests
 
 internal class MockTspHelper : ITspClientHelper
 {
-    public Task<TspToolResponse> ConvertSwaggerAsync(string swaggerReadmePath, string outputDirectory, bool isArm, bool fullyCompatible, bool isCli, CancellationToken ct)
+    public Task<TspToolResponse> ConvertSwaggerAsync(string swaggerReadmePath, string outputDirectory, bool isArm, bool fullyCompatible, bool isCli, CancellationToken ct = default)
         => Task.FromResult(new TspToolResponse { IsSuccessful = true, TypeSpecProject = outputDirectory });
-    public Task<TspToolResponse> UpdateGenerationAsync(string tspLocationPath, string outputDirectory, string? commitSha = null, bool isCli = false, CancellationToken ct = default)
-        => Task.FromResult(new TspToolResponse { IsSuccessful = true, TypeSpecProject = outputDirectory });
+    public Task<TspToolResponse> UpdateGenerationAsync(string packagePath, string? commitSha = null, bool isCli = false, CancellationToken ct = default)
+        => Task.FromResult(new TspToolResponse { IsSuccessful = true, TypeSpecProject = packagePath });
     public Task<TspToolResponse> InitializeGenerationAsync(string workingDirectory, string tspConfigPath, string[]? additionalArgs = null, CancellationToken ct = default)
         => Task.FromResult(new TspToolResponse { IsSuccessful = true, TypeSpecProject = workingDirectory });
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/CustomizedCodeUpdateToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/CustomizedCodeUpdateToolTests.cs
@@ -183,8 +183,8 @@ internal class MockTspHelper : ITspClientHelper
 {
     public Task<TspToolResponse> ConvertSwaggerAsync(string swaggerReadmePath, string outputDirectory, bool isArm, bool fullyCompatible, bool isCli, CancellationToken ct = default)
         => Task.FromResult(new TspToolResponse { IsSuccessful = true, TypeSpecProject = outputDirectory });
-    public Task<TspToolResponse> UpdateGenerationAsync(string packagePath, string? commitSha = null, bool isCli = false, CancellationToken ct = default)
-        => Task.FromResult(new TspToolResponse { IsSuccessful = true, TypeSpecProject = packagePath });
+    public Task<TspToolResponse> UpdateGenerationAsync(string tspLocationDirectory, string? commitSha = null, bool isCli = false, CancellationToken ct = default)
+        => Task.FromResult(new TspToolResponse { IsSuccessful = true, TypeSpecProject = tspLocationDirectory });
     public Task<TspToolResponse> InitializeGenerationAsync(string workingDirectory, string tspConfigPath, string[]? additionalArgs = null, CancellationToken ct = default)
         => Task.FromResult(new TspToolResponse { IsSuccessful = true, TypeSpecProject = workingDirectory });
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/ITspClientHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/ITspClientHelper.cs
@@ -6,7 +6,7 @@ namespace Azure.Sdk.Tools.Cli.Helpers;
 
 /// <summary>
 /// Abstraction for running common tsp-client commands (convert, update, generate, init).
-/// This centralizes npx invocation logic so multiple tools (Generate, Build, Update workflows)
+/// This centralizes npm exec invocation logic so multiple tools (Generate, Build, Update workflows)
 /// can share a single implementation without duplicating code.
 /// </summary>
 public interface ITspClientHelper
@@ -14,16 +14,22 @@ public interface ITspClientHelper
     /// <summary>
     /// Runs `tsp-client convert --swagger-readme <readme> --output-dir <out>` with optional flags.
     /// </summary>
-    Task<TspToolResponse> ConvertSwaggerAsync(string swaggerReadmePath, string outputDirectory, bool isArm, bool fullyCompatible, bool isCli, CancellationToken ct);
+    /// <param name="swaggerReadmePath">Path to the swagger readme file.</param>
+    /// <param name="outputDirectory">Directory to place the converted output.</param>
+    /// <param name="isArm">Whether this is an ARM (management plane) spec.</param>
+    /// <param name="fullyCompatible">Whether to use fully compatible mode.</param>
+    /// <param name="isCli">True when invoked from CLI flow (suppresses duplicate streamed output in error text).</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<TspToolResponse> ConvertSwaggerAsync(string swaggerReadmePath, string outputDirectory, bool isArm, bool fullyCompatible, bool isCli, CancellationToken ct = default);
 
     /// <summary>
-    /// Runs `tsp-client update --commit <commitSha>` to regenerate a TypeSpec client into the specified output directory.
+    /// Runs `tsp-client update` to regenerate a TypeSpec client using the tsp-location.yaml in the package directory.
     /// </summary>
-    /// <param name="tspLocationPath">Path to the tsp-location.yaml file.</param>
-    /// <param name="outputDirectory">Directory to place regenerated output (created if missing, must be empty or created new).</param>
+    /// <param name="packagePath">Path to the SDK package directory containing tsp-location.yaml.</param>
     /// <param name="commitSha">Optional commit SHA to update the tsp-location.yaml with before regeneration. If null, uses the commit SHA from the existing tsp-location.yaml.</param>
     /// <param name="isCli">True when invoked from CLI flow (suppresses duplicate streamed output in error text).</param>
-    Task<TspToolResponse> UpdateGenerationAsync(string tspLocationPath, string outputDirectory, string? commitSha = null, bool isCli = false, CancellationToken ct = default);
+    /// <param name="ct">Cancellation token.</param>
+    Task<TspToolResponse> UpdateGenerationAsync(string packagePath, string? commitSha = null, bool isCli = false, CancellationToken ct = default);
 
     /// <summary>
     /// Runs `tsp-client init` to initialize SDK generation from a tspconfig.yaml file.
@@ -31,5 +37,6 @@ public interface ITspClientHelper
     /// <param name="workingDirectory">Working directory where the SDK will be generated (typically the SDK repo root).</param>
     /// <param name="tspConfigPath">Path to the tspconfig.yaml file (can be local path or remote HTTPS URL).</param>
     /// <param name="additionalArgs">Optional additional arguments to pass to tsp-client init (e.g., ["--repo", "Azure/azure-rest-api-specs", "--emitter-options", "key=value"]).</param>
+    /// <param name="ct">Cancellation token.</param>
     Task<TspToolResponse> InitializeGenerationAsync(string workingDirectory, string tspConfigPath, string[]? additionalArgs = null, CancellationToken ct = default);
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/ITspClientHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/ITspClientHelper.cs
@@ -25,11 +25,11 @@ public interface ITspClientHelper
     /// <summary>
     /// Runs `tsp-client update` to regenerate a TypeSpec client using the tsp-location.yaml in the package directory.
     /// </summary>
-    /// <param name="packagePath">Path to the SDK package directory containing tsp-location.yaml.</param>
+    /// <param name="tspLocationDirectory">Path to the directory containing tsp-location.yaml.</param>
     /// <param name="commitSha">Optional commit SHA to update the tsp-location.yaml with before regeneration. If null, uses the commit SHA from the existing tsp-location.yaml.</param>
     /// <param name="isCli">True when invoked from CLI flow (suppresses duplicate streamed output in error text).</param>
     /// <param name="ct">Cancellation token.</param>
-    Task<TspToolResponse> UpdateGenerationAsync(string packagePath, string? commitSha = null, bool isCli = false, CancellationToken ct = default);
+    Task<TspToolResponse> UpdateGenerationAsync(string tspLocationDirectory, string? commitSha = null, bool isCli = false, CancellationToken ct = default);
 
     /// <summary>
     /// Runs `tsp-client init` to initialize SDK generation from a tspconfig.yaml file.

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Process/CommandHelpers.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Process/CommandHelpers.cs
@@ -40,6 +40,11 @@ public interface IGitCommandHelper
     public Task<ProcessResult> Run(GitOptions options, CancellationToken ct);
 }
 
+public interface INpmHelper
+{
+    public Task<ProcessResult> Run(NpmOptions options, CancellationToken ct);
+}
+
 public sealed class ProcessHelper(ILogger<ProcessHelper> logger, IRawOutputHelper outputHelper)
     : ProcessHelperBase<ProcessHelper>(logger, outputHelper), IProcessHelper
 {
@@ -74,4 +79,10 @@ public sealed class GitCommandHelper(ILogger<GitCommandHelper> logger, IRawOutpu
     : ProcessHelperBase<GitCommandHelper>(logger, outputHelper), IGitCommandHelper
 {
     public async Task<ProcessResult> Run(GitOptions options, CancellationToken ct) => await base.Run(options, ct);
+}
+
+public sealed class NpmHelper(ILogger<NpmHelper> logger, IRawOutputHelper outputHelper)
+    : ProcessHelperBase<NpmHelper>(logger, outputHelper), INpmHelper
+{
+    public async Task<ProcessResult> Run(NpmOptions options, CancellationToken ct) => await base.Run(options, ct);
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Process/Options/NpmOptions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Process/Options/NpmOptions.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Sdk.Tools.Cli.Helpers;
+
+public class NpmOptions : ProcessOptions, IProcessOptions
+{
+    private const string NPM = "npm";
+
+    public string? Prefix { get; }
+
+    private string shortName;
+    public override string ShortName
+    {
+        get
+        {
+            if (string.IsNullOrEmpty(shortName))
+            {
+                shortName = string.IsNullOrEmpty(Prefix) ? "npm" : $"npm-{Path.GetFileName(Prefix)}";
+            }
+            return shortName;
+        }
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NpmOptions"/> class for running 'npm exec' commands with an optional prefix.
+    /// </summary>
+    /// <param name="prefix">The npm prefix path. If provided, runs 'npm exec --prefix {prefix} -- {args}'. 
+    /// If null or empty, runs 'npm exec -- {args}'.</param>
+    /// <param name="args">The arguments to pass after the 'npm exec --' separator.</param>
+    /// <param name="logOutputStream">Whether to log the output stream. Defaults to true.</param>
+    /// <param name="workingDirectory">The working directory for the command. Defaults to current directory.</param>
+    /// <param name="timeout">The timeout for the command. Defaults to 2 minutes.</param>
+    public NpmOptions(
+        string? prefix,
+        string[] args,
+        bool logOutputStream = true,
+        string? workingDirectory = null,
+        TimeSpan? timeout = null
+    ) : this(BuildArgs(prefix, args), logOutputStream, workingDirectory, timeout)
+    {
+        Prefix = prefix;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NpmOptions"/> class for running any npm command.
+    /// </summary>
+    /// <param name="args">The full arguments to pass to npm (e.g., ["install"], ["run", "build"], ["ci"]).</param>
+    /// <param name="logOutputStream">Whether to log the output stream. Defaults to true.</param>
+    /// <param name="workingDirectory">The working directory for the command. Defaults to current directory.</param>
+    /// <param name="timeout">The timeout for the command. Defaults to 2 minutes.</param>
+    public NpmOptions(
+        string[] args,
+        bool logOutputStream = true,
+        string? workingDirectory = null,
+        TimeSpan? timeout = null
+    ) : base("npm", args, logOutputStream, workingDirectory, timeout) {}
+
+    private static string[] BuildArgs(string? prefix, string[] args)
+    {
+        if (string.IsNullOrEmpty(prefix))
+        {
+            return ["exec", "--", .. args];
+        }
+        return ["exec", "--prefix", prefix, "--", .. args];
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TspClientHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TspClientHelper.cs
@@ -79,20 +79,20 @@ public class TspClientHelper : ITspClientHelper
     }
 
     /// <inheritdoc />
-    public async Task<TspToolResponse> UpdateGenerationAsync(string packagePath, string? commitSha = null, bool isCli = false, CancellationToken ct = default)
+    public async Task<TspToolResponse> UpdateGenerationAsync(string tspLocationDirectory, string? commitSha = null, bool isCli = false, CancellationToken ct = default)
     {
-        var tspLocationPath = Path.Combine(packagePath, "tsp-location.yaml");
-        logger.LogInformation("tsp-client update: {packagePath}, commit: {commit}", packagePath, commitSha ?? "(latest)");
+        var tspLocationPath = Path.Combine(tspLocationDirectory, "tsp-location.yaml");
+        logger.LogInformation("tsp-client update: {tspLocationDirectory}, commit: {commit}", tspLocationDirectory, commitSha ?? "(latest)");
         
         if (!File.Exists(tspLocationPath))
         {
             return new TspToolResponse {
                 ResponseError = $"tsp-location.yaml not found at path: {tspLocationPath}",
-                TypeSpecProject = packagePath
+                TypeSpecProject = tspLocationDirectory
             };
         }
         
-        var repoRootFolder = await gitHelper.DiscoverRepoRootAsync(packagePath, ct);
+        var repoRootFolder = await gitHelper.DiscoverRepoRootAsync(tspLocationDirectory, ct);
         
         var args = new List<string> { "tsp-client", "update" };
         if (!string.IsNullOrEmpty(commitSha))
@@ -106,7 +106,7 @@ public class TspClientHelper : ITspClientHelper
             npmPrefix,
             args.ToArray(),
             logOutputStream: true,
-            workingDirectory: packagePath,
+            workingDirectory: tspLocationDirectory,
             timeout: TimeSpan.FromMinutes(CommandTimeoutInMinutes)
         );
 
@@ -118,14 +118,14 @@ public class TspClientHelper : ITspClientHelper
                 ResponseError = isCli
                     ? "Failed to regenerate TypeSpec client, see details in the above logs."
                     : "Failed to regenerate TypeSpec client, see generator output below" + Environment.NewLine + result.Output,
-                TypeSpecProject = packagePath
+                TypeSpecProject = tspLocationDirectory
             };
         }
 
         return new TspToolResponse
         {
             IsSuccessful = true,
-            TypeSpecProject = packagePath
+            TypeSpecProject = tspLocationDirectory
         };
     }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TspClientHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TspClientHelper.cs
@@ -8,36 +8,57 @@ namespace Azure.Sdk.Tools.Cli.Helpers;
 /// <inheritdoc />
 public class TspClientHelper : ITspClientHelper
 {
-    private readonly INpxHelper npxHelper;
+    private readonly INpmHelper npmHelper;
+    private readonly ITypeSpecHelper typeSpecHelper;
+    private readonly IGitHelper gitHelper;
     private readonly ILogger<TspClientHelper> logger;
     private const int CommandTimeoutInMinutes = 30;
 
-    public TspClientHelper(INpxHelper npxHelper, ILogger<TspClientHelper> logger)
+    public TspClientHelper(INpmHelper npmHelper, ITypeSpecHelper typeSpecHelper, IGitHelper gitHelper, ILogger<TspClientHelper> logger)
     {
-        this.npxHelper = npxHelper;
+        this.npmHelper = npmHelper;
+        this.typeSpecHelper = typeSpecHelper;
+        this.gitHelper = gitHelper;
         this.logger = logger;
     }
 
+    /// <summary>
+    /// Gets the npm prefix path based on the repository type.
+    /// For azure-rest-api-specs (public or private), uses the repo root folder directly.
+    /// For SDK repos, uses eng/common/tsp-client under the repo root.
+    /// </summary>
+    private async Task<string> GetNpmPrefixAsync(string repoRootFolder, CancellationToken ct)
+    {
+        var isSpecRepo = await typeSpecHelper.IsRepoPathForSpecRepoAsync(repoRootFolder, ct);
+        if (isSpecRepo)
+        {
+            return repoRootFolder;
+        }
+        return Path.Combine(repoRootFolder, "eng", "common", "tsp-client");
+    }
+
     /// <inheritdoc />
-    public async Task<TspToolResponse> ConvertSwaggerAsync(string swaggerReadmePath, string outputDirectory, bool isArm, bool fullyCompatible, bool isCli, CancellationToken ct)
+    public async Task<TspToolResponse> ConvertSwaggerAsync(string swaggerReadmePath, string outputDirectory, bool isArm, bool fullyCompatible, bool isCli, CancellationToken ct = default)
     {
         logger.LogInformation("tsp-client convert: {readme} -> {out} (arm={arm}, fullyCompatible={fc})", swaggerReadmePath, outputDirectory, isArm, fullyCompatible);
-        var npxOptions = new NpxOptions(
-            "@azure-tools/typespec-client-generator-cli",
+        var repoRootFolder = await gitHelper.DiscoverRepoRootAsync(swaggerReadmePath, ct);
+        var npmPrefix = await GetNpmPrefixAsync(repoRootFolder, ct);
+        var npmOptions = new NpmOptions(
+            npmPrefix,
             ["tsp-client", "convert", "--swagger-readme", swaggerReadmePath, "--output-dir", outputDirectory],
             logOutputStream: true
         );
 
         if (isArm)
         {
-            npxOptions.AddArgs("--arm");
+            npmOptions.AddArgs("--arm");
         }
         if (fullyCompatible)
         {
-            npxOptions.AddArgs("--fully-compatible");
+            npmOptions.AddArgs("--fully-compatible");
         }
 
-        var result = await npxHelper.Run(npxOptions, ct);
+        var result = await npmHelper.Run(npmOptions, ct);
         if (result.ExitCode != 0)
         {
             // Returning failure; omit verbose output in CLI mode since stream already logged.
@@ -57,18 +78,21 @@ public class TspClientHelper : ITspClientHelper
         };
     }
 
-    public async Task<TspToolResponse> UpdateGenerationAsync(string tspLocationPath, string outputDirectory, string? commitSha = null, bool isCli = false, CancellationToken ct = default)
+    /// <inheritdoc />
+    public async Task<TspToolResponse> UpdateGenerationAsync(string packagePath, string? commitSha = null, bool isCli = false, CancellationToken ct = default)
     {
-        logger.LogInformation("tsp-client update (tsp-location): {loc} -> {out}, commit: {commit}", tspLocationPath, outputDirectory, commitSha ?? "");
+        var tspLocationPath = Path.Combine(packagePath, "tsp-location.yaml");
+        logger.LogInformation("tsp-client update: {packagePath}, commit: {commit}", packagePath, commitSha ?? "(latest)");
         
         if (!File.Exists(tspLocationPath))
         {
             return new TspToolResponse {
                 ResponseError = $"tsp-location.yaml not found at path: {tspLocationPath}",
-                TypeSpecProject = outputDirectory
+                TypeSpecProject = packagePath
             };
         }
-        var workingDir = Path.GetDirectoryName(Path.GetFullPath(tspLocationPath))!;
+        
+        var repoRootFolder = await gitHelper.DiscoverRepoRootAsync(packagePath, ct);
         
         var args = new List<string> { "tsp-client", "update" };
         if (!string.IsNullOrEmpty(commitSha))
@@ -77,15 +101,16 @@ public class TspClientHelper : ITspClientHelper
             args.Add(commitSha);
         }
         
-        var npxOptions = new NpxOptions(
-            "@azure-tools/typespec-client-generator-cli",
+        var npmPrefix = await GetNpmPrefixAsync(repoRootFolder, ct);
+        var npmOptions = new NpmOptions(
+            npmPrefix,
             args.ToArray(),
             logOutputStream: true,
-            workingDirectory: workingDir,
+            workingDirectory: packagePath,
             timeout: TimeSpan.FromMinutes(CommandTimeoutInMinutes)
         );
 
-        var result = await npxHelper.Run(npxOptions, ct);
+        var result = await npmHelper.Run(npmOptions, ct);
         if (result.ExitCode != 0)
         {
             return new TspToolResponse
@@ -93,14 +118,14 @@ public class TspClientHelper : ITspClientHelper
                 ResponseError = isCli
                     ? "Failed to regenerate TypeSpec client, see details in the above logs."
                     : "Failed to regenerate TypeSpec client, see generator output below" + Environment.NewLine + result.Output,
-                TypeSpecProject = outputDirectory
+                TypeSpecProject = packagePath
             };
         }
 
         return new TspToolResponse
         {
             IsSuccessful = true,
-            TypeSpecProject = outputDirectory
+            TypeSpecProject = packagePath
         };
     }
 
@@ -116,15 +141,17 @@ public class TspClientHelper : ITspClientHelper
             arguments.AddRange(additionalArgs);
         }
 
-        var npxOptions = new NpxOptions(
-            "@azure-tools/typespec-client-generator-cli",
+        var repoRootFolder = await gitHelper.DiscoverRepoRootAsync(workingDirectory, ct);
+        var npmPrefix = await GetNpmPrefixAsync(repoRootFolder, ct);
+        var npmOptions = new NpmOptions(
+            npmPrefix,
             arguments.ToArray(),
             logOutputStream: true,
             workingDirectory: workingDirectory,
             timeout: TimeSpan.FromMinutes(CommandTimeoutInMinutes)
         );
 
-        var result = await npxHelper.Run(npxOptions, ct);
+        var result = await npmHelper.Run(npmOptions, ct);
         if (result.ExitCode != 0)
         {
             return new TspToolResponse

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
@@ -70,6 +70,7 @@ namespace Azure.Sdk.Tools.Cli.Services
 
             // Process Helper Classes
             services.AddSingleton<INpxHelper, NpxHelper>();
+            services.AddSingleton<INpmHelper, NpmHelper>();
             services.AddSingleton<IPowershellHelper, PowershellHelper>();
             services.AddSingleton<IProcessHelper, ProcessHelper>();
             services.AddSingleton<IMavenHelper, MavenHelper>();

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkGenerationTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkGenerationTool.cs
@@ -104,7 +104,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
                     logger.LogInformation("TypeSpec Project Path from tsp-location.yaml: {TypeSpecProjectPath}", typeSpecProjectPath);
 
                     // Run tsp-client update using the existing tsp-location.yaml
-                    var tspResult = await tspClientHelper.UpdateGenerationAsync(tspLocationPath, tspLocationDirectory, ct: ct);
+                    var tspResult = await tspClientHelper.UpdateGenerationAsync(tspLocationDirectory, ct: ct);
                     
                     if (!tspResult.IsSuccessful)
                     {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/CustomizedCodeUpdateTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/CustomizedCodeUpdateTool.cs
@@ -157,8 +157,7 @@ public class CustomizedCodeUpdateTool: LanguageMcpTool
                 };
             }
 
-            var tspLocationPath = Path.Combine(packagePath, "tsp-location.yaml");
-            var regenResult = await tspClientHelper.UpdateGenerationAsync(tspLocationPath, packagePath, commitSha, isCli: false, ct);
+            var regenResult = await tspClientHelper.UpdateGenerationAsync(packagePath, commitSha, isCli: false, ct);
             if (!regenResult.IsSuccessful)
             {
                 return new CustomizedCodeUpdateResponse
@@ -219,7 +218,7 @@ public class CustomizedCodeUpdateTool: LanguageMcpTool
 
             // Patches were applied, regenerate and build to validate
             logger.LogInformation("Patches were applied. Regenerating code to validate customizations...");
-            var (regenSuccess, regenError) = await RegenerateAfterPatchesAsync(tspLocationPath, packagePath, commitSha, ct);
+            var (regenSuccess, regenError) = await RegenerateAfterPatchesAsync(packagePath, commitSha, ct);
             if (!regenSuccess)
             {
                 logger.LogWarning("Code regeneration failed: {Error}", regenError);
@@ -269,11 +268,11 @@ public class CustomizedCodeUpdateTool: LanguageMcpTool
         }
     }
 
-    private async Task<(bool Success, string? ErrorMessage)> RegenerateAfterPatchesAsync(string tspLocationPath, string packagePath, string commitSha, CancellationToken ct)
+    private async Task<(bool Success, string? ErrorMessage)> RegenerateAfterPatchesAsync(string packagePath, string commitSha, CancellationToken ct)
     {
         try
         {
-            var regenResult = await tspClientHelper.UpdateGenerationAsync(tspLocationPath, packagePath, commitSha, isCli: false, ct);
+            var regenResult = await tspClientHelper.UpdateGenerationAsync(packagePath, commitSha, isCli: false, ct);
 
             if (!regenResult.IsSuccessful)
             {


### PR DESCRIPTION
Resolved https://github.com/Azure/azure-sdk-tools/issues/13667

**Key Changes:**
- Added `NpmOptions` class to encapsulate npm command execution options
- Replaced `tsp-client` call to use `npm exec` instead of `npx`
- Simplify signature of `UpdateGenerationAsync` method

**Test Screenshot:**
spec repo:
<img width="1742" height="1030" alt="image" src="https://github.com/user-attachments/assets/2a04cf34-ec5d-4cdb-9f99-8d643b8ba114" />

sdk repo:
<img width="2210" height="977" alt="image" src="https://github.com/user-attachments/assets/1fc4a549-2e52-4724-83de-0e2718f29a57" />
