### PR TITLE
[Teams Chatbot] Migrate sync knowledge pipeline to use 1ES template

### DIFF
--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/sync_knowledge.yml
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/sync_knowledge.yml
@@ -30,17 +30,28 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
+      networkIsolationPolicy: Permissive
     sdl:
+      # Turn off the build warnings caused by disabling some sdl checks
+      createAdoIssuesForJustificationsForDisablement: false
       sourceAnalysisPool:
         name: azsdk-pool
         image: windows-2022
         os: windows
-      psscriptanalyzer:
+      eslint:
         enabled: false
-        justificationForDisabling: >-
-          This pipeline only runs Node.js/TypeScript code. PSScriptAnalyzer flags
-          pre-existing issues in shared repo PowerShell scripts (eng/, tools/feed-cleaner)
-          that are not owned or modified by this pipeline.
+        justificationForDisabling: 'ESLint injected task has failures because it uses an old version of mkdirp. We should not fail for tools not controlled by the repo. See: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3499746'
+      codeql:
+        compiled:
+          enabled: false
+          justificationForDisabling: CodeQL times our pipelines out by running for 2+ hours before being force canceled.
+      componentgovernance:
+        enabled: false
+        justificationForDisabling: Manually enabling only on the main build job instead of running it on every job.
+      psscriptanalyzer:
+        compiled: true
+        break: true
+      policy: M365
       sourceRepositoriesToScan:
         exclude:
           - repository: azure-sdk-docs-eng.ms


### PR DESCRIPTION
The knowledge sync pipeline still not used **1ES-redirect template under eng folder**, since we checked other repos(azure-sdk-docs-eng.ms, internal-wiki) in ADO, and the template doesn't expose this option as a parameter, we'll meet this error if we simply extends the 1ES pipeline template: 

<img width="881" height="668" alt="image" src="https://github.com/user-attachments/assets/59d3232e-9dd0-4a4b-b0a7-d443d5182912" />

```
/v1/Jobs/SDLSourceAnalysisJob.yml@1ESPipelineTemplates (Line: 48, Col: 11): Unexpected value 'The repository ""azure-sdk-docs-eng.ms"" to be checked out has not been specified under sdl.sourceRepositoriesToScan.include or sdl.sourceRepositoriesToScan.exclude. For more information, visit [https://aka.ms/1espt/multi-repo-sdl](vscode-file://vscode-app/c:/Users/jiaqzhang/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html)'
/v1/Jobs/SDLSourceAnalysisJob.yml@1ESPipelineTemplates (Line: 48, Col: 11): Unexpected value 'The repository ""internal-wiki"" to be checked out has not been specified under sdl.sourceRepositoriesToScan.include or sdl.sourceRepositoriesToScan.exclude. For more information, visit [https://aka.ms/1espt/multi-repo-sdl](vscode-file://vscode-app/c:/Users/jiaqzhang/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html)'
```

So we choose to directly extends 1ES template, it also works
```
extends:
  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
```
Test run: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5945972&view=results