### PR TITLE
Lazy initialize AzureSdkKnowledgeBaseService

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/AzureSdkKnowledgeBaseService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/AzureSdkKnowledgeBaseService.cs
@@ -15,13 +15,16 @@ namespace Azure.Sdk.Tools.Cli.Services
     /// </summary>
     public class AzureSdkKnowledgeBaseService : IAzureSdkKnowledgeBaseService
     {
+        private IPublicClientApplication? _msalApp;
+
         private readonly HttpClient _httpClient;
         private readonly ILogger<AzureSdkKnowledgeBaseService> _logger;
         private readonly AzureSdkKnowledgeBaseOptions _options;
         private readonly JsonSerializerOptions _jsonOptions;
-        private readonly IPublicClientApplication? _msalApp;
         private readonly IList<string> scopes = new List<string>();
         private const string authUrl = "https://login.microsoftonline.com/organizations/";
+
+        private bool initialized = false;
 
         private static readonly ServiceInfo DefaultAzureSdkKnowledgeService = new()
         {
@@ -38,13 +41,20 @@ namespace Azure.Sdk.Tools.Cli.Services
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _options = options.Value ?? throw new ArgumentNullException(nameof(options));
-
             _jsonOptions = new JsonSerializerOptions
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                 WriteIndented = _options.EnableDebugLogging
             };
+        }
+
+        /// <summary>
+        /// Initializes the service, including setting up authentication if necessary.
+        /// This is separate from the constructor to allow for lazy initialization.
+        /// </summary>
+        private void Initialize()
+        {
             if (string.IsNullOrEmpty(_options.Endpoint))
             {
                 _logger.LogInformation("Azure knowledge base service endpoint has not been configured. You can set the environment variable {EndpointEnvironmentVariable}.", AzureSdkKnowledgeBaseOptions.EndpointEnvironmentVariable);
@@ -54,7 +64,8 @@ namespace Azure.Sdk.Tools.Cli.Services
                 _options.ClientId = DefaultAzureSdkKnowledgeService.ClientId;
             }
 
-            if (!string.IsNullOrEmpty(_options.ClientId)) {
+            if (!string.IsNullOrEmpty(_options.ClientId))
+            {
                 _logger.LogInformation("Azure knowledge base service endpoint and client id are configured. Initializing authentication.");
 
                 var builder = PublicClientApplicationBuilder
@@ -68,17 +79,25 @@ namespace Azure.Sdk.Tools.Cli.Services
                 ConfigureTokenCache(_msalApp);
             }
 
-            if (!string.IsNullOrEmpty(_options.AuthScope)) {
+            if (!string.IsNullOrEmpty(_options.AuthScope))
+            {
                 scopes.Add(_options.AuthScope);
             }
 
             ConfigureHttpClient();
+
+            initialized = true;
         }
 
         public async Task<CompletionResponse> SendCompletionRequestAsync(
             CompletionRequest request,
             CancellationToken cancellationToken = default)
         {
+            if (!initialized)
+            {
+                Initialize();
+            }
+
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
@@ -180,6 +199,7 @@ namespace Azure.Sdk.Tools.Cli.Services
 
             return isValid;
         }
+
         private async Task<AuthenticationResult> RetrieveAiCompletionAccessTokenAsync(CancellationToken cancellationToken = default)
         {
             if (_msalApp != null)
@@ -231,12 +251,14 @@ namespace Azure.Sdk.Tools.Cli.Services
                     throw new Exception("Failed to acquire authentication token after interactive authentication attempt.");
                 }
                 return authResult;
-            } else
+            }
+            else
             {
                 _logger.LogInformation("Azure knowledge base service client id not configured, skipping authentication.");
                 return null;
             }
         }
+
         private async Task<CompletionResponse> HandleHttpResponse(
             HttpResponseMessage response,
             CancellationToken cancellationToken)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/appsettings.json
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/appsettings.json
@@ -2,7 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Debug",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "System.Net.Http.HttpClient": "Warning"
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
Currently the `AzureSdkKnowledgeBaseService` does all its setup in the constructor, which includes info logging and other operations. As we force instantiate all tool classes on CLI startup in `CommandRunner.cs`, this causes the `TypeSpecAuthoringTool` to load `AzureSdkKnowledgeBaseService`. The effect was that we info logging distracting and irrelevant logs for any command, in addition to spending time doing configuration and authentication.

This PR fixes this issue by moving all config in the service to a lazy `Initialize()` method that only gets called when the service is used. Additionally the http client log level threshold is changed to `Warning` to prevent noisy request logs in typespec authoring requests.

Example problematic output:

```
⇉ ⇉ ⇉ dotnet run -- example hello-world foo
info: Azure.Sdk.Tools.Cli.Services.AzureSdkKnowledgeBaseService[0]
      Azure knowledge base service endpoint has not been configured. You can set the environment variable AZURE_SDK_KB_ENDPOINT.
info: Azure.Sdk.Tools.Cli.Services.AzureSdkKnowledgeBaseService[0]
      Using default endpoint: https://azuresdkqabot-dev-serve-authoring-epgbcvbpa3adcvcu.westus2-01.azurewebsites.net
info: Azure.Sdk.Tools.Cli.Services.AzureSdkKnowledgeBaseService[0]
      Azure knowledge base service endpoint and client id are configured. Initializing authentication.
info: Azure.Sdk.Tools.Cli.Tools.Example.HelloWorldTool[0]
      Echoing message: foobar
RESPONDING TO 'foobar' with SUCCESS: 0
Duration: 1ms

```