### PR TITLE
[azsdk] Test timing and selection improvements

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/README.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/README.md
@@ -61,9 +61,9 @@ COPILOT_INSTRUCTIONS_PATH_MCP_EVALS=local/path/to/.github/copilot-instructions.m
 ### Running Evaluations
 
 #### Using command line
+
 ```bash
-cd local/path/to/Azure.Sdk.Tools.Cli.Evaluations
-dotnet test
+dotnet test --filter 'Category==Evals'
 ```
 
 #### Using Test Explorer (Preferred)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenario.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/Scenario.cs
@@ -11,6 +11,8 @@ using NUnit.Framework;
 namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
 {
     [TestFixture]
+    [Explicit]
+    [Category("Evals")]
     public partial class Scenario
     {
         // Static services shared across all tests
@@ -27,15 +29,7 @@ namespace Azure.Sdk.Tools.Cli.Evaluations.Scenarios
         [OneTimeSetUp]
         public async Task GlobalSetup()
         {
-            if (!TestSetup.ShouldRunEvals())
-            {
-                Assert.Ignore("Skipping all tests: Required environment variables are not configured. " +
-                    "Set AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_MODEL_DEPLOYMENT_NAME, REPOSITORY_NAME, and COPILOT_INSTRUCTIONS_PATH_MCP_EVALS.");
-            }
-            else
-            {
-                TestSetup.ValidateEnvironmentConfiguration();
-            }
+            TestSetup.ValidateEnvironmentConfiguration();
 
             s_chatClient = TestSetup.GetChatClient();
             s_mcpClient = await TestSetup.GetMcpClientAsync();

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/CopilotAgents/CopilotAgentRunnerTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/CopilotAgents/CopilotAgentRunnerTests.cs
@@ -6,6 +6,8 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Moq;
 
+using static Azure.Sdk.Tools.Cli.Tests.TestHelpers.TestCategories;
+
 namespace Azure.Sdk.Tools.Cli.Tests.CopilotAgents;
 
 [TestFixture]
@@ -600,6 +602,7 @@ internal class CopilotAgentRunnerTests
     }
 
     [Test]
+    [Category(Integration)]
     public void RunAsync_WithInvalidGitHubToken_ThrowsNotAuthenticatedError()
     {
         // Arrange - Use an invalid GitHub token

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/CopilotAgents/CopilotAgentRunnerTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/CopilotAgents/CopilotAgentRunnerTests.cs
@@ -601,8 +601,8 @@ internal class CopilotAgentRunnerTests
 
     }
 
-    [Test]
-    [Category(Integration)]
+    [Test, Explicit]
+    [Category(CopilotAgent)]
     public void RunAsync_WithInvalidGitHubToken_ThrowsNotAuthenticatedError()
     {
         // Arrange - Use an invalid GitHub token

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/ProgressReporterTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/ProgressReporterTests.cs
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using Azure.Sdk.Tools.Cli.Helpers;
-using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
+using System.Diagnostics;
 using ModelContextProtocol;
 using Moq;
+using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Helpers;
 
@@ -144,6 +145,16 @@ public class ProgressReporterTests
 
     #region Heartbeat tests
 
+    private static async Task DelayWithRetry<T>(List<T> counter, int maxWait)
+    {
+        var timeout = TimeSpan.FromMilliseconds(100);
+        var sw = Stopwatch.StartNew();
+        while (counter.Count < maxWait && sw.Elapsed < timeout)
+        {
+            await Task.Delay(10);
+        }
+    }
+
     [Test]
     public async Task StartHeartbeat_EmitsHeartbeatsUntilDisposed()
     {
@@ -158,7 +169,7 @@ public class ProgressReporterTests
 
         await using (reporter.StartHeartbeat("Working", heartbeatInterval: TimeSpan.FromMilliseconds(5)))
         {
-            await Task.Delay(20);
+            await DelayWithRetry(reported, 2);
         }
 
         // Should have initial step report + at least 1 heartbeat
@@ -185,7 +196,7 @@ public class ProgressReporterTests
 
         await using (reporter.StartHeartbeat("Working", heartbeatInterval: TimeSpan.FromMilliseconds(5)))
         {
-            await Task.Delay(20);
+            await DelayWithRetry(reported, 2);
         }
 
         var countAfterDispose = reported.Count;
@@ -205,7 +216,7 @@ public class ProgressReporterTests
 
         await using (reporter.StartHeartbeat("Working", heartbeatInterval: TimeSpan.FromMilliseconds(5)))
         {
-            await Task.Delay(20);
+            await DelayWithRetry(_consoleOutput, 2);
         }
 
         // At least the step message + some heartbeats
@@ -274,7 +285,7 @@ public class ProgressReporterTests
 
         await using (reporter.StartHeartbeat("Working", heartbeatInterval: TimeSpan.FromMilliseconds(5)))
         {
-            await Task.Delay(20);
+            await DelayWithRetry(reported, 4);
         }
 
         // Heartbeat messages should use step index 2 (current step after NextStep increments)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/ProgressReporterTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/ProgressReporterTests.cs
@@ -156,9 +156,9 @@ public class ProgressReporterTests
 
         reporter.NextStep("Starting work");
 
-        await using (reporter.StartHeartbeat("Working", heartbeatInterval: TimeSpan.FromMilliseconds(50)))
+        await using (reporter.StartHeartbeat("Working", heartbeatInterval: TimeSpan.FromMilliseconds(5)))
         {
-            await Task.Delay(200);
+            await Task.Delay(20);
         }
 
         // Should have initial step report + at least 1 heartbeat
@@ -183,15 +183,15 @@ public class ProgressReporterTests
 
         reporter.NextStep("Step 1");
 
-        await using (reporter.StartHeartbeat("Working", heartbeatInterval: TimeSpan.FromMilliseconds(50)))
+        await using (reporter.StartHeartbeat("Working", heartbeatInterval: TimeSpan.FromMilliseconds(5)))
         {
-            await Task.Delay(200);
+            await Task.Delay(20);
         }
 
         var countAfterDispose = reported.Count;
 
         // Wait a bit more — no new heartbeats should appear
-        await Task.Delay(100);
+        await Task.Delay(50);
 
         Assert.That(reported.Count, Is.EqualTo(countAfterDispose));
     }
@@ -203,9 +203,9 @@ public class ProgressReporterTests
 
         reporter.NextStep("Step 1");
 
-        await using (reporter.StartHeartbeat("Working", heartbeatInterval: TimeSpan.FromMilliseconds(50)))
+        await using (reporter.StartHeartbeat("Working", heartbeatInterval: TimeSpan.FromMilliseconds(5)))
         {
-            await Task.Delay(200);
+            await Task.Delay(20);
         }
 
         // At least the step message + some heartbeats
@@ -223,16 +223,16 @@ public class ProgressReporterTests
 
         var heartbeat = reporter.StartHeartbeat("Working",
             ct: cts.Token,
-            heartbeatInterval: TimeSpan.FromMilliseconds(50));
+            heartbeatInterval: TimeSpan.FromMilliseconds(5));
 
-        await Task.Delay(200);
+        await Task.Delay(20);
         cts.Cancel();
 
         // DisposeAsync should complete without throwing
         await heartbeat.DisposeAsync();
 
         var countAfterCancel = _consoleOutput.Count;
-        await Task.Delay(100);
+        await Task.Delay(50);
 
         Assert.That(_consoleOutput.Count, Is.EqualTo(countAfterCancel));
     }
@@ -272,9 +272,9 @@ public class ProgressReporterTests
         reporter.NextStep("Step 1"); // progress = 1
         reporter.NextStep("Step 2"); // progress = 2
 
-        await using (reporter.StartHeartbeat("Working", heartbeatInterval: TimeSpan.FromMilliseconds(50)))
+        await using (reporter.StartHeartbeat("Working", heartbeatInterval: TimeSpan.FromMilliseconds(5)))
         {
-            await Task.Delay(200);
+            await Task.Delay(20);
         }
 
         // Heartbeat messages should use step index 2 (current step after NextStep increments)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/ProgressReporterTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/ProgressReporterTests.cs
@@ -145,11 +145,11 @@ public class ProgressReporterTests
 
     #region Heartbeat tests
 
-    private static async Task DelayWithRetry<T>(List<T> counter, int maxWait)
+    private static async Task DelayWithRetry<T>(List<T> counter, int maxRetries)
     {
         var timeout = TimeSpan.FromMilliseconds(100);
         var sw = Stopwatch.StartNew();
-        while (counter.Count < maxWait && sw.Elapsed < timeout)
+        while (counter.Count < maxRetries && sw.Elapsed < timeout)
         {
             await Task.Delay(10);
         }
@@ -285,7 +285,7 @@ public class ProgressReporterTests
 
         await using (reporter.StartHeartbeat("Working", heartbeatInterval: TimeSpan.FromMilliseconds(5)))
         {
-            await DelayWithRetry(reported, 4);
+            await DelayWithRetry(reported, 3);
         }
 
         // Heartbeat messages should use step index 2 (current step after NextStep increments)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/ProgramTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/ProgramTests.cs
@@ -10,9 +10,22 @@ internal class ProgramTests
         // Force app builder to build and verify things like DI lifetimes
         Assert.That(() => Program.CreateAppBuilder(["--help"], "hidden", LogLevel.None).Build(), Throws.Nothing);
 
-        // Run full builder setup and CLI parsing end to end
-        var result = await Program.Run(["-o", "hidden", "example", "hello-world", "test"], LogLevel.None);
-        Assert.That(result, Is.EqualTo(0));
+        // Suppress console output from the end-to-end CLI invocation
+        var originalOut = Console.Out;
+        var originalErr = Console.Error;
+        Console.SetOut(TextWriter.Null);
+        Console.SetError(TextWriter.Null);
+        try
+        {
+            // Run full builder setup and CLI parsing end to end
+            var result = await Program.Run(["-o", "hidden", "example", "hello-world", "test"], LogLevel.None);
+            Assert.That(result, Is.EqualTo(0));
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalErr);
+        }
     }
 
     [Test]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/FeedbackClassifierServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/FeedbackClassifierServiceTests.cs
