### PR TITLE
[APIView] Add clear message when review cannot be approved due to missing version

### DIFF
--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.spec.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.spec.ts
@@ -188,6 +188,7 @@ describe('ReviewPageOptionsComponent', () => {
         component.activeAPIRevision!.approvers = [];
         component.isCopilotReviewSupported = true;
         component.activeAPIRevisionIsApprovedByCurrentUser = false;
+        component.isMissingPackageVersion = false;
       });
 
       // Test cases that should return FALSE (approval NOT disabled)
@@ -266,7 +267,33 @@ describe('ReviewPageOptionsComponent', () => {
 
       it('should handle empty package version - should still disable when copilot required', () => {
         component.activeAPIRevision!.packageVersion = '';
+        component.isMissingPackageVersion = true;
         const isReviewByCopilotRequired = true;
+        const isVersionReviewedByCopilot = false;
+        const result = component['shouldDisableApproval'](isReviewByCopilotRequired, isVersionReviewedByCopilot);
+        expect(result).toBe(true);
+      });
+
+      it('should return true when package version is missing (empty string)', () => {
+        component.isMissingPackageVersion = true;
+        const isReviewByCopilotRequired = false;
+        const isVersionReviewedByCopilot = false;
+        const result = component['shouldDisableApproval'](isReviewByCopilotRequired, isVersionReviewedByCopilot);
+        expect(result).toBe(true);
+      });
+
+      it('should return true when package version is missing even when copilot review is completed', () => {
+        component.isMissingPackageVersion = true;
+        const isReviewByCopilotRequired = true;
+        const isVersionReviewedByCopilot = true;
+        const result = component['shouldDisableApproval'](isReviewByCopilotRequired, isVersionReviewedByCopilot);
+        expect(result).toBe(true);
+      });
+
+      it('should return true when package version is missing even if user already approved', () => {
+        component.isMissingPackageVersion = true;
+        component.activeAPIRevisionIsApprovedByCurrentUser = true;
+        const isReviewByCopilotRequired = false;
         const isVersionReviewedByCopilot = false;
         const result = component['shouldDisableApproval'](isReviewByCopilotRequired, isVersionReviewedByCopilot);
         expect(result).toBe(true);
@@ -309,6 +336,7 @@ describe('ReviewPageOptionsComponent', () => {
       beforeEach(() => {
         // Reset to default state for each test
         component.isCopilotReviewSupported = true;
+        component.isMissingPackageVersion = false;
         component.userProfile = { userName: 'testuser' } as UserProfile;
         component.activeAPIRevision = {
           approvers: [],
@@ -398,6 +426,37 @@ describe('ReviewPageOptionsComponent', () => {
 
         expect(component.isAPIRevisionApprovalDisabled).toBe(true);
         expect(component.apiRevisionApprovalBtnClass).toBe("btn btn-outline-secondary disabled");
+        expect(component.apiRevisionApprovalMessage).toBe("To approve the current API revision, it must first be reviewed by Copilot");
+      });
+
+      it('should show missing version message when package version is missing', () => {
+        component.activeAPIRevision!.approvers = [];
+        component.isMissingPackageVersion = true;
+
+        component['updateApprovalStates'](false, false);
+
+        expect(component.isAPIRevisionApprovalDisabled).toBe(true);
+        expect(component.apiRevisionApprovalBtnClass).toBe("btn btn-outline-secondary disabled");
+        expect(component.apiRevisionApprovalMessage).toBe("This API revision cannot be approved because it is missing a package version. Please ensure the package version is set.");
+      });
+
+      it('should prioritize missing version message over copilot message', () => {
+        component.activeAPIRevision!.approvers = [];
+        component.isMissingPackageVersion = true;
+
+        component['updateApprovalStates'](true, false);
+
+        expect(component.isAPIRevisionApprovalDisabled).toBe(true);
+        expect(component.apiRevisionApprovalMessage).toBe("This API revision cannot be approved because it is missing a package version. Please ensure the package version is set.");
+      });
+
+      it('should show copilot message when version exists but copilot review needed', () => {
+        component.activeAPIRevision!.approvers = [];
+        component.isMissingPackageVersion = false;
+
+        component['updateApprovalStates'](true, false);
+
+        expect(component.isAPIRevisionApprovalDisabled).toBe(true);
         expect(component.apiRevisionApprovalMessage).toBe("To approve the current API revision, it must first be reviewed by Copilot");
       });
     });


### PR DESCRIPTION

Fixes #13891

When an API revision is missing a package version, it cannot be approved since it will never progress to the release cycle. Previously, users saw a confusing message saying "you need to run Copilot" without understanding the actual blocker.

<img width="358" height="187" alt="image" src="https://github.com/user-attachments/assets/fbd71267-54bd-4c12-b259-fdb2d4ce11fe" />
