### PR TITLE
[eng/common] Add .gitignore for node_modules

### DIFF
--- a/eng/common/.gitignore
+++ b/eng/common/.gitignore
@@ -1,2 +1,4 @@
-# For folders containing package.json
+## Node
+
+# Dependency directories
 node_modules/


### PR DESCRIPTION
- prevents node_modules in subfolders (tsp-client, spelling) from being tracked by git in consuming repos
