### PR TITLE
Fix registry URL mismatch in Regenerate stage of emitter CI

### DIFF
--- a/eng/common/pipelines/templates/archetype-typespec-emitter.yml
+++ b/eng/common/pipelines/templates/archetype-typespec-emitter.yml
@@ -86,6 +86,11 @@ parameters:
 - name: EmitterPackagePath
   type: string
 
+# The DevOps npm registry URL used for publishing and consuming emitter packages.
+- name: NpmDevOpsFeedUrl
+  type: string
+  default: 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js-test-autorest/npm/registry/'
+
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
@@ -247,7 +252,7 @@ extends:
                 - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
                   parameters:
                     npmrcPath: $(buildArtifactsPath)/packages/.npmrc
-                    registryUrl: https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js-test-autorest/npm/registry/
+                    registryUrl: ${{ parameters.NpmDevOpsFeedUrl }}
         
                 # publish to devops feed
                 - pwsh: |
@@ -316,6 +321,7 @@ extends:
           - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
             parameters:
               npmrcPath: $(tspClientNpmrcPath)
+              registryUrl: ${{ parameters.NpmDevOpsFeedUrl }}
 
           - pwsh: |
               npm ci
@@ -413,6 +419,7 @@ extends:
           - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
             parameters:
               npmrcPath: $(emitterNpmrcPath)
+              registryUrl: ${{ parameters.NpmDevOpsFeedUrl }}
 
           - task: PowerShell@2
             displayName: Call regeneration script


### PR DESCRIPTION
## Problem

The Publish stage in `archetype-typespec-emitter.yml` publishes npm packages to the `azure-sdk-for-js-test-autorest` DevOps feed, but the Regenerate stage creates `.npmrc` files using the default registry (`azure-sdk-for-js`). This causes `npm error notarget` when the Regenerate stage tries to install the just-published emitter package from the wrong feed.

csharp dpg failure: https://dev.azure.com/azure-sdk/internal/internal%20Team/_build/results?buildId=6038696&view=logs&j=b6d1d2c2-c6f7-5ae9-8e6d-27240be19dee&t=d2bc40e7-9567-5de2-ff3e-e669d6739bb6&l=67
csharp mpg failure: https://dev.azure.com/azure-sdk/internal/internal%20Team/_build/results?buildId=6037527&view=logs&j=8801c396-f2ad-561a-91e9-39bda75f75d3&t=03297e7a-fd33-520c-a277-90f19b3e6970&l=68

## Fix

Added explicit `registryUrl` to both `create-authenticated-npmrc` calls in the Regenerate stage (Initialize and Generate jobs) to match the Publish stage feed:

```
registryUrl: https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js-test-autorest/npm/registry/
```

## Affected Stages

| Stage/Job | Before | After |
|-----------|--------|-------|
| Regenerate > Initialize | Default (`azure-sdk-for-js`) | `azure-sdk-for-js-test-autorest` |
| Regenerate > Generate | Default (`azure-sdk-for-js`) | `azure-sdk-for-js-test-autorest` |
