### PR TITLE
Use metadata.json to read cross language definitions

### DIFF
--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/ApiViewProperties.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/ApiViewProperties.java
@@ -14,45 +14,45 @@ import java.util.Optional;
 
 /**
  * Sometimes libraries carry additional metadata with them that can make the output from APIView more useful. This
- * class is used to store that metadata, as it is deserialized from the /META-INF/apiview_properties.json file.
+ * class is used to store that metadata, as it is deserialized from the /META-INF/[artifactid]_metadata.json file.
  */
 public class ApiViewProperties implements JsonSerializable<ApiViewProperties> {
     private Flavor flavor;
 
     // This is a map of model names and methods to their TypeSpec definition IDs.
-    private Map<String, String> crossLanguageDefinitionIds = new HashMap<>();
+    private Map<String, String> crossLanguageDefinitions = new HashMap<>();
 
     ApiViewProperties() { }
 
     /**
-     * Attempts to process the {@code apiview_properties.json} file in the jar file, if it exists.
+     * Attempts to process the {@code [artifactid]_metadata.json} file in the jar file, if it exists.
      *
      * @param fs the {@link FileSystem} representing the jar file
      */
     public static Optional<ApiViewProperties> fromSourcesJarFile(FileSystem fs, Pom pom) {
-        // the filename is [<artifactid>_]apiview_properties.json
+        // the filename is <artifactid>_metadata.json
         final String artifactId = pom.getArtifactId();
         final String artifactName = (artifactId != null && !artifactId.isEmpty()) ? (artifactId + "_") : "";
-        final String filePath = "/META-INF/" + artifactName + "apiview_properties.json";
+        final String filePath = "/META-INF/" + artifactName + "metadata.json";
         final Path apiviewPropertiesPath = fs.getPath(filePath);
 
         if (!Files.exists(apiviewPropertiesPath)) {
-            System.out.println("  No apiview_properties.json file found in jar file - continuing...");
+            System.out.println("  No metadata.json file found in jar file - continuing...");
             return Optional.empty();
         }
 
         try {
-            // we eagerly load the apiview_properties.json file into an ApiViewProperties object, so that it can
+            // we eagerly load the metadata.json file into an ApiViewProperties object, so that it can
             // be used throughout the analysis process, as required
             try (JsonReader reader = JsonProviders.createReader(Files.readAllBytes(apiviewPropertiesPath))) {
                 final ApiViewProperties properties = ApiViewProperties.fromJson(reader);
-                System.out.println("  Found apiview_properties.json file in jar file");
-                System.out.println("    - Found " + properties.getCrossLanguageDefinitionIds().size()
+                System.out.println("  Found metadata.json file in jar file");
+                System.out.println("    - Found " + properties.getCrossLanguageDefinitions().size()
                         + " cross-language definition IDs");
                 return Optional.of(properties);
             }
         } catch (IOException e) {
-            System.out.println("  ERROR: Unable to parse apiview_properties.json file in jar file - continuing...");
+            System.out.println("  ERROR: Unable to parse metadata.json file in jar file - continuing...");
             e.printStackTrace();
         }
 
@@ -65,14 +65,14 @@ public class ApiViewProperties implements JsonSerializable<ApiViewProperties> {
      * see how the API is implemented in each language.
      */
     public Optional<String> getCrossLanguageDefinitionId(String fullyQualifiedName) {
-        return Optional.ofNullable(crossLanguageDefinitionIds.get(fullyQualifiedName));
+        return Optional.ofNullable(crossLanguageDefinitions.get(fullyQualifiedName));
     }
 
     /**
      * Returns an unmodifiable map of all the cross-language definition IDs.
      */
-    public Map<String, String> getCrossLanguageDefinitionIds() {
-        return Collections.unmodifiableMap(crossLanguageDefinitionIds);
+    public Map<String, String> getCrossLanguageDefinitions() {
+        return Collections.unmodifiableMap(crossLanguageDefinitions);
     }
 
     public Flavor getFlavor() {
@@ -82,7 +82,7 @@ public class ApiViewProperties implements JsonSerializable<ApiViewProperties> {
     @Override
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject()
-            .writeMapField("CrossLanguageDefinitionId", crossLanguageDefinitionIds, JsonWriter::writeString);
+            .writeMapField("crossLanguageDefinitions", crossLanguageDefinitions, JsonWriter::writeString);
 
         if (flavor != null) {
             jsonWriter.writeStringField("flavor", flavor.getSerializationValue());
@@ -91,6 +91,15 @@ public class ApiViewProperties implements JsonSerializable<ApiViewProperties> {
         return jsonWriter.writeEndObject();
     }
 
+    /**
+     * Constructs an instance of {@code ApiViewProperties} from the provided {@code JsonReader}.
+     * The method reads the JSON structure and maps it to the fields of the {@code ApiViewProperties} object.
+     * It skips over any unrecognized fields in the JSON.
+     *
+     * @param jsonReader the JSON reader used to parse the input JSON structure
+     * @return an instance of {@code ApiViewProperties} constructed from the provided JSON data
+     * @throws IOException if an I/O error occurs while reading the JSON structure
+     */
     public static ApiViewProperties fromJson(JsonReader jsonReader) throws IOException {
         return jsonReader.readObject(reader -> {
             ApiViewProperties properties = new ApiViewProperties();
@@ -99,11 +108,12 @@ public class ApiViewProperties implements JsonSerializable<ApiViewProperties> {
                 String fieldName = reader.getFieldName();
                 reader.nextToken();
 
-                if ("CrossLanguageDefinitionId".equals(fieldName)) {
-                    properties.crossLanguageDefinitionIds = reader.readMap(JsonReader::getString);
+                if ("crossLanguageDefinitions".equals(fieldName)) {
+                    properties.crossLanguageDefinitions = reader.readMap(JsonReader::getString);
                 } else if ("flavor".equals(fieldName)) {
                     properties.flavor = Flavor.fromSerializationValue(reader.getString());
                 } else {
+                    // Skip unrecognized fields as metadata.json may contain additional data not relevant to APIView.
                     reader.skipChildren();
                 }
             }


### PR DESCRIPTION
This pull request updates how cross-language metadata is handled in the `ApiViewProperties` class and changes the naming and structure of the metadata file used by APIView. The main focus is on renaming the metadata file and standardizing the naming of fields and methods related to cross-language definitions for clarity and consistency.

**Metadata file and naming standardization:**

* The metadata file read from JARs is now named `[artifactid]_metadata.json` instead of `[artifactid]_apiview_properties.json`, and all references in code and log messages have been updated accordingly.
* The field, methods, and JSON key previously named `crossLanguageDefinitionIds`/`CrossLanguageDefinitionId` have been renamed to `crossLanguageDefinitions`/`crossLanguageDefinitions` for consistency and clarity throughout the codebase and JSON serialization/deserialization. [[1]](diffhunk://#diff-6baf82d1a289c74180693404db0faa283974c16dd5da918ec12b025a60143542L17-R55) [[2]](diffhunk://#diff-6baf82d1a289c74180693404db0faa283974c16dd5da918ec12b025a60143542L68-R75) [[3]](diffhunk://#diff-6baf82d1a289c74180693404db0faa283974c16dd5da918ec12b025a60143542L85-R85) [[4]](diffhunk://#diff-6baf82d1a289c74180693404db0faa283974c16dd5da918ec12b025a60143542L102-R116)

**Code robustness and documentation:**

* Added documentation for the `fromJson` method and updated it to skip unrecognized fields, making the deserialization process more robust to changes in the metadata file structure. [[1]](diffhunk://#diff-6baf82d1a289c74180693404db0faa283974c16dd5da918ec12b025a60143542R94-R102) [[2]](diffhunk://#diff-6baf82d1a289c74180693404db0faa283974c16dd5da918ec12b025a60143542L102-R116)