### PR TITLE
[APIView] PART 1 Shift APIView from `apiview.dev` to `apiview.org`

### DIFF
--- a/eng/pipelines/apiview-review-gen-javascript.yml
+++ b/eng/pipelines/apiview-review-gen-javascript.yml
@@ -1,4 +1,4 @@
-pr: none
+﻿pr: none
 
 trigger: none
 
@@ -12,7 +12,7 @@ parameters:
     default: '[{"ReviewID":"<reviewid>","RevisionID":"<revisionId>","FileID":"<fileid>","FileName":"<fileName>"}]'
   - name: APIViewURL
     type: string
-    default: 'https://apiview.dev'
+    default: 'https://apiview.org'
   - name: StorageContainerUrl
     type: string
     default: ''

--- a/eng/pipelines/apiview-review-gen-python.yml
+++ b/eng/pipelines/apiview-review-gen-python.yml
@@ -1,4 +1,4 @@
-pr: none
+﻿pr: none
 
 trigger: none
 
@@ -12,7 +12,7 @@ parameters:
     default: '[{"ReviewID":"<reviewid>","RevisionID":"<revisionId>","FileID":"<fileid>","FileName":"<fileName>"}]'
   - name: APIViewURL
     type: string
-    default: 'https://apiview.dev'
+    default: 'https://apiview.org'
   - name: StorageContainerUrl
     type: string
     default: ''

--- a/eng/pipelines/apiview-review-gen-typespec.yml
+++ b/eng/pipelines/apiview-review-gen-typespec.yml
@@ -1,4 +1,4 @@
-pr: none
+﻿pr: none
 
 trigger: none
 
@@ -8,7 +8,7 @@ parameters:
     default: '[{"ReviewID":"<reviewid>","RevisionID":"<revisionId>","SourceRepoName":"<RepoName>","FileName":"<fileName>","SourceBranchName":"<SourceBranchName>"}]'
   - name: APIViewURL
     type: string
-    default: 'https://apiview.dev'
+    default: 'https://apiview.org'
 
 pool:
   name: azsdk-pool

--- a/eng/scripts/Apiview-Update-Generated-Review.ps1
+++ b/eng/scripts/Apiview-Update-Generated-Review.ps1
@@ -1,10 +1,10 @@
-[CmdletBinding()]
+﻿[CmdletBinding()]
 param (
   [Parameter(Mandatory = $true)]
   [string]$BuildId,
   [string]$RepoName = "azure/azure-sdk-tools",
   [string]$ArtifactName = "apiview",
-  [string]$ApiviewUpdateUrl = "https://apiview.dev/review/UpdateApiReview"
+  [string]$ApiviewUpdateUrl = "https://apiview.org/review/UpdateApiReview"
 )
 
 ####################################################################################################################

--- a/packages/python-packages/apiview-copilot/src/_apiview.py
+++ b/packages/python-packages/apiview-copilot/src/_apiview.py
@@ -178,7 +178,7 @@ class ApiViewClient:
             endpoint = endpoint[1:]
 
         apiview_endpoints = {
-            "production": "https://apiview.dev",
+            "production": "https://apiview.org",
             "staging": "https://apiviewstagingtest.com",
         }
         endpoint_root = apiview_endpoints.get(self.environment)

--- a/src/dotnet/APIView/APIViewUnitTests/UnauthorizedPageModelTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/UnauthorizedPageModelTests.cs
@@ -87,8 +87,8 @@ public class UnauthorizedPageModelTests
     [Fact]
     public async Task OnGetAsync_WhenAuthorized_WithAllowedOrigin_RedirectsToReturnUrl()
     {
-        _pageModel.ReturnUrl = "https://spa.apiview.dev/Reviews";
-        _mockUrlHelper.Setup(u => u.IsLocalUrl("https://spa.apiview.dev/Reviews")).Returns(false);
+        _pageModel.ReturnUrl = "https://spa.apiview.org/Reviews";
+        _mockUrlHelper.Setup(u => u.IsLocalUrl("https://spa.apiview.org/Reviews")).Returns(false);
         _mockEnvironment.SetupGet(e => e.EnvironmentName).Returns(Environments.Development);
         _mockAuthorizationService
             .Setup(a => a.AuthorizeAsync(_testUser, null, Startup.RequireOrganizationPolicy))
@@ -97,7 +97,7 @@ public class UnauthorizedPageModelTests
         IActionResult result = await _pageModel.OnGetAsync();
         result.Should().BeOfType<RedirectResult>();
         RedirectResult redirectResult = result as RedirectResult;
-        redirectResult!.Url.Should().Be("https://spa.apiview.dev/Reviews");
+        redirectResult!.Url.Should().Be("https://spa.apiview.org/Reviews");
     }
 
     [Fact]

