### PR TITLE
[APIView] Link existing reviews to projects at creation time

### DIFF
--- a/src/dotnet/APIView/APIViewUnitTests/ProjectsManagerTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/ProjectsManagerTests.cs
@@ -232,7 +232,8 @@ public class ProjectsManagerTests
         Assert.Equal(ProjectChangeAction.Created, capturedProject.ChangeHistory[0].ChangeAction);
         Assert.Equal(capturedProject.Id, typeSpecReview.ProjectId);
         _mockReviewsRepository.Verify(r => r.UpsertReviewsAsync(
-            It.Is<IEnumerable<ReviewListItemModel>>(revs => revs.Count() == 1 && revs.First().Id == "ts-1")),
+            It.Is<IEnumerable<ReviewListItemModel>>(revs =>
+                revs.Any(rv => rv.Id == "ts-1"))),
             Times.Once);
     }
 

--- a/src/dotnet/APIView/APIViewUnitTests/TypeSpecMetadataIntegrationTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/TypeSpecMetadataIntegrationTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -162,7 +163,9 @@ public class TypeSpecMetadataIntegrationTests
 
         Assert.Equal(capturedProject.Id, typeSpecReview.ProjectId);
         _mockProjectsRepository.Verify(r => r.UpsertProjectAsync(capturedProject), Times.Once);
-        _mockReviewsRepository.Verify(r => r.UpsertReviewsAsync(new List<ReviewListItemModel> { typeSpecReview }), Times.Once);
+        _mockReviewsRepository.Verify(r => r.UpsertReviewsAsync(
+            It.Is<IEnumerable<ReviewListItemModel>>(revs => revs.Count() == 1 && revs.First().Id == typeSpecReview.Id)),
+            Times.Once);
     }
 
     [Fact]

--- a/src/dotnet/APIView/APIViewWeb/Managers/ProjectsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/ProjectsManager.cs
@@ -185,6 +185,8 @@ public class ProjectsManager : IProjectsManager
             var reconciled = await ReconcileReviewLinksAsync(userName, project, typeSpecReview.Id);
 
             // Apply reconciliation results to project.
+            project.ReviewIds ??= [];
+            project.ChangeHistory ??= [];
             project.ReviewIds.ExceptWith(reconciled.ReviewIdsToRemove);
             project.HistoricalReviewIds ??= [];
             project.HistoricalReviewIds.UnionWith(reconciled.HistoricalReviewIdsToAdd);
@@ -303,6 +305,11 @@ public class ProjectsManager : IProjectsManager
             }
 
             string previousProjectId = candidate.ProjectId;
+
+            if (string.Equals(previousProjectId, projectId, StringComparison.Ordinal))
+            {
+                continue;
+            }
 
             candidate.ProjectId = projectId;
             reviewIds.Add(candidate.Id);


### PR DESCRIPTION
closes: https://github.com/Azure/azure-sdk-tools/issues/14413

When a TypeSpec project is created, it now discovers and links existing reviews that match its expected packages — closing a gap where reviews were only linked during metadata updates.
