### PR TITLE
Override PATHEXT in azsdk cli run time when running commands

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
@@ -13,7 +13,7 @@
     <WarningsAsErrors>CA2254</WarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AssemblyName>azsdk</AssemblyName>
-    <VersionPrefix>0.5.18</VersionPrefix>
+    <VersionPrefix>0.5.19</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <!-- Package metadata -->

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.5.19 (2026-02-25)
+
+### Bugs Fixed
+
+- Override path extension variable to support running commands on Windows without extension.
+
 ## 0.5.18 (2026-02-24)
 
 ### Bugs Fixed

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Process/Options/ProcessOptions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Process/Options/ProcessOptions.cs
@@ -83,7 +83,7 @@ public class ProcessOptions : IProcessOptions
         var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         if (isWindows && windowsCommand != "pwsh" && windowsCommand != "powershell")
         {
-            args = ["/C", command, .. windowsArgs];
+            args = ["/C", windowsCommand, .. windowsArgs];
             command = CMD;
         }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Process/ProcessHelperBase.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Process/ProcessHelperBase.cs
@@ -8,6 +8,9 @@ namespace Azure.Sdk.Tools.Cli.Helpers;
 public abstract class ProcessHelperBase<T>(ILogger<T> logger, IRawOutputHelper outputHelper)
 {
     private List<string> WindowsDefaultProcess = ["pwsh", "powershell", ProcessOptions.CMD];
+    // WINDOWS_PATH_EXT is used to override Environment variable PATHEXT to support command lookup when running a process.
+    // This is required to support process run when MCP is used from copilot CLI which overrides PATHEXT to .CPL
+    private const string WINDOWS_PATH_EXT = ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.PY;.PYW;.CPL";
 
     /// <summary>
     /// Runs a process with the specified command and arguments in the given working directory.
@@ -51,6 +54,8 @@ public abstract class ProcessHelperBase<T>(ILogger<T> logger, IRawOutputHelper o
         {
             processStartInfo.ArgumentList.Add(arg);
         }
+        //Override PATHEXT to support command lookup
+        processStartInfo.Environment["PATHEXT"] = WINDOWS_PATH_EXT;
 
         ProcessResult result = new() { ExitCode = 1 };
 


### PR DESCRIPTION
This PR fixes "Command not found" issue when running a command without extension from MCP server. This issue happens only when running MCP server using copilot CLI.