### PR TITLE
[azsdk-cli] Mark long copilot test as explicit

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/TypeSpec/TypeSpecCustomizationServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/TypeSpec/TypeSpecCustomizationServiceTests.cs
@@ -63,6 +63,7 @@ internal class TypeSpecCustomizationServiceTests
     /// Will be skipped if Copilot is not available.
     /// </summary>
     [Test]
+    [Explicit]  // Mark as explicit/manual because this test takes 26 seconds
     public async Task ApplyCustomization_WithRealCopilotSdk_CompletesSuccessfully()
     {
 
@@ -112,7 +113,7 @@ internal class TypeSpecCustomizationServiceTests
         // The test verifies the service can run end-to-end with real LLM calls
         // The actual success may depend on the LLM's ability to complete the task
         Assert.That(result, Is.Not.Null);
-        
+
         // Log the result for manual inspection
         TestContext.WriteLine($"Success: {result.Success}");
         if (result.ChangesSummary?.Length > 0)


### PR DESCRIPTION
[azsdk-cli] Mark long copilot test as explicit. As a TODO I've created https://github.com/Azure/azure-sdk-tools/issues/13955 to provide a better place for these tests to run locally or in pipelines.

CC @chrisradek 