### PR TITLE
[APIView] Enable automatic deployment of APIView UX Test without prompt  on APIView-UX pipeline

### DIFF
--- a/src/dotnet/APIView/apiview.yml
+++ b/src/dotnet/APIView/apiview.yml
@@ -405,11 +405,11 @@ extends:
                   enableCustomDeployment: true
                   DeploymentType: zipDeploy
 
-      - ${{ if and(in(variables['Build.Reason'], 'Manual', ''), eq(variables['System.TeamProject'], 'internal')) }}:
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - stage: Test_UI_Publish
           displayName: Publish Test UI
           dependsOn: Build
-          condition: and(succeeded(), eq(coalesce(variables['runTestUIPublish'], 'true'), 'true'))
+          condition: and(succeeded(), eq(coalesce(variables['runTestUIPublish'], 'false'), 'true'))
 
           variables:
             - name: 'apiUrl'


### PR DESCRIPTION
Hinges on value of `runTestUIPublish`.

**APIView**
- not set (so defaults to false, but you can turn it on if you want)

**APIView-UX**
- hard set to true (not overridable)

The purpose is so that if you run APIView-UX, it just builds and deploys to UX test without waiting for another manual approval.