### PR TITLE
Fix Java release tag to include groupId in Update-DocsMsMetadata

### DIFF
--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -64,7 +64,12 @@ function GetAdjustedReadmeContent($ReadmeContent, $PackageInfo, $PackageMetadata
   }
   Write-Host "The service of package: $service"
   # Generate the release tag for use in link substitution
-  $tag = "$($PackageInfo.Name)_$($PackageInfo.Version)"
+  if ($Language -eq 'java' -and $PackageInfo.Group) {
+    $groupId = $PackageInfo.Group
+    $tag = "$($groupId)+$($PackageInfo.Name)_$($PackageInfo.Version)"
+  } else {
+    $tag = "$($PackageInfo.Name)_$($PackageInfo.Version)"
+  }
   Write-Host "The tag of package: $tag"
   $date = Get-Date -Format "MM/dd/yyyy"
 


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-java/issues/47938

For Java packages, the release tag used in link substitution now includes the groupId in the format \groupId+Name_Version\ (e.g., \com.azure+azure-core_1.0.0\).

Previously, the tag was always \Name_Version\ for all languages. Java packages require the groupId prefix to correctly match release tags.

### Changes
- added a condition for Java language to build the release tag as `GroupId+Name_Version` (`\eng/common/scripts/Update-DocsMsMetadata.ps1`)