### PR TITLE
Update lodash and tar dependencies to latest versions

### DIFF
--- a/tools/js-sdk-release-tools/package-lock.json
+++ b/tools/js-sdk-release-tools/package-lock.json
@@ -4908,15 +4908,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -6851,9 +6851,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.3.tgz",
-      "integrity": "sha512-ENg5JUHUm2rDD7IvKNFGzyElLXNjachNLp6RaGf4+JOgxXHkqA+gq81ZAMCUmtMtqBsoU62lcp6S27g1LCYGGQ==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",


### PR DESCRIPTION
This pull request updates dependencies in the `tools/js-sdk-release-tools/package-lock.json` file to address security, stability, or compatibility improvements. The most important changes are version bumps for several key packages.

Dependency updates:

* Upgraded `lodash` from version `4.17.21` to `4.17.23` to include the latest fixes and improvements.
* Upgraded `lodash-es` from version `4.17.21` to `4.17.23` for parity and security updates.
* Upgraded `tar` from version `7.5.3` to `7.5.7`, likely addressing bug fixes or vulnerabilities.

Describe the problem that is addressed by this PR
Two moderate-severity Prototype Pollution vulnerabilities in lodash's _.unset and _.omit functions (https://github.com/advisories/GHSA-xxjr-mmjv-4gpg) affecting transitive dependencies of @azure-tools/js-sdk-release-tools.