### PR TITLE
Add create-authenticated-npmrc step to emitter archetype

### DIFF
--- a/eng/common/pipelines/templates/archetype-typespec-emitter.yml
+++ b/eng/common/pipelines/templates/archetype-typespec-emitter.yml
@@ -101,12 +101,18 @@ extends:
       pool: ${{ parameters.Pool }}
       jobs:
       - job: Build
+        variables:
+          emitterNpmrcPath: $(Agent.TempDirectory)/${{ parameters.EmitterPackagePath }}/.npmrc
         steps:
         - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
           parameters:
             Paths: ${{ parameters.SparseCheckoutPaths }}
 
         - ${{ parameters.InitializationSteps }}
+
+        - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+          parameters:
+            npmrcPath: $(emitterNpmrcPath)
 
         # Initialize-WorkingDirectory.ps1 is responsible for setting the emitterVersion output variable.
         - task: PowerShell@2
@@ -126,6 +132,8 @@ extends:
                 -OutputDirectory "$(Build.ArtifactStagingDirectory)"
                 -UseTypeSpecNext:$${{ parameters.UseTypeSpecNext }}
                 -EmitterPackagePath:${{ parameters.EmitterPackagePath }}
+          env:
+            NPM_CONFIG_USERCONFIG: $(emitterNpmrcPath)
 
         - task: PowerShell@2
           displayName: 'Run build script'
@@ -137,6 +145,8 @@ extends:
               -TargetNpmJsFeed:$${{ parameters.PublishPublic }}
               -EmitterPackagePath:${{ parameters.EmitterPackagePath }}
               -GeneratorVersion: $(initialize.emitterVersion)
+          env:
+            NPM_CONFIG_USERCONFIG: $(emitterNpmrcPath)
 
         - pwsh: |
             $sourceBranch = '$(Build.SourceBranch)'
@@ -288,6 +298,7 @@ extends:
           pullRequestTargetBranch: 'main'
           buildArtifactsPath: $(Pipeline.Workspace)/build_artifacts
           branchName: $[stageDependencies.Build.Build.outputs['set_branch_name.branchName']]
+          tspClientNpmrcPath: $(Agent.TempDirectory)/tsp-client/.npmrc
         pool: ${{ parameters.Pool }}
         jobs:
         - job: Initialize
@@ -302,10 +313,16 @@ extends:
           - download: current
             displayName: Download pipeline artifacts
 
+          - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+            parameters:
+              npmrcPath: $(tspClientNpmrcPath)
+
           - pwsh: |
               npm ci
             displayName: Install tsp-client
             workingDirectory: $(Build.SourcesDirectory)/eng/common/tsp-client
+            env:
+              NPM_CONFIG_USERCONFIG: $(tspClientNpmrcPath)
 
           - pwsh: |
               # Resolve EmitterPackageJsonOutputPath to absolute path if it's relative
@@ -331,6 +348,8 @@ extends:
               }
             displayName: Generate emitter-package.json and emitter-package-lock files
             workingDirectory: $(Build.SourcesDirectory)/eng/common/tsp-client
+            env:
+              NPM_CONFIG_USERCONFIG: $(tspClientNpmrcPath)
 
           - ${{ parameters.InitializationSteps }}
 
@@ -372,6 +391,7 @@ extends:
           variables:
             matrixArtifactsPath: $(Pipeline.Workspace)/matrix_artifacts
             AzureSdkRepoName: $[format('azure-sdk/{0}', split(variables['Build.Repository.Name'], '/')[1])]
+            emitterNpmrcPath: $(Agent.TempDirectory)/${{ parameters.EmitterPackagePath }}/.npmrc
           steps:
           - checkout: self
           - pwsh: |
@@ -390,6 +410,10 @@ extends:
 
           - ${{ parameters.InitializationSteps }}
 
+          - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+            parameters:
+              npmrcPath: $(emitterNpmrcPath)
+
           - task: PowerShell@2
             displayName: Call regeneration script
             inputs:
@@ -399,6 +423,8 @@ extends:
                 -PackageDirectoriesFile "$(matrixArtifactsPath)/$(DirectoryList)"
               workingDirectory: $(Build.SourcesDirectory)
             continueOnError: true
+            env:
+              NPM_CONFIG_USERCONFIG: $(emitterNpmrcPath)
 
           - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
             parameters:
@@ -529,6 +555,7 @@ extends:
             matrix: ${{ parameters.TestMatrix }}
           variables:
             buildArtifactsPath: $(Pipeline.Workspace)/build_artifacts
+            emitterNpmrcPath: $(Agent.TempDirectory)/${{ parameters.EmitterPackagePath }}/.npmrc
           steps:
           - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
             parameters:
@@ -540,6 +567,10 @@ extends:
 
           - ${{ parameters.InitializationSteps }}
 
+          - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+            parameters:
+              npmrcPath: $(emitterNpmrcPath)
+
           - task: PowerShell@2
             displayName: 'Run initialize script'
             inputs:
@@ -548,6 +579,8 @@ extends:
               arguments: > 
                 -BuildArtifactsPath '$(buildArtifactsPath)/lock-files'
                 -EmitterPackagePath: ${{ parameters.EmitterPackagePath }}
+            env:
+              NPM_CONFIG_USERCONFIG: $(emitterNpmrcPath)
 
           - task: PowerShell@2
             displayName: 'Run test script'
@@ -558,6 +591,8 @@ extends:
                 $(TestArguments)
                 -OutputDirectory "$(Build.ArtifactStagingDirectory)"
                 -EmitterPackagePath: ${{ parameters.EmitterPackagePath }}
+            env:
+              NPM_CONFIG_USERCONFIG: $(emitterNpmrcPath)
 
           - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
             parameters:


### PR DESCRIPTION
npm does not walk up directories to find .npmrc, so create the .npmrc dynamically in each emitter package directory before running Initialize-WorkingDirectory.ps1 which invokes npm ci/install.