### PR TITLE
[azsdk] Output CLI logs to stderr

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Extensions/LoggingExtensions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Extensions/LoggingExtensions.cs
@@ -46,14 +46,10 @@ public static class LoggingExtensions
         }
     }
 
-    public static void ConfigureDefaultLogging(this IServiceCollection services, LogLevel logLevel, bool isCommandLine, bool debug = false)
+    public static void ConfigureDefaultLogging(this IServiceCollection services, LogLevel logLevel)
     {
         services.AddLogging(logging =>
         {
-            if (isCommandLine)
-            {
-                AddCliConsoleLogger(logging, debug);
-            }
             logging.SetMinimumLevel(logLevel);
         });
     }
@@ -65,7 +61,7 @@ public static class LoggingExtensions
             // Debug mode: use built-in SimpleConsole formatter (shows level + category + message)
             builder.AddSimpleConsole(options =>
             {
-                options.ColorBehavior = LoggerColorBehavior.Enabled;
+                options.ColorBehavior = LoggerColorBehavior.Default;
             });
         }
         else

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Extensions/LoggingExtensions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Extensions/LoggingExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.Extensions.Logging.Console;
+using Azure.Sdk.Tools.Cli.Formatters;
 using Azure.Sdk.Tools.Cli.Helpers;
 
 namespace Azure.Sdk.Tools.Cli.Extensions;
@@ -21,7 +22,7 @@ public static class LoggingExtensions
     // startup errors, we wouldn't want to swallow those as it could make debugging difficult.
     // This is a filter to make sure that we hide all non-error logs but show all
     // asp.net server logs even if they can't be sent over the mcp protocol.
-    public static void ConfigureMcpConsoleFallbackLogging(this ILoggingBuilder builder, bool isCommandLine)
+    public static void ConfigureMcpConsoleFallbackLogging(this ILoggingBuilder builder, bool isCommandLine, bool debug = false)
     {
         if (!isCommandLine)
         {
@@ -39,22 +40,47 @@ public static class LoggingExtensions
         }
         else
         {
-            builder.AddConsole(consoleLogOptions =>
-            {
-                consoleLogOptions.LogToStandardErrorThreshold = LogLevel.Error;
-            });
+            // In CLI mode, route ALL log levels to stderr so stdout is
+            // reserved exclusively for the command response.
+            AddCliConsoleLogger(builder, debug);
         }
     }
 