--- a/src/dotnet/APIView/APIViewWeb/Client/tests/unit/shared/helpers.spec.ts
+++ b/src/dotnet/APIView/APIViewWeb/Client/tests/unit/shared/helpers.spec.ts
@@ -15,43 +15,43 @@ test.describe('getReviewAndRevisionIdFromUrl should return valid review and revi
   var expectedResults = [
     {
       title: 'older revision returns correct values',
-      href: 'https://apiview.dev/Assemblies/Review/b08a59aad6fe47f1949b54a531e67fa9?revisionId=ae4bb4afdc104c07a0f0058e0c133b4f&doc=False',
+      href: 'https://apiview.org/Assemblies/Review/b08a59aad6fe47f1949b54a531e67fa9?revisionId=ae4bb4afdc104c07a0f0058e0c133b4f&doc=False',
       reviewId: 'b08a59aad6fe47f1949b54a531e67fa9',
       revisionId: 'ae4bb4afdc104c07a0f0058e0c133b4f',
     },
     {
       title: 'older revision returns correct values 2',
-      href: 'https://apiview.dev/Assemblies/Review/0ab7afb3131d4eacb1bfc1b0230fece8?revisionId=e822cfe035b148d2999a57e3e6b07460&doc=False',
+      href: 'https://apiview.org/Assemblies/Review/0ab7afb3131d4eacb1bfc1b0230fece8?revisionId=e822cfe035b148d2999a57e3e6b07460&doc=False',
       reviewId: '0ab7afb3131d4eacb1bfc1b0230fece8',
       revisionId: 'e822cfe035b148d2999a57e3e6b07460',
     },
     {
       title: 'latest revision returns correct reviewId and undefined revisionId',
-      href: 'https://apiview.dev/Assemblies/Review/7674e7e8fdd0496f80b29127673928ec',
+      href: 'https://apiview.org/Assemblies/Review/7674e7e8fdd0496f80b29127673928ec',
       reviewId: '7674e7e8fdd0496f80b29127673928ec',
       revisionId: undefined,
     },
     {
       title: 'latest revision returns correct reviewId and undefined revisionId 2',
-      href: 'https://apiview.dev/Assemblies/Review/0ab7afb3131d4eacb1bfc1b0230fece8',
+      href: 'https://apiview.org/Assemblies/Review/0ab7afb3131d4eacb1bfc1b0230fece8',
       reviewId: '0ab7afb3131d4eacb1bfc1b0230fece8',
       revisionId: undefined,
     },
     {
       title: 'review conversation page returns its reviewId',
-      href: 'https://apiview.dev/Assemblies/Conversation/7c1724b222bd4a49bfeba6100d77297e',
+      href: 'https://apiview.org/Assemblies/Conversation/7c1724b222bd4a49bfeba6100d77297e',
       reviewId: '7c1724b222bd4a49bfeba6100d77297e',
       revisionId: undefined,
     },
     {
       title: 'review revisions page returns its reviewId',
-      href: 'https://apiview.dev/Assemblies/Revisions/7c1724b222bd4a49bfeba6100d77297e',
+      href: 'https://apiview.org/Assemblies/Revisions/7c1724b222bd4a49bfeba6100d77297e',
       reviewId: '7c1724b222bd4a49bfeba6100d77297e',
       revisionId: undefined,
     },
     {
       title: 'review usage samples page returns its reviewId',
-      href: 'https://apiview.dev/Assemblies/Samples/7c1724b222bd4a49bfeba6100d77297e',
+      href: 'https://apiview.org/Assemblies/Samples/7c1724b222bd4a49bfeba6100d77297e',
       reviewId: '7c1724b222bd4a49bfeba6100d77297e',
       revisionId: undefined,
     },
@@ -69,19 +69,19 @@ test.describe('getReviewAndRevisionIdFromUrl should return valid review and revi
   var nonReviewExpectedResults = [
     {
       title: 'landing',
-      href: 'https://apiview.dev/',
+      href: 'https://apiview.org/',
     },
     {
       title: 'login',
-      href: 'https://apiview.dev/Login',
+      href: 'https://apiview.org/Login',
     },
     {
       title: 'profile',
-      href: 'https://apiview.dev/Assemblies/Profile/yeojunh',
+      href: 'https://apiview.org/Assemblies/Profile/yeojunh',
     },
     {
       title: 'review filter',
-      href: 'https://apiview.dev/?languages=C%252B%252B&state=Closed&state=Open&status=Approved&type=Automatic&type=Manual&type=PullRequest&pageNo=1&pageSize=50',
+      href: 'https://apiview.org/?languages=C%252B%252B&state=Closed&state=Open&status=Approved&type=Automatic&type=Manual&type=PullRequest&pageNo=1&pageSize=50',
     },
     {
       title: 'requested reviews',

--- a/src/dotnet/APIView/APIViewWeb/Helpers/URlHelpers.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/URlHelpers.cs
@@ -10,7 +10,7 @@ namespace APIViewWeb.Helpers
             return new List<string>() {
                     "https://spa.apiviewuxtest.com",
                     "https://spa.apiviewstagingtest.com",
-                    "https://spa.apiview.dev"
+                    "https://spa.apiview.org"
                 };
         }
 

--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_Layout.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_Layout.cshtml
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <meta name="google" content="notranslate" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>@ViewData["Title"] - apiview.dev</title>
+    <title>@ViewData["Title"] - apiview.org</title>
 
     <environment include="Development">
         <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" />
@@ -39,7 +39,7 @@
     <header>
         <nav class="navbar navbar-expand-sm navbar-toggleable-sm main-nav-cst-theme">
             <div class="container-fluid">
-                <a href="/" class="navbar-brand" data-clarity-region="apiview-home-logo"><img id="apiview-logo" alt="apiview-logo" src="~/icons/apiview.png" />apiview.dev</a>
+                <a href="/" class="navbar-brand" data-clarity-region="apiview-home-logo"><img id="apiview-logo" alt="apiview-logo" src="~/icons/apiview.png" />apiview.org</a>
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-controls="navbarSupportedContent"
                         aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>

--- a/src/dotnet/APIView/APIViewWeb/web.config
+++ b/src/dotnet/APIView/APIViewWeb/web.config
@@ -21,12 +21,12 @@
           <conditions logicalGrouping="MatchAny">
             <add input="{HTTP_HOST}" pattern="^apiview\.azurewebsites\.net$" />
           </conditions>
-          <action type="Redirect" url="http://apiview.dev/{R:0}" />
+          <action type="Redirect" url="https://apiview.org/{R:0}" />
         </rule>
         <rule name="Rewrite root SPA requests for staging instance">
           <match url="^((?!spa/).*)$" />
           <conditions logicalGrouping="MatchAll">
-            <add input="{HTTP_HOST}" pattern="^(spa\.apiviewuxtest\.com|spa\.apiview\.dev|spa\.apiviewstagingtest\.com)$" />
+            <add input="{HTTP_HOST}" pattern="^(spa\.apiviewuxtest\.com|spa\.apiview\.org|spa\.apiviewstagingtest\.com)$" />
             <add input="{REQUEST_FILENAME}" pattern="isFile" negate="true" />
             <add input="{REQUEST_FILENAME}" pattern="isDirectory" negate="true" />
           </conditions>

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/shared/nav-bar/nav-bar.component.html
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/shared/nav-bar/nav-bar.component.html
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-sm navbar-toggleable-sm main-nav-cst-theme">
     <div class="container-fluid">
-        <a href="/" class="navbar-brand"><img id="apiview-logo" alt="apiview-logo" src="{{assetsPath}}/images/apiview.png" />apiview.dev</a>
+        <a href="/" class="navbar-brand"><img id="apiview-logo" alt="apiview-logo" src="{{assetsPath}}/images/apiview.png" />apiview.org</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-controls="navbarSupportedContent"
                 aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>

--- a/src/dotnet/APIView/ClientSPA/src/index.html
+++ b/src/dotnet/APIView/ClientSPA/src/index.html
@@ -11,9 +11,9 @@
 
   <!-- Microsoft Clarity Analytics -->
   <script type="text/javascript">
-    // Only load Clarity in production (apiview.dev)
+    // Only load Clarity in production (apiview.org)
     const hostname = window.location.hostname;
-    const isProduction = hostname === 'apiview.dev' || hostname.endsWith('.apiview.dev');
+    const isProduction = hostname === 'apiview.org' || hostname.endsWith('.apiview.org');
 
     if (isProduction) {
       (function(c,l,a,r,i,t,y){

--- a/src/dotnet/APIView/apiview.yml
+++ b/src/dotnet/APIView/apiview.yml
@@ -469,11 +469,11 @@ extends:
 
           variables:
             - name: 'apiUrl'
-              value: 'https://apiview.dev/api/'
+              value: 'https://apiview.org/api/'
             - name: 'hubUrl'
-              value: 'https://apiview.dev/hubs/'
+              value: 'https://apiview.org/hubs/'
             - name: 'webAppUrl'
-              value: 'https://apiview.dev/'
+              value: 'https://apiview.org/'
 
           jobs:
             - deployment: Publish_to_Prod

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Configuration/APIViewConfiguration.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Configuration/APIViewConfiguration.cs
@@ -6,7 +6,7 @@ public static class APIViewConfiguration
 
     public static readonly Dictionary<string, string> BaseUrlEndpoints = new()
     {
-        { "production", "https://apiview.dev" },
+        { "production", "https://apiview.org" },
         { "staging", "https://apiviewstagingtest.com" },
         { "local", "http://localhost:5000" }
     };


### PR DESCRIPTION
Related to https://github.com/Azure/azure-sdk-tools/issues/8210.

This is 1 PR necessary to switch apiview.dev over to apiview.org temporarily while the Microsoft Domains team transfer ownership of apiview.dev from CloudFlare to Microsoft.

This PR does NOT change:
- scripts under `end\common`. That is in this PR (https://github.com/Azure/azure-sdk-tools/pull/14052)
- documentation or doc comments (to minimize the likelihood of them not being switched back)
- static test data