@@ -12,6 +12,8 @@ using Moq;
 using NUnit.Framework;
 using System.Reflection;
 
+using static Azure.Sdk.Tools.Cli.Tests.TestHelpers.TestCategories;
+
 namespace Azure.Sdk.Tools.Cli.Tests.Services;
 
 /// <summary>
@@ -23,7 +25,7 @@ public class FeedbackClassifierServiceTests
 {
     private Mock<ICopilotAgentRunner> _mockAgentRunner = null!;
     private Mock<ITypeSpecHelper> _mockTypeSpecHelper = null!;
-    private ILoggerFactory _loggerFactory = null!;
+    private Mock<ILoggerFactory> _mockLoggerFactory = null!;
     private string _testTspPath = null!;
     private string _specRepoRoot = null!;
     private string _typeSpecProjectPath = null!;
@@ -55,7 +57,9 @@ public class FeedbackClassifierServiceTests
     {
         _mockAgentRunner = new Mock<ICopilotAgentRunner>();
         _mockTypeSpecHelper = new Mock<ITypeSpecHelper>();
-        _loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+        _mockLoggerFactory = new Mock<ILoggerFactory>();
+        _mockLoggerFactory.Setup(f => f.CreateLogger(It.IsAny<string>()))
+            .Returns(new TestLogger<FeedbackClassifierService>());
         
         // Set up a fake tsp project path for mocked tests
         _specRepoRoot = Path.Combine(Path.GetTempPath(), "test-spec-repo-" + Guid.NewGuid().ToString("N")[..8]);
@@ -73,8 +77,6 @@ public class FeedbackClassifierServiceTests
     [TearDown]
     public void TearDown()
     {
-        _loggerFactory?.Dispose();
-        
         // Clean up temp files
         if (Directory.Exists(_specRepoRoot))
         {
@@ -88,7 +90,7 @@ public class FeedbackClassifierServiceTests
     {
         return new FeedbackClassifierService(
             _mockAgentRunner.Object,
-            _loggerFactory,
+            _mockLoggerFactory.Object,
             _mockTypeSpecHelper.Object);
     }
 
@@ -133,9 +135,13 @@ public class FeedbackClassifierServiceTests
             tokenUsageHelper,
             new TestLogger<CopilotAgentRunner>());
 
+        var mockLoggerFactory = new Mock<ILoggerFactory>();
+        mockLoggerFactory.Setup(f => f.CreateLogger(It.IsAny<string>()))
+            .Returns(new TestLogger<FeedbackClassifierService>());
+
         return new FeedbackClassifierService(
             copilotAgentRunner,
-            LoggerFactory.Create(builder => builder.AddConsole()),
+            mockLoggerFactory.Object,
             typeSpecHelper);
     }
 
@@ -374,13 +380,9 @@ public class FeedbackClassifierServiceTests
     /// - REQUIRES_MANUAL_INTERVENTION: Code-level changes (custom retry, serialization)
     /// </summary>
     [Test]
+    [Category(Integration)]
     public async Task Live_ClassifyAsync_AllFeedbackCategories_ClassifiesCorrectly()
     {
-        if (!await CopilotTestHelper.IsCopilotAvailableAsync())
-        {
-            Assert.Ignore("Skipping test as GitHub Copilot CLI is either not installed or not authenticated.");
-        }
-
         var service = CreateRealService();
 
         var items = new List<FeedbackItem>
@@ -439,13 +441,9 @@ public class FeedbackClassifierServiceTests
     /// This represents a retry scenario where previous TypeSpec customization attempt failed.
     /// </summary>
     [Test]
+    [Category(Integration)]
     public async Task Live_ClassifyAsync_WithErrorContext_ClassifiedAsRequiresManualIntervention()
     {
-        if (!await CopilotTestHelper.IsCopilotAvailableAsync())
-        {
-            Assert.Ignore("Skipping test as GitHub Copilot CLI is either not installed or not authenticated.");
-        }
-
         var service = CreateRealService();
 
         // Represents a retry scenario: originally TSP_APPLICABLE but failed compilation
@@ -478,13 +476,9 @@ public class FeedbackClassifierServiceTests
     /// Note: NextAction guidance generation was removed.
     /// </summary>
     [Test]
+    [Category(Integration)]
     public async Task Live_ClassifyAsync_RequiresManualInterventionItems_ClassifiedCorrectly()
     {
-        if (!await CopilotTestHelper.IsCopilotAvailableAsync())
-        {
-            Assert.Ignore("Skipping test as GitHub Copilot CLI is either not installed or not authenticated.");
-        }
-
         var service = CreateRealService();
 
         // Request that requires code-level SDK implementation - no TypeSpec decorator can address

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/FeedbackClassifierServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/FeedbackClassifierServiceTests.cs
@@ -379,8 +379,8 @@ public class FeedbackClassifierServiceTests
     /// - SUCCESS: Non-actionable (LGTM, keep as is, approvals)
     /// - REQUIRES_MANUAL_INTERVENTION: Code-level changes (custom retry, serialization)
     /// </summary>
-    [Test]
-    [Category(Integration)]
+    [Test, Explicit]
+    [Category(CopilotAgent)]
     public async Task Live_ClassifyAsync_AllFeedbackCategories_ClassifiesCorrectly()
     {
         var service = CreateRealService();
@@ -440,8 +440,8 @@ public class FeedbackClassifierServiceTests
     /// Live test: Verifies items with prior compilation error context are classified as REQUIRES_MANUAL_INTERVENTION.
     /// This represents a retry scenario where previous TypeSpec customization attempt failed.
     /// </summary>
-    [Test]
-    [Category(Integration)]
+    [Test, Explicit]
+    [Category(CopilotAgent)]
     public async Task Live_ClassifyAsync_WithErrorContext_ClassifiedAsRequiresManualIntervention()
     {
         var service = CreateRealService();
@@ -475,8 +475,8 @@ public class FeedbackClassifierServiceTests
     /// Live test: Verifies REQUIRES_MANUAL_INTERVENTION items are classified correctly.
     /// Note: NextAction guidance generation was removed.
     /// </summary>
-    [Test]
-    [Category(Integration)]
+    [Test, Explicit]
+    [Category(CopilotAgent)]
     public async Task Live_ClassifyAsync_RequiresManualInterventionItems_ClassifiedCorrectly()
     {
         var service = CreateRealService();

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/Go/GoLanguageServicesToolingTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/Go/GoLanguageServicesToolingTests.cs
@@ -127,7 +127,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
         }
 
         [Test]
-        [Category(Integration)]
+        [Category(RequiresGoTooling)]
         public async Task TestGoLanguageLinting()
         {
             var goRepoRoot = Environment.GetEnvironmentVariable("AZSDK_CLI_TEST_AZSDKGO")
@@ -144,7 +144,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
         }
 
         [Test]
-        [Category(Integration)]
+        [Category(RequiresGoTooling)]
         public async Task TestGetPackageInfo()
         {
             var actualSdkRepo = Environment.GetEnvironmentVariable("AZSDK_CLI_TEST_AZSDKGO")

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/Go/GoLanguageServicesToolingTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/Go/GoLanguageServicesToolingTests.cs
@@ -12,6 +12,7 @@ using static Azure.Sdk.Tools.Cli.Tests.TestHelpers.TestCategories;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Services
 {
+    [Explicit]
     [Category(RequiresGoTooling)]
     internal class GoLanguageServicesToolingTests
     {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/Go/GoLanguageServicesToolingTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/Go/GoLanguageServicesToolingTests.cs
@@ -12,7 +12,6 @@ using static Azure.Sdk.Tools.Cli.Tests.TestHelpers.TestCategories;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Services
 {
-    [Explicit]
     [Category(RequiresGoTooling)]
     internal class GoLanguageServicesToolingTests
     {
@@ -55,7 +54,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
             tempDir.Dispose();
         }
 
-        [Test]
+        [Test, Explicit]
         public async Task TestGoLanguageSpecificChecksBasic()
         {
             await File.WriteAllTextAsync(Path.Combine(packagePath, "main.go"), """
@@ -107,7 +106,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
             Assert.That(resp.ExitCode, Is.EqualTo(0));
         }
 
-        [Test]
+        [Test, Explicit]
         public async Task TestGoLanguageSpecificChecksCompileErrors()
         {
             await File.WriteAllTextAsync(Path.Combine(packagePath, "main.go"), """
@@ -126,7 +125,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
             });
         }
 
-        [Test]
+        [Test, Explicit]
         [Category(RequiresGoTooling)]
         public async Task TestGoLanguageLinting()
         {
@@ -143,7 +142,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
             });
         }
 
-        [Test]
+        [Test, Explicit]
         [Category(RequiresGoTooling)]
         public async Task TestGetPackageInfo()
         {
@@ -200,7 +199,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
             });
         }
 
-        [Test]
+        [Test, Explicit]
         public async Task TestLegacyGoMod()
         {
             using var tempFolder = TempDirectory.Create("legacy_go_mod");
@@ -235,7 +234,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
             Assert.That(version, Is.EqualTo(Version.Parse("1.23.0")));
         }
 
-        [Test]
+        [Test, Explicit]
         public void TestGetGoModVersionAsync()
         {
             using var tempDir = TempDirectory.Create("go_mod_test");
@@ -245,7 +244,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
             Assert.ThrowsAsync(typeof(Exception), async () => await GoLanguageService.GetGoModVersionAsync(goModPath));
         }
 
-        [Test]
+        [Test, Explicit]
         public async Task TestGetSubPath()
         {
             var subPath = await LangService.GetSubPath(packagePath);
@@ -271,7 +270,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
 
         #region HasCustomizations Tests
 
-        [Test]
+        [Test, Explicit]
         public void HasCustomizations_ReturnsPath_WhenInternalGenerateDirectoryExists()
         {
             var customizationDir = Path.Combine(packagePath, "internal", "generate");
@@ -283,7 +282,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
             Assert.That(result, Is.EqualTo(customizationDir));
         }
 
-        [Test]
+        [Test, Explicit]
         public void HasCustomizations_ReturnsPath_WhenTestdataGenerateDirectoryExists()
         {
             var customizationDir = Path.Combine(packagePath, "testdata", "generate");
@@ -295,7 +294,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
             Assert.That(result, Is.EqualTo(customizationDir));
         }
 
-        [Test]
+        [Test, Explicit]
         public void HasCustomizations_ReturnsNull_WhenNoCustomizationDirectoryExists()
         {
             // packagePath is already created without customization directories

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/Go/GoLanguageServicesToolingTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/Go/GoLanguageServicesToolingTests.cs
@@ -8,8 +8,11 @@ using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
+using static Azure.Sdk.Tools.Cli.Tests.TestHelpers.TestCategories;
+
 namespace Azure.Sdk.Tools.Cli.Tests.Services
 {
+    [Category(RequiresGoTooling)]
     internal class GoLanguageServicesToolingTests
     {
         private TempDirectory tempDir = null!;
@@ -18,8 +21,6 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
         private static string GoProgram => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "go.exe" : "go";
 
         private GoLanguageService LangService { get; set; } = null!;
-
-        private readonly Version goMinimumVersion = Version.Parse("1.24");
 
         [SetUp]
         public async Task SetUp()
@@ -44,20 +45,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
                 Mock.Of<ISpecGenSdkConfigHelper>(),
                 Mock.Of<IChangelogHelper>());
 
-            if (!await LangService.CheckDependencies(CancellationToken.None))
-            {
-                Assert.Ignore("golang tooling dependencies are not installed, can't run GoLanguageSpecificChecksTests");
-            }
-
             await LangService.CreateEmptyPackage(packagePath, "github.com/Azure/azure-sdk-for-go/sdk/template/aztemplate", CancellationToken.None);
-
-            // check that our current version of Go is new enough for these tests.
-            var version = await GoLanguageService.GetGoModVersionAsync(Path.Join(packagePath, "go.mod"));
-
-            if (version.CompareTo(goMinimumVersion) < 0)
-            {
-                Assert.Ignore($"You'll need Go {goMinimumVersion}+, in the path, for these tests");
-            }
         }
 
         [TearDown]
@@ -109,7 +97,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
             Assert.That(identityLine, Is.Not.EqualTo("github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.0"), "go get updates dependencies properly");
 
             var currentVersion = await GoLanguageService.GetGoModVersionAsync(goModPath);
-            Assert.That(currentVersion, Is.GreaterThanOrEqualTo(goMinimumVersion));
+            Assert.That(currentVersion, Is.GreaterThanOrEqualTo(Version.Parse("1.24")));
 
             resp = await LangService.FormatCode(packagePath, false, CancellationToken.None);
             Assert.That(resp.ExitCode, Is.EqualTo(0));
@@ -138,9 +126,11 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
         }
 
         [Test]
+        [Category(Integration)]
         public async Task TestGoLanguageLinting()
         {
-            var goRepoRoot = IgnoreTestIfRepoNotConfigured();
+            var goRepoRoot = Environment.GetEnvironmentVariable("AZSDK_CLI_TEST_AZSDKGO")
+                ?? throw new InconclusiveException("AZSDK_CLI_TEST_AZSDKGO is not set to a Go repo path");
 
             var resp = await LangService.LintCode(Path.Join(goRepoRoot, "sdk", "template", "aztemplate"));
 
@@ -153,9 +143,11 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
         }
 
         [Test]
+        [Category(Integration)]
         public async Task TestGetPackageInfo()
         {
-            var actualSdkRepo = IgnoreTestIfRepoNotConfigured();
+            var actualSdkRepo = Environment.GetEnvironmentVariable("AZSDK_CLI_TEST_AZSDKGO")
+                ?? throw new InconclusiveException("AZSDK_CLI_TEST_AZSDKGO is not set to a Go repo path");
             var fullPackagePath = Path.Join(actualSdkRepo, "sdk/messaging/azservicebus");
             var packageInfo = await LangService.GetPackageInfo(fullPackagePath);
 
@@ -260,24 +252,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
         }
 
         /// <summary>
-        /// Ignores the test if you don't have a path to a real Go repo configured.
+        /// Creates a test Go package at the given directory with a go.mod and internal/version.go.
         /// </summary>
-        /// <returns></returns>
-        private static string IgnoreTestIfRepoNotConfigured()
-        {
-            // Setting this lets you run tests that require a live environment.
-            const string GoLiveTestVarName = "AZSDK_CLI_TEST_AZSDKGO";
-            var actualSdkRepo = Environment.GetEnvironmentVariable(GoLiveTestVarName);
-
-            if (actualSdkRepo != null)
-            {
-                return actualSdkRepo;
-            }
-
-            Assert.Ignore("Live testing disabled for GoLanguageServiceTests: AZSDK_CLI_TEST_AZSDKGO is not set to a Go repo path");
-            return "";
-        }
-
         private static async Task CreateTestGoPackageAsync(string packageDirectory, string modulePath)
         {
             Directory.CreateDirectory(packageDirectory);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/TypeSpec/TypeSpecCustomizationServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/TypeSpec/TypeSpecCustomizationServiceTests.cs
@@ -9,6 +9,8 @@ using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 using GitHub.Copilot.SDK;
 using Moq;
 
+using static Azure.Sdk.Tools.Cli.Tests.TestHelpers.TestCategories;
+
 namespace Azure.Sdk.Tools.Cli.Tests.Services.TypeSpec;
 
 /// <summary>
@@ -63,14 +65,9 @@ internal class TypeSpecCustomizationServiceTests
     /// Will be skipped if Copilot is not available.
     /// </summary>
     [Test]
-    [Explicit]  // Mark as explicit/manual because this test takes 26 seconds
+    [Category(Integration)]
     public async Task ApplyCustomization_WithRealCopilotSdk_CompletesSuccessfully()
     {
-        if (!await CopilotTestHelper.IsCopilotAvailableAsync())
-        {
-            Assert.Ignore("Skipping test as GitHub Copilot CLI is either not installed or not authenticated.");
-        }
-
         var logger = new TestLogger<TypeSpecCustomizationService>();
         var rawOutputHelper = Mock.Of<IRawOutputHelper>();
         var npxHelper = new NpxHelper(

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/TypeSpec/TypeSpecCustomizationServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/TypeSpec/TypeSpecCustomizationServiceTests.cs
@@ -64,8 +64,8 @@ internal class TypeSpecCustomizationServiceTests
     /// Requires GitHub Copilot CLI to be installed and authenticated.
     /// Will be skipped if Copilot is not available.
     /// </summary>
-    [Test]
-    [Category(Integration)]
+    [Test, Explicit]
+    [Category(CopilotAgent)]
     public async Task ApplyCustomization_WithRealCopilotSdk_CompletesSuccessfully()
     {
         var logger = new TestLogger<TypeSpecCustomizationService>();

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/TypeSpec/TypeSpecCustomizationServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/TypeSpec/TypeSpecCustomizationServiceTests.cs
@@ -62,7 +62,6 @@ internal class TypeSpecCustomizationServiceTests
     /// <summary>
     /// Live integration test that makes actual LLM calls through the GitHub Copilot SDK.
     /// Requires GitHub Copilot CLI to be installed and authenticated.
-    /// Will be skipped if Copilot is not available.
     /// </summary>
     [Test, Explicit]
     [Category(CopilotAgent)]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/TestHelpers/TestCategories.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/TestHelpers/TestCategories.cs
@@ -34,7 +34,7 @@ public static class TestCategories
 
     /// <summary>
     /// Evaluation tests that require Azure OpenAI, MCP server, and related env vars.
-    /// Defined in the Evaluations project's Scenario base class.
+    /// Used to categorize evaluation scenarios in the Evaluations project.
     /// </summary>
     public const string Evals = "Evals";
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/TestHelpers/TestCategories.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/TestHelpers/TestCategories.cs
@@ -11,8 +11,19 @@ namespace Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 public static class TestCategories
 {
     /// <summary>
-    /// Tests that call real external services (GitHub Copilot LLM, Azure OpenAI, etc.)
-    /// and require authentication / network access.
+    /// Tests that call real GitHub Copilot Agent / LLM endpoints
+    /// and require the Copilot CLI to be installed and authenticated.
+    /// </summary>
+    public const string CopilotAgent = "CopilotAgent";
+
+    /// <summary>
+    /// Tests that call real Azure OpenAI endpoints
+    /// and require AZURE_OPENAI_ENDPOINT (and related env vars) to be set.
+    /// </summary>
+    public const string OpenAI = "OpenAI";
+
+    /// <summary>
+    /// Tests that require a real SDK repository clone and related env vars.
     /// </summary>
     public const string Integration = "Integration";
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/TestHelpers/TestCategories.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/TestHelpers/TestCategories.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Sdk.Tools.Cli.Tests.TestHelpers;
+
+/// <summary>
+/// Constants for NUnit test categories used to filter tests.
+/// Use with [Category(TestCategories.XYZ)] to mark tests.
+/// Filter at the CLI: dotnet test --filter "Category!=Integration"
+/// </summary>
+public static class TestCategories
+{
+    /// <summary>
+    /// Tests that call real external services (GitHub Copilot LLM, Azure OpenAI, etc.)
+    /// and require authentication / network access.
+    /// </summary>
+    public const string Integration = "Integration";
+
+    /// <summary>
+    /// Tests that require Go tooling (go CLI) to be installed and at a minimum version.
+    /// </summary>
+    public const string RequiresGoTooling = "RequiresGoTooling";
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/TestHelpers/TestCategories.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/TestHelpers/TestCategories.cs
@@ -6,7 +6,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 /// <summary>
 /// Constants for NUnit test categories used to filter tests.
 /// Use with [Category(TestCategories.XYZ)] to mark tests.
-/// Filter at the CLI: dotnet test --filter "Category!=Integration"
+/// Filter at the CLI: dotnet test --filter "Category==Evals"
 /// </summary>
 public static class TestCategories
 {
@@ -23,12 +23,18 @@ public static class TestCategories
     public const string OpenAI = "OpenAI";
 
     /// <summary>
-    /// Tests that require a real SDK repository clone and related env vars.
+    /// Tests that require real/mock data upstream in devops work items
     /// </summary>
-    public const string Integration = "Integration";
+    public const string ReleasePlan = "ReleasePlan";
 
     /// <summary>
     /// Tests that require Go tooling (go CLI) to be installed and at a minimum version.
     /// </summary>
     public const string RequiresGoTooling = "RequiresGoTooling";
+
+    /// <summary>
+    /// Evaluation tests that require Azure OpenAI, MCP server, and related env vars.
+    /// Defined in the Evaluations project's Scenario base class.
+    /// </summary>
+    public const string Evals = "Evals";
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Generators/ReadMeGeneratorToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Generators/ReadMeGeneratorToolTests.cs
@@ -8,6 +8,8 @@ using Azure.Sdk.Tools.Cli.Telemetry;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Tests.Mocks.Services;
 
+using static Azure.Sdk.Tools.Cli.Tests.TestHelpers.TestCategories;
+
 namespace Azure.Sdk.Tools.Cli.Tests.Tools.Generators
 {
     internal class ReadMeGeneratorToolTests
@@ -68,21 +70,14 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.Generators
         }
 
         [Test]
+        [Category(Integration)]
         public void TestReadmeGeneratorToolLive()
         {
-            var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT");
+            var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")
+                ?? throw new InconclusiveException("AZURE_OPENAI_ENDPOINT is not set");
 
-            if (endpoint == null)
-            {
-                Assert.Ignore("Skipping test as AZURE_OPENAI_ENDPOINT is not set");
-            }
-
-            var languageRepo = Environment.GetEnvironmentVariable("AZURE_SDK_FOR_GO_PATH");
-
-            if (languageRepo == null)
-            {
-                Assert.Ignore("Skipping test as AZURE_SDK_FOR_GO_PATH is not set");
-            }
+            var languageRepo = Environment.GetEnvironmentVariable("AZURE_SDK_FOR_GO_PATH")
+                ?? throw new InconclusiveException("AZURE_SDK_FOR_GO_PATH is not set");
 
             var command = tool.GetCommandInstances().First();
             var readmeOutputPath = Path.GetTempFileName();

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Generators/ReadMeGeneratorToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Generators/ReadMeGeneratorToolTests.cs
@@ -71,7 +71,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.Generators
         [Category(TestCategories.OpenAI)]
         public void TestReadmeGeneratorToolLive()
         {
-            var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")
+            var _ = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")
                 ?? throw new InconclusiveException("AZURE_OPENAI_ENDPOINT is not set");
 
             var languageRepo = Environment.GetEnvironmentVariable("AZURE_SDK_FOR_GO_PATH")

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Generators/ReadMeGeneratorToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Generators/ReadMeGeneratorToolTests.cs
@@ -8,8 +8,6 @@ using Azure.Sdk.Tools.Cli.Telemetry;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Tests.Mocks.Services;
 
-using static Azure.Sdk.Tools.Cli.Tests.TestHelpers.TestCategories;
-
 namespace Azure.Sdk.Tools.Cli.Tests.Tools.Generators
 {
     internal class ReadMeGeneratorToolTests
@@ -69,8 +67,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.Generators
             }
         }
 
-        [Test]
-        [Category(Integration)]
+        [Test, Explicit]
+        [Category(TestCategories.OpenAI)]
         public void TestReadmeGeneratorToolLive()
         {
             var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanManualTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanManualTests.cs
@@ -12,6 +12,8 @@ using Azure.Sdk.Tools.Cli.Tools.ReleasePlan;
 using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Helpers;
 using Moq;
 
+using static Azure.Sdk.Tools.Cli.Tests.TestHelpers.TestCategories;
+
 namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
 {
     internal class ReleasePlanManualTests
@@ -59,8 +61,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             releasePlan = new ReleasePlanTool(devOpsService, gitHelper, typeSpecHelper, logger, userHelper, gitHubService, environmentHelper, inputSanitizer, httpClient, Mock.Of<INpxHelper>());
         }
 
-        [Test] // disabled by default because it makes real API calls
-        [Ignore("Manual test - requires real API calls")]
+        [Test, Explicit]
+        [Category(TestCategories.ReleasePlan)]
         public async Task Test_UpdateExclusionJustification()
         {
             int releasePlanWorkItemId = 28940; // replace with a real release plan ID
@@ -73,8 +75,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             Assert.That(exclusionJustification, Is.EqualTo(releasePlanInfo.LanguageExclusionRequesterNote));
         }
 
-        [Test] // disabled by default because it makes real API calls
-        [Ignore("Manual test - requires real API calls")]
+        [Test, Explicit]
+        [Category(TestCategories.ReleasePlan)]
         public async Task Test_UpdateExclusionJustificationWithLanguage()
         {
             int releasePlanWorkItemId = 28940; // replace with a real release plan ID
@@ -88,14 +90,14 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         }
 
 
-        [Test] // disabled by default because it makes real API calls
-        [Ignore("Manual test - requires real API calls")]
+        [Test, Explicit]
+        [Category(TestCategories.ReleasePlan)]
         public async Task Test_Get_ReleaseExclusionStatus()
         {
             int releasePlan = 28940; // replace with a real release plan ID
             var releasePlanInfo = await this.devOpsService.GetReleasePlanForWorkItemAsync(releasePlan);
             Assert.IsNotNull(releasePlanInfo);
-            
+
             var pythonSdk = releasePlanInfo.SDKInfo.FirstOrDefault(sdk => sdk.Language.Equals("Python", StringComparison.OrdinalIgnoreCase));
             Assert.IsNotNull(pythonSdk);
             Assert.That(pythonSdk.ReleaseExclusionStatus, Is.EqualTo("Requested"));

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanManualTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanManualTests.cs
@@ -1,18 +1,8 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Azure.Sdk.Tools.Cli.Helpers;
-using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Services;
-using Azure.Sdk.Tools.Cli.Tests.Mocks.Services;
 using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 using Azure.Sdk.Tools.Cli.Tools.ReleasePlan;
-using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Helpers;
 using Moq;
-
-using static Azure.Sdk.Tools.Cli.Tests.TestHelpers.TestCategories;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
 {


### PR DESCRIPTION
Running `dotnet test` in the solution root has started to take over 70 seconds due to the inclusion of evals, other integration tests, and sleeps. Additionally there is a ton of noisy output from tests, either due to skip conditions or places that aren't using `TestLogger` or a mocked logger.

This PR moves all integration tests that require specific environment setup into their own test categories that can be run with `dotnet test --filter 'Category==<FOO>'` and fixes the output noise. Unfortunately when using `[Explicit]` in nunit it will still print all the test names that were excluded, but I think this is an ok start.

@samvaity @praveenkuttappan @jeo02 This PR changes how the eval tests are invoked (`dotnet test --filter 'Category==Evals'`) so let me know if you have issues with this. There are some other alternatives I have in mind as well.