### PR TITLE
[AVC] Add error handling for deserialization of comments

### DIFF
--- a/packages/python-packages/apiview-copilot/app.py
+++ b/packages/python-packages/apiview-copilot/app.py
@@ -100,7 +100,7 @@ async def submit_api_review_job(
             comments=job_request.comments,
         )
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
     job_id = reviewer.job_id
     db_manager.review_jobs.create(job_id, data={"status": ApiReviewJobStatus.InProgress, "finished": None})
 

--- a/packages/python-packages/apiview-copilot/cli.py
+++ b/packages/python-packages/apiview-copilot/cli.py
@@ -299,7 +299,7 @@ def _local_review(
             write_debug_logs=debug_log,
         )
     except ValueError as e:
-        raise CLIError(str(e))
+        raise CLIError(str(e)) from e
     reviewer.run()
     reviewer.close()
 

--- a/packages/python-packages/apiview-copilot/src/_apiview_reviewer.py
+++ b/packages/python-packages/apiview-copilot/src/_apiview_reviewer.py
@@ -34,6 +34,7 @@ from src._utils import get_language_pretty_name
 
 # Set up package root for log and metadata paths
 _PACKAGE_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+logger = logging.getLogger(__name__)
 
 # Configure logger to write to project root error.log and info.log
 error_log_file = os.path.join(_PACKAGE_ROOT, "error.log")
@@ -215,21 +216,27 @@ class ApiViewReview:
             return []
         parsed = []
         has_errors = False
+        first_error: Optional[ValidationError] = None
         for item in comments:
             if not isinstance(item, dict):
                 has_errors = True
+                logger.debug("Existing comment is not a dict and will be skipped: %r", item)
                 continue
             try:
                 normalized = ApiViewReview._normalize_comment_keys(dict(item))
                 parsed.append(ExistingComment(**normalized))
-            except ValidationError:
+            except ValidationError as exc:
                 has_errors = True
+                if first_error is None:
+                    first_error = exc
+                logger.debug("ValidationError while parsing existing comment %r", item, exc_info=exc)
         if has_errors:
-            raise ValueError(
+            message = (
                 "Existing comment schema did not match expected. "
                 "Each comment must have: lineNo (int), createdBy (str), commentText (str), createdOn (ISO datetime). "
                 "Optional: upvotes, downvotes, isResolved."
             )
+            raise ValueError(message) from first_error
         return parsed
 
     def _print_comment_counts(self):

--- a/packages/python-packages/apiview-copilot/tests/existing_comments_test.py
+++ b/packages/python-packages/apiview-copilot/tests/existing_comments_test.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-# pylint: disable=missing-class-docstring,missing-function-docstring,redefined-outer-name,unused-argument
+# pylint: disable=missing-class-docstring,missing-function-docstring,redefined-outer-name,unused-argument,protected-access
 
 """
 Tests for existing comment parsing and validation in ApiViewReview.


### PR DESCRIPTION
If the format of existing comments is incorrect, the API will now return the following 400 error:
`Existing comment schema did not match expected. Each comment must have: lineNo (int), createdBy (str), commentText (str), createdOn (ISO datetime). Optional: upvotes, downvotes, isResolved.`