### PR TITLE
Add azure-typespec-authoring Copilot CLI plugin

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "azure-typespec-authoring",
+  "owner": {
+    "name": "Azure SDK Team",
+    "email": "azsdkeng@microsoft.com"
+  },
+  "metadata": {
+    "description": "Marketplace for TypeSpec API specification authoring plugins.",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "azure-typespec-authoring",
+      "description": "Author, modify, and troubleshoot .tsp files for Azure ARM and data-plane API specifications.",
+      "version": "0.0.1-alpha",
+      "source": "plugin"
+    }
+  ]
+}

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "azure-sdk-mcp": {
+      "type": "stdio",
+      "command": "pwsh",
+      "args": ["mcp/azure-sdk-mcp.ps1", "-Run"]
+    }
+  }
+}

--- a/plugin/mcp/azure-sdk-mcp.ps1
+++ b/plugin/mcp/azure-sdk-mcp.ps1
@@ -1,0 +1,179 @@
+#!/usr/bin/env pwsh
+
+#Requires -Version 7.0
+#Requires -PSEdition Core
+
+param(
+    [string]$FileName = 'Azure.Sdk.Tools.Cli',
+    [string]$Package = 'azsdk',
+    [string]$Version, # Default to latest
+    [string]$InstallDirectory = '',
+    [string]$Repository = 'Azure/azure-sdk-tools',
+    [string]$RunDirectory = (Resolve-Path (Join-Path $PSScriptRoot .. .. ..)),
+    [switch]$Run,
+    [switch]$UpdateVsCodeConfig,
+    [switch]$UpdatePathInProfile
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot 'scripts' 'Helpers' 'AzSdkTool-Helpers.ps1')
+
+$toolInstallDirectory = $InstallDirectory ? $InstallDirectory : (Get-CommonInstallDirectory)
+
+$mcpMode = $Run
+
+# Log to console or MCP client json-rpc
+function log([object]$message, [switch]$warn, [switch]$err) {
+    [string]$messageString = $message
+
+    # Assume we are in an MCP client context when `-Run` is specified
+    # otherwise print to console normally
+    if (!$mcpMode) {
+        if ($err) {
+            Write-Error $messageString -ErrorAction Continue
+        }
+        elseif ($warn) {
+            Write-Warning $messageString
+        }
+        else {
+            Write-Host $messageString
+        }
+        return;
+    }
+
+    $level = switch ($message) {
+        { $_ -is [System.Management.Automation.ErrorRecord] } { 'error' }
+        { $_ -is [System.Management.Automation.WarningRecord] } { 'warning' }
+        default { 'notice' }
+    }
+
+    # If message stringifies as a valid error message we want to print it
+    # otherwise print stack for calls to external binaries
+    if ($messageString -eq 'System.Management.Automation.RemoteException') {
+        $messageString = $message.ScriptStackTrace
+    }
+
+    # Log json-rpc messages so the MCP client doesn't print
+    # '[warning] Failed to parse message:'
+    $messageObject = @{
+        jsonrpc = "2.0"
+        method  = "notifications/message"
+        params  = @{
+            level  = $level
+            logger = "installer"
+            data   = $messageString
+        }
+    }
+
+    Write-Host ($messageObject | ConvertTo-Json -Depth 100 -Compress)
+}
+
+if ($UpdateVsCodeConfig) {
+    $vscodeConfigPath = Join-Path $PSScriptRoot ".." ".." ".." ".vscode" "mcp.json"
+    if (Test-Path $vscodeConfigPath) {
+        $vscodeConfig = Get-Content -Raw $vscodeConfigPath | ConvertFrom-Json -AsHashtable
+    }
+    else {
+        $vscodeConfig = @{}
+    }
+    $serverKey = "azure-sdk-mcp"
+    $serverConfig = @{
+        "type"    = "stdio"
+        "command" = "$PSCommandPath"
+    }
+    $orderedServers = [ordered]@{
+        $serverKey = $serverConfig
+    }
+    if (-not $vscodeConfig.ContainsKey('servers')) {
+        $vscodeConfig['servers'] = @{}
+    }
+    foreach ($key in $vscodeConfig.servers.Keys) {
+        if ($key -ne $serverKey) {
+            $orderedServers[$key] = $vscodeConfig.servers[$key]
+        }
+    }
+    $vscodeConfig.servers = $orderedServers
+    log "Updating vscode mcp config at $vscodeConfigPath"
+    $vscodeConfig | ConvertTo-Json -Depth 10 | Set-Content -Path $vscodeConfigPath -Force
+}
+
+# Install to a temp directory first so we don't dump out all the other
+# release zip contents to one of the users bin directories.
+$tmp = $env:TEMP ? $env:TEMP : [System.IO.Path]::GetTempPath()
+$guid = [System.Guid]::NewGuid()
+$tempInstallDirectory = Join-Path $tmp "azsdk-install-$($guid)"
+
+if ($mcpMode) {
+    try {
+        # Swallow all output and re-log so we can wrap any
+        # output from the inner function as json-rpc
+        $tempExe = Install-Standalone-Tool `
+            -Version $Version `
+            -FileName $FileName `
+            -Package $Package `
+            -Directory $tempInstallDirectory `
+            -Repository $Repository `
+            *>&1
+        | Tee-Object -Variable _
+        | ForEach-Object { log $_; $_ }
+        | Select-Object -Last 1
+    }
+    catch {
+        log -err $_
+        exit 1
+    }
+}
+else {
+    $tempExe = Install-Standalone-Tool `
+        -Version $Version `
+        -FileName $FileName `
+        -Package $Package `
+        -Directory $tempInstallDirectory `
+        -Repository $Repository `
+
+}
+
+if (-not (Test-Path $toolInstallDirectory)) {
+    New-Item -ItemType Directory -Path $toolInstallDirectory -Force | Out-Null
+}
+$exeName = Split-Path $tempExe -Leaf
+$exeDestination = Join-Path $toolInstallDirectory $exeName
+
+# Try to copy the new version
+$updateSucceeded = $false
+try {
+    Copy-Item -Path $tempExe -Destination $exeDestination -Force
+    $updateSucceeded = $true
+}
+catch {
+    if ($Run -and (Test-Path $exeDestination)) {
+        # In MCP mode and the executable exists, warn and fall back to the existing installed version
+        log -warn "Could not update '$exeDestination': $($_.Exception.Message)"
+        log -warn "Falling back to the currently installed version."
+    }
+    else {
+        # In update-only mode or the executable does not exist, exit with error
+        log -err "Could not install or update '$exeDestination': $($_.Exception.Message)"
+        exit 1
+    }
+}
+
+# Clean up temp directory
+if (Test-Path $tempInstallDirectory) {
+    Remove-Item -Path $tempInstallDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+if ($updateSucceeded) {
+    log "Executable $package is installed at $exeDestination"
+}
+if (!$UpdatePathInProfile) {
+    log -warn "To add the tool to PATH for new shell sessions, re-run with -UpdatePathInProfile to modify the shell profile file."
+}
+else {
+    Add-InstallDirectoryToPathInProfile -InstallDirectory $toolInstallDirectory
+    log -warn "'$exeName' will be available in PATH for new shell sessions."
+}
+
+if ($Run) {
+    Start-Process -WorkingDirectory $RunDirectory -FilePath $exeDestination -ArgumentList 'start' -NoNewWindow -Wait
+}

--- a/plugin/mcp/scripts/Helpers/AzSdkTool-Helpers.ps1
+++ b/plugin/mcp/scripts/Helpers/AzSdkTool-Helpers.ps1
@@ -1,0 +1,252 @@
+Set-StrictMode -Version 4
+
+function Get-SystemArchitecture {
+    $unameOutput = uname -m
+    switch ($unameOutput) {
+        "x86_64" { return "X86_64" }
+        "aarch64" { return "ARM64" }
+        "arm64" { return "ARM64" }
+        default { throw "Unable to determine system architecture. uname -m returned $unameOutput." }
+    }
+}
+
+function Get-Package-Meta(
+    [Parameter(mandatory = $true)]
+    $FileName,
+    [Parameter(mandatory = $true)]
+    $Package
+) {
+    $ErrorActionPreferenceDefault = $ErrorActionPreference
+    $ErrorActionPreference = "Stop"
+
+    $AVAILABLE_BINARIES = @{
+        "Windows" = @{
+            "AMD64" = @{
+                "system"     = "Windows"
+                "machine"    = "AMD64"
+                "file_name"  = "$FileName-standalone-win-x64.zip"
+                "executable" = "$Package.exe"
+            }
+        }
+        "Linux"   = @{
+            "X86_64" = @{
+                "system"     = "Linux"
+                "machine"    = "X86_64"
+                "file_name"  = "$FileName-standalone-linux-x64.tar.gz"
+                "executable" = "$Package"
+            }
+            "ARM64"  = @{
+                "system"     = "Linux"
+                "machine"    = "ARM64"
+                "file_name"  = "$FileName-standalone-linux-arm64.tar.gz"
+                "executable" = "$Package"
+            }
+        }
+        "Darwin"  = @{
+            "X86_64" = @{
+                "system"     = "Darwin"
+                "machine"    = "X86_64"
+                "file_name"  = "$FileName-standalone-osx-x64.zip"
+                "executable" = "$Package"
+            }
+            "ARM64"  = @{
+                "system"     = "Darwin"
+                "machine"    = "ARM64"
+                "file_name"  = "$FileName-standalone-osx-arm64.zip"
+                "executable" = "$Package"
+            }
+        }
+    }
+
+    if ($IsWindows) {
+        $os = "Windows"
+        # we only support x64 on windows, if that doesn't work the platform is unsupported
+        $machine = "AMD64"
+    }
+    elseif ($IsLinux) {
+        $os = "Linux"
+        $machine = Get-SystemArchitecture
+    }
+    elseif ($IsMacOS) {
+        $os = "Darwin"
+        $machine = Get-SystemArchitecture
+    }
+    else {
+        $os = "unknown"
+    }
+
+    $ErrorActionPreference = $ErrorActionPreferenceDefault
+
+    return $AVAILABLE_BINARIES[$os][$machine]
+}
+
+function Clear-Directory ($path) {
+    if (Test-Path -Path $path) {
+        Remove-Item -Path $path -Recurse -Force
+    }
+    New-Item -ItemType Directory -Path $path -Force
+}
+
+function isNewVersion(
+    [Parameter(mandatory = $true)]
+    $Version,
+    [Parameter(mandatory = $true)]
+    $Directory
+) {
+    $savedVersionTxt = Join-Path $Directory "downloaded_version.txt"
+    if (Test-Path $savedVersionTxt) {
+        $result = (Get-Content -Raw $savedVersionTxt).Trim()
+
+        if ($result -eq $Version) {
+            return $false
+        }
+    }
+
+    return $true
+}
+
+<#
+.SYNOPSIS
+Installs a standalone version of an engsys tool.
+.PARAMETER Version
+The version of the tool to install. Requires a full version to be provided. EG "1.0.0-dev.20240617.1"
+.PARAMETER Directory
+The directory within which the exe will exist after this function invokes. Defaults to "."
+#>
+function Install-Standalone-Tool (
+    [Parameter()]
+    [string]$Version,
+    [Parameter(mandatory = $true)]
+    [string]$FileName,
+    [Parameter(mandatory = $true)]
+    [string]$Package,
+    [Parameter()]
+    [string]$Repository = "Azure/azure-sdk-tools",
+    [Parameter()]
+    $Directory = "."
+) {
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+
+    $systemDetails = Get-Package-Meta -FileName $FileName -Package $Package
+
+    if (!(Test-Path $Directory) -and $Directory -ne ".") {
+        New-Item -ItemType Directory -Path $Directory -Force | Out-Null
+    }
+
+    $tag = "${Package}_${Version}"
+
+    if (!$Version -or $Version -eq "*") {
+        Write-Host "Attempting to find latest version for package '$Package'"
+        $releasesUrl = "https://api.github.com/repos/$Repository/releases"
+        $releases = Invoke-RestMethod -Uri $releasesUrl
+        $found = $false
+        foreach ($release in $releases) {
+            if ($release.tag_name -like "$Package*") {
+                $tag = $release.tag_name
+                $Version = $release.tag_name -replace "${Package}_", ""
+                $found = $true
+                break
+            }
+        }
+        if ($found -eq $false) {
+            throw "No release found for package '$Package'"
+        }
+    }
+
+    $downloadFolder = Resolve-Path $Directory
+    $downloadUrl = "https://github.com/$Repository/releases/download/$tag/$($systemDetails.file_name)"
+    $downloadFile = $downloadUrl.Split('/')[-1]
+    $downloadLocation = Join-Path $downloadFolder $downloadFile
+    $savedVersionTxt = Join-Path $downloadFolder "downloaded_version.txt"
+    $executable_path = Join-Path $downloadFolder $systemDetails.executable
+
+    if (isNewVersion $version $downloadFolder) {
+        Write-Host "Installing '$Package' '$Version' to '$downloadFolder' from $downloadUrl"
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $downloadLocation
+
+        if ($downloadFile -like "*.zip") {
+            Expand-Archive -Path $downloadLocation -DestinationPath $downloadFolder -Force
+        }
+        elseif ($downloadFile -like "*.tar.gz") {
+            tar -xzf $downloadLocation -C $downloadFolder
+        }
+        else {
+            throw "Unsupported file format"
+        }
+
+        # Remove the downloaded file after extraction
+        Remove-Item -Path $downloadLocation -Force
+
+        # Record downloaded version
+        Set-Content -Path $savedVersionTxt -Value $Version
+
+        # Set executable permissions if on macOS (Darwin)
+        if ($IsMacOS) {
+            chmod 755 $executable_path
+        }
+    }
+    else {
+        Write-Host "Target version '$Version' already present in target directory '$downloadFolder'"
+    }
+
+    return $executable_path
+}
+
+function Get-CommonInstallDirectory {
+    $installDirectory = Join-Path $HOME "bin"
+    if (-not (Test-Path $installDirectory)) {
+        New-Item -ItemType Directory -Path $installDirectory -Force | Out-Null
+    }
+
+    # Update PATH in current session
+    if (-not ($env:PATH -like "*$InstallDirectory*")) {
+        $env:PATH += ";$InstallDirectory"
+    }
+
+    return $installDirectory
+}
+
+function Add-InstallDirectoryToPathInProfile(
+    [Parameter()]
+    [string]$InstallDirectory = (Get-CommonInstallDirectory)
+) {
+    $powershellProfilePath = $PROFILE
+    $bashrcPath = Join-Path $HOME ".bashrc"
+    $zshrcPath = Join-Path $HOME ".zshrc"
+    $markerComment = "  # azsdk install path"
+    $pathCommand = ""
+    $configFile = ""
+
+    if ($IsWindows) {  # expect powershell for windows, cmd.exe path update is not currently supported
+        $configFile = $powershellProfilePath
+        $pathCommand = "if (-not (`$env:PATH -like `'*$InstallDirectory*`')) { `$env:PATH += ';$InstallDirectory`' }" + $markerComment
+    }
+    elseif ($IsLinux) {  # handle bash or zsh shells for linux
+        if (Test-Path $zshrcPath) {
+            $configFile = $zshrcPath
+        }
+        else {
+            $configFile = $bashrcPath
+        }
+        $pathCommand = "export PATH=`"`$PATH:$InstallDirectory`"" + $markerComment
+    }
+    elseif ($IsMacOS) {  # mac os should use zsh by default
+        $configFile = $zshrcPath
+        $pathCommand = "export PATH=`"`$PATH:$InstallDirectory`"" + $markerComment
+    }
+    else {
+        throw "Unsupported platform"
+    }
+
+    if (-not (Test-Path $configFile)) {
+        New-Item -ItemType File -Path $configFile -Force | Out-Null
+    }
+
+    $configContent = Get-Content $configFile -Raw
+
+    if (!$configContent -or !$configContent.Contains($markerComment)) {
+        Write-Host "Adding installation to PATH in shell profile at '$configFile'"
+        Add-Content -Path $configFile -Value ([Environment]::NewLine + $pathCommand)
+    }
+}

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "azure-typespec-authoring",
+  "description": "Azure TypeSpec API specification authoring plugin. Author, modify, and troubleshoot .tsp files for Azure ARM and data-plane API specifications.",
+  "version": "0.0.1-alpha",
+  "author": {
+    "name": "Azure SDK Team",
+    "url": "https://github.com/Azure/azure-sdk-tools"
+  },
+  "homepage": "https://github.com/Azure/azure-sdk-tools",
+  "repository": "https://github.com/Azure/azure-sdk-tools",
+  "keywords": ["azure", "typespec", "api", "arm", "specification", "authoring"],
+  "skills": "skills/",
+  "mcpServers": ".mcp.json"
+}

