### PR TITLE
resolve analyzer failure and support multiple os

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/Typespec/AuthoringScenario.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/Typespec/AuthoringScenario.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Azure.Sdk.Tools.Cli.Benchmarks.Infrastructure;
 using Azure.Sdk.Tools.Cli.Benchmarks.Models;
@@ -186,9 +187,11 @@ namespace Azure.Sdk.Tools.Cli.Benchmarks.Scenarios.Typespec
             await workspace.RunCommandAsync("pwsh", "./eng/common/mcp/azure-sdk-mcp.ps1", "-InstallDirectory", workspace.RootPath);
 
             // Configure the path to the installed MCP executable for this scenario
-            AzsdkMcpPath = Path.Combine(workspace.RootPath, "azsdk.exe");
+            // Check if running on Windows
+            bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            AzsdkMcpPath = Path.Combine(workspace.RootPath, isWindows ? "azsdk.exe" : "azsdk");
 
-            
+
             // TODO: Download and Start Azure Knowledge Base locally. Currently we need to manually start the Azure Knowledge Base server locally.
             //await workspace.RunCommandAsync("")
         }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Validation/Validators/VerifyResultWithAIValidate.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Validation/Validators/VerifyResultWithAIValidate.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Azure.Sdk.Tools.Cli.Benchmarks.Infrastructure;
 using Azure.Sdk.Tools.Cli.Benchmarks.Models;
 using GitHub.Copilot.SDK;
@@ -60,13 +55,13 @@ namespace Azure.Sdk.Tools.Cli.Benchmarks.Validation.Validators
                 }
             };
 
-            await using var session = await client.CreateSessionAsync(sessionConfig);
+            await using var session = await client.CreateSessionAsync(sessionConfig, cancellationToken);
 
             SessionConfigHelper.ConfigureAgentActivityLogging(session);
             // Send prompt and wait for completion
             var messageOptions = new MessageOptions { Prompt = VerificationPrompt };
 
-            var result = await session.SendAndWaitAsync(messageOptions, TimeSpan.FromMinutes(5));
+            var result = await session.SendAndWaitAsync(messageOptions, TimeSpan.FromMinutes(5), cancellationToken);
 
             if (result == null || result.Data == null || string.IsNullOrEmpty(result.Data.Content))
             {


### PR DESCRIPTION
Current main branch enable 'Enforce cancellation token usage' analyzer, need to forward cancellation token to method to call.
And correct the azsdk execution name for different os.