### PR TITLE
Make the public devOps feed the default registry for .npmrc creation.

### DIFF
--- a/eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+++ b/eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
@@ -3,6 +3,7 @@ parameters:
     type: string
   - name: registryUrl
     type: string
+    default: 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/'
   - name: CustomCondition
     type: string
     default: succeeded()


### PR DESCRIPTION
- Set the public DevOps feed as default  registry for .npmrc creation.