--- a/plugin/skills/azure-typespec-author/SKILL.md
+++ b/plugin/skills/azure-typespec-author/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: azure-typespec-author
+license: MIT
+metadata:
+  version: "0.0.1"
+description: "Author or modify Azure TypeSpec API specifications in the azure-rest-api-specs repository. USE FOR: Any task that creates, modifies, or troubleshoots .tsp files or TypeSpec API specifications — including but not limited to API versioning (e.g. add new preview version, add new stable version), ARM or data-plane resource definitions (tracked, proxy, extension, child resources), resource operations (CRUD, PATCH, custom actions, async/LRO), models, enums, unions, properties, decorators, constraints, and swagger-to-TypeSpec conversion. DO NOT USE FOR: SDK generation from TypeSpec, releasing SDK packages, single MCP tool calls that do not require multi-step workflows. TOOLS/COMMANDS: azsdk_typespec_generate_authoring_plan, azsdk_run_typespec_validation"
+compatibility: >-
+  Requires: azure-sdk-mcp server with azsdk_typespec_generate_authoring_plan and azsdk_run_typespec_validation tools.
+---
+
+# Azure TypeSpec Author
+
+## MCP Prerequisites
+
+Requires `azure-sdk-mcp` server with TypeSpec authoring and validation tools.
+
+## MCP Tools
+
+| Tool                                     | Purpose                              |
+| ---------------------------------------- | ------------------------------------ |
+| `azsdk_typespec_generate_authoring_plan` | Generate grounded authoring plan     |
+| `azsdk_run_typespec_validation`          | Validate TypeSpec compilation + lint |
+
+## Principles
+
+1. **Mandatory for ALL `.tsp` edits** — even a single `?` change can be breaking.
+2. **Minimal, scoped edits** — only change what the request requires.
+3. **Always validate** — run `azsdk_run_typespec_validation` after every edit.
+4. **Always cite references** — provide links that justify the approach.
+
+## Task Types
+
+| Type                  | Description                                                       | Examples                                               |
+| --------------------- | ----------------------------------------------------------------- | ------------------------------------------------------ |
+| **API Versioning**    | Adding a new preview or stable API version to an existing service | "add new preview version", "promote preview to stable" |
+| **General Authoring** | Any other TypeSpec authoring task that modifies `.tsp` files      | "add a resource", "add CRUD operations", "add LRO"    |
+
+## Steps
+
+All tasks follow a 5-step workflow. Steps 2–3 branch by task type; the rest are shared.
+
+1. **Analyze Project** — Follow the [project analysis guide](references/analyze-project.md) to collect project context and determine task type.
+
+2. **Intake & Clarification**
+   - *API Versioning:* determine the versioning scenario from Step 1, use [agentic search](references/agentic-search.md) with the scenario URL below to collect information from user. Be sure to use a user-friendly way to collect required inputs from user. e.g., list the existing features (resources, operations, properties) from the latest version and then ask the user which to carry over or exclude, instead of asking for raw input.
+
+     | Latest  | Target  | URL to fetch                                                                          |
+     | ------- | ------- | ------------------------------------------------------------------------------------- |
+     | preview | preview | `https://azure.github.io/typespec-azure/docs/howtos/versioning/arm/02-preview-after-preview/` |
+     | preview | stable  | `https://azure.github.io/typespec-azure/docs/howtos/versioning/arm/03-stable-after-preview/`  |
+     | stable  | preview | `https://azure.github.io/typespec-azure/docs/howtos/versioning/arm/04-preview-after-stable/`  |
+     | stable  | stable  | `https://azure.github.io/typespec-azure/docs/howtos/versioning/arm/05-stable-after-stable/`   |
+
+   - *General Authoring:* follow [intake guide](references/general-authoring-intake.md).
+
+3. **Retrieve Solution**
+   - *API Versioning:* search the downloaded guide content for implementation steps via [agentic search](references/agentic-search.md) and generate solution. No MCP tool call needed.
+   - *General Authoring:* invoke `azsdk_typespec_generate_authoring_plan` with request, context from Steps 1–2, and project root path. Do not proceed without a grounded plan.
+
+4. **Apply Changes** — Confirm uncertainties with user, make minimal `.tsp` edits, prefer official templates from retrieved context.
+
+5. **Validate** — Follow the [validation guide](references/validation.md).

