### PR TITLE
Remove existing .npmrc when releasing to npm js

### DIFF
--- a/eng/common/pipelines/templates/jobs/npm-publish.yml
+++ b/eng/common/pipelines/templates/jobs/npm-publish.yml
@@ -69,6 +69,22 @@ jobs:
           displayName: 'Packages to be published'
 
         - ${{ if eq(parameters.Registry, 'https://registry.npmjs.org/') }}:
+        
+          - task: PowerShell@2
+            displayName: 'Delete repo .npmrc'
+            condition: and(succeeded(), ne(variables['SkipPublishing'], 'true'))
+            inputs:
+              targetType: inline
+              script: |
+                $npmrcPath = "$(System.DefaultWorkingDirectory)/.npmrc"
+                if (Test-Path $npmrcPath) {
+                  Remove-Item -Path $npmrcPath -Force
+                  Write-Host "Deleted $npmrcPath to use default npmjs registry."
+                } else {
+                  Write-Host "No repo .npmrc found at $npmrcPath."
+                }
+              pwsh: true
+
           - task: EsrpRelease@9
             displayName: 'Publish ${{ parameters.ArtifactName }} via ESRP'
             condition: and(succeeded(), ne(variables['SkipPublishing'], 'true'))


### PR DESCRIPTION
### Packages impacted by this PR
- All

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/37076

### Describe the problem that is addressed by this PR
- When releasing to npmjs remove existing .npmrc in the repo that points to devOps feed