-    public static void ConfigureDefaultLogging(this IServiceCollection services, LogLevel logLevel, bool isCommandLine)
+    public static void ConfigureDefaultLogging(this IServiceCollection services, LogLevel logLevel, bool isCommandLine, bool debug = false)
     {
         services.AddLogging(logging =>
         {
             if (isCommandLine)
             {
-                logging.AddConsole();
+                AddCliConsoleLogger(logging, debug);
             }
             logging.SetMinimumLevel(logLevel);
+        });
+    }
+
+    private static void AddCliConsoleLogger(ILoggingBuilder builder, bool debug)
+    {
+        if (debug)
+        {
+            // Debug mode: use built-in SimpleConsole formatter (shows level + category + message)
+            builder.AddSimpleConsole(options =>
+            {
+                options.ColorBehavior = LoggerColorBehavior.Enabled;
+            });
+        }
+        else
+        {
+            // Normal mode: use our custom formatter (message-only with color coding)
+            builder.AddConsoleFormatter<SimpleCliConsoleFormatter, ConsoleFormatterOptions>();
+        }
+
+        builder.AddConsole(consoleLogOptions =>
+        {
+            consoleLogOptions.LogToStandardErrorThreshold = LogLevel.Trace;
+            if (!debug)
+            {
+                consoleLogOptions.FormatterName = SimpleCliConsoleFormatter.FormatterName;
+            }
         });
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Formatters/SimpleCliConsoleFormatter.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Formatters/SimpleCliConsoleFormatter.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Options;
+
+namespace Azure.Sdk.Tools.Cli.Formatters;
+
+/// <summary>
+/// A console log formatter for CLI mode that outputs just the log message
+/// with ANSI color coding:
+///   - Info: default color
+///   - Warning: yellow
+///   - Error/Critical: red
+///
+/// In debug mode, the built-in SimpleConsole formatter is used instead.
+/// </summary>
+public sealed class SimpleCliConsoleFormatter : ConsoleFormatter, IDisposable
+{
+    public const string FormatterName = "simple-cli";
+
+    private const string AnsiReset = "\x1b[0m";
+    private const string AnsiYellow = "\x1b[33m";
+    private const string AnsiRed = "\x1b[31m";
+
+    private readonly IDisposable? _optionsReloadToken;
+    private ConsoleFormatterOptions _options;
+
+    public SimpleCliConsoleFormatter(IOptionsMonitor<ConsoleFormatterOptions> options)
+        : base(FormatterName)
+    {
+        _options = options.CurrentValue;
+        _optionsReloadToken = options.OnChange(updated => _options = updated);
+    }
+
+    public override void Write<TState>(
+        in LogEntry<TState> logEntry,
+        IExternalScopeProvider? scopeProvider,
+        TextWriter textWriter)
+    {
+        var message = logEntry.Formatter?.Invoke(logEntry.State, logEntry.Exception);
+        if (message is null)
+        {
+            return;
+        }
+
+        var (colorStart, colorEnd) = logEntry.LogLevel switch
+        {
+            LogLevel.Warning => (AnsiYellow, AnsiReset),
+            LogLevel.Error or LogLevel.Critical => (AnsiRed, AnsiReset),
+            _ => ((string?)null, (string?)null),
+        };
+
+        if (colorStart is not null)
+        {
+            textWriter.Write(colorStart);
+        }
+
+        textWriter.WriteLine(message);
+
+        if (logEntry.Exception is not null)
+        {
+            textWriter.WriteLine(logEntry.Exception.ToString());
+        }
+
+        if (colorEnd is not null)
+        {
+            textWriter.Write(colorEnd);
+        }
+    }
+
+    public void Dispose()
+    {
+        _optionsReloadToken?.Dispose();
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Formatters/SimpleCliConsoleFormatter.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Formatters/SimpleCliConsoleFormatter.cs
@@ -25,6 +25,7 @@ public sealed class SimpleCliConsoleFormatter : ConsoleFormatter, IDisposable
     private const string AnsiRed = "\x1b[31m";
 
     private readonly IDisposable? _optionsReloadToken;
+    private readonly bool _useColor;
     private ConsoleFormatterOptions _options;
 
     public SimpleCliConsoleFormatter(IOptionsMonitor<ConsoleFormatterOptions> options)
@@ -32,6 +33,7 @@ public sealed class SimpleCliConsoleFormatter : ConsoleFormatter, IDisposable
     {
         _options = options.CurrentValue;
         _optionsReloadToken = options.OnChange(updated => _options = updated);
+        _useColor = !Console.IsErrorRedirected;
     }
 
     public override void Write<TState>(
@@ -45,12 +47,12 @@ public sealed class SimpleCliConsoleFormatter : ConsoleFormatter, IDisposable
             return;
         }
 
-        var (colorStart, colorEnd) = logEntry.LogLevel switch
+        var (colorStart, colorEnd) = _useColor ? logEntry.LogLevel switch
         {
             LogLevel.Warning => (AnsiYellow, AnsiReset),
             LogLevel.Error or LogLevel.Critical => (AnsiRed, AnsiReset),
             _ => ((string?)null, (string?)null),
-        };
+        } : ((string?)null, (string?)null);
 
         if (colorStart is not null)
         {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/OutputHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/OutputHelper.cs
@@ -161,7 +161,7 @@ public class OutputHelper : IOutputHelper, IRawOutputHelper
     {
         if (OutputMode != OutputModes.Mcp && OutputMode != OutputModes.Hidden)
         {
-            Console.WriteLine(output);
+            Console.Error.WriteLine(output);
         }
     }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Program.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Program.cs
@@ -51,7 +51,7 @@ public class Program
         // In MCP server mode skip console output except for fatal server errors (which may happen
         // before the MCP logging transport is initialized).
         // All other logs will be redirected via the mcp logger over json-rpc to the mcp client only
-        builder.Logging.ConfigureMcpConsoleFallbackLogging(isCommandLine);
+        builder.Logging.ConfigureMcpConsoleFallbackLogging(isCommandLine, debug);
 
         // Skip azure client and noisy third-party logging
         builder.Logging.AddFilter((category, level) =>
@@ -73,7 +73,7 @@ public class Program
         });
 
         // add the console logger
-        builder.Services.ConfigureDefaultLogging(logLevel, isCommandLine);
+        builder.Services.ConfigureDefaultLogging(logLevel, isCommandLine, debug);
 
         var outputMode = !isCommandLine ? OutputHelper.OutputModes.Mcp : outputFormat switch
         {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Program.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Program.cs
@@ -72,8 +72,8 @@ public class Program
             return level >= logLevel;
         });
 
-        // add the console logger
-        builder.Services.ConfigureDefaultLogging(logLevel, isCommandLine, debug);
+        // Set the minimum log level
+        builder.Services.ConfigureDefaultLogging(logLevel);
 
         var outputMode = !isCommandLine ? OutputHelper.OutputModes.Mcp : outputFormat switch
         {


### PR DESCRIPTION
Output CLI logs to stderr. This is more conventional for CLI app design and will make it easier to store actual response output in variables and/or pipe `-o json` to pwsh/jq/etc.