--- a/plugin/skills/azure-typespec-author/references/agentic-search.md
+++ b/plugin/skills/azure-typespec-author/references/agentic-search.md
@@ -1,0 +1,16 @@
+# Agentic Search
+
+Generic procedure for fetching external documentation and searching it locally.
+
+## Input
+
+A set of document URLs to fetch (provided by the caller).
+
+## Procedure
+
+1. **Create temp folder** — create a temporary directory for downloaded content (e.g., `<os-temp>/typespec-references/`).
+2. **Fetch documents** — for each URL, download the page content and save it as a `.md` file in the temp folder. Use the URL path to derive the filename (e.g., `02-preview-after-preview.md`).
+3. **Search locally** — read the downloaded files and search for the information relevant to the current task. Extract key instructions, code examples, and patterns.
+4. **Build plan** — synthesize the extracted content into a concrete implementation plan grounded in the downloaded material.
+
+> Do not proceed without a plan grounded in the downloaded reference material.

--- a/plugin/skills/azure-typespec-author/references/analyze-project.md
+++ b/plugin/skills/azure-typespec-author/references/analyze-project.md
@@ -1,0 +1,29 @@
+# Analyze Project
+
+Analyze the TypeSpec project and collect the inputs below. Ask **up to 6 concise questions** for any that are missing.
+
+| #   | Input                       | Example                                                          |
+| --- | --------------------------- | ---------------------------------------------------------------- |
+| 1   | Spec root / folder          | `/specification/widget/resource-manager/Microsoft.Widget/Widget` |
+| 2   | Path to `tspconfig.yaml`    | `<spec-root>/tspconfig.yaml`                                     |
+| 3   | Service type                | management-plane / data-plane                                    |
+| 4   | Existing API versions       | `2024-01-01 (stable)`, `2024-06-01-preview`                      |
+| 5   | Latest API version          | Most recent entry in the `Versions` enum                         |
+| 6   | Current working API version | The version being added or modified this session                 |
+| 7   | Intent                      | add / modify / fix                                               |
+| 8   | Target resource/interface   | Resource or operation name (if known)                            |
+| 9   | Constraints                 | Breaking-change limits, naming rules, emitter targets, etc.      |
+
+Display the results before proceeding:
+
+```
+Spec Root:       /path/to/project
+tspconfig.yaml:  /path/to/project/tspconfig.yaml
+Service Type:    management-plane
+API Versions:    2024-01-01 (stable), 2024-06-01-preview (preview)
+Latest Version:  2024-06-01-preview
+Working Version: [TBD]
+Intent:          [add/modify/fix]
+Target:          [resource/operation if known]
+Constraints:     [if any]
+```

