### PR TITLE
Use both NPM_CONFIG_USERCONFIG and NPM_CONFIG_REGISTRY to give the pi…

### DIFF
--- a/eng/common/pipelines/templates/jobs/npm-publish.yml
+++ b/eng/common/pipelines/templates/jobs/npm-publish.yml
@@ -67,12 +67,6 @@ jobs:
             Write-Host "##vso[task.setvariable variable=TagName]$tag"
             Write-Host "Publishing packages with tag: $tag"
           displayName: 'Packages to be published'
-
-        - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
-          parameters:
-            npmrcPath: $(ArtifactPath)/.npmrc
-            registryUrl: ${{ parameters.Registry }}
-            CustomCondition: and(succeeded(), ne(variables['SkipPublishing'], 'true'))
   
         - ${{ if eq(parameters.Registry, 'https://registry.npmjs.org/') }}:
 
@@ -119,6 +113,13 @@ jobs:
             condition: and(succeeded(), ne(variables['SkipPublishing'], 'true'))
 
         - ${{ else }}:
+
+          - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+            parameters:
+              npmrcPath: $(ArtifactPath)/.npmrc
+              registryUrl: ${{ parameters.Registry }}
+              CustomCondition: and(succeeded(), ne(variables['SkipPublishing'], 'true'))
+
           - pwsh: |
               foreach ($package in (dir $(ArtifactPath) *.tgz -Recurse)) {
                 Write-Host "npm publish $package --verbose --access public --tag $(TagName) --registry ${{ parameters.Registry }}"

--- a/eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+++ b/eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
@@ -7,6 +7,7 @@ parameters:
   WorkingDirectory: ''
   ScriptDirectory: eng/common/scripts
   NpmConfigUserConfig: ''
+  NpmConfigRegistry: ''
 
 steps:
 - task: PowerShell@2
@@ -26,3 +27,5 @@ steps:
     GH_TOKEN: $(azuresdk-github-pat)
     ${{ if ne(parameters.NpmConfigUserConfig, '') }}:
       NPM_CONFIG_USERCONFIG: ${{ parameters.NpmConfigUserConfig }}
+    ${{ if ne(parameters.NpmConfigRegistry, '') }}:
+      NPM_CONFIG_REGISTRY: ${{ parameters.NpmConfigRegistry }}

--- a/eng/common/pipelines/templates/steps/update-docsms-metadata.yml
+++ b/eng/common/pipelines/templates/steps/update-docsms-metadata.yml
@@ -32,6 +32,9 @@ parameters:
   - name: NpmConfigUserConfig
     type: string
     default: ''
+  - name: NpmConfigRegistry
+    type: string
+    default: ''
 steps:
   - ${{ if eq(length(parameters.PackageInfoLocations), 0) }}:
     - pwsh: |
@@ -97,6 +100,8 @@ steps:
       env:
         ${{ if ne(parameters.NpmConfigUserConfig, '') }}:
           NPM_CONFIG_USERCONFIG: ${{ parameters.NpmConfigUserConfig }}
+        ${{ if ne(parameters.NpmConfigRegistry, '') }}:
+          NPM_CONFIG_REGISTRY: ${{ parameters.NpmConfigRegistry }}
 
     - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
       parameters:


### PR DESCRIPTION
- Use both `NPM_CONFIG_USERCONFIG` and `NPM_CONFIG_REGISTRY` to give the pipeline more flexibility.
- `NPM_CONFIG_REGISTRY` overrides all other registry settings in `.npmrc`
- Revert `npm-publish.yml` to only create authenticated `.npmrc` when publishing to DevOps