### PR TITLE
[azsdk] Skip copilot-cli auto-bundling in CI

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.Agents.Persistent" Version="1.2.0-beta.5" />
-    <PackageReference Include="GitHub.Copilot.SDK" Version="0.1.29" />
+    <PackageReference Include="GitHub.Copilot.SDK" Version="0.1.32" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.5.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.12.0" />
     <PackageReference Include="Microsoft.Graph" Version="5.79.0" />
@@ -86,5 +86,11 @@
   <Delete Files="$(PublishDir)$(AssemblyName).staticwebassets.endpoints.json" Condition="Exists('$(PublishDir)$(AssemblyName).staticwebassets.endpoints.json')" />
   </Target>
   <!-- END Exclude asp net configs from release archives -->
+
+  <!-- The default auto-bundling breaks CI due to networking/compliance constraints -->
+  <!-- See https://github.com/github/copilot-sdk/pull/494 -->
+  <PropertyGroup Condition="'$(TF_BUILD)' == 'True'">
+    <CopilotSkipCliDownload>true</CopilotSkipCliDownload>
+  </PropertyGroup>
 
 </Project>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CopilotAgents/CopilotAgentRunner.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CopilotAgents/CopilotAgentRunner.cs
@@ -99,7 +99,7 @@ public class CopilotAgentRunner(
             OnPermissionRequest = (request, invocation) =>
             {
                 logger.LogDebug("Auto-approving permission request for tool execution");
-                return Task.FromResult(new PermissionRequestResult { Kind = "approved" });
+                return Task.FromResult(new PermissionRequestResult { Kind = PermissionRequestResultKind.Approved });
             }
         };
 
@@ -156,14 +156,14 @@ public class CopilotAgentRunner(
             sessionError = null; // Reset error state for each iteration
 
             logger.LogDebug("Sending message iteration {Iteration}", iterations);
-            
+
             // Create TCS before sending to ensure we don't miss the event
             sessionIdleTcs = new TaskCompletionSource();
-            
+
             // SendAsync returns the message ID but doesn't wait for processing
             // We need to wait for SessionIdleEvent to know when the agent is done
             await session.SendAsync(new MessageOptions { Prompt = prompt }, ct);
-            
+
             // Wait for the session to become idle (all tool calls completed)
             // Use cancellation-aware wait with timeout to prevent indefinite hangs
             logger.LogDebug("Waiting for session to become idle...");
@@ -197,13 +197,13 @@ public class CopilotAgentRunner(
                     throw new InvalidOperationException(
                         $"Agent failed to call Exit tool after {maxExitRetries} reminders");
                 }
-                logger.LogWarning("Agent completed without calling Exit tool (attempt {Attempt}/{Max}). Prompting to call Exit.", 
+                logger.LogWarning("Agent completed without calling Exit tool (attempt {Attempt}/{Max}). Prompting to call Exit.",
                     exitRetries, maxExitRetries);
                 prompt = "You did not call the Exit tool. You are running autonomously and must not ask for user input or confirmation. " +
                          "If the task is incomplete, continue working. If the task is complete, call the Exit tool with your result now.";
                 continue;
             }
-            
+
             // Reset exit retries on successful Exit call
             exitRetries = 0;
 

--- a/tools/azsdk-cli/ci.yml
+++ b/tools/azsdk-cli/ci.yml
@@ -31,6 +31,17 @@ extends:
     VerifyChangelog: true
     # GitHub.Copilot.SDK dependency is not strong name signed. Skip validation in order to sign azsdk cli.
     RequireStrongNames: false
+    # Install copilot-cli separately from the copilot agent sdk.
+    # We skip the auto-bundling due to network/compliance restrictions
+    TestPreSteps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '24.x'
+        displayName: Install Node.js
+      - script: |
+          npm install --global @github/copilot@1.0.5  --registry https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-tools/npm/registry/
+          copilot --version
+        displayName: Install Copilot CLI
     StandaloneExeMatrix:
       - rid: linux-x64
         framework: net8.0


### PR DESCRIPTION
The npm package download component of the copilot agent build is causing issues on our pipeline runners due to network restrictions. This PR updates CI and the csproj to install copilot-cli separately.

> error MSB3923: Failed to download file "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-0.0.420.tgz".  Permission denied (registry.npmjs.org:443) ---> Permission denied [/mnt/vss/_work/1/s/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj]