--- a/plugin/skills/azure-typespec-author/references/general-authoring-intake.md
+++ b/plugin/skills/azure-typespec-author/references/general-authoring-intake.md
@@ -1,0 +1,56 @@
+# Intake — General Authoring
+
+> Step 1 (Analyze Project) must be complete. Do not re-collect those inputs.
+
+### Step 2.1: Identify the Case
+
+| Case | Name              | Description                                            | Service Type |
+| ---- | ----------------- | ------------------------------------------------------ | ------------ |
+| 1    | Add Resource Type | Define a new ARM resource with operations              | ARM          |
+| 2    | Add Operations    | Add CRUD or custom actions on a resource               | ARM          |
+| 3    | Add LRO           | Add or configure an async/long-running operation       | ARM          |
+| 4    | Add Patch         | Add a PATCH/update operation                           | ARM          |
+| 5    | Add Paging        | Add or configure pagination on list operations         | ARM          |
+
+- **Match found** → collect case-specific inputs (Step 2.2).
+- **No match** → skip to Step 3 using Step 1 analysis and the user's request.
+
+### Step 2.2: Collect Inputs
+
+**Case 1 — Add Resource Type**
+Collect: target API version, resource name (PascalCase), hierarchy (top-level or nested + parent), properties (name, type, required/optional).
+Defaults: top-level → `TrackedResource`, child → `ProxyResource`. Operations: `createOrReplace` (PUT/async), `get`, `update/patch`, `delete` (async), list by parent. Top-level adds list by subscription. Use `createOrReplace` (not `createOrUpdate`), `ArmCustomPatch` for PATCH.
+
+> Top-level tracked resources MUST have `listByResourceGroup` and `listBySubscription`.
+
+**Case 2 — Add Operations**
+Collect: target resource, operation type (CRUD or custom), operation name (custom actions), request/response models (custom actions).
+Defaults: never async → GET, LIST, HEAD. Default async → PUT, DELETE. Default sync → PATCH. Always ask user → POST/action.
+
+> Use `createOrReplace` templates (not `createOrUpdate`). Use `ArmCustomPatch` for PATCH.
+
+**Case 3 — Add LRO**
+Collect: target resource/operation, LRO template (e.g., `ArmResourceCreateOrReplaceAsync`), final state polling (if non-standard).
+
+> PUT and DELETE default to async. GET, LIST, HEAD can never be async.
+
+**Case 4 — Add Patch**
+Collect: target resource, patchable properties.
+
+> Use `ArmCustomPatch` with updatable properties from the resource and its `properties` bag. PATCH defaults to sync.
+
+**Case 5 — Add Paging**
+Collect: target list operation(s), paging type (default ARM or custom).
+
+> ARM list operations (`ArmResourceListByParent`, `ArmListBySubscription`) include paging by default.
+
+### Step 2.3: Confirm
+
+Display collected information and wait for user confirmation:
+
+```
+Case:              [Name]
+Target Version:    [version]
+Requested Changes: [summary]
+```
+

