### PR TITLE
[azsdk-cli] Exclude asp net config files from release archive

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
@@ -70,4 +70,22 @@
     <None Include="CHANGELOG.md" Pack="true" PackagePath="CHANGELOG.md" />
     <None Include="../README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
+
+  <!-- START Exclude asp net configs from release archives -->
+  <ItemGroup>
+    <Content Update="appsettings*.json" CopyToPublishDirectory="Never" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
+    <IsWebConfigTransformDisabled>true</IsWebConfigTransformDisabled>
+  </PropertyGroup>
+
+  <Target Name="RemoveStaticWebAssetsEndpointsManifest"
+        AfterTargets="Publish">
+  <Delete Files="$(PublishDir)$(AssemblyName).staticwebassets.endpoints.json"
+          Condition="Exists('$(PublishDir)$(AssemblyName).staticwebassets.endpoints.json')" />
+  </Target>
+  <!-- END Exclude asp net configs from release archives -->
+
 </Project>


### PR DESCRIPTION
[azsdk-cli] Exclude asp net config files from release archive

We don't need the cruft of all the asp net config files that get included by default from dotnet publish

```
-a---           2/12/2026  4:30 PM            113 appsettings.Development.json
-a---           2/12/2026  4:30 PM            136 appsettings.json
-a---           2/12/2026  4:30 PM      173433120 azsdk.exe
-a---           2/12/2026  4:30 PM         301964 azsdk.pdb
-a---           2/12/2026  4:30 PM             53 azsdk.staticwebassets.endpoints.json
-a---           2/12/2026  4:30 PM          29104 Azure.Sdk.Tools.CodeownersUtils.pdb
-a---           2/12/2026  4:30 PM            462 web.config
```