### PR TITLE
[APIView] Add TypeSpec metadata file support for APIView

### DIFF
--- a/eng/common/scripts/Detect-Api-Changes.ps1
+++ b/eng/common/scripts/Detect-Api-Changes.ps1
@@ -57,6 +57,13 @@ function Submit-Request($filePath, $packageInfo)
         $query.Add('codeFile', $reviewFileName)
         # Pass only relative path in package artifact directory when code file is also present
         $query.Add('filePath', (Split-Path -Leaf $filePath))
+
+        $metadataFileFullName = Join-Path -Path $ArtifactPath $packageName "typespec-metadata.json"
+        if (Test-Path $metadataFileFullName)
+        {
+            $query.Add('metadataFile', "typespec-metadata.json")
+            LogInfo "Found TypeSpec metadata file: typespec-metadata.json"
+        }
     }
     else
     {

--- a/eng/scripts/Create-Apiview-Token-TypeSpec.ps1
+++ b/eng/scripts/Create-Apiview-Token-TypeSpec.ps1
@@ -26,6 +26,7 @@ function Generate-Apiview-File($packagePath)
     npm install
     npm list
     npx tsp compile . --emit=@azure-tools/typespec-apiview --option "@azure-tools/typespec-apiview.emitter-output-dir={project-root}/output/apiview.json"
+    npx tsp compile . --emit=@azure-tools/typespec-metadata --option "@azure-tools/typespec-metadata.output-file={project-root}/output/typespec-metadata.json" --option "@azure-tools/typespec-metadata.format=json"
     Pop-Location
 }
 


### PR DESCRIPTION
This PR enables the TypeSpec pipeline to generate and pass metadata files to the APIView API, supporting the Project-based Organization feature.

Related:
- https://github.com/Azure/azure-rest-api-specs/pull/40239