### PR TITLE
Fix extra colon in JS API parser variable declarations without type annotations

### DIFF
--- a/tools/apiview/parsers/js-api-parser/src/tokenGenerators/variable.ts
+++ b/tools/apiview/parsers/js-api-parser/src/tokenGenerators/variable.ts
@@ -35,20 +35,25 @@ function generate(item: ApiVariable, deprecated?: boolean): GeneratorResult {
   nameToken.RenderClasses = ["variable"];
   tokens.push(nameToken);
 
-  // Add colon and type
-  tokens.push(createToken(TokenKind.Punctuation, ":", { hasSuffixSpace: true, deprecated }));
-
+  // Add colon and type (only if type annotation exists)
   const typeText = item.variableTypeExcerpt?.text?.trim();
   let children;
 
   if (typeText) {
+    tokens.push(createToken(TokenKind.Punctuation, ":", { hasSuffixSpace: true, deprecated }));
     children = parseTypeText(typeText, tokens, deprecated);
   }
 
   // Add initializer value if present (e.g., = 1000000)
   const initializerText = item.initializerExcerpt?.text?.trim();
   if (initializerText) {
-    tokens.push(createToken(TokenKind.Punctuation, "=", { hasPrefixSpace: true, hasSuffixSpace: true, deprecated }));
+    tokens.push(
+      createToken(TokenKind.Punctuation, "=", {
+        hasPrefixSpace: true,
+        hasSuffixSpace: true,
+        deprecated,
+      }),
+    );
     tokens.push(createToken(TokenKind.StringLiteral, initializerText, { deprecated }));
   }
 

--- a/tools/apiview/parsers/js-api-parser/test/tokenGenerators/variable.spec.ts
+++ b/tools/apiview/parsers/js-api-parser/test/tokenGenerators/variable.spec.ts
@@ -68,7 +68,10 @@ function createDefaultExportExcerptTokens(varName: string, typeValue: string): E
 describe("variableTokenGenerator", () => {
   describe("isValid", () => {
     it("returns true for variable items", () => {
-      const mockVariable = { kind: ApiItemKind.Variable, displayName: "testVariable" } as ApiVariable;
+      const mockVariable = {
+        kind: ApiItemKind.Variable,
+        displayName: "testVariable",
+      } as ApiVariable;
       expect(variableTokenGenerator.isValid(mockVariable)).toBe(true);
     });
 
@@ -93,8 +96,16 @@ describe("variableTokenGenerator", () => {
 
       const { tokens } = variableTokenGenerator.generate(mockVariable, false);
 
-      expect(tokens[0]).toMatchObject({ Kind: TokenKind.Keyword, Value: "export", HasSuffixSpace: true });
-      expect(tokens[1]).toMatchObject({ Kind: TokenKind.Keyword, Value: "const", HasSuffixSpace: true });
+      expect(tokens[0]).toMatchObject({
+        Kind: TokenKind.Keyword,
+        Value: "export",
+        HasSuffixSpace: true,
+      });
+      expect(tokens[1]).toMatchObject({
+        Kind: TokenKind.Keyword,
+        Value: "const",
+        HasSuffixSpace: true,
+      });
       expect(tokens[2]).toMatchObject({
         Kind: TokenKind.MemberName,
         Value: "myString",
@@ -102,7 +113,11 @@ describe("variableTokenGenerator", () => {
         NavigationDisplayName: "myString",
         RenderClasses: ["variable"],
       });
-      expect(tokens[3]).toMatchObject({ Kind: TokenKind.Punctuation, Value: ":", HasSuffixSpace: true });
+      expect(tokens[3]).toMatchObject({
+        Kind: TokenKind.Punctuation,
+        Value: ":",
+        HasSuffixSpace: true,
+      });
     });
 
     it("marks all tokens as deprecated when deprecated flag is true", () => {
@@ -159,7 +174,11 @@ describe("variableTokenGenerator", () => {
       ["[string, number, boolean]", "[string, number, boolean]"],
       ["typeof SomeClass", "typeof SomeClass"],
     ])("handles %s type", (typeText) => {
-      const mockVariable = createMockVariable("testVar", typeText, createBasicExcerptTokens("testVar", typeText));
+      const mockVariable = createMockVariable(
+        "testVar",
+        typeText,
+        createBasicExcerptTokens("testVar", typeText),
+      );
       const { tokens } = variableTokenGenerator.generate(mockVariable, false);
 
       expect(tokens.length).toBeGreaterThan(0);
@@ -203,7 +222,11 @@ describe("variableTokenGenerator", () => {
     });
 
     it("throws an error for invalid item kind", () => {
-      const mockClass = { kind: ApiItemKind.Class, displayName: "TestClass", excerptTokens: [] } as any;
+      const mockClass = {
+        kind: ApiItemKind.Class,
+        displayName: "TestClass",
+        excerptTokens: [],
+      } as any;
       expect(() => variableTokenGenerator.generate(mockClass, false)).toThrow(
         "Invalid item TestClass of kind Class for Variable token generator.",
       );
@@ -261,6 +284,26 @@ describe("variableTokenGenerator", () => {
 
       const equalsToken = tokens.find((t) => t.Value === "=");
       expect(equalsToken).toBeUndefined();
+    });
+
+    it("does not emit colon when variable has no type annotation", () => {
+      const mockVariable = createMockVariable(
+        "AI_OPERATION_NAME",
+        "",
+        createBasicExcerptTokens("AI_OPERATION_NAME", ""),
+        '"ai.operation.name"',
+      );
+
+      const { tokens } = variableTokenGenerator.generate(mockVariable, false);
+
+      const colonToken = tokens.find((t) => t.Value === ":");
+      expect(colonToken).toBeUndefined();
+
+      const equalsToken = tokens.find((t) => t.Value === "=");
+      expect(equalsToken).toBeDefined();
+
+      const valueToken = tokens.find((t) => t.Value === '"ai.operation.name"');
+      expect(valueToken).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Fix a bug in the JS API parser where a colon `:` punctuation token was unconditionally emitted for all variable declarations, even when the variable had no type annotation
- Variables with only an initializer (no type) rendered incorrectly as `export const FOO: = "bar";` instead of `export const FOO = "bar";`
- Move the colon emission inside the `if (typeText)` check so it only appears when a type annotation is present

### Before
```
export const AI_OPERATION_NAME: = "ai.operation.name";
```

### After
```
export const AI_OPERATION_NAME = "ai.operation.name";
```

Variables with type annotations are unaffected and continue to render correctly:
```
export const isBrowser: boolean;
```