### PR TITLE
[APIView] Revert staging back to apiviewstagingtest.com

### DIFF
--- a/packages/python-packages/apiview-copilot/src/_apiview.py
+++ b/packages/python-packages/apiview-copilot/src/_apiview.py
@@ -179,7 +179,7 @@ class ApiViewClient:
 
         apiview_endpoints = {
             "production": "https://apiview.dev",
-            "staging": "https://apiview.org",
+            "staging": "https://apiviewstagingtest.com",
         }
         endpoint_root = apiview_endpoints.get(self.environment)
         endpoint = f"{endpoint_root}/{endpoint}"

--- a/src/dotnet/APIView/APIViewWeb/Helpers/URlHelpers.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/URlHelpers.cs
@@ -10,8 +10,7 @@ namespace APIViewWeb.Helpers
             return new List<string>() {
                     "https://spa.apiviewuxtest.com",
                     "https://spa.apiviewstagingtest.com",
-                    "https://spa.apiview.dev",
-                    "https://spa.apiview.org"
+                    "https://spa.apiview.dev"
                 };
         }
 

--- a/src/dotnet/APIView/APIViewWeb/web.config
+++ b/src/dotnet/APIView/APIViewWeb/web.config
@@ -14,7 +14,7 @@
           <conditions logicalGrouping="MatchAny">
             <add input="{HTTP_HOST}" pattern="^apiviewstaging\.azurewebsites\.net$" />
           </conditions>
-          <action type="Redirect" url="https://apiview.org/{R:0}" />
+          <action type="Redirect" url="https://apiviewstagingtest.com/{R:0}" />
         </rule>
         <rule name="Redirect requests to default azure websites domain" stopProcessing="true">
           <match url="(.*)" />
@@ -26,7 +26,7 @@
         <rule name="Rewrite root SPA requests for staging instance">
           <match url="^((?!spa/).*)$" />
           <conditions logicalGrouping="MatchAll">
-            <add input="{HTTP_HOST}" pattern="^(spa\.apiviewuxtest\.com|spa\.apiview\.dev|spa\.apiviewstagingtest\.com|spa\.apiview\.org)$" />
+            <add input="{HTTP_HOST}" pattern="^(spa\.apiviewuxtest\.com|spa\.apiview\.dev|spa\.apiviewstagingtest\.com)$" />
             <add input="{REQUEST_FILENAME}" pattern="isFile" negate="true" />
             <add input="{REQUEST_FILENAME}" pattern="isDirectory" negate="true" />
           </conditions>

--- a/src/dotnet/APIView/apiview.yml
+++ b/src/dotnet/APIView/apiview.yml
@@ -351,11 +351,11 @@ extends:
 
           variables:
             - name: 'apiUrl'
-              value: 'https://apiview.org/api/'
+              value: 'https://apiviewstagingtest.com/api/'
             - name: 'hubUrl'
-              value: 'https://apiview.org/hubs/'
+              value: 'https://apiviewstagingtest.com/hubs/'
             - name: 'webAppUrl'
-              value: 'https://apiview.org/'
+              value: 'https://apiviewstagingtest.com/'
 
           jobs:
             - job: Publish_to_Staging

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/APIView/ApiViewReviewToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/APIView/ApiViewReviewToolTests.cs
@@ -118,7 +118,7 @@ public class ApiViewReviewToolTests
     public async Task UrlExtraction_WithValidApiViewUrl_ShouldExtractCorrectRevisionId()
     {
         string apiViewUrl =
-            "https://spa.apiview.org/review/96672963bb5747db9d65d32df5f82d5a?activeApiRevisionId=2668702652604dad92d75feb1321c7a4";
+            "https://spa.apiviewstagingtest.com/review/96672963bb5747db9d65d32df5f82d5a?activeApiRevisionId=2668702652604dad92d75feb1321c7a4";
         string expectedRevisionId = "2668702652604dad92d75feb1321c7a4";
         string expectedComments = "Test comments";
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Configuration/APIViewConfiguration.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Configuration/APIViewConfiguration.cs
@@ -7,7 +7,7 @@ public static class APIViewConfiguration
     public static readonly Dictionary<string, string> BaseUrlEndpoints = new()
     {
         { "production", "https://apiview.dev" },
-        { "staging", "https://apiview.org" },
+        { "staging", "https://apiviewstagingtest.com" },
         { "local", "http://localhost:5000" }
     };
 


### PR DESCRIPTION
Related: #8210.

This migrates APIView staging from apiview.org back to apiviewstagingtest.com.

Once merged and deployed:
- [x] Update Github OAuth app
- [x] Update staging AppConfig `APIView-Host-Url` and `APIView-SPA-Host-Url` and sentinel value
- [x] Remove `apiview.org` custom domain in Azure Portal
- [x] Clear browser cache
- [x] Verify staging is properly restored to `apiviewstagingtest.com`