### PR TITLE
[APIView] Add Permissions and Projects containers to Cosmos DB sync

### DIFF
--- a/eng/scripts/python/apiview-syncdb/sync_cosmosdb.py
+++ b/eng/scripts/python/apiview-syncdb/sync_cosmosdb.py
@@ -22,7 +22,7 @@ http_logger.setLevel(logging.WARNING)
 
 COSMOS_SELECT_ID_PARTITIONKEY_QUERY = "select c.id, c.{0} as partitionKey, c._ts from {1} c"
 
-COSMOS_CONTAINERS = ["APIRevisions", "Reviews", "Comments", "PullRequests", "SamplesRevisions"]
+COSMOS_CONTAINERS = ["APIRevisions", "Reviews", "Comments", "PullRequests", "SamplesRevisions", "Permissions", "Projects"]
 BACKUP_CONTAINER = "backups"
 BLOB_NAME_PATTERN ="cosmos/{0}/{1}"
 


### PR DESCRIPTION
Adds Permissions and Projects containers to the list of Cosmos DB containers that are synced from production backups to staging environments.

part of https://github.com/Azure/azure-sdk-tools/issues/8784 & https://github.com/Azure/azure-sdk-tools/issues/13301