### PR TITLE
[APIView] PART 2 Update eng\common scripts for switch from `apiview.dev` to `apiview.org`

### DIFF
--- a/eng/common/pipelines/templates/steps/detect-api-changes.yml
+++ b/eng/common/pipelines/templates/steps/detect-api-changes.yml
@@ -7,7 +7,7 @@ parameters:
 steps:
   - ${{ if eq(variables['Build.Reason'],'PullRequest') }}:
     - pwsh: |
-        $apiChangeDetectRequestUrl = "https://apiview.dev/api/PullRequests/CreateAPIRevisionIfAPIHasChanges"
+        $apiChangeDetectRequestUrl = "https://apiview.org/api/PullRequests/CreateAPIRevisionIfAPIHasChanges"
         echo "##vso[task.setvariable variable=ApiChangeDetectRequestUrl]$apiChangeDetectRequestUrl"
       displayName: "Set API change detect request URL"
       condition: and(succeededOrFailed(), ${{ parameters.Condition}}, eq(variables['ApiChangeDetectRequestUrl'], ''))

--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -10,7 +10,7 @@ Param (
   [string] $BuildId,
   [string] $PackageName = "",
   [string] $ConfigFileDir = "",
-  [string] $APIViewUri = "https://apiview.dev/autoreview",
+  [string] $APIViewUri = "https://apiview.org/autoreview",
   [string] $ArtifactName = "packages",
   [bool] $MarkPackageAsShipped = $false,
   [Parameter(Mandatory=$False)]

--- a/eng/common/scripts/Helpers/ApiView-Helpers.ps1
+++ b/eng/common/scripts/Helpers/ApiView-Helpers.ps1
@@ -124,7 +124,7 @@ function Set-ApiViewCommentForRelatedIssues {
   param (
     [Parameter(Mandatory = $true)]
     [string]$HeadCommitish,
-    [string]$APIViewHost = "https://apiview.dev",
+    [string]$APIViewHost = "https://apiview.org",
     [ValidateNotNullOrEmpty()]
     [Parameter(Mandatory = $true)]
     $AuthToken
@@ -241,7 +241,7 @@ function Set-ApiViewCommentForPR {
 # Helper function used to create API review requests for Spec generation SDKs pipelines
 function Create-API-Review {
   param (
-    [string]$apiviewEndpoint = "https://apiview.dev/api/PullRequests/CreateAPIRevisionIfAPIHasChanges",
+    [string]$apiviewEndpoint = "https://apiview.org/api/PullRequests/CreateAPIRevisionIfAPIHasChanges",
     [string]$specGenSDKArtifactPath,
     [string]$apiviewArtifactName,
     [string]$buildId,

--- a/eng/common/scripts/Validate-All-Packages.ps1
+++ b/eng/common/scripts/Validate-All-Packages.ps1
@@ -11,7 +11,7 @@ Param (
   [string]$ConfigFileDir,
   [string]$BuildDefinition,
   [string]$PipelineUrl,
-  [string]$APIViewUri  = "https://apiview.dev/AutoReview/GetReviewStatus",
+  [string]$APIViewUri  = "https://apiview.org/AutoReview/GetReviewStatus",
   [bool] $IsReleaseBuild = $false,
   [Parameter(Mandatory=$False)]
   [array] $PackageInfoFiles


### PR DESCRIPTION
Related to #8210.

This is 1 PR necessary to switch `apiview.dev` over to `apiview.org` temporarily while the Microsoft Domains team transfer ownership of `apiview.dev` from CloudFlare to Microsoft. It can only be merged once APIView has been deployed. 

Will need to follow:
https://github.com/Azure/azure-sdk-tools/blob/main/doc/common/common_engsys.md