### PR TITLE
Bump azsdk changelog. Create gh release only after signing.

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-publish-net.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-publish-net.yml
@@ -63,6 +63,19 @@ stages:
           artifactName: packages-signed
           targetPath: $(Artifacts)
 
+      - ${{ if and(eq(parameters.ShouldTag, 'true'), eq(parameters.ShouldPublishExecutables, 'true')) }}:
+        - ${{ each target in parameters.ExeMatrix }}:
+          - task: DownloadPipelineArtifact@2
+            displayName: Download ${{ target.rid }} Binary
+            inputs:
+              artifact: standalone-${{ target.rid }}
+              path: $(Binaries)
+        - template: ../steps/platform-specific-signing.yml
+          parameters:
+            BinariesPath: $(Binaries)
+            BuildScriptsPath: $(BuildToolScripts)
+            ExeMatrix: ${{ parameters.ExeMatrix }}
+
       - ${{ if eq(parameters.ShouldTag, 'true') }}:
         # sets output variable $(release)
         - task: PowerShell@2
@@ -76,19 +89,6 @@ stages:
             arguments: '-artifactLocation $(Artifacts) -workingDirectory $(System.DefaultWorkingDirectory) -packageRepository Nuget -releaseSha $(Build.SourceVersion) -repoId $(Build.Repository.Id)'
           env:
             GH_TOKEN: $(azuresdk-github-pat)
-
-      - ${{ if and(eq(parameters.ShouldTag, 'true'), eq(parameters.ShouldPublishExecutables, 'true')) }}:
-        - ${{ each target in parameters.ExeMatrix }}:
-          - task: DownloadPipelineArtifact@2
-            displayName: Download ${{ target.rid }} Binary
-            inputs:
-              artifact: standalone-${{ target.rid }}
-              path: $(Binaries)
-        - template: ../steps/platform-specific-signing.yml
-          parameters:
-            BinariesPath: $(Binaries)
-            BuildScriptsPath: $(BuildToolScripts)
-            ExeMatrix: ${{ parameters.ExeMatrix }}
 
         - task: PowerShell@2
           displayName: 'Post to github release'

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
@@ -13,7 +13,7 @@
     <WarningsAsErrors>CA2254</WarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AssemblyName>azsdk</AssemblyName>
-    <VersionPrefix>0.5.20</VersionPrefix>
+    <VersionPrefix>0.6.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <!-- Package metadata -->

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,17 +1,14 @@
 # Release History
 
-## 0.5.20 (Unreleased)
+## 0.6.0 (2026-02-27)
 
 ### Features Added
 
 - Added auto-install to `azsdk verify setup` MCP and CLI tool, enabling auto-installing of supported missing requirements
 - Changed the CLI interface for verifying setup to `azsdk verify setup check` for non-install mode, and `azsdk verify setup install`
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Added `azsdk eng package-info` command for CI pipeline package manifest generation
+- Switch Go language service to use C# native package info generation
+- Customized code update tool now uses copilot sdk
 
 ## 0.5.19 (2026-02-25)
 


### PR DESCRIPTION
- [azsdk] Add 0.6.0 release changelog
- Only create git release after signing is complete