### PR TITLE
[APIView] Fix thread count when resolving/unresolving from side panel

### DIFF
--- a/src/dotnet/APIView/ClientSPA/src/app/_components/conversations/conversations.component.spec.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/conversations/conversations.component.spec.ts
@@ -217,7 +217,7 @@ describe('ConversationComponent', () => {
       expect(component.numberOfActiveThreads).toBe(1);
     });
 
-it('should unresolve only the specific thread and not affect other threads on the same element', () => {
+    it('should unresolve only the specific thread and not affect other threads on the same element', () => {
       const apiRevisions = [
         { id: 'rev-1', createdOn: '2021-10-01T00:00:00Z' },
         { id: 'rev-2', createdOn: '2022-10-01T00:00:00Z' }
@@ -261,6 +261,60 @@ it('should unresolve only the specific thread and not affect other threads on th
 
       // Now 2 active threads (thread-1 and thread-3)
       expect(component.numberOfActiveThreads).toBe(2);
+    });
+
+    it('should correctly resolve/unresolve legacy comments without threadId using elementId as fallback', () => {
+      const apiRevisions = [
+        { id: 'rev-1', createdOn: '2021-10-01T00:00:00Z' },
+        { id: 'rev-2', createdOn: '2022-10-01T00:00:00Z' }
+      ] as APIRevision[];
+
+      const comments = [
+        // Legacy thread on elem-1: no threadId, resolved
+        { id: 'c1', elementId: 'elem-1', threadId: '', apiRevisionId: 'rev-1', isResolved: true },
+        { id: 'c2', elementId: 'elem-1', threadId: '', apiRevisionId: 'rev-1', isResolved: true },
+        // Normal thread on elem-2: has threadId, unresolved
+        { id: 'c3', elementId: 'elem-2', threadId: 'thread-2', apiRevisionId: 'rev-1', isResolved: false }
+      ] as CommentItemModel[];
+
+      component.apiRevisions = apiRevisions;
+      component.comments = comments;
+      component.createCommentThreads();
+
+      // Initially 1 unresolved thread (thread-2)
+      expect(component.numberOfActiveThreads).toBe(1);
+
+      // Unresolve legacy thread — the update payload uses elementId as the threadId (fallback behavior)
+      (component as any).applyCommentResolutionUpdate({
+        elementId: 'elem-1',
+        threadId: 'elem-1', // threadId equals elementId in legacy/fallback case
+        commentThreadUpdateAction: CommentThreadUpdateAction.CommentUnResolved
+      });
+
+      // Legacy comments on elem-1 should now be unresolved
+      const legacyComments = component.comments.filter(c => c.elementId === 'elem-1');
+      expect(legacyComments.every(c => !c.isResolved)).toBe(true);
+
+      // thread-2 should still be unresolved (not affected)
+      const thread2Comments = component.comments.filter(c => c.threadId === 'thread-2');
+      expect(thread2Comments.every(c => !c.isResolved)).toBe(true);
+
+      // Now 2 active threads (legacy elem-1 thread and thread-2)
+      expect(component.numberOfActiveThreads).toBe(2);
+
+      // Resolve the legacy thread back
+      (component as any).applyCommentResolutionUpdate({
+        elementId: 'elem-1',
+        threadId: 'elem-1',
+        commentThreadUpdateAction: CommentThreadUpdateAction.CommentResolved
+      });
+
+      // Legacy comments should be resolved again
+      const legacyCommentsAfterResolve = component.comments.filter(c => c.elementId === 'elem-1');
+      expect(legacyCommentsAfterResolve.every(c => c.isResolved)).toBe(true);
+
+      // Back to 1 active thread
+      expect(component.numberOfActiveThreads).toBe(1);
     });
   });
 });

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/conversations/conversations.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/conversations/conversations.component.ts
@@ -349,8 +349,12 @@ export class ConversationsComponent implements OnChanges, OnDestroy {
     const isResolved = commentUpdates.commentThreadUpdateAction === CommentThreadUpdateAction.CommentResolved;
     this.comments.filter(c => {
       if (commentUpdates.threadId) {
-        return c.threadId === commentUpdates.threadId || 
-               (!c.threadId && c.elementId === commentUpdates.threadId);
+        // Match by threadId normally; in legacy cases where threadId was used as elementId,
+        // only match comments without a threadId whose elementId equals the provided elementId.
+        return c.threadId === commentUpdates.threadId ||
+               (!c.threadId &&
+                commentUpdates.elementId === commentUpdates.threadId &&
+                c.elementId === commentUpdates.elementId);
       }
       return c.elementId === commentUpdates.elementId;
     }).forEach(c => {


### PR DESCRIPTION
Unresolving a thread from the Conversations side panel caused incorrect thread counts (e.g., 2 → 1 → 4 instead of 2 → 1 → 2).

When comments don't have a `threadId`, the system uses `elementId` as a fallback. The resolution filter wasn't handling this fallback case, causing it to miss comments that should be updated.

This was introduced by https://github.com/Azure/azure-sdk-tools/commit/bee0b70680d11a1eb1cff4a645c802910b4f8448