### PR TITLE
[sdk-testgen] bump @azure-tools/codegen to 2.10.1

### DIFF
--- a/tools/sdk-testgen/package-lock.json
+++ b/tools/sdk-testgen/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@autorest/codemodel": "^4.19.3",
                 "@autorest/extension-base": "^3.5.0",
-                "@azure-tools/codegen": "^3.0.283",
+                "@azure-tools/codegen": "^2.10.1",
                 "@types/jest": "^30.0.0",
                 "@types/lodash": "^4.17.5",
                 "@types/node": "^25.0.3",
@@ -61,42 +61,6 @@
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/@autorest/codemodel/node_modules/@azure-tools/async-io": {
-            "version": "3.0.254",
-            "resolved": "https://registry.npmjs.org/@azure-tools/async-io/-/async-io-3.0.254.tgz",
-            "integrity": "sha512-X1C7XdyCuo50ch9FzKtTvmK18FgDxxf1Bbt3cSoknQqeDaRegHSSCO+zByq2YA4NvUzKXeZ1engh29IDxZXgpQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@azure-tools/tasks": "~3.0.255",
-                "proper-lockfile": "~2.0.1"
-            },
-            "engines": {
-                "node": ">=10.12.0"
-            }
-        },
-        "node_modules/@autorest/codemodel/node_modules/@azure-tools/codegen": {
-            "version": "2.10.1",
-            "resolved": "https://registry.npmjs.org/@azure-tools/codegen/-/codegen-2.10.1.tgz",
-            "integrity": "sha512-fZfREKjQnBTscjObgK4LuyZNFaofoCNQDNz0jl1i8fYNwCM5EOF9BXwtEtobuEyCpPUNDxQ/KKO65eWzirqk4w==",
-            "license": "MIT",
-            "dependencies": {
-                "@azure-tools/async-io": "~3.0.0",
-                "js-yaml": "~4.1.0",
-                "semver": "^7.7.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@autorest/codemodel/node_modules/@azure-tools/tasks": {
-            "version": "3.0.255",
-            "resolved": "https://registry.npmjs.org/@azure-tools/tasks/-/tasks-3.0.255.tgz",
-            "integrity": "sha512-GjALNLz7kWMEdRVbaN5g0cJHNAr3XVTbP0611Mv2UzMgGL6FOhNZJK+oPHJKLDR8EEDZNnkwPlyi7B+INXUSQA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.12.0"
-            }
-        },
         "node_modules/@autorest/extension-base": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/@autorest/extension-base/-/extension-base-3.6.0.tgz",
@@ -110,7 +74,7 @@
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/@autorest/extension-base/node_modules/@azure-tools/async-io": {
+        "node_modules/@azure-tools/async-io": {
             "version": "3.0.254",
             "resolved": "https://registry.npmjs.org/@azure-tools/async-io/-/async-io-3.0.254.tgz",
             "integrity": "sha512-X1C7XdyCuo50ch9FzKtTvmK18FgDxxf1Bbt3cSoknQqeDaRegHSSCO+zByq2YA4NvUzKXeZ1engh29IDxZXgpQ==",
@@ -123,7 +87,7 @@
                 "node": ">=10.12.0"
             }
         },
