### PR TITLE
[APIView] Allow comments on removed lines and show unresolved orphan comments in code view. 

### DIFF
--- a/src/dotnet/APIView/APIViewUnitTests/APIRevisionsManagerTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/APIRevisionsManagerTests.cs
@@ -1706,5 +1706,75 @@ public class APIRevisionsManagerTests
         _mockAPIRevisionsRepository.Verify(x => x.UpsertAPIRevisionAsync(It.Is<APIRevisionListItemModel>(r => r.DiagnosticsHash == "new-hash")), Times.Once);
     }
 
+    [Fact]
+    public async Task GetReviewQualityScoreAsync_OrphanedCommentsWithNoElementId_EachScoredIndependently()
+    {
+        var revision = CreateRevisionForQualityTest();
+        // Orphaned comments: no ThreadId and no ElementId (empty string simulates missing elementId)
+        var comments = new List<CommentItemModel>
+        {
+            CreateComment(CommentSeverity.MustFix, elementId: "", threadId: null),
+            CreateComment(CommentSeverity.ShouldFix, elementId: "", threadId: null),
+            CreateComment(CommentSeverity.ShouldFix, elementId: "", threadId: null)
+        };
+        // Each comment gets a unique Id from IdHelper.GenerateId() in the model constructor
+        _mockAPIRevisionsRepository.Setup(x => x.GetAPIRevisionAsync(revision.Id)).ReturnsAsync(revision);
+        _mockCommentsRepository.Setup(x => x.GetCommentsAsync(revision.ReviewId, false, CommentType.APIRevision))
+            .ReturnsAsync(comments);
+
+        var result = await _manager.GetReviewQualityScoreAsync(revision.Id);
+
+        // Each orphaned comment should be scored independently, not collapsed into one thread
+        // 100 - 20 (MustFix) - 10 (ShouldFix) - 10 (ShouldFix) = 60
+        Assert.Equal(60, result.Score);
+        Assert.Equal(1, result.UnresolvedMustFixCount);
+        Assert.Equal(2, result.UnresolvedShouldFixCount);
+        Assert.Equal(3, result.TotalUnresolvedCount);
+    }
+
+    [Fact]
+    public async Task GetReviewQualityScoreAsync_OrphanedCommentsWithNullElementId_EachScoredIndependently()
+    {
+        var revision = CreateRevisionForQualityTest();
+        // Orphaned comments: no ThreadId and null ElementId
+        var comments = new List<CommentItemModel>
+        {
+            new CommentItemModel
+            {
+                ReviewId = "review-1",
+                APIRevisionId = "rev-1",
+                CommentType = CommentType.APIRevision,
+                Severity = CommentSeverity.MustFix,
+                IsResolved = false,
+                CommentText = "Orphan 1",
+                ElementId = null,
+                ThreadId = null,
+                CreatedOn = DateTime.UtcNow
+            },
+            new CommentItemModel
+            {
+                ReviewId = "review-1",
+                APIRevisionId = "rev-1",
+                CommentType = CommentType.APIRevision,
+                Severity = CommentSeverity.MustFix,
+                IsResolved = false,
+                CommentText = "Orphan 2",
+                ElementId = null,
+                ThreadId = null,
+                CreatedOn = DateTime.UtcNow.AddMinutes(1)
+            }
+        };
+        _mockAPIRevisionsRepository.Setup(x => x.GetAPIRevisionAsync(revision.Id)).ReturnsAsync(revision);
+        _mockCommentsRepository.Setup(x => x.GetCommentsAsync(revision.ReviewId, false, CommentType.APIRevision))
+            .ReturnsAsync(comments);
+
+        var result = await _manager.GetReviewQualityScoreAsync(revision.Id);
+
+        // Both orphaned comments should be scored independently: 100 - 20 - 20 = 60
+        Assert.Equal(60, result.Score);
+        Assert.Equal(2, result.UnresolvedMustFixCount);
+        Assert.Equal(2, result.TotalUnresolvedCount);
+    }
+
     #endregion
 }

--- a/src/dotnet/APIView/APIViewUnitTests/CodeFileHelpersTest.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/CodeFileHelpersTest.cs
@@ -405,6 +405,65 @@ namespace APIViewUnitTests
         }
 
         [Fact]
