### PR TITLE
Auto-detect APIView environment from URL domain

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/APIView/ApiViewReviewToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/APIView/ApiViewReviewToolTests.cs
@@ -31,7 +31,7 @@ public class ApiViewReviewToolTests
             .Setup(x => x.GetCommentsByRevisionAsync(revisionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedComments);
 
-        APIViewResponse response = await apiViewReviewTool.GetComments(apiViewUrl, null, CancellationToken.None);
+        APIViewResponse response = await apiViewReviewTool.GetComments(apiViewUrl, null, ct: CancellationToken.None);
 
         Assert.That(response.Result, Is.EqualTo(expectedComments));
         Assert.That(response.ResponseError, Is.Null);
@@ -46,7 +46,7 @@ public class ApiViewReviewToolTests
             .Setup(x => x.GetCommentsByRevisionAsync("test-revision-456", It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedComments);
 
-        APIViewResponse response = await apiViewReviewTool.GetComments(apiViewUrl, null, CancellationToken.None);
+        APIViewResponse response = await apiViewReviewTool.GetComments(apiViewUrl, null, ct: CancellationToken.None);
 
         Assert.That(response.Result, Is.EqualTo(expectedComments));
         Assert.That(response.ResponseError, Is.Null);
@@ -57,7 +57,7 @@ public class ApiViewReviewToolTests
     {
         string invalidUrl = "https://apiview.dev/review/123"; // Missing activeApiRevisionId
 
-        APIViewResponse result = await apiViewReviewTool.GetComments(invalidUrl, null, CancellationToken.None);
+        APIViewResponse result = await apiViewReviewTool.GetComments(invalidUrl, null, ct: CancellationToken.None);
 
         Assert.That(result.ResponseError, Does.Contain("activeApiRevisionId"));
     }
@@ -67,13 +67,13 @@ public class ApiViewReviewToolTests
     {
         string malformedUrl = "not-a-valid-url";
 
-        APIViewResponse result = await apiViewReviewTool.GetComments(malformedUrl, null, CancellationToken.None);
+        APIViewResponse result = await apiViewReviewTool.GetComments(malformedUrl, null, ct: CancellationToken.None);
 
         _mockApiViewService
             .Setup(x => x.GetCommentsByRevisionAsync(malformedUrl, It.IsAny<CancellationToken>()))
             .ReturnsAsync((string?)null);
 
-        result = await apiViewReviewTool.GetComments(malformedUrl, null, CancellationToken.None);
+        result = await apiViewReviewTool.GetComments(malformedUrl, null, ct: CancellationToken.None);
         Assert.That(result.ResponseError, Does.Contain("Failed to get comments: Input needs to be a valid APIView URL"));
     }
 
@@ -86,7 +86,7 @@ public class ApiViewReviewToolTests
             .Setup(x => x.GetCommentsByRevisionAsync(revisionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((string?)null);
 
-        APIViewResponse result = await apiViewReviewTool.GetComments(apiViewUrl, null, CancellationToken.None);
+        APIViewResponse result = await apiViewReviewTool.GetComments(apiViewUrl, null, ct: CancellationToken.None);
 
         Assert.That(result.ResponseError, Does.Contain("Failed to retrieve comments"));
     }
@@ -100,7 +100,7 @@ public class ApiViewReviewToolTests
             .Setup(x => x.GetCommentsByRevisionAsync(revisionId, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("Service error"));
 
-        APIViewResponse result = await apiViewReviewTool.GetComments(apiViewUrl, null, CancellationToken.None);
+        APIViewResponse result = await apiViewReviewTool.GetComments(apiViewUrl, null, ct: CancellationToken.None);
 
         Assert.That(result.ResponseError, Does.Contain("Failed to get comments: Service error"));
     }
@@ -109,7 +109,7 @@ public class ApiViewReviewToolTests
     public async Task GetRevisionComments_WithEmptyRevisionId_ReturnsError()
     {
         string emptyRevisionId = "";
-        APIViewResponse result = await apiViewReviewTool.GetComments(emptyRevisionId, null, CancellationToken.None);
+        APIViewResponse result = await apiViewReviewTool.GetComments(emptyRevisionId, null, ct: CancellationToken.None);
 
         Assert.That(result.ResponseError, Does.Contain("cannot be null or empty"));
     }
@@ -126,7 +126,7 @@ public class ApiViewReviewToolTests
             .Setup(x => x.GetCommentsByRevisionAsync(expectedRevisionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedComments);
 
-        await apiViewReviewTool.GetComments(apiViewUrl, null, CancellationToken.None);
+        await apiViewReviewTool.GetComments(apiViewUrl, null, ct: CancellationToken.None);
         _mockApiViewService.Verify(x => x.GetCommentsByRevisionAsync(expectedRevisionId, It.IsAny<CancellationToken>()), Times.Once);
     }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/APIView/ApiViewReviewToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/APIView/ApiViewReviewToolTests.cs
@@ -31,7 +31,7 @@ public class ApiViewReviewToolTests
             .Setup(x => x.GetCommentsByRevisionAsync(revisionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedComments);
 
-        APIViewResponse response = await apiViewReviewTool.GetComments(apiViewUrl, CancellationToken.None);
+        APIViewResponse response = await apiViewReviewTool.GetComments(apiViewUrl, null, CancellationToken.None);
 
         Assert.That(response.Result, Is.EqualTo(expectedComments));
         Assert.That(response.ResponseError, Is.Null);
@@ -46,7 +46,7 @@ public class ApiViewReviewToolTests
             .Setup(x => x.GetCommentsByRevisionAsync("test-revision-456", It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedComments);
 
-        APIViewResponse response = await apiViewReviewTool.GetComments(apiViewUrl, CancellationToken.None);
+        APIViewResponse response = await apiViewReviewTool.GetComments(apiViewUrl, null, CancellationToken.None);
 
         Assert.That(response.Result, Is.EqualTo(expectedComments));
         Assert.That(response.ResponseError, Is.Null);
@@ -57,7 +57,7 @@ public class ApiViewReviewToolTests
     {
         string invalidUrl = "https://apiview.dev/review/123"; // Missing activeApiRevisionId
 
-        APIViewResponse result = await apiViewReviewTool.GetComments(invalidUrl, CancellationToken.None);
+        APIViewResponse result = await apiViewReviewTool.GetComments(invalidUrl, null, CancellationToken.None);
 
         Assert.That(result.ResponseError, Does.Contain("activeApiRevisionId"));
     }
@@ -67,13 +67,13 @@ public class ApiViewReviewToolTests
     {
         string malformedUrl = "not-a-valid-url";
 
-        APIViewResponse result = await apiViewReviewTool.GetComments(malformedUrl, CancellationToken.None);
+        APIViewResponse result = await apiViewReviewTool.GetComments(malformedUrl, null, CancellationToken.None);
 
         _mockApiViewService
             .Setup(x => x.GetCommentsByRevisionAsync(malformedUrl, It.IsAny<CancellationToken>()))
             .ReturnsAsync((string?)null);
 
-        result = await apiViewReviewTool.GetComments(malformedUrl, CancellationToken.None);
+        result = await apiViewReviewTool.GetComments(malformedUrl, null, CancellationToken.None);
         Assert.That(result.ResponseError, Does.Contain("Failed to get comments: Input needs to be a valid APIView URL"));
     }
 
@@ -86,7 +86,7 @@ public class ApiViewReviewToolTests
             .Setup(x => x.GetCommentsByRevisionAsync(revisionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((string?)null);
 
-        APIViewResponse result = await apiViewReviewTool.GetComments(apiViewUrl, CancellationToken.None);
+        APIViewResponse result = await apiViewReviewTool.GetComments(apiViewUrl, null, CancellationToken.None);
 
         Assert.That(result.ResponseError, Does.Contain("Failed to retrieve comments"));
     }
@@ -100,7 +100,7 @@ public class ApiViewReviewToolTests
             .Setup(x => x.GetCommentsByRevisionAsync(revisionId, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("Service error"));
 
-        APIViewResponse result = await apiViewReviewTool.GetComments(apiViewUrl, CancellationToken.None);
+        APIViewResponse result = await apiViewReviewTool.GetComments(apiViewUrl, null, CancellationToken.None);
 
         Assert.That(result.ResponseError, Does.Contain("Failed to get comments: Service error"));
     }
@@ -109,7 +109,7 @@ public class ApiViewReviewToolTests
     public async Task GetRevisionComments_WithEmptyRevisionId_ReturnsError()
     {
         string emptyRevisionId = "";
-        APIViewResponse result = await apiViewReviewTool.GetComments(emptyRevisionId, CancellationToken.None);
+        APIViewResponse result = await apiViewReviewTool.GetComments(emptyRevisionId, null, CancellationToken.None);
 
         Assert.That(result.ResponseError, Does.Contain("cannot be null or empty"));
     }
@@ -126,7 +126,7 @@ public class ApiViewReviewToolTests
             .Setup(x => x.GetCommentsByRevisionAsync(expectedRevisionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedComments);
 
-        await apiViewReviewTool.GetComments(apiViewUrl, CancellationToken.None);
+        await apiViewReviewTool.GetComments(apiViewUrl, null, CancellationToken.None);
         _mockApiViewService.Verify(x => x.GetCommentsByRevisionAsync(expectedRevisionId, It.IsAny<CancellationToken>()), Times.Once);
     }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/DelegateAPIViewFeedbackToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/DelegateAPIViewFeedbackToolTests.cs
@@ -3,6 +3,7 @@
 
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Services.APIView;
 using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 using Azure.Sdk.Tools.Cli.Tools.TypeSpec;
 using Moq;
@@ -16,6 +17,7 @@ public class DelegateAPIViewFeedbackToolTests
     private DelegateAPIViewFeedbackTool _tool = null!;
     private Mock<IAPIViewFeedbackService> _mockService = null!;
     private Mock<IGitHubService> _mockGitHubService = null!;
+    private Mock<IAPIViewService> _mockApiViewService = null!;
     private TestLogger<DelegateAPIViewFeedbackTool> _logger = null!;
 
     [SetUp]
@@ -24,7 +26,8 @@ public class DelegateAPIViewFeedbackToolTests
         _logger = new TestLogger<DelegateAPIViewFeedbackTool>();
         _mockService = new Mock<IAPIViewFeedbackService>();
         _mockGitHubService = new Mock<IGitHubService>();
-        _tool = new DelegateAPIViewFeedbackTool(_mockService.Object, _mockGitHubService.Object, _logger);
+        _mockApiViewService = new Mock<IAPIViewService>();
+        _tool = new DelegateAPIViewFeedbackTool(_mockService.Object, _mockGitHubService.Object, _mockApiViewService.Object, _logger);
     }
 
     #region No Comments Tests

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/APIView/APIViewHttpService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/APIView/APIViewHttpService.cs
@@ -49,10 +49,9 @@ public class APIViewHttpService : IAPIViewHttpService
 
     public async Task<(string? content, int statusCode)> GetAsync(string endpoint, CancellationToken ct)
     {
-        string baseUrl = _baseUrl;
         HttpClient httpClient = await GetOrCreateAuthenticatedClientAsync(ct);
 
-        string requestUrl = $"{baseUrl}{endpoint}";
+        string requestUrl = $"{_baseUrl}{endpoint}";
         using HttpResponseMessage response = await httpClient.GetAsync(requestUrl, ct);
 
         string content = await response.Content.ReadAsStringAsync(ct);
@@ -73,10 +72,9 @@ public class APIViewHttpService : IAPIViewHttpService
 
     public async Task<(string? content, int statusCode)> PostAsync(string endpoint, CancellationToken ct)
     {
-        string baseUrl = _baseUrl;
         HttpClient httpClient = await GetOrCreateAuthenticatedClientAsync(ct);
 
-        string requestUrl = $"{baseUrl}{endpoint}";
+        string requestUrl = $"{_baseUrl}{endpoint}";
         using HttpResponseMessage response = await httpClient.PostAsync(requestUrl, new StringContent(string.Empty), ct);
 
         string content = await response.Content.ReadAsStringAsync(ct);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/APIView/APIViewHttpService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/APIView/APIViewHttpService.cs
@@ -4,6 +4,7 @@ namespace Azure.Sdk.Tools.Cli.Services.APIView;
 
 public interface IAPIViewHttpService
 {
+    void ConfigureEnvironment(string environment);
     Task<(string? content, int statusCode)> GetAsync(string endpoint, CancellationToken ct);
     Task<(string? content, int statusCode)> PostAsync(string endpoint, CancellationToken ct);
 }
@@ -13,8 +14,9 @@ public class APIViewHttpService : IAPIViewHttpService
     private readonly IAPIViewAuthenticationService _authService;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<APIViewHttpService> _logger;
-    private readonly string _environment;
-    private readonly string _baseUrl;
+
+    private string _environment = "production";
+    private string _baseUrl = APIViewConfiguration.BaseUrlEndpoints["production"];
 
     private HttpClient? _cachedClient;
     private DateTime _cacheExpiry = DateTime.MinValue;
@@ -29,15 +31,28 @@ public class APIViewHttpService : IAPIViewHttpService
         _httpClientFactory = httpClientFactory;
         _authService = authService;
         _logger = logger;
-        _environment = Environment.GetEnvironmentVariable("APIVIEW_ENVIRONMENT") ?? "production";
-        _baseUrl = APIViewConfiguration.BaseUrlEndpoints[_environment];
+    }
+
+    public void ConfigureEnvironment(string environment)
+    {
+        // Skip invalidation if the environment hasn't changed
+        if (_environment == environment)
+        {
+            return;
+        }
+        _environment = environment;
+        _baseUrl = APIViewConfiguration.BaseUrlEndpoints[environment];
+        // Invalidate cached client since auth scopes differ per environment
+        _cachedClient = null;
+        _cacheExpiry = DateTime.MinValue;
     }
 
     public async Task<(string? content, int statusCode)> GetAsync(string endpoint, CancellationToken ct)
     {
+        string baseUrl = _baseUrl;
         HttpClient httpClient = await GetOrCreateAuthenticatedClientAsync(ct);
 
-        string requestUrl = $"{_baseUrl}{endpoint}";
+        string requestUrl = $"{baseUrl}{endpoint}";
         using HttpResponseMessage response = await httpClient.GetAsync(requestUrl, ct);
 
         string content = await response.Content.ReadAsStringAsync(ct);
@@ -58,9 +73,10 @@ public class APIViewHttpService : IAPIViewHttpService
 
     public async Task<(string? content, int statusCode)> PostAsync(string endpoint, CancellationToken ct)
     {
+        string baseUrl = _baseUrl;
         HttpClient httpClient = await GetOrCreateAuthenticatedClientAsync(ct);
 
-        string requestUrl = $"{_baseUrl}{endpoint}";
+        string requestUrl = $"{baseUrl}{endpoint}";
         using HttpResponseMessage response = await httpClient.PostAsync(requestUrl, new StringContent(string.Empty), ct);
 
         string content = await response.Content.ReadAsStringAsync(ct);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/APIView/APIViewService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/APIView/APIViewService.cs
@@ -3,6 +3,11 @@ namespace Azure.Sdk.Tools.Cli.Services.APIView;
 
 public interface IAPIViewService
 {
+    /// <summary>
+    /// Configures the HTTP service to target the environment inferred from the given APIView URL.
+    /// Call this once before making any requests for a given URL.
+    /// </summary>
+    void ConfigureForUrl(string apiViewUrl, string? explicitEnvironment = null);
     Task<string?> GetRevisionContent(string apiRevisionId, string reviewId, string contentReturnType, CancellationToken ct);
     Task<string?> GetCommentsByRevisionAsync(string revisionId, CancellationToken ct);
     Task<string?> GetMetadata(string revisionId, CancellationToken ct);
@@ -42,6 +47,29 @@ public class APIViewService : IAPIViewService
     {
         _httpService = httpService;
         _logger = logger;
+    }
+
+    public void ConfigureForUrl(string apiViewUrl, string? explicitEnvironment = null)
+    {
+        string environment = ResolveEnvironment(apiViewUrl, explicitEnvironment);
+        _httpService.ConfigureEnvironment(environment);
+    }
+
+    private static string ResolveEnvironment(string url, string? explicitEnvironment)
+    {
+        if (!string.IsNullOrEmpty(explicitEnvironment))
+        {
+            return explicitEnvironment;
+        }
+        if (url.Contains("apiviewstagingtest.com", StringComparison.OrdinalIgnoreCase))
+        {
+            return "staging";
+        }
+        if (url.Contains("localhost", StringComparison.OrdinalIgnoreCase))
+        {
+            return "local";
+        }
+        return "production";
     }
 
     public async Task<string?> GetCommentsByRevisionAsync(string revisionId, CancellationToken ct)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/APIViewFeedbackService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/APIViewFeedbackService.cs
@@ -372,6 +372,7 @@ Respond in JSON format:
     {
         _logger.LogInformation("Preprocessing APIView feedback from: {Url}", apiViewUrl);
         var (revisionId, _) = APIViewReviewTool.ExtractIdsFromUrl(apiViewUrl);
+        _apiViewService.ConfigureForUrl(apiViewUrl);
         var comments = await GetConsolidatedComments(revisionId, ct);
         var feedbackItems = comments.Select(c =>
         {
@@ -388,6 +389,7 @@ Respond in JSON format:
     public async Task<string?> GetLanguageAsync(string apiViewUrl, CancellationToken ct = default)
     {
         var (revisionId, _) = APIViewReviewTool.ExtractIdsFromUrl(apiViewUrl);
+        _apiViewService.ConfigureForUrl(apiViewUrl);
         var metadata = await ParseReviewMetadata(revisionId, ct);
         return metadata.Language;
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/APIView/APIViewReviewTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/APIView/APIViewReviewTool.cs
@@ -46,6 +46,11 @@ public class APIViewReviewTool : MCPMultiCommandTool
         Required = true
     };
 
+    private readonly Option<string> environmentOption = new("--environment")
+    {
+        Description = "The APIView environment to connect to: production, staging, or local. Auto-detected from the URL if not specified."
+    };
+
     private readonly Option<string> buildIdOption = new("--build-id")
     {
         Description = "The Azure DevOps build ID",
@@ -156,10 +161,10 @@ public class APIViewReviewTool : MCPMultiCommandTool
 
     protected override List<Command> GetCommands() =>
     [
-        new McpCommand(GetCommentsCmd, "Get comments for a specific APIView URL", ApiViewGetCommentsToolName) { apiViewUrlOption },
+        new McpCommand(GetCommentsCmd, "Get comments for a specific APIView URL", ApiViewGetCommentsToolName) { apiViewUrlOption, environmentOption },
         new(GetContentCmd, "Get content by APIView URL")
         {
-            apiViewUrlOption, outputFileOption, contentReturnTypeOption
+            apiViewUrlOption, outputFileOption, contentReturnTypeOption, environmentOption
         },
         new(CreateCIRevisionCmd, "Create an API revision from Azure DevOps pipeline artifacts (CI/release pipeline usage)")
         {
@@ -191,11 +196,12 @@ public class APIViewReviewTool : MCPMultiCommandTool
     }
 
     [McpServerTool(Name = ApiViewGetCommentsToolName), Description("Get API review comments and feedback from APIView for a package. Retrieves all reviewer comments left on the API review.")]
-    public async Task<APIViewResponse> GetComments(string apiViewUrl, CancellationToken ct = default)
+    public async Task<APIViewResponse> GetComments(string apiViewUrl, string? environment = null, CancellationToken ct = default)
     {
         try
         {
             (string revisionId, _) = ExtractIdsFromUrl(apiViewUrl);
+            _apiViewService.ConfigureForUrl(apiViewUrl, environment);
 
             string? result = await _apiViewService.GetCommentsByRevisionAsync(revisionId, ct);
             if (result == null)
@@ -217,7 +223,8 @@ public class APIViewReviewTool : MCPMultiCommandTool
     private async Task<APIViewResponse> GetComments(ParseResult parseResult, CancellationToken ct)
     {
         string? apiViewUrl = parseResult.GetValue(apiViewUrlOption);
-        return await GetComments(apiViewUrl!, ct);
+        string? environment = parseResult.GetValue(environmentOption);
+        return await GetComments(apiViewUrl!, environment, ct);
     }
 
     private async Task<APIViewResponse> GetContent(ParseResult parseResult, CancellationToken ct)
@@ -225,6 +232,7 @@ public class APIViewReviewTool : MCPMultiCommandTool
         string? apiViewUrl = parseResult.GetValue(apiViewUrlOption);
         string? outputFile = parseResult.GetValue(outputFileOption);
         string? contentType = parseResult.GetValue(contentReturnTypeOption);
+        string? environment = parseResult.GetValue(environmentOption);
 
         if (!Enum.TryParse<ContentType>(contentType, ignoreCase: true, out _))
         {
@@ -232,6 +240,7 @@ public class APIViewReviewTool : MCPMultiCommandTool
             return new APIViewResponse { ResponseError = $"Invalid content type '{contentType}'. Must be one of: {validValues}." };
         }
 
+        _apiViewService.ConfigureForUrl(apiViewUrl!, environment);
         (string revisionId, string reviewId) = ExtractIdsFromUrl(apiViewUrl!);
         try
         {
@@ -375,6 +384,10 @@ public class APIViewReviewTool : MCPMultiCommandTool
             return new APIViewResponse { ResponseError = $"Failed to create API revision: {ex.Message}" };
         }
     }
+
+    internal static string ResolveEnvironment(string url, string? explicitEnvironment) =>
+        url.Contains("apiviewstagingtest.com", StringComparison.OrdinalIgnoreCase) ? "staging" :
+        url.Contains("localhost", StringComparison.OrdinalIgnoreCase) ? "local" : "production";
 
     public static (string revisionId, string reviewId) ExtractIdsFromUrl(string url)
     {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/DelegateAPIViewFeedbackTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/DelegateAPIViewFeedbackTool.cs
@@ -7,6 +7,7 @@ using Azure.Sdk.Tools.Cli.Commands;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Prompts.Templates;
 using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Services.APIView;
 using Azure.Sdk.Tools.Cli.Tools.APIView;
 using Azure.Sdk.Tools.Cli.Tools.Core;
 using ModelContextProtocol.Server;
@@ -21,6 +22,7 @@ public class DelegateAPIViewFeedbackTool : MCPTool
 
     private readonly IAPIViewFeedbackService _service;
     private readonly IGitHubService _gitHubService;
+    private readonly IAPIViewService _apiViewService;
     private readonly ILogger<DelegateAPIViewFeedbackTool> _logger;
 
     private readonly Argument<string> _apiViewUrlArg = new("apiview-url")
@@ -46,10 +48,12 @@ public class DelegateAPIViewFeedbackTool : MCPTool
     public DelegateAPIViewFeedbackTool(
         IAPIViewFeedbackService service,
         IGitHubService gitHubService,
+        IAPIViewService apiViewService,
         ILogger<DelegateAPIViewFeedbackTool> logger)
     {
         _service = service;
         _gitHubService = gitHubService;
+        _apiViewService = apiViewService;
         _logger = logger;
     }
 
@@ -86,8 +90,9 @@ public class DelegateAPIViewFeedbackTool : MCPTool
             }
             _logger.LogInformation("Fetching APIView feedback from {Url}", apiViewUrl);
 
-            // Extract revision ID from URL
+            // Extract revision ID from URL and configure the correct environment
             var (revisionId, reviewId) = APIViewReviewTool.ExtractIdsFromUrl(apiViewUrl);
+            _apiViewService.ConfigureForUrl(apiViewUrl);
 
             _logger.LogInformation("Extracted revisionId: {RevisionId}, reviewId: {ReviewId}", revisionId, reviewId);
 


### PR DESCRIPTION
closing #13656 in favor of this.

The `azsdk_apiview_get_comments` tool required users to manually set `APIVIEW_ENVIRONMENT` to match the URL's target environment. Querying `apiviewstagingtest.com` with default `production` environment returned empty results.

## Changes

- **Added domain-based detection** in `APIViewReviewTool.GetEnvironmentFromUrl()`:
  - `apiviewstagingtest.com` → staging
  - `localhost` → local
  - default → production
  - `APIVIEW_ENVIRONMENT` override preserved (takes precedence)

- **Threading environment through call chain**:
  - `APIViewReviewTool` extracts environment from URL, passes downstream
  - `IAPIViewService.GetCommentsByRevisionAsync/GetRevisionContent` accept environment parameter
  - `IAPIViewHttpService.GetAsync` accepts environment instead of reading env var internally

- **Removed** `APIViewHttpService.GetEnvironment()` static method

## Example

```bash
# Before: required manual env var setup
export APIVIEW_ENVIRONMENT=staging
azsdk apiview get-comments --url "https://apiviewstagingtest.com/review/..."

# After: works automatically
azsdk apiview get-comments --url "https://apiviewstagingtest.com/review/..."
```
