### PR TITLE
update typespec project path in release status telemetry

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/PackageReleaseStatusToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/PackageReleaseStatusToolTests.cs
@@ -143,7 +143,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                         PackageName = "azure-test-package",
                         PullRequestStatus = "InProgress"
                     }
-                }
+                },
+                APISpecProjectPath = "specification/test/project"
             };
 
             mockDevOpsService
@@ -161,6 +162,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             Assert.That(result.ResponseError, Is.Null);
             Assert.That(result.ReleaseStatus, Is.EqualTo("Released"));
             Assert.That(result.PackageName, Is.EqualTo("azure-test-package"));
+            Assert.That(result.TypeSpecProject, Is.EqualTo("specification/test/project"));
 
             mockDevOpsService.Verify(
                 x => x.UpdateWorkItemAsync(12345, It.Is<Dictionary<string, string>>(d => 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/PackageReleaseStatusTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/PackageReleaseStatusTool.cs
@@ -128,6 +128,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 }
 
                 response.ReleasePlanId = releasePlan.ReleasePlanId;
+                response.TypeSpecProject = releasePlan.APISpecProjectPath;
                 logger.LogInformation("Updating release status for package {packageName} in release plan work item {workItemId}", packageName, releasePlan.WorkItemId);
 
                 // Update the release status for the specific language


### PR DESCRIPTION
Update TypeSpec project path found in the release plan in response so that it will be available in telemetry.