### PR TITLE
Update agent testing bug

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -374,7 +374,18 @@ namespace Azure.Sdk.Tools.Cli.Services
                         // If agent test mode is enabled or if it's a test release plan then skip release plans.
                         if (IsAgentTesting != isTestReleasePlan)
                         {
-                            logger.LogInformation("Skipping test release plans because either it's test release plan or agent test mode is enabled.");
+                            var planKind = isTestReleasePlan ? "test" : "non-test";
+                            var reason = IsAgentTesting
+                                ? "agent test mode is enabled and this is not a test release plan"
+                                : "agent test mode is disabled and this is a test release plan";
+
+                            logger.LogInformation(
+                                "Skipping {PlanKind} release plan work item {WorkItemId} because {Reason}. IsAgentTesting={IsAgentTesting}, IsTestReleasePlan={IsTestReleasePlan}",
+                                planKind,
+                                parentWorkItemId,
+                                reason,
+                                IsAgentTesting,
+                                isTestReleasePlan);
                             continue;
                         }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -370,10 +370,11 @@ namespace Azure.Sdk.Tools.Cli.Services
                             continue;
                         }
 
-                        // If agent test mode is enabled then skip all non test release plans.
-                        if (IsAgentTesting && parentWorkItem.Fields.TryGetValue("System.Tags", out Object? value) && value is String tags && !tags.Contains(RELEASE_PLANNER_APP_TEST))
+                        var isTestReleasePlan = parentWorkItem.Fields.TryGetValue("System.Tags", out Object? value) && value is String tags && tags.Contains(RELEASE_PLANNER_APP_TEST);
+                        // If agent test mode is enabled or if it's a test release plan then skip release plans.
+                        if (IsAgentTesting != isTestReleasePlan)
                         {
-                            logger.LogInformation("Agent test mode is enabled. Skipping release plans without testing tag.");
+                            logger.LogInformation("Skipping test release plans because either it's test release plan or agent test mode is enabled.");
                             continue;
                         }
 


### PR DESCRIPTION
Fix test release plan when agency test mode is not enabled and fetch only test release plans when agent test mode is enabled.