### PR TITLE
Add Provisioning label to common-labels.csv with ffeb77 color

### DIFF
--- a/tools/github/data/common-labels.csv
+++ b/tools/github/data/common-labels.csv
@@ -218,7 +218,7 @@ Policy,,e99695
 Policy Insights,,e99695
 PostgreSQL,,e99695
 PowerBI,,e99695
-Provisioning,This issue is related to a provisioning library.,ffeb77
+Provisioning,,ffeb77
 PureStorage,,e99695
 Purview,,e99695
 Quantum,,e99695


### PR DESCRIPTION
Fixes #14484

Adds the `Provisioning` label to `tools/github/data/common-labels.csv` with color `ffeb77` (no description), matching the `Client` and `Mgmt` labels.

The label has also been created/updated on all repositories listed in `tools/github/data/repositories.txt`.