### PR TITLE
[APIView] Make tabs border match other bars

### DIFF
--- a/src/dotnet/APIView/ClientSPA/src/app/_components/shared/review-page-layout/review-page-layout.component.scss
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/shared/review-page-layout/review-page-layout.component.scss
@@ -4,7 +4,8 @@
         display: flex;
         align-items: center;
         gap: 0;
-        border-bottom: 1px solid var(--border-color);
+        border: 1px solid var(--border-color);
+        border-radius: 6px;
         background: var(--base-fg-color);
         padding: 0 0.5rem;
     }


### PR DESCRIPTION
<img width="390" height="125" alt="image" src="https://github.com/user-attachments/assets/f78bd947-3cad-456b-9cb6-6b3e212fb468" />

Makes the API/Comments/Samples bar have the same border style as other places. 