--- a/plugin/skills/azure-typespec-author/references/validation.md
+++ b/plugin/skills/azure-typespec-author/references/validation.md
@@ -1,0 +1,47 @@
+# Validation
+
+After applying changes (Step 4), run through all sub-steps below in order.
+
+| Sub-step | Action                | When            |
+| -------- | --------------------- | --------------- |
+| 5.1      | TypeSpec Validation   | Always          |
+| 5.2      | Example Verification  | Always          |
+| 5.3      | Breaking Change Check | Stable API only |
+
+### Step 5.1: TypeSpec Validation
+
+Invoke `azsdk_run_typespec_validation` with the project root path.
+
+- **Pass** → proceed to Step 5.2.
+- **Fail** → fix with minimal, scoped changes, then re-run. Repeat until resolved.
+
+> Never skip this step, even for trivial changes.
+
+### Step 5.2: Example Verification
+
+Verify that files under `examples/` are consistent with the current API version:
+
+1. Each operation should have a corresponding example file.
+2. Example payloads should reflect the latest schema (property names, types, required fields).
+3. The `api-version` query parameter should match the working version from Step 1.
+
+If examples are missing or outdated → **restart from Step 2** to update them.
+
+### Step 5.3: Breaking Change Check
+
+> Applies only when adding a stable API version. Skip otherwise.
+
+Compare changes against the **latest published stable version** and flag:
+
+| Type                          | Example                                      |
+| ----------------------------- | -------------------------------------------- |
+| Removed or renamed property   | `provisioningState` → `status`               |
+| Changed property type         | `string` → `int32`                           |
+| Changed required ↔ optional   | optional `location` becomes required         |
+| Removed resource or operation | `DELETE /widgets/{id}` no longer exists      |
+| Changed response status code  | `200 OK` → `202 Accepted`                   |
+| Removed enum member           | `"Running"` removed from `ProvisioningState` |
+
+If breaking changes are detected:
+1. List each with before/after comparison.
+2. Require explicit user confirmation before proceeding.


