### PR TITLE
[APIView] Remove NotifySubscribersOnNewRevisionAsync functionality

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -603,7 +603,6 @@ namespace APIViewWeb.Managers
             await _notificationManager.SubscribeAsync(review, user);
             await _reviewsRepository.UpsertReviewAsync(review);
             await _apiRevisionsRepository.UpsertAPIRevisionAsync(apiRevision);
-            await _notificationManager.NotifySubscribersOnNewRevisionAsync(review, apiRevision, user);
 
             if (!String.IsNullOrEmpty(review.Language) && review.Language == ApiViewConstants.SwaggerLanguage)
             {

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/INotificationManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/INotificationManager.cs
@@ -12,7 +12,6 @@ namespace APIViewWeb.Managers
         public Task NotifyApproversOfReview(ClaimsPrincipal user, string apiRevisionId, HashSet<string> reviewers);
         public Task NotifyApproversOnNamespaceReviewRequest(ClaimsPrincipal user, ReviewListItemModel review, IEnumerable<ReviewListItemModel> languageReviews = null, string notes = "");
         public Task NotifyStakeholdersOfManualApproval(ReviewListItemModel review, IEnumerable<ReviewListItemModel> associatedReviews);
-        public Task NotifySubscribersOnNewRevisionAsync(ReviewListItemModel review, APIRevisionListItemModel revision, ClaimsPrincipal user);
         public Task ToggleSubscribedAsync(ClaimsPrincipal user, string reviewId, bool? state = null);
         public Task SubscribeAsync(ReviewListItemModel review, ClaimsPrincipal user);
         public Task UnsubscribeAsync(ReviewListItemModel review, ClaimsPrincipal user);

--- a/src/dotnet/APIView/APIViewWeb/Managers/NotificationManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/NotificationManager.cs
@@ -94,13 +94,6 @@ namespace APIViewWeb.Managers
             }
         }
 
-        public async Task NotifySubscribersOnNewRevisionAsync(ReviewListItemModel review, APIRevisionListItemModel revision, ClaimsPrincipal user)
-        {
-            var uri = new Uri($"{_apiviewEndpoint}/Assemblies/Review/{review.Id}");
-            var htmlContent = $"A new revision, <a href='{uri.ToString()}'>{PageModelHelpers.ResolveRevisionLabel(revision)}</a>," +
-                $" was uploaded by <b>{revision.CreatedBy}</b>.";
-            await SendEmailsAsync(review, user, htmlContent, null);
-        }
         /// <summary>
         /// Toggle Subscription to a Review
         /// </summary>


### PR DESCRIPTION
In order to align with new notification system an email notification is no longer sent on new api revision upload