-        "node_modules/@autorest/extension-base/node_modules/@azure-tools/codegen": {
+        "node_modules/@azure-tools/codegen": {
             "version": "2.10.1",
             "resolved": "https://registry.npmjs.org/@azure-tools/codegen/-/codegen-2.10.1.tgz",
             "integrity": "sha512-fZfREKjQnBTscjObgK4LuyZNFaofoCNQDNz0jl1i8fYNwCM5EOF9BXwtEtobuEyCpPUNDxQ/KKO65eWzirqk4w==",
@@ -137,90 +101,13 @@
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/@autorest/extension-base/node_modules/@azure-tools/tasks": {
+        "node_modules/@azure-tools/tasks": {
             "version": "3.0.255",
             "resolved": "https://registry.npmjs.org/@azure-tools/tasks/-/tasks-3.0.255.tgz",
             "integrity": "sha512-GjALNLz7kWMEdRVbaN5g0cJHNAr3XVTbP0611Mv2UzMgGL6FOhNZJK+oPHJKLDR8EEDZNnkwPlyi7B+INXUSQA==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.12.0"
-            }
-        },
-        "node_modules/@azure-tools/async-io": {
-            "version": "4.0.246",
-            "resolved": "https://registry.npmjs.org/@azure-tools/async-io/-/async-io-4.0.246.tgz",
-            "integrity": "sha512-4w2xfBcT0dj/IYp9t/fsBvuzTrV8faQnCs3URqfui9RBnoHVj12p8FdxCRKuRaN5CRPQlZ6XW4eMhp1wu5E8GQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@azure-tools/tasks": "~4.0.246",
-                "proper-lockfile": "~2.0.1"
-            },
-            "engines": {
-                "node": ">=12.13.0"
-            }
-        },
-        "node_modules/@azure-tools/codegen": {
-            "version": "3.0.283",
-            "resolved": "https://registry.npmjs.org/@azure-tools/codegen/-/codegen-3.0.283.tgz",
-            "integrity": "sha512-vhR+WTEFtdXvMcozaV5pQ7fZaAY9uqTUOSlk1No/USmpS3ax2/I61zrSaNJwN+Y5rw0JrVWCyezYfPMV7/WGSg==",
-            "license": "MIT",
-            "dependencies": {
-                "@azure-tools/async-io": "~4.0.246",
-                "@azure-tools/linq": "~4.0.255",
-                "js-yaml": "3.13.1",
-                "semver": "^5.5.1"
-            },
-            "engines": {
-                "node": ">=12.13.0"
-            }
-        },
-        "node_modules/@azure-tools/codegen/node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "license": "MIT",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
-        "node_modules/@azure-tools/codegen/node_modules/js-yaml": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
-        "node_modules/@azure-tools/codegen/node_modules/semver": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
-        "node_modules/@azure-tools/linq": {
-            "version": "4.0.255",
-            "resolved": "https://registry.npmjs.org/@azure-tools/linq/-/linq-4.0.255.tgz",
-            "integrity": "sha512-sNOhJil+UY+6OqXdOWKWnfBrk48kU4Z9QYF3xTxFk85QOjDkhvlTIYH30n3NkDg1QmqzFEPAorKk0N3oTIEHHw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12.13.0"
-            }
-        },
-        "node_modules/@azure-tools/tasks": {
-            "version": "4.0.246",
-            "resolved": "https://registry.npmjs.org/@azure-tools/tasks/-/tasks-4.0.246.tgz",
-            "integrity": "sha512-ojnEXV1RIzsC9XpEoDGU8n1X6uiwaz5bhJeXtqK2tOLJFMNM0BK37CQN60FiBvZCZQADsyw2GC4r6FuHHMceEA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12.13.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -1043,9 +930,9 @@
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "version": "3.14.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
@@ -5856,9 +5743,10 @@
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -6735,15 +6623,6 @@
                 "node": ">=4.0.0"
             }
         },
-        "node_modules/proper-lockfile/node_modules/retry": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-            "integrity": "sha512-ZXUSQYTHdl3uS7IuCehYfMzKyIDBNoAuUblvy5oGO5UJSUTmStUUVPXbA9Qxd173Bgre53yCQczQuHgRWAdvJQ==",
-            "license": "MIT",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6905,6 +6784,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/retry": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+            "integrity": "sha512-ZXUSQYTHdl3uS7IuCehYfMzKyIDBNoAuUblvy5oGO5UJSUTmStUUVPXbA9Qxd173Bgre53yCQczQuHgRWAdvJQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/reusify": {

--- a/tools/sdk-testgen/package.json
+++ b/tools/sdk-testgen/package.json
@@ -32,7 +32,7 @@
     "dependencies": {
         "@autorest/codemodel": "^4.19.3",
         "@autorest/extension-base": "^3.5.0",
-        "@azure-tools/codegen": "^3.0.283",
+        "@azure-tools/codegen": "^2.10.1",
         "@types/jest": "^30.0.0",
         "@types/node": "^25.0.3",
         "@typescript-eslint/eslint-plugin": "^8.18.2",


### PR DESCRIPTION
- 2.10.1 is actually newer than 3.0.283, which was a preview
- bumps transitive dep "js-yaml"