### PR DESCRIPTION
## What

Add a GitHub Copilot CLI plugin (`azure-typespec-authoring`) for authoring Azure TypeSpec API specifications.

## Why

Service teams need guidance when writing and modifying `.tsp` files for Azure ARM and data-plane API specifications. This plugin provides an `azure-typespec-author` skill that assists with:

- **API Versioning** — adding new preview/stable versions following the correct workflow
- **General Authoring** — defining resources, operations (CRUD, LRO, Patch, Paging), models, enums, decorators, and constraints
- **Validation** — compiling and linting TypeSpec projects after changes

## Plugin Structure

```
.github/plugin/marketplace.json          # Marketplace manifest
plugin/
├── plugin.json                           # Plugin manifest
├── .mcp.json                             # MCP server configuration
├── mcp/
│   ├── azure-sdk-mcp.ps1                # MCP server entry point
│   └── scripts/Helpers/
│       └── AzSdkTool-Helpers.ps1        # MCP tool helpers
└── skills/
    └── azure-typespec-author/
        ├── SKILL.md                      # Skill definition (5-step workflow)
        └── references/
            ├── agentic-search.md         # Doc fetch and local search procedure
            ├── analyze-project.md        # Step 1 — Project analysis
            ├── general-authoring-intake.md # Step 2 — Intake (general authoring)
            └── validation.md             # Step 5 — Validation and checks
```

## Installation

```shell
copilot plugin marketplace add Azure/azure-sdk-tools
copilot plugin install azure-typespec-authoring@azure-typespec-authoring
```

## MCP Tools Used

| Tool | Purpose |
|------|---------|
| `azsdk_typespec_generate_authoring_plan` | Generate grounded authoring plan |
| `azsdk_run_typespec_validation` | Validate TypeSpec compilation + lint |