### PR TITLE
[APIView] Diagnostic Updates

### DIFF
--- a/src/dotnet/APIView/ClientSPA/src/app/_components/conversations/conversations.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/conversations/conversations.component.ts
@@ -340,6 +340,9 @@ export class ConversationsComponent implements OnChanges, OnDestroy {
           this.addCommentToCommentThread(commentUpdates);
         }
         break;
+      case CommentThreadUpdateAction.CommentTextUpdate:
+        this.updateCommentTextInCommentThread(commentUpdates);
+        break;
       case CommentThreadUpdateAction.CommentResolved:
         this.applyCommentResolutionUpdate(commentUpdates);
         break;
@@ -348,7 +351,14 @@ export class ConversationsComponent implements OnChanges, OnDestroy {
 
   private updateCommentTextInCommentThread(commentUpdates: CommentUpdatesDto) {
     if (this.comments.some(c => c.id === commentUpdates.commentId!)) {
-      this.comments.find(c => c.id === commentUpdates.commentId!)!.commentText = commentUpdates.commentText!;
+      const comment = this.comments.find(c => c.id === commentUpdates.commentId!)!;
+      if (commentUpdates.commentText !== undefined) {
+        comment.commentText = commentUpdates.commentText;
+      }
+      if (commentUpdates.severity !== undefined) {
+        comment.severity = commentUpdates.severity;
+      }
+      this.createCommentThreads();
     }
   }
 

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/shared/comment-severity/comment-severity.component.html
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/shared/comment-severity/comment-severity.component.html
@@ -12,6 +12,8 @@
         placeholder="Severity"
         [style]="{'width': '140px'}"
         styleClass="severity-dropdown"
+        overlayStyleClass="severity-dropdown-panel"
+        appendTo="body"
         (click)="$event.stopPropagation()">
       </p-select>
     </div>
@@ -37,6 +39,8 @@
           optionValue="value"
           [style]="{'min-width': '100px', 'font-size': '0.75rem'}"
           styleClass="severity-dropdown"
+          overlayStyleClass="severity-dropdown-panel"
+          appendTo="body"
           (click)="$event.stopPropagation()">
         </p-select>
       </div>

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/shared/comment-thread/comment-thread.component.html
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/shared/comment-thread/comment-thread.component.html
@@ -109,13 +109,13 @@
                             </a>
                         </ng-template>
                     </p-menu>
-                    <button [attr.data-btn-id]="comment.id" (click)="toggleUpVoteAction($event)" class="p-panel-header-icon p-link">
+                    <button *ngIf="!isDiagnostic(comment)" [attr.data-btn-id]="comment.id" (click)="toggleUpVoteAction($event)" class="p-panel-header-icon p-link">
                         <span *ngIf="comment.upvotes.length > 0; else noUpVotes" class="bi bi-hand-thumbs-up-fill emoji-active" pTooltip="{{comment.upvotes.join(', ')}}" tooltipPosition="bottom">{{comment.upvotes.length}}</span>
                         <ng-template #noUpVotes>
                             <span class="bi bi-hand-thumbs-up"></span>
                         </ng-template>
                     </button>
-                    <button *ngIf="comment.createdBy == 'azure-sdk'" [attr.data-btn-id]="comment.id" (click)="toggleDownVoteAction($event)" class="p-panel-header-icon p-link">
+                    <button *ngIf="comment.createdBy == 'azure-sdk' && !isDiagnostic(comment)" [attr.data-btn-id]="comment.id" (click)="toggleDownVoteAction($event)" class="p-panel-header-icon p-link">
                         <span *ngIf="comment.downvotes.length > 0; else noDownVotes" class="bi bi-hand-thumbs-down-fill emoji-active" pTooltip="{{comment.downvotes.join(', ')}}" tooltipPosition="bottom">{{comment.downvotes.length}}</span>
                         <ng-template #noDownVotes>
                             <span class="bi bi-hand-thumbs-down"></span>
@@ -189,6 +189,7 @@
   [allCodePanelRowData]="allCodePanelRowData"
   [userProfile]="userProfile"
   [preferredApprovers]="preferredApprovers"
+    [isApplyingChanges]="isBatchUpdating"
   [(visible)]="showRelatedCommentsDialog"
   (resolveSelectedComments)="onResolveSelectedComments($event)">
 </app-related-comments-dialog>

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/shared/related-comments-dialog/related-comments-dialog.component.html
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/shared/related-comments-dialog/related-comments-dialog.component.html
@@ -97,7 +97,7 @@
       <div class="d-flex align-items-center justify-content-end gap-2 mb-3">
         <!-- Disposition Dropdown -->
         <p-select
-          [options]="dispositionOptions"
+          [options]="availableDispositionOptions"
           [(ngModel)]="selectedDisposition"
           optionLabel="label"
           optionValue="value"
@@ -129,10 +129,10 @@
         </app-comment-severity>
 
         <!-- Vertical Separator -->
-        <div class="vr mx-2"></div>
+        <div *ngIf="!isDiagnosticCorrelationContext" class="vr mx-2"></div>
 
         <!-- Vote Buttons -->
-        <div class="d-flex align-items-center vote-section">
+        <div *ngIf="!isDiagnosticCorrelationContext" class="d-flex align-items-center vote-section">
           <button
             type="button"
             class="btn btn-link p-2 vote-btn"
@@ -148,6 +148,11 @@
             <span [ngClass]="hasBatchDownvote() ? 'bi bi-hand-thumbs-down-fill emoji-active fs-5' : 'bi bi-hand-thumbs-down text-muted fs-5'"></span>
           </button>
         </div>
+      </div>
+
+      <div *ngIf="isDiagnosticCorrelationContext" class="alert alert-info py-2 px-3 mb-3" role="alert">
+        <i class="bi bi-info-circle me-1"></i>
+        Diagnostic correlation group: delete and vote actions are disabled.
       </div>
 
       <!-- Inline Feedback Section (appears when downvoting AI comments for keepOpen/resolve) -->
@@ -248,18 +253,26 @@
         <button
           type="button"
           class="btn btn-outline-secondary"
+          [disabled]="isApplyingChanges"
           (click)="onHide()">
           Cancel
         </button>
         <button
           type="button"
           class="btn btn-primary"
-          [disabled]="getSelectedCount() === 0 || (showInlineFeedback && selectedDisposition !== 'delete' && !canSubmitFeedback) || !isDeletionReasonValid"
+          [disabled]="isApplyingChanges || getSelectedCount() === 0 || (showInlineFeedback && selectedDisposition !== 'delete' && !canSubmitFeedback) || !isDeletionReasonValid"
           (click)="resolveSelected()">
-          <i class="pi pi-check"></i>
-          Apply Changes ({{ getSelectedCount() }})
+          <ng-container *ngIf="!isApplyingChanges">
+            <i class="pi pi-check"></i>
+            Apply Changes ({{ getSelectedCount() }})
+          </ng-container>
+          <ng-container *ngIf="isApplyingChanges">
+            <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+            Updating...
+          </ng-container>
         </button>
       </div>
+
     </div>
   </div>
 </p-dialog>


### PR DESCRIPTION
This PR

- Adds correlation IDs to diagnostics which are backfilled if needed to associate multiple instances of the same diagnostic.
- Disables feedback and delete options on diagnostics.
- Makes the update button spin when applied so the UI does not appear to "not update".
- Fixed a bug with the severity dropdown in bulk update.
