### PR TITLE
[azsdk] integrate TypeSpec customizations into CodeCustomiztionUpdateTool

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/SdkGenerationToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/SdkGenerationToolTests.cs
@@ -83,16 +83,16 @@ public class SdkGenerationToolTests
     public async Task GenerateSdkAsync_WithTspLocationPath_CallsRunTspUpdate()
     {
         // Arrange
-    var tspLocationPath = Path.Combine(_tempDirectory.DirectoryPath, TspLocationFileName);
+        var tspLocationPath = Path.Combine(_tempDirectory.DirectoryPath, TspLocationFileName);
         File.WriteAllText(tspLocationPath, TestTspLocationContent);
 
-        var expectedResult = new Models.Responses.TypeSpec.TspToolResponse 
-        { 
-            IsSuccessful = true, 
+        var expectedResult = new Models.Responses.TypeSpec.TspToolResponse
+        {
+            IsSuccessful = true,
             TypeSpecProject = Path.GetDirectoryName(tspLocationPath)!
         };
         _mockTspClientHelper
-            .Setup(x => x.UpdateGenerationAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.UpdateGenerationAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedResult);
 
         // Act
@@ -104,7 +104,7 @@ public class SdkGenerationToolTests
         Assert.That(result.NextSteps, Is.Not.Null);
         Assert.That(result.NextSteps, Has.Count.GreaterThan(0));
         Assert.That(result.NextSteps?.First(), Does.Contain("build the code"));
-        _mockTspClientHelper.Verify(x => x.UpdateGenerationAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockTspClientHelper.Verify(x => x.UpdateGenerationAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Test]
@@ -128,9 +128,9 @@ public class SdkGenerationToolTests
         _mockGitHelper.Setup(x => x.DiscoverRepoRootAsync(_tempDirectory.DirectoryPath, It.IsAny<CancellationToken>())).ReturnsAsync(_tempDirectory.DirectoryPath);
         _mockGitHelper.Setup(x => x.GetRepoNameAsync(_tempDirectory.DirectoryPath, It.IsAny<CancellationToken>())).ReturnsAsync("azure-sdk-for-net");
 
-        var expectedResult = new Models.Responses.TypeSpec.TspToolResponse 
-        { 
-            IsSuccessful = true, 
+        var expectedResult = new Models.Responses.TypeSpec.TspToolResponse
+        {
+            IsSuccessful = true,
             TypeSpecProject = _tempDirectory.DirectoryPath
         };
         _mockTspClientHelper
@@ -153,7 +153,7 @@ public class SdkGenerationToolTests
     public async Task GenerateSdkAsync_WithLocalTspConfigPath_ValidInputs_CallsRunTspInit()
     {
         // Arrange
-    var tspConfigPath = Path.Combine(_tempDirectory.DirectoryPath, TspConfigFileName);
+        var tspConfigPath = Path.Combine(_tempDirectory.DirectoryPath, TspConfigFileName);
         File.WriteAllText(tspConfigPath, TestTspConfigContent);
 
         // Mock GitHelper to return valid repo root
@@ -161,9 +161,9 @@ public class SdkGenerationToolTests
         _mockGitHelper.Setup(x => x.GetRepoNameAsync(_tempDirectory.DirectoryPath, It.IsAny<CancellationToken>())).ReturnsAsync("azure-sdk-for-net");
         _mockGitHelper.Setup(x => x.GetRepoFullNameAsync(tspConfigPath, true, It.IsAny<CancellationToken>())).ReturnsAsync(DefaultSpecRepo);
 
-        var expectedResult = new Models.Responses.TypeSpec.TspToolResponse 
-        { 
-            IsSuccessful = true, 
+        var expectedResult = new Models.Responses.TypeSpec.TspToolResponse
+        {
+            IsSuccessful = true,
             TypeSpecProject = _tempDirectory.DirectoryPath
         };
         _mockTspClientHelper
@@ -205,9 +205,9 @@ public class SdkGenerationToolTests
         _mockGitHelper.Setup(x => x.DiscoverRepoRootAsync(_tempDirectory.DirectoryPath, It.IsAny<CancellationToken>())).ReturnsAsync(_tempDirectory.DirectoryPath);
         _mockGitHelper.Setup(x => x.GetRepoNameAsync(_tempDirectory.DirectoryPath, It.IsAny<CancellationToken>())).ReturnsAsync("azure-sdk-for-net");
 
-        var failedResult = new Models.Responses.TypeSpec.TspToolResponse 
-        { 
-            IsSuccessful = false, 
+        var failedResult = new Models.Responses.TypeSpec.TspToolResponse
+        {
+            IsSuccessful = false,
             ResponseError = "Failed to initialize TypeSpec generation, see details in the logs.",
             TypeSpecProject = _tempDirectory.DirectoryPath
         };
@@ -279,9 +279,9 @@ public class SdkGenerationToolTests
         _mockGitHelper.Setup(x => x.GetRepoNameAsync(_tempDirectory.DirectoryPath, It.IsAny<CancellationToken>())).ReturnsAsync("azure-sdk-for-net");
         _mockGitHelper.Setup(x => x.GetRepoFullNameAsync(tspConfigPath, false, It.IsAny<CancellationToken>())).ReturnsAsync(DefaultSpecRepo);
 
-        var expectedResult = new Models.Responses.TypeSpec.TspToolResponse 
-        { 
-            IsSuccessful = true, 
+        var expectedResult = new Models.Responses.TypeSpec.TspToolResponse
+        {
+            IsSuccessful = true,
             TypeSpecProject = _tempDirectory.DirectoryPath
         };
         _mockTspClientHelper
@@ -315,9 +315,9 @@ public class SdkGenerationToolTests
         _mockGitHelper.Setup(x => x.DiscoverRepoRootAsync(_tempDirectory.DirectoryPath, It.IsAny<CancellationToken>())).ReturnsAsync(_tempDirectory.DirectoryPath);
         _mockGitHelper.Setup(x => x.GetRepoNameAsync(_tempDirectory.DirectoryPath, It.IsAny<CancellationToken>())).ReturnsAsync("azure-sdk-for-net");
 
-        var expectedResult = new Models.Responses.TypeSpec.TspToolResponse 
-        { 
-            IsSuccessful = true, 
+        var expectedResult = new Models.Responses.TypeSpec.TspToolResponse
+        {
+            IsSuccessful = true,
             TypeSpecProject = _tempDirectory.DirectoryPath
         };
         _mockTspClientHelper
@@ -351,9 +351,9 @@ public class SdkGenerationToolTests
         _mockGitHelper.Setup(x => x.GetRepoNameAsync(_tempDirectory.DirectoryPath, It.IsAny<CancellationToken>())).ReturnsAsync("azure-sdk-for-net");
         _mockGitHelper.Setup(x => x.GetRepoFullNameAsync(tspConfigPath, false, It.IsAny<CancellationToken>())).ReturnsAsync(DefaultSpecRepo);
 
-        var expectedResult = new Models.Responses.TypeSpec.TspToolResponse 
-        { 
-            IsSuccessful = true, 
+        var expectedResult = new Models.Responses.TypeSpec.TspToolResponse
+        {
+            IsSuccessful = true,
             TypeSpecProject = _tempDirectory.DirectoryPath
         };
         _mockTspClientHelper

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/ITspClientHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/ITspClientHelper.cs
@@ -28,8 +28,9 @@ public interface ITspClientHelper
     /// <param name="tspLocationDirectory">Path to the directory containing tsp-location.yaml.</param>
     /// <param name="commitSha">Optional commit SHA to update the tsp-location.yaml with before regeneration. If null, uses the commit SHA from the existing tsp-location.yaml.</param>
     /// <param name="isCli">True when invoked from CLI flow (suppresses duplicate streamed output in error text).</param>
+    /// <param name="localSpecRepoPath">Optional path to a local spec repo. When provided, tsp-client copies files from the local filesystem instead of cloning from a remote repo.</param>
     /// <param name="ct">Cancellation token.</param>
-    Task<TspToolResponse> UpdateGenerationAsync(string tspLocationDirectory, string? commitSha = null, bool isCli = false, CancellationToken ct = default);
+    Task<TspToolResponse> UpdateGenerationAsync(string tspLocationDirectory, string? commitSha = null, bool isCli = false, string? localSpecRepoPath = null, CancellationToken ct = default);
 
     /// <summary>
     /// Runs `tsp-client init` to initialize SDK generation from a tspconfig.yaml file.

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TspClientHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TspClientHelper.cs
@@ -79,28 +79,34 @@ public class TspClientHelper : ITspClientHelper
     }
 
     /// <inheritdoc />
-    public async Task<TspToolResponse> UpdateGenerationAsync(string tspLocationDirectory, string? commitSha = null, bool isCli = false, CancellationToken ct = default)
+    public async Task<TspToolResponse> UpdateGenerationAsync(string tspLocationDirectory, string? commitSha = null, bool isCli = false, string? localSpecRepoPath = null, CancellationToken ct = default)
     {
         var tspLocationPath = Path.Combine(tspLocationDirectory, "tsp-location.yaml");
-        logger.LogInformation("tsp-client update: {tspLocationDirectory}, commit: {commit}", tspLocationDirectory, commitSha ?? "(latest)");
-        
+        logger.LogInformation("tsp-client update: {tspLocationDirectory}, commit: {commit}, localSpecRepo: {localSpecRepo}", tspLocationDirectory, commitSha ?? "(latest)", localSpecRepoPath ?? "(none)");
+
         if (!File.Exists(tspLocationPath))
         {
-            return new TspToolResponse {
+            return new TspToolResponse
+            {
                 ResponseError = $"tsp-location.yaml not found at path: {tspLocationPath}",
                 TypeSpecProject = tspLocationDirectory
             };
         }
-        
+
         var repoRootFolder = await gitHelper.DiscoverRepoRootAsync(tspLocationDirectory, ct);
-        
+
         var args = new List<string> { "tsp-client", "update" };
         if (!string.IsNullOrEmpty(commitSha))
         {
             args.Add("--commit");
             args.Add(commitSha);
         }
-        
+        if (!string.IsNullOrEmpty(localSpecRepoPath))
+        {
+            args.Add("--local-spec-repo");
+            args.Add(localSpecRepoPath);
+        }
+
         var npmPrefix = await GetNpmPrefixAsync(repoRootFolder, ct);
         var npmOptions = new NpmOptions(
             npmPrefix,

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/CustomizedCodeUpdateResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/CustomizedCodeUpdateResponse.cs
@@ -24,6 +24,7 @@ public class CustomizedCodeUpdateResponse : PackageResponseBase
         public const string NoLanguageService = "NoLanguageService";
         public const string InvalidInput = "InvalidInput";
         public const string UnexpectedError = "UnexpectedError";
+        public const string TypeSpecCustomizationFailed = "TypeSpecCustomizationFailed";
     }
 
     [JsonPropertyName("message")]
@@ -33,6 +34,13 @@ public class CustomizedCodeUpdateResponse : PackageResponseBase
     [JsonPropertyName("errorCode")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ErrorCode { get; set; }
+
+    /// <summary>
+    /// Summary of TypeSpec client.tsp changes applied during the TypeSpec Customizations phase.
+    /// </summary>
+    [JsonPropertyName("typeSpecChangesSummary")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? TypeSpecChangesSummary { get; set; }
 
     protected override string Format()
     {
@@ -44,6 +52,14 @@ public class CustomizedCodeUpdateResponse : PackageResponseBase
         if (!string.IsNullOrWhiteSpace(ErrorCode))
         {
             sb.AppendLine($"ErrorCode: {ErrorCode}");
+        }
+        if (TypeSpecChangesSummary is { Count: > 0 })
+        {
+            sb.AppendLine("TypeSpec Changes:");
+            foreach (var change in TypeSpecChangesSummary)
+            {
+                sb.AppendLine($"  - {change}");
+            }
         }
         return sb.ToString();
     }


### PR DESCRIPTION
This PR adds the TypeSpec customization service to the CodeCustomizationUpdateTool. It assumes that the azure-rest-api-specs repo and the azure-sdk-for-\* repos are both available locally, so it has been updated to take the typespec project path, and no longer requires a commit sha.

This also updates the sdk regen/build to happen after the typespec customizations are applied.

There is one part of the integration for scenario 2 - https://github.com/Azure/azure-sdk-tools/pull/13642 includes integrating the classifier into the CodeCustomizationUpdateTool, which will be responsible for determining if the tool is done with its work, or if changes can be handled by the tool.