### PR TITLE
[APView] Keep CI Build Phase on Windows

### DIFF
--- a/src/dotnet/APIView/apiview.yml
+++ b/src/dotnet/APIView/apiview.yml
@@ -91,9 +91,9 @@ extends:
           - job: 'Build'
 
             pool:
-              name: $(LINUXPOOL)
-              image: $(LINUXVMIMAGE)
-              os: linux
+              name: $(WINDOWSPOOL)
+              image: $(WINDOWSVMIMAGE)
+              os: windows
 
             templateContext:
               sdl: 


### PR DESCRIPTION
The webapps for APIView are Windows based, so we need to keep the build artifact Windows based. This PR maintains the test phase as Linux. 