### PR TITLE
[azsdk] Revert debug logging changes

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/appsettings.json
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/appsettings.json
@@ -2,7 +2,7 @@
   "Logging": {
     "LogLevel": {
       "Default": "Warning",
-      "Azure.Sdk": "Debug"
+      "Azure.Sdk": "Information"
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
Reverting the local logging config changes made in https://github.com/Azure/azure-sdk-tools/pull/14371 to unblock CI. The validate tool names against markdown references CI check is failing because an errant debug log is preventing the `list -o json` output from being parsed.

We have some better changes coming from @samvaity which will improve our log level processing a bit more and will replace this change.