+        public void CollectUserCommentsForRow_RemovedRowWithMatchingActiveLine_HidesDuplicateThread()
+        {
+            var comment = new CommentItemModel
+            {
+                ElementId = "same-element-id", CommentText = "comment text", CreatedBy = "test-user"
+            };
+
+            var codePanelRawData = new CodePanelRawData
+            {
+                Comments = new List<CommentItemModel> { comment },
+                AddedDiffLineIds = ["same-element-id"]
+            };
+
+            var removedRow = new CodePanelRowData { RowClassesObj = new HashSet<string> { "removed" } };
+
+            var method = typeof(CodeFileHelpers).GetMethod("CollectUserCommentsForRow",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+            var result = (CodePanelRowData)method.Invoke(null, new object[]
+            {
+                codePanelRawData, "same-element-id", "test-node-hash", removedRow
+            });
+
+            Assert.NotNull(result);
+            Assert.Empty(result.CommentsObj);
+            Assert.Equal("bi bi-chat-right-text hide", removedRow.ToggleCommentsClasses);
+        }
+
+        [Fact]
+        public void CollectUserCommentsForRow_RemovedRowWithoutMatchingActiveLine_ShowsThread()
+        {
+            var comment = new CommentItemModel
+            {
+                ElementId = "deleted-only-element", CommentText = "comment text", CreatedBy = "test-user"
+            };
+
+            var codePanelRawData = new CodePanelRawData
+            {
+                Comments = new List<CommentItemModel> { comment },
+                AddedDiffLineIds = []
+            };
+
+            var removedRow = new CodePanelRowData { RowClassesObj = new HashSet<string> { "removed" } };
+
+            var method = typeof(CodeFileHelpers).GetMethod("CollectUserCommentsForRow",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+            var result = (CodePanelRowData)method.Invoke(null, new object[]
+            {
+                codePanelRawData, "deleted-only-element", "test-node-hash", removedRow
+            });
+
+            Assert.NotNull(result);
+            Assert.Single(result.CommentsObj);
+            Assert.Equal("deleted-only-element", result.CommentsObj[0].ElementId);
+            Assert.Equal("bi bi-chat-right-text show", removedRow.ToggleCommentsClasses);
+        }
+
+        [Fact]
         public void FindDiff_DecoratorOnlyInDiff_ShouldAppearBeforeRelatedClass()
         {
             var activeLines = new List<ReviewLine>

--- a/src/dotnet/APIView/APIViewWeb/Helpers/CodeFileHelpers.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/CodeFileHelpers.cs
@@ -22,6 +22,8 @@ namespace APIViewWeb.Helpers
         {
             var codePanelData = new CodePanelData();
             var reviewLines = codePanelRawData.activeRevisionCodeFile.ReviewLines;
+            codePanelRawData.ActiveRevisionLineIds = GetLineIds(codePanelRawData.activeRevisionCodeFile.ReviewLines);
+            codePanelRawData.AddedDiffLineIds = [];
 
             // Create root node
             var rootNodeId = "root";
@@ -42,6 +44,7 @@ namespace APIViewWeb.Helpers
                 if (!hasSameApis)
                 {
                     reviewLines = FindDiff(reviewLines, codePanelRawData.diffRevisionCodeFile.ReviewLines);
+                    codePanelRawData.AddedDiffLineIds = GetLineIds(reviewLines, l => l.DiffKind == DiffKind.Added);
                     // Remap nodeIdHashed for documentation to diff adjusted nodeIdHashed so that documentation is correctly listed on review.
                     RemapDocumentationLines(reviewLines, codePanelData.ActiveDocumentationMap);
                     // Remap documentation is diff revision using node hash ID for active revision. We don't need to show documentation if it's node itself is not present in active revision.
@@ -363,10 +366,26 @@ namespace APIViewWeb.Helpers
         {
             var commentRowData = new CodePanelRowData();
             var commentsForRow = new List<CommentItemModel>();
-            if (!string.IsNullOrEmpty(nodeId) && !codePanelRowData.RowClassesObj.Contains("removed"))
+            bool isRemovedRow = codePanelRowData.RowClassesObj.Contains("removed");
+            if (!string.IsNullOrEmpty(nodeId) && !isRemovedRow)
             {
                 codePanelRowData.ToggleCommentsClasses = "bi bi-chat-right-text can-show";
                 commentsForRow = codePanelRawData.Comments.Where(c => nodeId == c.ElementId).ToList();
+            }
+            else if (!string.IsNullOrEmpty(nodeId) && isRemovedRow)
+            {
+                // Prefer rendering on green when active and removed rows share the same line id.
+                if (!codePanelRawData.AddedDiffLineIds.Contains(nodeId))
+                {
+                    commentsForRow = codePanelRawData.Comments.Where(c => nodeId == c.ElementId).ToList();
+                    codePanelRowData.ToggleCommentsClasses = commentsForRow.Any()
+                        ? "bi bi-chat-right-text show"
+                        : "bi bi-chat-right-text hide";
+                }
+                else
+                {
+                    codePanelRowData.ToggleCommentsClasses = "bi bi-chat-right-text hide";
+                }
             }
             else
             {
@@ -388,6 +407,29 @@ namespace APIViewWeb.Helpers
                 commentRowData.IsHiddenAPI = codePanelRowData.IsHiddenAPI;
             }
             return commentRowData;
+        }
+
+        private static HashSet<string> GetLineIds(IEnumerable<ReviewLine> lines, Func<ReviewLine, bool> predicate = null)
+        {
+            HashSet<string> lineIds = [];
+            AddLineIds(lines, lineIds, predicate ?? (_ => true));
+            return lineIds;
+        }
+
+        private static void AddLineIds(IEnumerable<ReviewLine> lines, HashSet<string> lineIds, Func<ReviewLine, bool> predicate)
+        {
+            foreach (var line in lines)
+            {
+                if (predicate(line) && !string.IsNullOrEmpty(line.LineId))
+                {
+                    lineIds.Add(line.LineId);
+                }
+
+                if (line.Children?.Count > 0)
+                {
+                    AddLineIds(line.Children, lineIds, predicate);
+                }
+            }
         }
 
         private static void InsertCodePanelRowData(CodePanelData codePanelData, CodePanelRowData rowData, string nodeIdHashed, CodePanelRawData codePanelRawData, CodePanelRowData commentsForRow = null)

--- a/src/dotnet/APIView/APIViewWeb/LeanControllers/CommentsController.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanControllers/CommentsController.cs
@@ -82,7 +82,20 @@ namespace APIViewWeb.LeanControllers
         {
             IEnumerable<CommentItemModel> comments =
                 await _commentsManager.GetCommentsAsync(reviewId, isDeleted, commentType);
-            return new LeanJsonResult(comments, StatusCodes.Status200OK);
+
+            // --- DIAGNOSTIC LOGGING: Comments endpoint type breakdown ---
+            var commentsList = comments.ToList();
+            var apiRevisionComments = commentsList.Where(c => c.CommentType == CommentType.APIRevision).ToList();
+            var sampleRevisionComments = commentsList.Where(c => c.CommentType == CommentType.SampleRevision).ToList();
+            _logger.LogWarning("[Comments] ReviewId={ReviewId}, Total={Total}, APIRevision={API}, SampleRevision={Sample}, RequestedType={Type}",
+                reviewId, commentsList.Count, apiRevisionComments.Count, sampleRevisionComments.Count, commentType?.ToString() ?? "(all)");
+            foreach (var sc in sampleRevisionComments)
+            {
+                _logger.LogWarning("[Comments] SampleRevision comment: Id={Id}, ThreadId={ThreadId}, ElementId={ElementId}, IsResolved={IsResolved}, Severity={Severity}, Text={Text}",
+                    sc.Id, sc.ThreadId ?? "(null)", sc.ElementId ?? "(null)", sc.IsResolved, sc.Severity?.ToString() ?? "(null)", sc.CommentText?.Substring(0, Math.Min(sc.CommentText?.Length ?? 0, 80)));
+            }
+
+            return new LeanJsonResult(commentsList, StatusCodes.Status200OK);
         }
 
         /// <summary>

--- a/src/dotnet/APIView/APIViewWeb/LeanControllers/ReviewsController.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanControllers/ReviewsController.cs
@@ -266,8 +266,42 @@ namespace APIViewWeb.LeanControllers
                     .Concat(diagnosticComments);
                 List<CommentItemModel> visibleComments = CommentVisibilityHelper.GetVisibleComments(allCommentsWithSyncedDiagnostics, activeApiRevisionId);
 
+                // --- DIAGNOSTIC LOGGING: Code Panel Pipeline ---
+                var allSyncedList = allCommentsWithSyncedDiagnostics.ToList();
+                _logger.LogWarning("[CodePanel] ReviewId={ReviewId}, ActiveRevisionId={RevisionId}", reviewId, activeApiRevisionId);
+                _logger.LogWarning("[CodePanel] Total comments from DB (pre-sync): {Count}", allCommentsFromDb.Count());
+                _logger.LogWarning("[CodePanel] After diagnostic sync + rebuild: {Count} (non-diagnostic: {NonDiag}, diagnostic: {Diag})",
+                    allSyncedList.Count,
+                    allSyncedList.Count(c => c.CommentSource != CommentSource.Diagnostic),
+                    allSyncedList.Count(c => c.CommentSource == CommentSource.Diagnostic));
+                _logger.LogWarning("[CodePanel] After GetVisibleComments: {Count}", visibleComments.Count);
+                foreach (var c in visibleComments)
+                {
+                    _logger.LogWarning("[CodePanel]   Comment Id={Id}, ThreadId={ThreadId}, ElementId={ElementId}, IsResolved={IsResolved}, Severity={Severity}, Source={Source}, Text={Text}",
+                        c.Id, c.ThreadId ?? "(null)", c.ElementId ?? "(null)", c.IsResolved, c.Severity?.ToString() ?? "(null)", c.CommentSource, c.CommentText?.Substring(0, Math.Min(c.CommentText?.Length ?? 0, 80)));
+                }
+
                 // Code panel additionally excludes resolved comments from non-active revisions
                 List<CommentItemModel> filteredComments = visibleComments.Where(c => !c.IsResolved || c.APIRevisionId == activeApiRevisionId).ToList();
+
+                _logger.LogWarning("[CodePanel] After code-panel filter (!IsResolved || same revision): {Count}", filteredComments.Count);
+                var droppedByCodePanelFilter = visibleComments.Where(c => c.IsResolved && c.APIRevisionId != activeApiRevisionId).ToList();
+                if (droppedByCodePanelFilter.Any())
+                {
+                    _logger.LogWarning("[CodePanel] Dropped by code-panel filter (resolved + different revision): {Count}", droppedByCodePanelFilter.Count);
+                    foreach (var d in droppedByCodePanelFilter)
+                    {
+                        _logger.LogWarning("[CodePanel]   Dropped Id={Id}, RevisionId={RevisionId}, IsResolved={IsResolved}", d.Id, d.APIRevisionId, d.IsResolved);
+                    }
+                }
+
+                // Log thread grouping to compare with quality score
+                var codePanelThreads = filteredComments
+                    .GroupBy(c => !string.IsNullOrEmpty(c.ThreadId) ? c.ThreadId : (!string.IsNullOrEmpty(c.ElementId) ? c.ElementId : c.Id))
+                    .ToList();
+                var codePanelUnresolvedThreads = codePanelThreads.Where(g => g.Any(c => !c.IsResolved)).Count();
+                _logger.LogWarning("[CodePanel] Thread groups: {Total}, Unresolved threads: {Unresolved}", codePanelThreads.Count, codePanelUnresolvedThreads);
+
                 var codePanelRawData = new CodePanelRawData()
                 {
                     activeRevisionCodeFile = activeRevisionReviewCodeFile,

--- a/src/dotnet/APIView/APIViewWeb/LeanControllers/ReviewsController.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanControllers/ReviewsController.cs
@@ -271,6 +271,8 @@ namespace APIViewWeb.LeanControllers
                 var codePanelRawData = new CodePanelRawData()
                 {
                     activeRevisionCodeFile = activeRevisionReviewCodeFile,
+                    ActiveApiRevisionId = activeApiRevisionId,
+                    DiffApiRevisionId = diffApiRevisionId,
                     Comments = filteredComments
                 };
 

--- a/src/dotnet/APIView/APIViewWeb/LeanModels/CodePanelModels.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanModels/CodePanelModels.cs
@@ -12,9 +12,15 @@ namespace APIViewWeb.LeanModels
         public IEnumerable<CommentItemModel> Comments { get; set; } = new List<CommentItemModel>();
         public CodeFile activeRevisionCodeFile{ get; set; }
         public CodeFile diffRevisionCodeFile { get; set; }
+        public string ActiveApiRevisionId { get; set; }
+        public string DiffApiRevisionId { get; set; }
         public bool ApplySkipDiff { get; set; }
         public bool SkipDocsWhenDiffing { get; set; }
         public bool IsFirstCodeLineAdded { get; set; } // Used to determine if the first CodePanelRowData of type CodeLine has been added
+        [JsonIgnore]
+        public HashSet<string> ActiveRevisionLineIds { get; set; } = [];
+        [JsonIgnore]
+        public HashSet<string> AddedDiffLineIds { get; set; } = [];
     }
 
     public class CodePanelRowData

--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -1549,9 +1549,16 @@ namespace APIViewWeb.Managers
             // Group comments by conversation thread. Only the thread-starting comment's severity
             // should be counted — replies within a thread do not carry their own severity and must
             // not inflate the score. Use ThreadId when available, falling back to ElementId for
-            // legacy comments that predate thread support.
+            // legacy comments that predate thread support. When both are empty (orphaned comments
+            // with no visible elementId), fall back to the comment's own Id so each orphan is
+            // scored independently rather than being collapsed into a single group.
             var threads = unresolvedComments
-                .GroupBy(c => !string.IsNullOrEmpty(c.ThreadId) ? c.ThreadId : c.ElementId)
+                .GroupBy(c =>
+                {
+                    if (!string.IsNullOrEmpty(c.ThreadId)) return c.ThreadId;
+                    if (!string.IsNullOrEmpty(c.ElementId)) return c.ElementId;
+                    return c.Id;
+                })
                 .ToList();
 
             // For each thread, pick the first comment (by creation date) as the representative.

--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -40,6 +41,7 @@ namespace APIViewWeb.Managers
         private readonly ICosmosCommentsRepository _commentsRepository;
         private readonly TelemetryClient _telemetryClient;
         private readonly IProjectsManager _projectsManager;
+        private readonly ILogger<APIRevisionsManager> _logger;
         private readonly HashSet<string> _upgradeDisabledLangs = new HashSet<string>();
 
         public APIRevisionsManager(
@@ -57,6 +59,7 @@ namespace APIViewWeb.Managers
             ICosmosCommentsRepository commentsRepository,
             TelemetryClient telemetryClient,
             IProjectsManager projectsManager,
+            ILogger<APIRevisionsManager> logger,
             IConfiguration configuration)
         {
             _reviewsRepository = reviewsRepository;
@@ -73,6 +76,7 @@ namespace APIViewWeb.Managers
             _commentsRepository = commentsRepository;
             _telemetryClient = telemetryClient;
             _projectsManager = projectsManager;
+            _logger = logger;
             var backgroundTaskDisabledLangs = configuration["ReviewUpdateDisabledLanguages"];
             if(!string.IsNullOrEmpty(backgroundTaskDisabledLangs))
             {
@@ -1541,10 +1545,25 @@ namespace APIViewWeb.Managers
             // Apply the shared visibility filter so that only comments relevant to this
             // revision are considered. Same rules as the Conversations panel and code panel.
             var visibleComments = CommentVisibilityHelper.GetVisibleComments(allComments, apiRevisionId);
-            
+
+            // --- DIAGNOSTIC LOGGING: Quality Score Pipeline ---
+            _logger.LogWarning("[QualityScore] RevisionId={RevisionId}, ReviewId={ReviewId}", apiRevisionId, revision.ReviewId);
+            _logger.LogWarning("[QualityScore] Total comments from DB: {Count}", allComments.Count);
+            _logger.LogWarning("[QualityScore] After GetVisibleComments: {Count} (non-diagnostic: {NonDiag}, diagnostic: {Diag})",
+                visibleComments.Count,
+                visibleComments.Count(c => c.CommentSource != CommentSource.Diagnostic),
+                visibleComments.Count(c => c.CommentSource == CommentSource.Diagnostic));
+            foreach (var c in visibleComments)
+            {
+                _logger.LogWarning("[QualityScore]   Comment Id={Id}, ThreadId={ThreadId}, ElementId={ElementId}, IsResolved={IsResolved}, Severity={Severity}, Source={Source}, Text={Text}",
+                    c.Id, c.ThreadId ?? "(null)", c.ElementId ?? "(null)", c.IsResolved, c.Severity?.ToString() ?? "(null)", c.CommentSource, c.CommentText?.Substring(0, Math.Min(c.CommentText?.Length ?? 0, 80)));
+            }
+
             var unresolvedComments = visibleComments
                 .Where(c => !c.IsResolved)
                 .ToList();
+
+            _logger.LogWarning("[QualityScore] Unresolved comments: {Count}", unresolvedComments.Count);
 
             // Group comments by conversation thread. Only the thread-starting comment's severity
             // should be counted — replies within a thread do not carry their own severity and must
@@ -1561,11 +1580,25 @@ namespace APIViewWeb.Managers
                 })
                 .ToList();
 
+            _logger.LogWarning("[QualityScore] Thread groups (unresolved): {Count}", threads.Count);
+            foreach (var thread in threads)
+            {
+                _logger.LogWarning("[QualityScore]   ThreadKey={Key}, CommentCount={Count}, CommentIds=[{Ids}]",
+                    thread.Key, thread.Count(), string.Join(", ", thread.Select(c => c.Id)));
+            }
+
             // For each thread, pick the first comment (by creation date) as the representative.
             // Its severity determines the thread's severity for scoring purposes.
             var threadRepresentatives = threads
                 .Select(g => g.OrderBy(c => c.CreatedOn).First())
                 .ToList();
+
+            _logger.LogWarning("[QualityScore] Thread representatives (scored): {Count}", threadRepresentatives.Count);
+            foreach (var rep in threadRepresentatives)
+            {
+                _logger.LogWarning("[QualityScore]   Rep Id={Id}, Severity={Severity}, Source={Source}, ThreadId={ThreadId}, ElementId={ElementId}",
+                    rep.Id, rep.Severity?.ToString() ?? "(null)", rep.CommentSource, rep.ThreadId ?? "(null)", rep.ElementId ?? "(null)");
+            }
 
             var score = new ReviewQualityScore();
             double totalPenalty = 0.0;

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.html
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.html
@@ -6,6 +6,13 @@
     <span *ngIf="loadingMessage" class="mt-2 text-muted">{{ loadingMessage }}</span>
 </div>
 <div *ngIf="codePanelRowSource;" id="viewport" tabindex="0" class="{{languageSafeName!}}" role="region" aria-label="Scrollable code panel" (click)="onCodePanelItemClick($event)" (keydown)="onKeyDown($event)">
+  <div *ngFor="let indicator of orphanUnresolvedThreadIndicators" class="unresolved-orphan-indicator">
+    <small class="d-flex align-items-center">
+      <i class="bi bi-exclamation-circle-fill me-1" [ngClass]="indicator.severityIconClass"></i>
+      Unresolved <span *ngIf="indicator.severityLabel">&nbsp;{{ indicator.severityLabel }}&nbsp;</span> comment by&nbsp;<b>{{ indicator.createdBy }}</b>
+      <a class="ms-1 unresolved-toggler" (click)="showOrphanUnresolvedThread(indicator.elementId, indicator.targetApiRevisionId)"><i class="bi bi-arrows-expand"></i>&nbsp;Show</a>
+    </small>
+  </div>
   <p-message class="sticky-top" *ngIf="showNoDiffInContentMessage()" severity="info" icon="bi bi-info-circle" text="There are no differences between the two API revisions"></p-message>
   <div *uiScroll="let item of codePanelRowSource; let index = index" class="code-line" [attr.data-node-id]="item.nodeIdHashed"
     [attr.data-row-position-in-group]="item.rowPositionInGroup" [attr.data-row-type]="item.type" [ngClass]="getRowClassObject(item)">

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.html
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.html
@@ -6,37 +6,6 @@
     <span *ngIf="loadingMessage" class="mt-2 text-muted">{{ loadingMessage }}</span>
 </div>
 <div *ngIf="codePanelRowSource;" id="viewport" tabindex="0" class="{{languageSafeName!}}" role="region" aria-label="Scrollable code panel" (click)="onCodePanelItemClick($event)" (keydown)="onKeyDown($event)">
-  <div *ngFor="let indicator of orphanUnresolvedThreadIndicators" class="unresolved-orphan-indicator">
-    <small class="d-flex align-items-center indicator-label">
-      <i class="bi bi-exclamation-circle-fill me-1" [ngClass]="indicator.severityIconClass"></i>
-      Unresolved <span *ngIf="indicator.severityLabel">&nbsp;{{ indicator.severityLabel }}&nbsp;</span> comment by&nbsp;<b>{{ indicator.createdBy }}</b>
-      <span class="ms-1 unresolved-toggler" (click)="toggleOrphanIndicator(indicator.threadKey)"><i class="bi" [ngClass]="indicator.expanded ? 'bi-arrows-collapse' : 'bi-arrows-expand'"></i>&nbsp;{{ indicator.expanded ? 'Hide' : 'Show' }}</span>
-      <span class="ms-2 unresolved-diff-link" (click)="showOrphanUnresolvedThread(indicator.elementId, indicator.targetApiRevisionId)"><i class="bi bi-arrow-left-right"></i>&nbsp;View in diff</span>
-    </small>
-    <div *ngIf="indicator.expanded" class="orphan-expanded-section">
-      <div class="orphan-removed-line">
-        <span class="removed-line-prefix">-</span>
-        <span class="removed-line-text">{{ indicator.elementId }}</span>
-      </div>
-      <div class="orphan-comment-wrapper">
-      <app-comment-thread *ngIf="indicator.commentThreadRowData"
-        [codePanelRowData]="indicator.commentThreadRowData"
-        [allComments]="allComments"
-        [allCodePanelRowData]="codePanelRowData"
-        [userProfile]="userProfile"
-        [reviewId]="reviewId || ''"
-        (cancelCommentActionEmitter)="handleCancelCommentActionEmitter($event)"
-        (saveCommentActionEmitter)="handleSaveCommentActionEmitter($event)"
-        (deleteCommentActionEmitter)="handleDeleteCommentActionEmitter($event)"
-        (commentResolutionActionEmitter)="handleCommentResolutionActionEmitter($event)"
-        (commentUpvoteActionEmitter)="handleCommentUpvoteActionEmitter($event)"
-        (commentDownvoteActionEmitter)="handleCommentDownvoteActionEmitter($event)"
-        (commentThreadNavigationEmitter)="handleCommentThreadNavigationEmitter($event)"
-        (batchResolutionActionEmitter)="handleBatchResolutionActionEmitter($event)">
-      </app-comment-thread>
-      </div>
-    </div>
-  </div>
   <p-message class="sticky-top" *ngIf="showNoDiffInContentMessage()" severity="info" icon="bi bi-info-circle" text="There are no differences between the two API revisions"></p-message>
   <div *uiScroll="let item of codePanelRowSource; let index = index" class="code-line" [attr.data-node-id]="item.nodeIdHashed"
     [attr.data-row-position-in-group]="item.rowPositionInGroup" [attr.data-row-type]="item.type" [ngClass]="getRowClassObject(item)">
@@ -95,6 +64,39 @@
         [userProfile]="userProfile"
         (closeCrossLanguageViewEmitter)="handleCloseCrossLanguageViewEmitter($event)"
       ></app-cross-lang-view>
+    </ng-container>
+    <ng-container *ngIf="item.type === CodePanelRowDatatype.OrphanIndicator">
+      <div class="orphan-indicator-content">
+        <small class="d-flex align-items-center indicator-label">
+          <i class="bi bi-exclamation-circle-fill me-1" [ngClass]="item.orphanIndicatorData?.severityIconClass"></i>
+          Unresolved <span *ngIf="item.orphanIndicatorData?.severityLabel">&nbsp;{{ item.orphanIndicatorData?.severityLabel }}&nbsp;</span> comment by&nbsp;<b>{{ item.comments?.[0]?.createdBy }}</b>
+          <span class="ms-1 unresolved-toggler" (click)="toggleOrphanIndicatorRow($event, item)"><i class="bi" [ngClass]="item.orphanIndicatorData?.expanded ? 'bi-arrows-collapse' : 'bi-arrows-expand'"></i>&nbsp;{{ item.orphanIndicatorData?.expanded ? 'Hide' : 'Show' }}</span>
+          <span class="ms-2 unresolved-diff-link" (click)="showOrphanUnresolvedThread(item.nodeId, item.orphanIndicatorData?.targetApiRevisionId || '')"><i class="bi bi-arrow-left-right"></i>&nbsp;View in diff</span>
+        </small>
+        <div *ngIf="item.orphanIndicatorData?.expanded" class="orphan-expanded-section">
+          <div class="orphan-removed-line">
+            <span class="removed-line-prefix">-</span>
+            <span class="removed-line-text">{{ item.nodeId }}</span>
+          </div>
+          <div class="orphan-comment-wrapper">
+            <app-comment-thread *ngIf="item.orphanIndicatorData?.commentThreadRowData"
+              [codePanelRowData]="item.orphanIndicatorData!.commentThreadRowData!"
+              [allComments]="allComments"
+              [allCodePanelRowData]="codePanelRowData"
+              [userProfile]="userProfile"
+              [reviewId]="reviewId || ''"
+              (cancelCommentActionEmitter)="handleCancelCommentActionEmitter($event)"
+              (saveCommentActionEmitter)="handleSaveCommentActionEmitter($event)"
+              (deleteCommentActionEmitter)="handleDeleteCommentActionEmitter($event)"
+              (commentResolutionActionEmitter)="handleCommentResolutionActionEmitter($event)"
+              (commentUpvoteActionEmitter)="handleCommentUpvoteActionEmitter($event)"
+              (commentDownvoteActionEmitter)="handleCommentDownvoteActionEmitter($event)"
+              (commentThreadNavigationEmitter)="handleCommentThreadNavigationEmitter($event)"
+              (batchResolutionActionEmitter)="handleBatchResolutionActionEmitter($event)">
+            </app-comment-thread>
+          </div>
+        </div>
+      </div>
     </ng-container>
   </div>
 </div>

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.html
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.html
@@ -7,11 +7,35 @@
 </div>
 <div *ngIf="codePanelRowSource;" id="viewport" tabindex="0" class="{{languageSafeName!}}" role="region" aria-label="Scrollable code panel" (click)="onCodePanelItemClick($event)" (keydown)="onKeyDown($event)">
   <div *ngFor="let indicator of orphanUnresolvedThreadIndicators" class="unresolved-orphan-indicator">
-    <small class="d-flex align-items-center">
+    <small class="d-flex align-items-center indicator-label">
       <i class="bi bi-exclamation-circle-fill me-1" [ngClass]="indicator.severityIconClass"></i>
       Unresolved <span *ngIf="indicator.severityLabel">&nbsp;{{ indicator.severityLabel }}&nbsp;</span> comment by&nbsp;<b>{{ indicator.createdBy }}</b>
-      <a class="ms-1 unresolved-toggler" (click)="showOrphanUnresolvedThread(indicator.elementId, indicator.targetApiRevisionId)"><i class="bi bi-arrows-expand"></i>&nbsp;Show</a>
+      <span class="ms-1 unresolved-toggler" (click)="toggleOrphanIndicator(indicator.threadKey)"><i class="bi" [ngClass]="indicator.expanded ? 'bi-arrows-collapse' : 'bi-arrows-expand'"></i>&nbsp;{{ indicator.expanded ? 'Hide' : 'Show' }}</span>
+      <span class="ms-2 unresolved-diff-link" (click)="showOrphanUnresolvedThread(indicator.elementId, indicator.targetApiRevisionId)"><i class="bi bi-arrow-left-right"></i>&nbsp;View in diff</span>
     </small>
+    <div *ngIf="indicator.expanded" class="orphan-expanded-section">
+      <div class="orphan-removed-line">
+        <span class="removed-line-prefix">-</span>
+        <span class="removed-line-text">{{ indicator.elementId }}</span>
+      </div>
+      <div class="orphan-comment-wrapper">
+      <app-comment-thread *ngIf="indicator.commentThreadRowData"
+        [codePanelRowData]="indicator.commentThreadRowData"
+        [allComments]="allComments"
+        [allCodePanelRowData]="codePanelRowData"
+        [userProfile]="userProfile"
+        [reviewId]="reviewId || ''"
+        (cancelCommentActionEmitter)="handleCancelCommentActionEmitter($event)"
+        (saveCommentActionEmitter)="handleSaveCommentActionEmitter($event)"
+        (deleteCommentActionEmitter)="handleDeleteCommentActionEmitter($event)"
+        (commentResolutionActionEmitter)="handleCommentResolutionActionEmitter($event)"
+        (commentUpvoteActionEmitter)="handleCommentUpvoteActionEmitter($event)"
+        (commentDownvoteActionEmitter)="handleCommentDownvoteActionEmitter($event)"
+        (commentThreadNavigationEmitter)="handleCommentThreadNavigationEmitter($event)"
+        (batchResolutionActionEmitter)="handleBatchResolutionActionEmitter($event)">
+      </app-comment-thread>
+      </div>
+    </div>
   </div>
   <p-message class="sticky-top" *ngIf="showNoDiffInContentMessage()" severity="info" icon="bi bi-info-circle" text="There are no differences between the two API revisions"></p-message>
   <div *uiScroll="let item of codePanelRowSource; let index = index" class="code-line" [attr.data-node-id]="item.nodeIdHashed"

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.scss
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.scss
@@ -26,6 +26,44 @@
         p-messages.sticky-top {
             z-index: 1 !important;
         }
+
+        .unresolved-orphan-indicator {
+            margin: 4px 10px;
+            margin-left: 42px;
+            padding: 3px 8px;
+            background-color: var(--base-fg-color);
+            border-left: 2px solid var(--danger-color);
+            border-radius: 2px;
+            width: fit-content;
+            color: var(--text-muted-color);
+
+            .bi-exclamation-circle-fill {
+                color: var(--danger-color);
+            }
+
+            .severity-icon-must-fix {
+                color: var(--severity-must-fix-text);
+            }
+
+            .severity-icon-should-fix {
+                color: var(--severity-should-fix-text);
+            }
+
+            .severity-icon-suggestion {
+                color: var(--severity-suggestion-text);
+            }
+
+            .severity-icon-question {
+                color: var(--severity-question-text);
+            }
+
+            .unresolved-toggler {
+                color: var(--danger-color);
+                font-weight: bolder;
+                cursor: pointer;
+                text-decoration: none;
+            }
+        }
     }
 
     .code-line {

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.scss
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.scss
@@ -28,14 +28,17 @@
         }
 
         .unresolved-orphan-indicator {
-            margin: 4px 10px;
-            margin-left: 42px;
-            padding: 3px 8px;
-            background-color: var(--base-fg-color);
-            border-left: 2px solid var(--danger-color);
-            border-radius: 2px;
-            width: fit-content;
+            margin: 4px 0;
             color: var(--text-muted-color);
+
+            .indicator-label {
+                margin-left: 42px;
+                padding: 3px 8px;
+                background-color: var(--base-fg-color);
+                border-left: 2px solid var(--danger-color);
+                border-radius: 2px;
+                width: fit-content;
+            }
 
             .bi-exclamation-circle-fill {
                 color: var(--danger-color);
@@ -62,6 +65,49 @@
                 font-weight: bolder;
                 cursor: pointer;
                 text-decoration: none;
+            }
+
+            .unresolved-diff-link {
+                color: var(--text-muted-color);
+                cursor: pointer;
+                font-weight: normal;
+                &:hover {
+                    color: var(--primary-color);
+                }
+            }
+
+            .orphan-expanded-section {
+                margin-top: 6px;
+
+                .orphan-removed-line {
+                    background-color: rgba(255, 0, 0, 0.25);
+                    padding: 2px 8px;
+                    padding-left: calc(42px + 8px);
+                    font-family: Consolas, monospace;
+                    font-size: 14px;
+                    line-height: 1.5;
+                    width: 100%;
+                    box-sizing: border-box;
+
+                    .removed-line-prefix {
+                        color: var(--text-muted-color);
+                        margin-right: 8px;
+                        user-select: none;
+                    }
+
+                    .removed-line-text {
+                        color: var(--base-text-color);
+                    }
+                }
+
+                .orphan-comment-wrapper {
+                    padding-left: calc(var(--max-line-number-width, 40px) + 10px);
+
+                    app-comment-thread {
+                        display: block;
+                        width: min(1000px, calc(100cqw - 100px));
+                    }
+                }
             }
         }
     }

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.scss
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.scss
@@ -145,6 +145,11 @@
             color: var(--text-muted-color);
 
             .orphan-indicator-content {
+                position: sticky;
+                left: 0;
+                width: fit-content;
+                max-width: 100cqw;
+
                 .indicator-label {
                     margin-left: 42px;
                     padding: 3px 8px;

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.scss
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.scss
@@ -26,90 +26,6 @@
         p-messages.sticky-top {
             z-index: 1 !important;
         }
-
-        .unresolved-orphan-indicator {
-            margin: 4px 0;
-            color: var(--text-muted-color);
-
-            .indicator-label {
-                margin-left: 42px;
-                padding: 3px 8px;
-                background-color: var(--base-fg-color);
-                border-left: 2px solid var(--danger-color);
-                border-radius: 2px;
-                width: fit-content;
-            }
-
-            .bi-exclamation-circle-fill {
-                color: var(--danger-color);
-            }
-
-            .severity-icon-must-fix {
-                color: var(--severity-must-fix-text);
-            }
-
-            .severity-icon-should-fix {
-                color: var(--severity-should-fix-text);
-            }
-
-            .severity-icon-suggestion {
-                color: var(--severity-suggestion-text);
-            }
-
-            .severity-icon-question {
-                color: var(--severity-question-text);
-            }
-
-            .unresolved-toggler {
-                color: var(--danger-color);
-                font-weight: bolder;
-                cursor: pointer;
-                text-decoration: none;
-            }
-
-            .unresolved-diff-link {
-                color: var(--text-muted-color);
-                cursor: pointer;
-                font-weight: normal;
-                &:hover {
-                    color: var(--primary-color);
-                }
-            }
-
-            .orphan-expanded-section {
-                margin-top: 6px;
-
-                .orphan-removed-line {
-                    background-color: rgba(255, 0, 0, 0.25);
-                    padding: 2px 8px;
-                    padding-left: calc(42px + 8px);
-                    font-family: Consolas, monospace;
-                    font-size: 14px;
-                    line-height: 1.5;
-                    width: 100%;
-                    box-sizing: border-box;
-
-                    .removed-line-prefix {
-                        color: var(--text-muted-color);
-                        margin-right: 8px;
-                        user-select: none;
-                    }
-
-                    .removed-line-text {
-                        color: var(--base-text-color);
-                    }
-                }
-
-                .orphan-comment-wrapper {
-                    padding-left: calc(var(--max-line-number-width, 40px) + 10px);
-
-                    app-comment-thread {
-                        display: block;
-                        width: min(1000px, calc(100cqw - 100px));
-                    }
-                }
-            }
-        }
     }
 
     .code-line {
@@ -223,6 +139,93 @@
             filter: var(--hidden-api-filter);
         }
 
+        &.orphan-indicator {
+            display: block;
+            padding: 4px 0;
+            color: var(--text-muted-color);
+
+            .orphan-indicator-content {
+                .indicator-label {
+                    margin-left: 42px;
+                    padding: 3px 8px;
+                    background-color: var(--base-fg-color);
+                    border-left: 2px solid var(--danger-color);
+                    border-radius: 2px;
+                    width: fit-content;
+                }
+
+                .bi-exclamation-circle-fill {
+                    color: var(--danger-color);
+                }
+
+                .severity-icon-must-fix {
+                    color: var(--severity-must-fix-text);
+                }
+
+                .severity-icon-should-fix {
+                    color: var(--severity-should-fix-text);
+                }
+
+                .severity-icon-suggestion {
+                    color: var(--severity-suggestion-text);
+                }
+
+                .severity-icon-question {
+                    color: var(--severity-question-text);
+                }
+
+                .unresolved-toggler {
+                    color: var(--danger-color);
+                    font-weight: bolder;
+                    cursor: pointer;
+                    text-decoration: none;
+                }
+
+                .unresolved-diff-link {
+                    color: var(--text-muted-color);
+                    cursor: pointer;
+                    font-weight: normal;
+                    &:hover {
+                        color: var(--primary-color);
+                    }
+                }
+
+                .orphan-expanded-section {
+                    margin-top: 6px;
+
+                    .orphan-removed-line {
+                        background-color: rgba(255, 0, 0, 0.25);
+                        padding: 2px 8px;
+                        padding-left: calc(42px + 8px);
+                        font-family: Consolas, monospace;
+                        font-size: 14px;
+                        line-height: 1.5;
+                        width: 100%;
+                        box-sizing: border-box;
+
+                        .removed-line-prefix {
+                            color: var(--text-muted-color);
+                            margin-right: 8px;
+                            user-select: none;
+                        }
+
+                        .removed-line-text {
+                            color: var(--base-text-color);
+                        }
+                    }
+
+                    .orphan-comment-wrapper {
+                        padding-left: calc(var(--max-line-number-width, 40px) + 10px);
+
+                        app-comment-thread {
+                            display: block;
+                            width: min(1000px, calc(100cqw - 100px));
+                        }
+                    }
+                }
+            }
+        }
+
         .diff-change {
             background-color: var(--dark-overlay);
             border-radius: 2px;
@@ -271,7 +274,7 @@
             content: '';
             display: inline-block;
             width: 28px; // padding (6px) + icon width (14px) + padding (6px) + borders (2px) = 28px
-            height: 26px; // matches button height
+            height: 21px; // matches line-height (14px * 1.5)
             margin-left: 6px; // matches button margin-left
         }
 

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.spec.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.spec.ts
@@ -89,6 +89,147 @@ describe('CodePanelComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  describe('diff comment behavior', () => {
+    it('should allow adding comments on removed rows in diff mode when row has content', () => {
+      const removedRow = new CodePanelRowData();
+      removedRow.type = CodePanelRowDatatype.CodeLine;
+      removedRow.rowClasses = new Set<string>(['removed']);
+      removedRow.rowOfTokens = [{ value: 'removed line' } as any];
+
+      component.isDiffView = true;
+      component.userProfile = {} as any;
+
+      expect(component.canAddComment(removedRow)).toBe(true);
+    });
+
+    it('should route new comment creation from removed rows to diff revision', () => {
+      const commentsService = TestBed.inject(CommentsService);
+      const createCommentSpy = vi.spyOn(commentsService, 'createComment').mockReturnValue(of({ threadId: 'new-thread' } as CommentItemModel));
+      vi.spyOn(component as any, 'addCommentToCommentThread').mockImplementation(() => {});
+
+      component.reviewId = 'review-1';
+      component.activeApiRevisionId = 'active-rev';
+      component.diffApiRevisionId = 'diff-rev';
+      component.isDiffView = true;
+      component.codePanelData = {
+        nodeMetaData: {
+          'hash-1': {
+            codeLines: [{ rowClasses: new Set<string>(['removed']), nodeId: 'line-1' }]
+          }
+        }
+      } as any;
+
+      component.handleSaveCommentActionEmitter({
+        nodeId: 'line-1',
+        nodeIdHashed: 'hash-1',
+        associatedRowPositionInGroup: 0,
+        commentText: 'new comment',
+        allowAnyOneToResolve: false,
+        severity: undefined,
+        isReply: false,
+        commentThreadUpdateAction: CommentThreadUpdateAction.CommentCreated,
+      } as CommentUpdatesDto);
+
+      expect(createCommentSpy).toHaveBeenCalledWith(
+        'review-1',
+        'diff-rev',
+        'line-1',
+        'new comment',
+        0,
+        true,
+        undefined,
+        undefined
+      );
+    });
+
+    it('should immediately display new comment on green row when red and green share same elementId', () => {
+      const commentsService = TestBed.inject(CommentsService);
+      vi.spyOn(commentsService, 'createComment').mockReturnValue(of({
+        id: 'comment-1',
+        threadId: 'thread-1',
+        elementId: 'shared-id'
+      } as CommentItemModel));
+
+      const addCommentSpy = vi.spyOn(component as any, 'addCommentToCommentThread').mockImplementation(() => {});
+      vi.spyOn(component as any, 'removeItemsFromScroller').mockImplementation(() => Promise.resolve());
+
+      component.reviewId = 'review-1';
+      component.activeApiRevisionId = 'active-rev';
+      component.diffApiRevisionId = 'diff-rev';
+      component.isDiffView = true;
+      component.codePanelData = {
+        nodeMetaData: {
+          redNode: {
+            codeLines: [{ rowClasses: new Set<string>(['removed']), nodeId: 'shared-id', nodeIdHashed: 'redNode', rowPositionInGroup: 0 }],
+            commentThread: {
+              0: [{
+                type: CodePanelRowDatatype.CommentThread,
+                nodeIdHashed: 'redNode',
+                associatedRowPositionInGroup: 0,
+                threadId: 'thread-1',
+                comments: []
+              }]
+            }
+          },
+          greenNode: {
+            codeLines: [{ rowClasses: new Set<string>(), nodeId: 'shared-id', nodeIdHashed: 'greenNode', rowPositionInGroup: 0 }],
+            commentThread: {}
+          }
+        }
+      } as any;
+
+      component.handleSaveCommentActionEmitter({
+        nodeId: 'shared-id',
+        nodeIdHashed: 'redNode',
+        associatedRowPositionInGroup: 0,
+        commentText: 'new comment',
+        threadId: 'thread-1',
+        allowAnyOneToResolve: false,
+        severity: undefined,
+        isReply: false,
+        commentThreadUpdateAction: CommentThreadUpdateAction.CommentCreated,
+      } as CommentUpdatesDto);
+
+      const forwardedUpdates = addCommentSpy.mock.calls[0][0] as CommentUpdatesDto;
+      expect(forwardedUpdates.nodeIdHashed).toBe('greenNode');
+      expect(forwardedUpdates.associatedRowPositionInGroup).toBe(0);
+      expect(forwardedUpdates.nodeId).toBe('shared-id');
+    });
+
+    it('should keep non-diff comment creation on active revision', () => {
+      const commentsService = TestBed.inject(CommentsService);
+      const createCommentSpy = vi.spyOn(commentsService, 'createComment').mockReturnValue(of({ threadId: 'new-thread' } as CommentItemModel));
+      vi.spyOn(component as any, 'addCommentToCommentThread').mockImplementation(() => {});
+
+      component.reviewId = 'review-1';
+      component.activeApiRevisionId = 'active-rev';
+      component.diffApiRevisionId = 'diff-rev';
+      component.isDiffView = false;
+
+      component.handleSaveCommentActionEmitter({
+        nodeId: 'line-1',
+        nodeIdHashed: 'hash-1',
+        associatedRowPositionInGroup: 0,
+        commentText: 'new comment',
+        allowAnyOneToResolve: false,
+        severity: undefined,
+        isReply: false,
+        commentThreadUpdateAction: CommentThreadUpdateAction.CommentCreated,
+      } as CommentUpdatesDto);
+
+      expect(createCommentSpy).toHaveBeenCalledWith(
+        'review-1',
+        'active-rev',
+        'line-1',
+        'new comment',
+        0,
+        true,
+        undefined,
+        undefined
+      );
+    });
+  });
+
   describe('copyReviewTextToClipBoard', () => {
     it('should copy formatted review text to clipboard', async () => {
       const token1 = new StructuredToken();

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.spec.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.spec.ts
@@ -230,6 +230,72 @@ describe('CodePanelComponent', () => {
     });
   });
 
+  describe('orphan unresolved thread indicators', () => {
+    it('should create indicator for unresolved comment whose elementId is not visible', () => {
+      component.activeApiRevisionId = 'active-rev';
+      component.codePanelRowData = [
+        { type: CodePanelRowDatatype.CodeLine, nodeId: 'visible-id', rowOfTokens: [{ value: 'line' }] } as any
+      ];
+      component.allComments = [
+        {
+          id: 'c1',
+          threadId: 'thread-1',
+          elementId: 'deleted-id',
+          createdBy: 'tjprescott',
+          apiRevisionId: 'old-rev',
+          isResolved: false,
+          isDeleted: false,
+          severity: CommentSeverity.MustFix
+        } as CommentItemModel
+      ];
+
+      (component as any).updateOrphanUnresolvedThreadIndicators();
+
+      expect(component.orphanUnresolvedThreadIndicators.length).toBe(1);
+      expect(component.orphanUnresolvedThreadIndicators[0].severityLabel).toBe('MUST FIX');
+      expect(component.orphanUnresolvedThreadIndicators[0].severityIconClass).toBe('severity-icon-must-fix');
+      expect(component.orphanUnresolvedThreadIndicators[0].elementId).toBe('deleted-id');
+    });
+
+    it('should handle string-typed severity from JSON deserialization', () => {
+      component.activeApiRevisionId = 'active-rev';
+      component.codePanelRowData = [
+        { type: CodePanelRowDatatype.CodeLine, nodeId: 'visible-id', rowOfTokens: [{ value: 'line' }] } as any
+      ];
+      component.allComments = [
+        {
+          id: 'c1',
+          threadId: 'thread-1',
+          elementId: 'deleted-id',
+          createdBy: 'AlitzelMendez',
+          apiRevisionId: 'old-rev',
+          isResolved: false,
+          isDeleted: false,
+          severity: 'ShouldFix' as any
+        } as CommentItemModel
+      ];
+
+      (component as any).updateOrphanUnresolvedThreadIndicators();
+
+      expect(component.orphanUnresolvedThreadIndicators.length).toBe(1);
+      expect(component.orphanUnresolvedThreadIndicators[0].severityLabel).toBe('SHOULD FIX');
+      expect(component.orphanUnresolvedThreadIndicators[0].severityIconClass).toBe('severity-icon-should-fix');
+    });
+
+    it('should navigate to diff context when showing orphan unresolved thread', () => {
+      const navigateSpy = vi.spyOn((component as any).router, 'navigate').mockResolvedValue(true);
+      component.activeApiRevisionId = 'active-rev';
+
+      component.showOrphanUnresolvedThread('deleted-id', 'old-rev');
+
+      expect(navigateSpy).toHaveBeenCalled();
+      const queryParams = navigateSpy.mock.calls[0][1].queryParams;
+      expect(queryParams.diffApiRevisionId).toBe('old-rev');
+      expect(queryParams.nId).toBe('deleted-id');
+      navigateSpy.mockRestore();
+    });
+  });
+
   describe('copyReviewTextToClipBoard', () => {
     it('should copy formatted review text to clipboard', async () => {
       const token1 = new StructuredToken();

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.spec.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.spec.ts
@@ -356,6 +356,85 @@ describe('CodePanelComponent', () => {
       (component as any).updateOrphanUnresolvedThreadIndicators();
       expect(component.orphanUnresolvedThreadIndicators[0].expanded).toBe(true);
     });
+
+    it('should remove orphan indicator when thread is resolved via applyCommentResolutionUpdate', () => {
+      component.activeApiRevisionId = 'active-rev';
+      component.codePanelRowData = [
+        { type: CodePanelRowDatatype.CodeLine, nodeId: 'visible-id', rowOfTokens: [{ value: 'line' }] } as any
+      ];
+      component.allComments = [
+        {
+          id: 'c1',
+          threadId: 'thread-1',
+          elementId: 'deleted-id',
+          createdBy: 'author',
+          apiRevisionId: 'old-rev',
+          isResolved: false,
+          isDeleted: false,
+          severity: CommentSeverity.ShouldFix
+        } as CommentItemModel
+      ];
+
+      (component as any).updateOrphanUnresolvedThreadIndicators();
+      expect(component.orphanUnresolvedThreadIndicators.length).toBe(1);
+
+      // Simulate resolution via applyCommentResolutionUpdate (orphan path)
+      (component as any).applyCommentResolutionUpdate({
+        commentThreadUpdateAction: CommentThreadUpdateAction.CommentResolved,
+        nodeIdHashed: 'deleted-id',
+        threadId: 'thread-1',
+        elementId: 'deleted-id',
+        associatedRowPositionInGroup: 0,
+        resolvedBy: 'resolver'
+      } as CommentUpdatesDto);
+
+      // allComments should be marked resolved
+      expect(component.allComments[0].isResolved).toBe(true);
+      // Orphan indicator should be removed
+      expect(component.orphanUnresolvedThreadIndicators.length).toBe(0);
+    });
+
+    it('should resolve orphan with null threadId (legacy comments) by matching elementId', () => {
+      component.activeApiRevisionId = 'active-rev';
+      component.codePanelRowData = [
+        { type: CodePanelRowDatatype.CodeLine, nodeId: 'visible-id', rowOfTokens: [{ value: 'line' }] } as any
+      ];
+      component.allComments = [
+        {
+          id: 'c1',
+          threadId: undefined,
+          elementId: 'deleted-id',
+          createdBy: 'author',
+          apiRevisionId: 'old-rev',
+          isResolved: false,
+          isDeleted: false,
+          severity: CommentSeverity.Question
+        } as CommentItemModel
+      ];
+
+      (component as any).updateOrphanUnresolvedThreadIndicators();
+      expect(component.orphanUnresolvedThreadIndicators.length).toBe(1);
+      // actualThreadId should be undefined for legacy comments
+      expect(component.orphanUnresolvedThreadIndicators[0].actualThreadId).toBeUndefined();
+
+      // Expand and verify the row uses empty threadId (not the elementId fallback)
+      component.toggleOrphanIndicator('deleted-id');
+      const rowData = component.orphanUnresolvedThreadIndicators[0].commentThreadRowData!;
+      expect(rowData.threadId).toBe('');
+
+      // Simulate resolution with empty threadId (matching backend behavior)
+      (component as any).applyCommentResolutionUpdate({
+        commentThreadUpdateAction: CommentThreadUpdateAction.CommentResolved,
+        nodeIdHashed: 'deleted-id',
+        threadId: '',
+        elementId: 'deleted-id',
+        associatedRowPositionInGroup: 0,
+        resolvedBy: 'resolver'
+      } as CommentUpdatesDto);
+
+      expect(component.allComments[0].isResolved).toBe(true);
+      expect(component.orphanUnresolvedThreadIndicators.length).toBe(0);
+    });
   });
 
   describe('copyReviewTextToClipBoard', () => {
@@ -710,6 +789,53 @@ describe('CodePanelComponent', () => {
       commentsService.notifySeverityChanged('comment-999', CommentSeverity.ShouldFix);
 
       expect(row.comments[0].severity).toBe(CommentSeverity.Question);
+    });
+  });
+
+  describe('Unresolved markers refresh on quality score refresh', () => {
+    let commentsService: CommentsService;
+
+    beforeEach(() => {
+      commentsService = TestBed.inject(CommentsService);
+    });
+
+    it('should call refreshUnresolvedMarkers when unresolvedMarkersRefreshNeeded$ emits', () => {
+      const refreshSpy = vi.spyOn(component, 'refreshUnresolvedMarkers').mockImplementation(() => {});
+
+      component.ngOnInit();
+
+      commentsService.notifyQualityScoreRefresh();
+
+      expect(refreshSpy).toHaveBeenCalled();
+    });
+
+    it('should update orphan indicators and hasActiveConversation via refreshUnresolvedMarkers', () => {
+      component.activeApiRevisionId = 'active-rev';
+      component.codePanelRowData = [
+        { type: CodePanelRowDatatype.CodeLine, nodeId: 'visible-id', rowOfTokens: [{ value: 'line' }] } as any
+      ];
+      component.allComments = [
+        {
+          id: 'c1',
+          threadId: 'thread-1',
+          elementId: 'deleted-id',
+          createdBy: 'author',
+          apiRevisionId: 'old-rev',
+          isResolved: false,
+          isDeleted: false,
+          severity: CommentSeverity.ShouldFix
+        } as CommentItemModel
+      ];
+
+      component.refreshUnresolvedMarkers();
+
+      expect(component.orphanUnresolvedThreadIndicators.length).toBe(1);
+
+      // Simulate the conversations panel unresolving and then resolving
+      component.allComments[0].isResolved = true;
+      component.refreshUnresolvedMarkers();
+
+      expect(component.orphanUnresolvedThreadIndicators.length).toBe(0);
     });
   });
 });

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.spec.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.spec.ts
@@ -255,6 +255,8 @@ describe('CodePanelComponent', () => {
       expect(component.orphanUnresolvedThreadIndicators[0].severityLabel).toBe('MUST FIX');
       expect(component.orphanUnresolvedThreadIndicators[0].severityIconClass).toBe('severity-icon-must-fix');
       expect(component.orphanUnresolvedThreadIndicators[0].elementId).toBe('deleted-id');
+      expect(component.orphanUnresolvedThreadIndicators[0].comments.length).toBe(1);
+      expect(component.orphanUnresolvedThreadIndicators[0].expanded).toBe(false);
     });
 
     it('should handle string-typed severity from JSON deserialization', () => {
@@ -293,6 +295,66 @@ describe('CodePanelComponent', () => {
       expect(queryParams.diffApiRevisionId).toBe('old-rev');
       expect(queryParams.nId).toBe('deleted-id');
       navigateSpy.mockRestore();
+    });
+
+    it('should toggle expanded state of orphan indicator', () => {
+      component.activeApiRevisionId = 'active-rev';
+      component.codePanelRowData = [
+        { type: CodePanelRowDatatype.CodeLine, nodeId: 'visible-id', rowOfTokens: [{ value: 'line' }] } as any
+      ];
+      component.allComments = [
+        {
+          id: 'c1',
+          threadId: 'thread-1',
+          elementId: 'deleted-id',
+          createdBy: 'tjprescott',
+          apiRevisionId: 'old-rev',
+          isResolved: false,
+          isDeleted: false,
+          commentText: 'This needs fixing',
+          severity: CommentSeverity.MustFix
+        } as CommentItemModel
+      ];
+
+      (component as any).updateOrphanUnresolvedThreadIndicators();
+      expect(component.orphanUnresolvedThreadIndicators[0].expanded).toBe(false);
+      expect(component.orphanUnresolvedThreadIndicators[0].commentThreadRowData).toBeNull();
+
+      component.toggleOrphanIndicator('thread-1');
+      expect(component.orphanUnresolvedThreadIndicators[0].expanded).toBe(true);
+      expect(component.orphanUnresolvedThreadIndicators[0].commentThreadRowData).not.toBeNull();
+      expect(component.orphanUnresolvedThreadIndicators[0].commentThreadRowData!.comments.length).toBe(1);
+      expect(component.orphanUnresolvedThreadIndicators[0].commentThreadRowData!.nodeId).toBe('deleted-id');
+
+      component.toggleOrphanIndicator('thread-1');
+      expect(component.orphanUnresolvedThreadIndicators[0].expanded).toBe(false);
+    });
+
+    it('should preserve expanded state when indicators are rebuilt', () => {
+      component.activeApiRevisionId = 'active-rev';
+      component.codePanelRowData = [
+        { type: CodePanelRowDatatype.CodeLine, nodeId: 'visible-id', rowOfTokens: [{ value: 'line' }] } as any
+      ];
+      component.allComments = [
+        {
+          id: 'c1',
+          threadId: 'thread-1',
+          elementId: 'deleted-id',
+          createdBy: 'tjprescott',
+          apiRevisionId: 'old-rev',
+          isResolved: false,
+          isDeleted: false,
+          severity: CommentSeverity.MustFix
+        } as CommentItemModel
+      ];
+
+      (component as any).updateOrphanUnresolvedThreadIndicators();
+      component.toggleOrphanIndicator('thread-1');
+      expect(component.orphanUnresolvedThreadIndicators[0].expanded).toBe(true);
+
+      // Re-run the update (simulating data change)
+      (component as any).updateOrphanUnresolvedThreadIndicators();
+      expect(component.orphanUnresolvedThreadIndicators[0].expanded).toBe(true);
     });
   });
 

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.ts
@@ -35,6 +35,7 @@ export class CodePanelComponent implements OnChanges {
   @Input() scrollToNodeId: string | undefined;
   @Input() reviewId: string | undefined;
   @Input() activeApiRevisionId: string | undefined;
+  @Input() diffApiRevisionId: string | undefined;
   @Input() userProfile: UserProfile | undefined;
   @Input() showLineNumbers: boolean = true;
   @Input() showDocumentation: boolean = true;
@@ -227,19 +228,10 @@ export class CodePanelComponent implements OnChanges {
   canAddComment(item: CodePanelRowData): boolean {
     const hasNonWhitespaceContent = item.rowOfTokens &&
                                      item.rowOfTokens.some(token => token.value && token.value.trim().length > 0);
-
-    // Handle rowClasses being either a Set or an Array (can happen after JSON deserialization)
-    let isRemoved = false;
-    if (item.rowClasses) {
-      if (item.rowClasses instanceof Set) {
-        isRemoved = item.rowClasses.has('removed');
-      } else if (Array.isArray(item.rowClasses)) {
-        isRemoved = (item.rowClasses as unknown as string[]).includes('removed');
-      }
-    }
+    const isRemoved = this.isRemovedRow(item);
 
     return item.type === CodePanelRowDatatype.CodeLine &&
-           !isRemoved &&
+           (!isRemoved || this.isDiffView) &&
            this.userProfile !== undefined &&
            hasNonWhitespaceContent;
   }
@@ -745,13 +737,19 @@ export class CodePanelComponent implements OnChanges {
     else {
       const isNewThread = commentUpdates.isReply === false;
       const resolutionLocked = commentUpdates.allowAnyOneToResolve !== undefined ? !commentUpdates.allowAnyOneToResolve : false;
-      this.commentsService.createComment(this.reviewId!, this.activeApiRevisionId!, commentUpdates.nodeId!, commentUpdates.commentText!, CommentType.APIRevision, resolutionLocked, commentUpdates.severity, commentUpdates.threadId)
+      const targetRevisionId = this.getTargetRevisionIdForComment(commentUpdates);
+      commentUpdates.revisionId = targetRevisionId;
+      this.commentsService.createComment(this.reviewId!, targetRevisionId, commentUpdates.nodeId!, commentUpdates.commentText!, CommentType.APIRevision, resolutionLocked, commentUpdates.severity, commentUpdates.threadId)
         .pipe(take(1)).subscribe({
             next: (response: CommentItemModel) => {
               if (!commentUpdates.threadId && response.threadId) {
                 commentUpdates.threadId = response.threadId;
               }
-              this.addCommentToCommentThread(commentUpdates, response);
+              const displayUpdates = this.getDisplayLocationForNewComment(commentUpdates, response);
+              this.addCommentToCommentThread(displayUpdates, response);
+              commentUpdates.nodeIdHashed = displayUpdates.nodeIdHashed;
+              commentUpdates.associatedRowPositionInGroup = displayUpdates.associatedRowPositionInGroup;
+              commentUpdates.nodeId = displayUpdates.nodeId;
               commentUpdates.comment = response;
               // Only refresh quality score for new threads, not replies
               if (isNewThread) {
@@ -761,6 +759,112 @@ export class CodePanelComponent implements OnChanges {
           }
         );
       }
+  }
+
+  private getTargetRevisionIdForComment(commentUpdates: CommentUpdatesDto): string {
+    if (!this.isDiffView) {
+      return this.activeApiRevisionId!;
+    }
+
+    const row = this.getAssociatedCodeLineRow(commentUpdates);
+    if (row && this.isRemovedRow(row)) {
+      return this.diffApiRevisionId || this.activeApiRevisionId!;
+    }
+
+    return this.activeApiRevisionId!;
+  }
+
+  private getDisplayLocationForNewComment(commentUpdates: CommentUpdatesDto, newComment: CommentItemModel): CommentUpdatesDto {
+    if (!this.isDiffView) {
+      return commentUpdates;
+    }
+
+    const sourceRow = this.getAssociatedCodeLineRow(commentUpdates);
+    if (!sourceRow || !this.isRemovedRow(sourceRow)) {
+      return commentUpdates;
+    }
+
+    const elementId = newComment.elementId || commentUpdates.nodeId;
+    const preferredGreenRow = this.findPreferredGreenRowByElementId(elementId);
+    if (!preferredGreenRow) {
+      return commentUpdates;
+    }
+
+    // Remove the temporary empty thread row from red so new comment appears where it will persist.
+    this.removePendingEmptyThread(commentUpdates);
+
+    return {
+      ...commentUpdates,
+      nodeIdHashed: preferredGreenRow.nodeIdHashed,
+      associatedRowPositionInGroup: preferredGreenRow.rowPositionInGroup,
+      nodeId: preferredGreenRow.nodeId
+    };
+  }
+
+  private findPreferredGreenRowByElementId(elementId: string | undefined): CodePanelRowData | undefined {
+    if (!elementId || !this.codePanelData?.nodeMetaData) {
+      return undefined;
+    }
+
+    for (const nodeMetaData of Object.values(this.codePanelData.nodeMetaData)) {
+      for (const row of nodeMetaData.codeLines ?? []) {
+        if (row.nodeId === elementId && !this.isRemovedRow(row)) {
+          return row;
+        }
+      }
+    }
+
+    return undefined;
+  }
+
+  private removePendingEmptyThread(commentUpdates: CommentUpdatesDto): void {
+    const nodeIdHashed = commentUpdates.nodeIdHashed;
+    const position = commentUpdates.associatedRowPositionInGroup;
+    if (!nodeIdHashed || position === undefined) {
+      return;
+    }
+
+    const nodeMetaData = this.codePanelData?.nodeMetaData?.[nodeIdHashed];
+    const threads = nodeMetaData?.commentThread?.[position];
+    if (!threads) {
+      return;
+    }
+
+    const pendingThread = this.findCommentThread(threads, commentUpdates.threadId);
+    if (!pendingThread || (pendingThread.comments && pendingThread.comments.length > 0)) {
+      return;
+    }
+
+    this.removeItemsFromScroller(nodeIdHashed, CodePanelRowDatatype.CommentThread, 'toggleCommentsClasses', 'show', 'can-show', position, commentUpdates.threadId);
+
+    const threadIndex = this.findCommentThreadIndex(threads, commentUpdates.threadId);
+    if (threadIndex > -1) {
+      threads.splice(threadIndex, 1);
+    }
+  }
+
+  private getAssociatedCodeLineRow(commentUpdates: CommentUpdatesDto): CodePanelRowData | undefined {
+    if (!commentUpdates.nodeIdHashed || commentUpdates.associatedRowPositionInGroup === undefined) {
+      return undefined;
+    }
+
+    return this.codePanelData?.nodeMetaData[commentUpdates.nodeIdHashed]?.codeLines[commentUpdates.associatedRowPositionInGroup];
+  }
+
+  private isRemovedRow(row: CodePanelRowData | undefined): boolean {
+    if (!row?.rowClasses) {
+      return false;
+    }
+
+    if (row.rowClasses instanceof Set) {
+      return row.rowClasses.has('removed');
+    }
+
+    if (Array.isArray(row.rowClasses)) {
+      return (row.rowClasses as unknown as string[]).includes('removed');
+    }
+
+    return false;
   }
 
   handleDeleteCommentActionEmitter(commentUpdates: CommentUpdatesDto) {

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.ts
@@ -76,7 +76,10 @@ export class CodePanelComponent implements OnChanges {
     createdBy: string,
     severityLabel: string,
     severityIconClass: string,
-    targetApiRevisionId: string
+    targetApiRevisionId: string,
+    comments: CommentItemModel[],
+    expanded: boolean,
+    commentThreadRowData: CodePanelRowData | null
   }[] = [];
 
   constructor(private changeDetectorRef: ChangeDetectorRef, private commentsService: CommentsService,
@@ -190,6 +193,32 @@ export class CodePanelComponent implements OnChanges {
     queryParams[DIFF_API_REVISION_ID_QUERY_PARAM] = targetApiRevisionId;
     queryParams[SCROLL_TO_NODE_QUERY_PARAM] = elementId;
     this.router.navigate([], { queryParams });
+  }
+
+  toggleOrphanIndicator(threadKey: string) {
+    const indicator = this.orphanUnresolvedThreadIndicators.find(i => i.threadKey === threadKey);
+    if (indicator) {
+      indicator.expanded = !indicator.expanded;
+      if (indicator.expanded && !indicator.commentThreadRowData) {
+        indicator.commentThreadRowData = this.buildOrphanCommentThreadRowData(indicator);
+      }
+    }
+  }
+
+  private buildOrphanCommentThreadRowData(indicator: {
+    threadKey: string, elementId: string, comments: CommentItemModel[]
+  }): CodePanelRowData {
+    const row = new CodePanelRowData();
+    row.type = CodePanelRowDatatype.CommentThread;
+    row.nodeId = indicator.elementId;
+    row.nodeIdHashed = indicator.elementId;
+    row.threadId = indicator.threadKey;
+    row.rowClasses = new Set<string>(['user-comment-thread']);
+    row.associatedRowPositionInGroup = 0;
+    row.comments = [...indicator.comments];
+    row.showReplyTextBox = false;
+    row.isResolvedCommentThread = false;
+    return row;
   }
 
   getLineMenu(row: CodePanelRowData) {
@@ -893,6 +922,10 @@ export class CodePanelComponent implements OnChanges {
   }
 
   private updateOrphanUnresolvedThreadIndicators(): void {
+    const existingIndicators = new Map(
+      this.orphanUnresolvedThreadIndicators.map(i => [i.threadKey, i])
+    );
+
     const visibleLineIds = new Set(
       (this.codePanelRowData || [])
         .filter(row => row.type === CodePanelRowDatatype.CodeLine)
@@ -928,13 +961,17 @@ export class CodePanelComponent implements OnChanges {
         const nonActiveRevisionComment = comments.find(c => c.apiRevisionId && c.apiRevisionId !== this.activeApiRevisionId);
         const targetApiRevisionId = nonActiveRevisionComment?.apiRevisionId || representative.apiRevisionId;
 
+        const wasExpanded = existingIndicators.get(threadKey);
         return {
           threadKey,
           elementId: representative.elementId,
           createdBy: representative.createdBy,
           severityLabel: this.getSeverityLabel(comments),
           severityIconClass: this.getSeverityIconClass(comments),
-          targetApiRevisionId
+          targetApiRevisionId,
+          comments: [...comments],
+          expanded: !!wasExpanded?.expanded,
+          commentThreadRowData: wasExpanded?.commentThreadRowData || null
         };
       })
       .filter((item): item is {
@@ -943,7 +980,10 @@ export class CodePanelComponent implements OnChanges {
         createdBy: string,
         severityLabel: string,
         severityIconClass: string,
-        targetApiRevisionId: string
+        targetApiRevisionId: string,
+        comments: CommentItemModel[],
+        expanded: boolean,
+        commentThreadRowData: CodePanelRowData | null
       } => !!item)
       .sort((a, b) => a.threadKey.localeCompare(b.threadKey));
   }

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.ts
@@ -6,7 +6,7 @@ import { getQueryParams } from 'src/app/_helpers/router-helpers';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CodeLineRowNavigationDirection, convertRowOfTokensToString, isDiffRow, DIFF_ADDED, DIFF_REMOVED, getCodePanelRowDataClass, getStructuredTokenClass } from 'src/app/_helpers/common-helpers';
 import { DIFF_API_REVISION_ID_QUERY_PARAM, SCROLL_TO_NODE_QUERY_PARAM } from 'src/app/_helpers/router-helpers';
-import { CodePanelData, CodePanelRowData, CodePanelRowDatatype, CrossLanguageContentDto, CrossLanguageRowDto } from 'src/app/_models/codePanelModels';
+import { CodePanelData, CodePanelRowData, CodePanelRowDatatype, CrossLanguageContentDto, CrossLanguageRowDto, OrphanIndicatorData } from 'src/app/_models/codePanelModels';
 import { StructuredToken } from 'src/app/_models/structuredToken';
 import { CommentItemModel, CommentSeverity, CommentSource, CommentType } from 'src/app/_models/commentItemModel';
 import { UserProfile } from 'src/app/_models/userProfile';
@@ -72,6 +72,7 @@ export class CodePanelComponent implements OnChanges {
   menuItemsLineActions: MenuItem[] = [];
   orphanUnresolvedThreadIndicators: {
     threadKey: string,
+    actualThreadId: string | undefined,
     elementId: string,
     createdBy: string,
     severityLabel: string,
@@ -81,6 +82,7 @@ export class CodePanelComponent implements OnChanges {
     expanded: boolean,
     commentThreadRowData: CodePanelRowData | null
   }[] = [];
+  private orphanRowCount: number = 0;
 
   constructor(private changeDetectorRef: ChangeDetectorRef, private commentsService: CommentsService,
     private signalRService: SignalRService, private route: ActivatedRoute, private router: Router,
@@ -108,20 +110,24 @@ export class CodePanelComponent implements OnChanges {
     this.commentsService.severityChanged$.pipe(takeUntil(this.destroy$)).subscribe(({ commentId, newSeverity }) => {
       this.updateCommentSeverity(commentId, newSeverity);
     });
+
+    this.commentsService.unresolvedMarkersRefreshNeeded$.pipe(takeUntil(this.destroy$)).subscribe(() => {
+      this.refreshUnresolvedMarkers();
+    });
   }
 
   async ngOnChanges(changes: SimpleChanges) {
     if (changes['codePanelRowData']) {
       if (changes['codePanelRowData'].currentValue.length > 0) {
+        this.orphanRowCount = 0; // reset since we got fresh data
+        this.updateOrphanUnresolvedThreadIndicators();
         this.loadCodePanelViewPort();
         this.updateHasActiveConversations();
       } else {
         this.isLoading = true;
         this.codePanelRowSource = undefined;
       }
-    }
-
-    if (changes['codePanelRowData'] || changes['allComments'] || changes['activeApiRevisionId']) {
+    } else if (changes['allComments'] || changes['activeApiRevisionId']) {
       this.updateOrphanUnresolvedThreadIndicators();
     }
 
@@ -205,14 +211,48 @@ export class CodePanelComponent implements OnChanges {
     }
   }
 
+  async toggleOrphanIndicatorRow(event: Event, item: CodePanelRowData) {
+    event.stopPropagation();
+    if (!item.orphanIndicatorData) return;
+
+    item.orphanIndicatorData.expanded = !item.orphanIndicatorData.expanded;
+    if (item.orphanIndicatorData.expanded && !item.orphanIndicatorData.commentThreadRowData) {
+      item.orphanIndicatorData.commentThreadRowData = this.buildOrphanCommentThreadRowData({
+        threadKey: item.orphanIndicatorData.threadKey,
+        actualThreadId: item.orphanIndicatorData.actualThreadId,
+        elementId: item.nodeId,
+        comments: item.comments
+      });
+    }
+
+    // Also sync into the indicators array
+    const indicator = this.orphanUnresolvedThreadIndicators.find(
+      i => i.threadKey === item.orphanIndicatorData!.threadKey
+    );
+    if (indicator) {
+      indicator.expanded = item.orphanIndicatorData.expanded;
+      indicator.commentThreadRowData = item.orphanIndicatorData.commentThreadRowData;
+    }
+
+    await this.codePanelRowSource?.adapter?.relax();
+    await this.codePanelRowSource?.adapter?.fix({
+      updater: ({ data }) => {
+        if (data === item) {
+          return true;
+        }
+        return true;
+      }
+    });
+  }
+
   private buildOrphanCommentThreadRowData(indicator: {
-    threadKey: string, elementId: string, comments: CommentItemModel[]
+    threadKey: string, actualThreadId: string | undefined, elementId: string, comments: CommentItemModel[]
   }): CodePanelRowData {
     const row = new CodePanelRowData();
     row.type = CodePanelRowDatatype.CommentThread;
     row.nodeId = indicator.elementId;
     row.nodeIdHashed = indicator.elementId;
-    row.threadId = indicator.threadKey;
+    row.threadId = indicator.actualThreadId || '';
     row.rowClasses = new Set<string>(['user-comment-thread']);
     row.associatedRowPositionInGroup = 0;
     row.comments = [...indicator.comments];
@@ -921,11 +961,24 @@ export class CodePanelComponent implements OnChanges {
     return false;
   }
 
+  /**
+   * Single method to refresh all unresolved-marker state.
+   * Called whenever quality-score refresh fires so that orphan
+   * indicators, hasActiveConversation, and change detection all
+   * stay in sync with the latest comment resolution data.
+   */
+  refreshUnresolvedMarkers(): void {
+    this.updateOrphanUnresolvedThreadIndicators();
+    this.updateHasActiveConversations();
+    this.changeDetectorRef.detectChanges();
+  }
+
   private updateOrphanUnresolvedThreadIndicators(): void {
     const existingIndicators = new Map(
       this.orphanUnresolvedThreadIndicators.map(i => [i.threadKey, i])
     );
 
+    // Skip orphan rows when computing visible line IDs
     const visibleLineIds = new Set(
       (this.codePanelRowData || [])
         .filter(row => row.type === CodePanelRowDatatype.CodeLine)
@@ -964,6 +1017,7 @@ export class CodePanelComponent implements OnChanges {
         const wasExpanded = existingIndicators.get(threadKey);
         return {
           threadKey,
+          actualThreadId: representative.threadId,
           elementId: representative.elementId,
           createdBy: representative.createdBy,
           severityLabel: this.getSeverityLabel(comments),
@@ -974,18 +1028,46 @@ export class CodePanelComponent implements OnChanges {
           commentThreadRowData: wasExpanded?.commentThreadRowData || null
         };
       })
-      .filter((item): item is {
-        threadKey: string,
-        elementId: string,
-        createdBy: string,
-        severityLabel: string,
-        severityIconClass: string,
-        targetApiRevisionId: string,
-        comments: CommentItemModel[],
-        expanded: boolean,
-        commentThreadRowData: CodePanelRowData | null
-      } => !!item)
-      .sort((a, b) => a.threadKey.localeCompare(b.threadKey));
+      .filter((item) => !!item)
+      .sort((a, b) => a.threadKey.localeCompare(b.threadKey)) as typeof this.orphanUnresolvedThreadIndicators;
+
+    this.syncOrphanRowsInCodePanelData();
+  }
+
+  private syncOrphanRowsInCodePanelData(): void {
+    // Remove previously injected orphan rows from the beginning
+    if (this.orphanRowCount > 0) {
+      this.codePanelRowData.splice(0, this.orphanRowCount);
+    }
+
+    // Create new orphan rows from the indicators
+    const orphanRows: CodePanelRowData[] = this.orphanUnresolvedThreadIndicators.map(indicator => {
+      const row = new CodePanelRowData();
+      row.type = CodePanelRowDatatype.OrphanIndicator;
+      row.nodeId = indicator.elementId;
+      row.nodeIdHashed = `orphan-${indicator.threadKey}`;
+      row.rowClasses = new Set<string>(['orphan-indicator']);
+      row.comments = [...indicator.comments];
+      row.orphanIndicatorData = {
+        threadKey: indicator.threadKey,
+        actualThreadId: indicator.actualThreadId,
+        severityLabel: indicator.severityLabel,
+        severityIconClass: indicator.severityIconClass,
+        targetApiRevisionId: indicator.targetApiRevisionId,
+        expanded: indicator.expanded,
+        commentThreadRowData: indicator.commentThreadRowData
+      };
+      return row;
+    });
+
+    // Prepend orphan rows
+    this.codePanelRowData.unshift(...orphanRows);
+    this.orphanRowCount = orphanRows.length;
+
+    // If scroller is already initialized, reload it to pick up the changes
+    if (this.codePanelRowSource?.adapter?.isLoading === false) {
+      this.codePanelRowSource?.adapter?.reload(0);
+    }
   }
 
   private getSeverityLabel(comments: CommentItemModel[]): string {
@@ -1045,6 +1127,9 @@ export class CodePanelComponent implements OnChanges {
         next: () => {
           this.applyCommentResolutionUpdate(commentUpdates);
           this.commentsService.notifyQualityScoreRefresh();
+        },
+        error: (err) => {
+          console.error('Failed to resolve comments:', err);
         }
       });
     }
@@ -1053,6 +1138,9 @@ export class CodePanelComponent implements OnChanges {
         next: () => {
           this.applyCommentResolutionUpdate(commentUpdates);
           this.commentsService.notifyQualityScoreRefresh();
+        },
+        error: (err) => {
+          console.error('Failed to unresolve comments:', err);
         }
       });
     }
@@ -1611,6 +1699,9 @@ export class CodePanelComponent implements OnChanges {
         }
       }
     }
+    if (!hasActiveConversation && this.orphanUnresolvedThreadIndicators.length > 0) {
+      hasActiveConversation = true;
+    }
     this.hasActiveConversationEmitter.emit(hasActiveConversation);
   }
 
@@ -1839,7 +1930,14 @@ export class CodePanelComponent implements OnChanges {
   private applyCommentResolutionUpdate(commentUpdates: CommentUpdatesDto) {
     const nodeMetaData = this.codePanelData?.nodeMetaData?.[commentUpdates.nodeIdHashed!];
     if (!nodeMetaData?.commentThread?.[commentUpdates.associatedRowPositionInGroup!]) {
-      this.updateHasActiveConversations();
+      // Orphan thread: update global allComments isResolved state directly
+      const isResolved = (commentUpdates.commentThreadUpdateAction === CommentThreadUpdateAction.CommentResolved);
+      (this.allComments || [])
+        .filter(c => c.elementId === commentUpdates.elementId
+          && (c.threadId || null) === (commentUpdates.threadId || null)
+          && !c.isDeleted)
+        .forEach(c => c.isResolved = isResolved);
+      this.refreshUnresolvedMarkers();
       return;
     }
     const commentThreads = nodeMetaData.commentThread[commentUpdates.associatedRowPositionInGroup!];
@@ -1858,7 +1956,7 @@ export class CodePanelComponent implements OnChanges {
 
       this.updateItemInScroller({ ...commentThread });
     }
-    this.updateHasActiveConversations();
+    this.refreshUnresolvedMarkers();
   }
 
   private toggleCommentUpVote(data: CommentUpdatesDto) {

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.ts
@@ -5,7 +5,7 @@ import { CommentsService } from 'src/app/_services/comments/comments.service';
 import { getQueryParams } from 'src/app/_helpers/router-helpers';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CodeLineRowNavigationDirection, convertRowOfTokensToString, isDiffRow, DIFF_ADDED, DIFF_REMOVED, getCodePanelRowDataClass, getStructuredTokenClass } from 'src/app/_helpers/common-helpers';
-import { SCROLL_TO_NODE_QUERY_PARAM } from 'src/app/_helpers/router-helpers';
+import { DIFF_API_REVISION_ID_QUERY_PARAM, SCROLL_TO_NODE_QUERY_PARAM } from 'src/app/_helpers/router-helpers';
 import { CodePanelData, CodePanelRowData, CodePanelRowDatatype, CrossLanguageContentDto, CrossLanguageRowDto } from 'src/app/_models/codePanelModels';
 import { StructuredToken } from 'src/app/_models/structuredToken';
 import { CommentItemModel, CommentSeverity, CommentSource, CommentType } from 'src/app/_models/commentItemModel';
@@ -17,6 +17,7 @@ import { CommentThreadUpdateAction, CommentUpdatesDto } from 'src/app/_dtos/comm
 import { Menu } from 'primeng/menu';
 import { CodeLineSearchInfo, CodeLineSearchMatch } from 'src/app/_models/codeLineSearchInfo';
 import { DoublyLinkedList } from 'src/app/_helpers/doubly-linkedlist';
+import { CommentSeverityHelper } from 'src/app/_helpers/comment-severity.helper';
 
 @Component({
     selector: 'app-code-panel',
@@ -69,6 +70,14 @@ export class CodePanelComponent implements OnChanges {
   diffNodeNavigationPointer: number | undefined = undefined;
 
   menuItemsLineActions: MenuItem[] = [];
+  orphanUnresolvedThreadIndicators: {
+    threadKey: string,
+    elementId: string,
+    createdBy: string,
+    severityLabel: string,
+    severityIconClass: string,
+    targetApiRevisionId: string
+  }[] = [];
 
   constructor(private changeDetectorRef: ChangeDetectorRef, private commentsService: CommentsService,
     private signalRService: SignalRService, private route: ActivatedRoute, private router: Router,
@@ -107,6 +116,10 @@ export class CodePanelComponent implements OnChanges {
         this.isLoading = true;
         this.codePanelRowSource = undefined;
       }
+    }
+
+    if (changes['codePanelRowData'] || changes['allComments'] || changes['activeApiRevisionId']) {
+      this.updateOrphanUnresolvedThreadIndicators();
     }
 
     if (changes['loadFailed'] && changes['loadFailed'].currentValue) {
@@ -165,6 +178,18 @@ export class CodePanelComponent implements OnChanges {
 
   getTokenClassObject(token: StructuredToken) {
     return getStructuredTokenClass(token);
+  }
+
+  showOrphanUnresolvedThread(elementId: string, targetApiRevisionId: string) {
+    if (!targetApiRevisionId || targetApiRevisionId === this.activeApiRevisionId) {
+      this.scrollToNode(undefined, elementId);
+      return;
+    }
+
+    const queryParams = getQueryParams(this.route);
+    queryParams[DIFF_API_REVISION_ID_QUERY_PARAM] = targetApiRevisionId;
+    queryParams[SCROLL_TO_NODE_QUERY_PARAM] = elementId;
+    this.router.navigate([], { queryParams });
   }
 
   getLineMenu(row: CodePanelRowData) {
@@ -865,6 +890,102 @@ export class CodePanelComponent implements OnChanges {
     }
 
     return false;
+  }
+
+  private updateOrphanUnresolvedThreadIndicators(): void {
+    const visibleLineIds = new Set(
+      (this.codePanelRowData || [])
+        .filter(row => row.type === CodePanelRowDatatype.CodeLine)
+        .map(row => row.nodeId)
+        .filter((id): id is string => !!id)
+    );
+
+    const activeComments = (this.allComments || []).filter(comment => !comment.isDeleted);
+    const grouped = activeComments.reduce((acc, comment) => {
+      const key = comment.threadId || comment.elementId;
+      if (!key) {
+        return acc;
+      }
+      if (!acc[key]) {
+        acc[key] = [];
+      }
+      acc[key].push(comment);
+      return acc;
+    }, {} as { [key: string]: CommentItemModel[] });
+
+    this.orphanUnresolvedThreadIndicators = Object.entries(grouped)
+      .map(([threadKey, comments]) => {
+        const isResolvedThread = comments.some(c => c.isResolved);
+        if (isResolvedThread) {
+          return undefined;
+        }
+
+        const representative = comments[0];
+        if (!representative?.elementId || visibleLineIds.has(representative.elementId)) {
+          return undefined;
+        }
+
+        const nonActiveRevisionComment = comments.find(c => c.apiRevisionId && c.apiRevisionId !== this.activeApiRevisionId);
+        const targetApiRevisionId = nonActiveRevisionComment?.apiRevisionId || representative.apiRevisionId;
+
+        return {
+          threadKey,
+          elementId: representative.elementId,
+          createdBy: representative.createdBy,
+          severityLabel: this.getSeverityLabel(comments),
+          severityIconClass: this.getSeverityIconClass(comments),
+          targetApiRevisionId
+        };
+      })
+      .filter((item): item is {
+        threadKey: string,
+        elementId: string,
+        createdBy: string,
+        severityLabel: string,
+        severityIconClass: string,
+        targetApiRevisionId: string
+      } => !!item)
+      .sort((a, b) => a.threadKey.localeCompare(b.threadKey));
+  }
+
+  private getSeverityLabel(comments: CommentItemModel[]): string {
+    const highestSeverity = this.getHighestSeverity(comments);
+
+    switch (highestSeverity) {
+      case CommentSeverity.MustFix:
+        return 'MUST FIX';
+      case CommentSeverity.ShouldFix:
+        return 'SHOULD FIX';
+      case CommentSeverity.Suggestion:
+        return 'SUGGESTION';
+      case CommentSeverity.Question:
+        return 'QUESTION';
+      default:
+        return '';
+    }
+  }
+
+  private getSeverityIconClass(comments: CommentItemModel[]): string {
+    const highestSeverity = this.getHighestSeverity(comments);
+    switch (CommentSeverityHelper.getSeverityBadgeClass(highestSeverity)) {
+      case 'severity-must-fix':
+        return 'severity-icon-must-fix';
+      case 'severity-should-fix':
+        return 'severity-icon-should-fix';
+      case 'severity-suggestion':
+        return 'severity-icon-suggestion';
+      case 'severity-question':
+        return 'severity-icon-question';
+      default:
+        return '';
+    }
+  }
+
+  private getHighestSeverity(comments: CommentItemModel[]): CommentSeverity | null {
+    return comments
+      .map(comment => CommentSeverityHelper.getSeverityEnumValue(comment.severity))
+      .filter((severity): severity is CommentSeverity => severity !== null)
+      .sort((a, b) => b - a)[0] ?? null;
   }
 
   handleDeleteCommentActionEmitter(commentUpdates: CommentUpdatesDto) {

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-page/review-page.component.html
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-page/review-page.component.html
@@ -53,6 +53,7 @@
                         [language]="language" [languageSafeName]="languageSafeName"
                         [isDiffView]="!!diffApiRevisionId"
                         [reviewId]="reviewId!" [activeApiRevisionId]="activeApiRevisionId!"
+                        [diffApiRevisionId]="diffApiRevisionId!"
                         [userProfile]="userProfile"
                         [allComments]="comments"
                         [loadFailed]="loadFailed"

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/shared/comment-thread/comment-thread.component.spec.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/shared/comment-thread/comment-thread.component.spec.ts
@@ -303,6 +303,36 @@ describe('CommentThreadComponent', () => {
       expect(component.threadResolvedStateToggleText).toBe('Show');
       expect(component.threadResolvedStateToggleIcon).toBe('bi-arrows-expand');
     });
+
+    it('should emit the actual comment threadId, not the row grouping key', () => {
+      const emitSpy = vi.spyOn(component.commentResolutionActionEmitter, 'emit');
+
+      // Set up: row's threadId is a grouping key (e.g., elementId for legacy),
+      // but the comment has a different real threadId
+      component.codePanelRowData!.threadId = 'grouping-key-element1';
+      component.codePanelRowData!.comments[0].threadId = 'actual-db-thread-id';
+
+      component.handleThreadResolutionButtonClick('Resolve');
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ threadId: 'actual-db-thread-id' })
+      );
+    });
+
+    it('should emit undefined threadId for legacy comments without threadId', () => {
+      const emitSpy = vi.spyOn(component.commentResolutionActionEmitter, 'emit');
+
+      // Simulate conversations panel where row threadId = elementId (grouping fallback),
+      // but the comment's actual threadId is undefined (legacy)
+      component.codePanelRowData!.threadId = 'element1';
+      component.codePanelRowData!.comments[0].threadId = undefined as any;
+
+      component.handleThreadResolutionButtonClick('Unresolve');
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ threadId: undefined })
+      );
+    });
   });
 
   describe('batch resolution functionality', () => {

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/shared/comment-thread/comment-thread.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/shared/comment-thread/comment-thread.component.ts
@@ -627,7 +627,13 @@ export class CommentThreadComponent {
       {
         commentThreadUpdateAction: isResolving ? CommentThreadUpdateAction.CommentResolved : CommentThreadUpdateAction.CommentUnResolved,
         elementId: this.codePanelRowData!.comments[0].elementId,
-        threadId: this.codePanelRowData!.threadId,
+        // Use the actual DB threadId from the first comment, not the row's
+        // grouping key.  In the conversations panel the grouping key falls back
+        // to elementId for legacy comments (no threadId in DB), which causes the
+        // backend filter (c.ThreadId == threadId) to match nothing and silently
+        // skip the update.  The comment's own threadId is null for those legacy
+        // threads, which correctly maps to the backend's default parameter.
+        threadId: this.codePanelRowData!.comments[0]?.threadId,
         nodeIdHashed: this.codePanelRowData!.nodeIdHashed,
         associatedRowPositionInGroup: this.codePanelRowData!.associatedRowPositionInGroup,
         resolvedBy: this.userProfile?.userName

--- a/src/dotnet/APIView/ClientSPA/src/app/_models/codePanelModels.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_models/codePanelModels.ts
@@ -9,7 +9,18 @@ export enum CodePanelRowDatatype {
   Diagnostics = "diagnostics",
   CommentThread = "commentThread",
   CrossLanguage = "crossLanguage",
-  Separator = "separator"
+  Separator = "separator",
+  OrphanIndicator = "orphanIndicator"
+}
+
+export interface OrphanIndicatorData {
+  threadKey: string;
+  actualThreadId: string | undefined;
+  severityLabel: string;
+  severityIconClass: string;
+  targetApiRevisionId: string;
+  expanded: boolean;
+  commentThreadRowData: CodePanelRowData | null;
 }
 
 export class CodePanelRowData {
@@ -35,6 +46,7 @@ export class CodePanelRowData {
   commentThreadIsResolvedBy: string;
   isHiddenAPI: boolean;
   draftCommentText: string = '';
+  orphanIndicatorData?: OrphanIndicatorData;
   
   constructor(
     type: string = '',

--- a/src/dotnet/APIView/ClientSPA/src/app/_services/comments/comments.service.spec.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_services/comments/comments.service.spec.ts
@@ -57,4 +57,17 @@ describe('CommentsService', () => {
     expect(req.request.headers.has('Content-Type')).toBe(false);
     req.flush({}); // Mock response
   });
+
+  it('should emit on both qualityScoreRefreshNeeded$ and unresolvedMarkersRefreshNeeded$ when notifyQualityScoreRefresh is called', () => {
+    let qualityEmitted = false;
+    let markersEmitted = false;
+
+    service.qualityScoreRefreshNeeded$.subscribe(() => { qualityEmitted = true; });
+    service.unresolvedMarkersRefreshNeeded$.subscribe(() => { markersEmitted = true; });
+
+    service.notifyQualityScoreRefresh();
+
+    expect(qualityEmitted).toBe(true);
+    expect(markersEmitted).toBe(true);
+  });
 });

--- a/src/dotnet/APIView/ClientSPA/src/app/_services/comments/comments.service.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_services/comments/comments.service.ts
@@ -13,11 +13,15 @@ export class CommentsService {
   private _qualityScoreRefreshNeeded = new Subject<void>();
   qualityScoreRefreshNeeded$ = this._qualityScoreRefreshNeeded.asObservable();
 
+  private _unresolvedMarkersRefreshNeeded = new Subject<void>();
+  unresolvedMarkersRefreshNeeded$ = this._unresolvedMarkersRefreshNeeded.asObservable();
+
   private _severityChanged = new Subject<{ commentId: string, newSeverity: CommentSeverity }>();
   severityChanged$ = this._severityChanged.asObservable();
 
   notifyQualityScoreRefresh() {
     this._qualityScoreRefreshNeeded.next();
+    this._unresolvedMarkersRefreshNeeded.next();
   }
 
   notifySeverityChanged(commentId: string, newSeverity: CommentSeverity) {


### PR DESCRIPTION
This PR allows the commenting and display of comment threads on removed lines in diff view.

It also displays a marker, similar to the "Resolve comment" marker, that shows unresolved threads that are "orphaned" (i.e. elementId is not including in current revision) so they can be expanded, reviewed and resolved.

**TODO**
- [ ] Make the comments appear where they logically *should* go instead of at the top
