### PR TITLE
Pass RequireStrongNames param to nuget signing template

### DIFF
--- a/eng/pipelines/templates/jobs/nuget-publish.yml
+++ b/eng/pipelines/templates/jobs/nuget-publish.yml
@@ -23,6 +23,9 @@ parameters:
   - name: VerifyChangelog
     type: boolean
     default: false
+  - name: RequireStrongNames
+    type: boolean
+    default: true
 
 jobs:
   - job: PrePackagePublish
@@ -70,6 +73,7 @@ jobs:
           parameters:
             PackagesPath: $(Artifacts)
             BuildToolsPath: $(BuildToolPath)
+            RequireStrongNames: ${{ parameters.RequireStrongNames }}
 
       - ${{ if eq(parameters.ShouldPublishSymbols, true) }}:
         - template: pipelines/steps/publish-symbols.yml@azure-sdk-build-tools

--- a/eng/pipelines/templates/stages/archetype-sdk-publish-net.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-publish-net.yml
@@ -37,6 +37,7 @@ stages:
       ArtifactName: packages
       Feed: ${{ parameters.Feed }}
       VerifyChangelog: ${{ parameters.VerifyChangelog }}
+      RequireStrongNames: ${{ parameters.RequireStrongNames }}
       ${{ if parameters.PublishEnvironment }}:
         PublishEnvironment: ${{ parameters.PublishEnvironment }}
 


### PR DESCRIPTION
Issue: RequireStrongNames param is not passed to nuget signing step so it is always using default even if it's turned off in the pipeline.