### PR TITLE
Remove authoring specific parameters

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/AuthoringScenarioLoader.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/AuthoringScenarioLoader.cs
@@ -16,7 +16,7 @@ public static class AuthoringScenarioLoader
     /// Loads all AuthoringScenario instances from JSON files in the TestData directory.
     /// </summary>
     /// <returns>An enumerable of AuthoringScenario instances.</returns>
-    public static IEnumerable<AuthoringScenario> LoadFromJsonFiles(string? authoringSpecRepo = null, string? authoringSkillPath = null)
+    public static IEnumerable<AuthoringScenario> LoadFromJsonFiles()
     {
         // Look for TestData in the source directory, not the build output
         var baseDir = AppContext.BaseDirectory;
@@ -77,8 +77,8 @@ public static class AuthoringScenarioLoader
                     testTspFiles: testCase.TestFiles,
                     toolsToCall: testCase.ToolsToCall,
                     verifyPlan: testCase.VerifyPlan ?? new List<string>(),
-                    authoringSpecRepo: authoringSpecRepo,
-                    authoringSkillPath: authoringSkillPath
+                    authoringSpecRepo: testCase.AuthoringSpecRepo,
+                    authoringSkillPath: testCase.AuthoringSkillPath
                 );
             }
         }
@@ -115,6 +115,12 @@ public static class AuthoringScenarioLoader
 
         [JsonPropertyName("verifyPlan")]
         public List<string>? VerifyPlan { get; set; }
+
+        [JsonPropertyName("authoringSpecRepo")]
+        public string? AuthoringSpecRepo { get; set; }
+
+        [JsonPropertyName("authoringSkillPath")]
+        public string? AuthoringSkillPath { get; set; }
 
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/BenchmarkRunner.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/BenchmarkRunner.cs
@@ -198,7 +198,7 @@ public class BenchmarkRunner : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    private static RepoConfig ApplyRefOverride(RepoConfig repo, Dictionary<string, string>? overrides)
+    private static RepoConfig ApplyRefOverride(RepoConfig repo, Dictionary<string, string?>? overrides)
     {
         if (overrides == null)
         {
@@ -206,7 +206,7 @@ public class BenchmarkRunner : IDisposable
         }
 
         var key = $"{repo.Owner}/{repo.Name}";
-        if (overrides.TryGetValue(key, out var newRef))
+        if (overrides.TryGetValue(key, out var newRef) && newRef != null)
         {
             Console.WriteLine($"[Benchmark] Overriding ref for {key}: {repo.Ref} → {newRef}");
             return repo.WithRef(newRef);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/BenchmarkRunner.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/BenchmarkRunner.cs
@@ -38,9 +38,12 @@ public class BenchmarkRunner : IDisposable
 
         try
         {
+            // Apply ref overrides to repo config
+            var repo = ApplyRefOverride(scenario.Repo, options.RefOverrides);
+
             // 1. Environment Setup - prepare workspace
             Console.WriteLine($"[Benchmark] Preparing workspace for {scenario.Name}...");
-            workspace = await _workspaceManager.PrepareAsync(scenario.Repo, scenario.Name);
+            workspace = await _workspaceManager.PrepareAsync(repo, scenario.Name);
 
             // 2. Run scenario setup (if any)
             Console.WriteLine($"[Benchmark] Running scenario setup...");
@@ -193,5 +196,22 @@ public class BenchmarkRunner : IDisposable
     {
         // WorkspaceManager handles its own cleanup
         GC.SuppressFinalize(this);
+    }
+
+    private static RepoConfig ApplyRefOverride(RepoConfig repo, Dictionary<string, string>? overrides)
+    {
+        if (overrides == null)
+        {
+            return repo;
+        }
+
+        var key = $"{repo.Owner}/{repo.Name}";
+        if (overrides.TryGetValue(key, out var newRef))
+        {
+            Console.WriteLine($"[Benchmark] Overriding ref for {key}: {repo.Ref} → {newRef}");
+            return repo.WithRef(newRef);
+        }
+
+        return repo;
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/ScenarioDiscovery.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/ScenarioDiscovery.cs
@@ -16,7 +16,7 @@ public static class ScenarioDiscovery
     /// Discovers all non-abstract classes that inherit from <see cref="BenchmarkScenario"/>
     /// and returns instances of them.
     /// </summary>
-    public static IEnumerable<BenchmarkScenario> DiscoverAll(string? authoringSpecRepo = null, string? authoringSkillPath = null)
+    public static IEnumerable<BenchmarkScenario> DiscoverAll()
     {
         var scenarioType = typeof(BenchmarkScenario);
         var assembly = Assembly.GetExecutingAssembly();
@@ -44,7 +44,7 @@ public static class ScenarioDiscovery
         }
 
         // discovery all AuthoringScenarios from json files
-        var authoringScenarios = AuthoringScenarioLoader.LoadFromJsonFiles(authoringSpecRepo, authoringSkillPath);
+        var authoringScenarios = AuthoringScenarioLoader.LoadFromJsonFiles();
         foreach (var scenario in authoringScenarios)
         {
             yield return scenario;
@@ -55,12 +55,10 @@ public static class ScenarioDiscovery
     /// Finds a scenario by name (case-insensitive).
     /// </summary>
     /// <param name="name">The name of the scenario to find.</param>
-    /// <param name="authoringSkillRepo">The repository containing the authoring skill to override (optional).</param>
-    /// <param name="authoringSkillPath">The path of the authoring skill to use (optional).</param>         
     /// <returns>The scenario if found, null otherwise.</returns>
-    public static BenchmarkScenario? FindByName(string name, string? authoringSpecRepo = null, string? authoringSkillPath = null)
+    public static BenchmarkScenario? FindByName(string name)
     {
-        return DiscoverAll(authoringSpecRepo, authoringSkillPath)
+        return DiscoverAll()
             .FirstOrDefault(s => s.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Models/BenchmarkOptions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Models/BenchmarkOptions.cs
@@ -27,4 +27,10 @@ public class BenchmarkOptions
     /// Show agent activity during execution.
     /// </summary>
     public bool Verbose { get; init; }
+
+    /// <summary>
+    /// Ref overrides keyed by "Owner/Name". When a scenario's repo matches,
+    /// the ref is replaced before workspace preparation.
+    /// </summary>
+    public Dictionary<string, string>? RefOverrides { get; init; }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Models/BenchmarkOptions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Models/BenchmarkOptions.cs
@@ -30,7 +30,7 @@ public class BenchmarkOptions
 
     /// <summary>
     /// Ref overrides keyed by "Owner/Name". When a scenario's repo matches,
-    /// the ref is replaced before workspace preparation.
+    /// the ref is replaced before workspace preparation. Null values mean no override.
     /// </summary>
-    public Dictionary<string, string>? RefOverrides { get; init; }
+    public Dictionary<string, string?>? RefOverrides { get; init; }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Models/RepoConfig.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Models/RepoConfig.cs
@@ -66,16 +66,33 @@ public class RepoConfig
     /// <returns>A tuple of (owner, name, gitRef) where owner and gitRef may be null.</returns>
     public static (string? Owner, string Name, string? Ref) ParseRepoString(string input)
     {
+        if (!TryParseRepoString(input, out var result))
+        {
+            throw new ArgumentException($"Invalid repo format: '{input}'. Expected 'Owner/Name:Ref', 'Owner/Name', or 'Name'.", nameof(input));
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Attempts to parse a repo string in the format "Owner/Name:Ref", "Owner/Name", or "Name".
+    /// </summary>
+    /// <returns>True if parsing succeeded; false otherwise.</returns>
+    public static bool TryParseRepoString(string input, out (string? Owner, string Name, string? Ref) result)
+    {
+        result = default;
+        input = input.Trim();
         var match = Regex.Match(input, @"^(?:(?<owner>[^/:\s]+)/)?(?<name>[^/:\s]+)(?::(?<ref>.+))?$");
         if (!match.Success)
         {
-            throw new ArgumentException($"Invalid repo format: '{input}'. Expected 'Owner/Name:Ref', 'Owner/Name', or 'Name'.", nameof(input));
+            return false;
         }
 
         var owner = match.Groups["owner"].Success ? match.Groups["owner"].Value : null;
         var name = match.Groups["name"].Value;
         var gitRef = match.Groups["ref"].Success ? match.Groups["ref"].Value : null;
 
-        return (owner, name, gitRef);
+        result = (owner, name, gitRef);
+        return true;
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Models/RepoConfig.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Models/RepoConfig.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Text.RegularExpressions;
-
 namespace Azure.Sdk.Tools.Cli.Benchmarks.Models;
 
 /// <summary>
@@ -61,38 +59,26 @@ public class RepoConfig
     };
 
     /// <summary>
-    /// Parses a repo string in the format "Owner/Name:Ref", "Owner/Name", or "Name".
-    /// </summary>
-    /// <returns>A tuple of (owner, name, gitRef) where owner and gitRef may be null.</returns>
-    public static (string? Owner, string Name, string? Ref) ParseRepoString(string input)
-    {
-        if (!TryParseRepoString(input, out var result))
-        {
-            throw new ArgumentException($"Invalid repo format: '{input}'. Expected 'Owner/Name:Ref', 'Owner/Name', or 'Name'.", nameof(input));
-        }
-
-        return result;
-    }
-
-    /// <summary>
-    /// Attempts to parse a repo string in the format "Owner/Name:Ref", "Owner/Name", or "Name".
+    /// Parses a repo string in the format "Owner/Name" or "Owner/Name:Ref".
     /// </summary>
     /// <returns>True if parsing succeeded; false otherwise.</returns>
-    public static bool TryParseRepoString(string input, out (string? Owner, string Name, string? Ref) result)
+    public static bool TryParse(string input, out string owner, out string name, out string? gitRef)
     {
-        result = default;
-        input = input.Trim();
-        var match = Regex.Match(input, @"^(?:(?<owner>[^/:\s]+)/)?(?<name>[^/:\s]+)(?::(?<ref>.+))?$");
-        if (!match.Success)
+        owner = name = string.Empty;
+        gitRef = null;
+
+        var colonIndex = input.IndexOf(':');
+        var repoKey = colonIndex >= 0 ? input[..colonIndex] : input;
+        gitRef = colonIndex >= 0 ? input[(colonIndex + 1)..] : null;
+
+        var parts = repoKey.Split('/');
+        if (parts.Length != 2 || string.IsNullOrWhiteSpace(parts[0]) || string.IsNullOrWhiteSpace(parts[1]))
         {
             return false;
         }
 
-        var owner = match.Groups["owner"].Success ? match.Groups["owner"].Value : null;
-        var name = match.Groups["name"].Value;
-        var gitRef = match.Groups["ref"].Success ? match.Groups["ref"].Value : null;
-
-        result = (owner, name, gitRef);
+        owner = parts[0];
+        name = parts[1];
         return true;
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Models/RepoConfig.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Models/RepoConfig.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Text.RegularExpressions;
+
 namespace Azure.Sdk.Tools.Cli.Benchmarks.Models;
 
 /// <summary>
@@ -45,4 +47,35 @@ public class RepoConfig
     /// The HTTPS clone URL for the repository.
     /// </summary>
     public string CloneUrl => $"https://github.com/{EffectiveOwner}/{Name}.git";
+
+    /// <summary>
+    /// Returns a new <see cref="RepoConfig"/> with the specified ref, preserving all other properties.
+    /// </summary>
+    public RepoConfig WithRef(string newRef) => new()
+    {
+        Owner = Owner,
+        Name = Name,
+        ForkOwner = ForkOwner,
+        Ref = newRef,
+        SparseCheckoutPaths = SparseCheckoutPaths
+    };
+
+    /// <summary>
+    /// Parses a repo string in the format "Owner/Name:Ref", "Owner/Name", or "Name".
+    /// </summary>
+    /// <returns>A tuple of (owner, name, gitRef) where owner and gitRef may be null.</returns>
+    public static (string? Owner, string Name, string? Ref) ParseRepoString(string input)
+    {
+        var match = Regex.Match(input, @"^(?:(?<owner>[^/:\s]+)/)?(?<name>[^/:\s]+)(?::(?<ref>.+))?$");
+        if (!match.Success)
+        {
+            throw new ArgumentException($"Invalid repo format: '{input}'. Expected 'Owner/Name:Ref', 'Owner/Name', or 'Name'.", nameof(input));
+        }
+
+        var owner = match.Groups["owner"].Success ? match.Groups["owner"].Value : null;
+        var name = match.Groups["name"].Value;
+        var gitRef = match.Groups["ref"].Success ? match.Groups["ref"].Value : null;
+
+        return (owner, name, gitRef);
+    }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Program.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Program.cs
@@ -98,13 +98,8 @@ public class Program
 
     private static void HandleListCommand(string[]? tags, string[]? repos)
     {
-        var (repoFilters, _, error) = ParseRepoOptions(repos);
-        if (error != null)
-        {
-            Console.WriteLine($"Error: {error}");
-            return;
-        }
-        var scenarios = FilterScenarios(ScenarioDiscovery.DiscoverAll(), tags, repoFilters).ToList();
+        var repoOptions = ParseRepoOptions(repos);
+        var scenarios = FilterScenarios(ScenarioDiscovery.DiscoverAll(), tags, repoOptions).ToList();
 
         if (scenarios.Count == 0)
         {
@@ -160,18 +155,13 @@ public class Program
         }
 
         // Parse --repo for filtering and optional ref override
-        var (repoFilters, refOverrides, repoError) = ParseRepoOptions(repos);
-        if (repoError != null)
-        {
-            Console.WriteLine($"Error: {repoError}");
-            return 1;
-        }
+        var repoOptions = ParseRepoOptions(repos);
 
         var scenariosToRun = new List<BenchmarkScenario>();
 
         if (all)
         {
-            scenariosToRun.AddRange(FilterScenarios(ScenarioDiscovery.DiscoverAll(), tags, repoFilters));
+            scenariosToRun.AddRange(FilterScenarios(ScenarioDiscovery.DiscoverAll(), tags, repoOptions));
             if (scenariosToRun.Count == 0)
             {
                 var filters = new List<string>();
@@ -227,9 +217,9 @@ public class Program
             Console.WriteLine("  (overridden via --model flag)");
         }
         Console.WriteLine($"Parallelism: {parallel}");
-        if (refOverrides != null)
+        if (repoOptions != null)
         {
-            foreach (var (repoKey, gitRef) in refOverrides)
+            foreach (var (repoKey, gitRef) in repoOptions.Where(kv => kv.Value != null))
             {
                 Console.WriteLine($"Ref override: {repoKey} → {gitRef}");
             }
@@ -241,7 +231,7 @@ public class Program
             CleanupPolicy = cleanup,
             Model = model,
             Verbose = verbose,
-            RefOverrides = refOverrides
+            RefOverrides = repoOptions
         };
 
         var results = new ConcurrentBag<(BenchmarkScenario Scenario, BenchmarkResult Result)>();
@@ -321,55 +311,44 @@ public class Program
         return resultsList.All(r => r.Result.Passed) ? 0 : 1;
     }
 
-    private static IEnumerable<BenchmarkScenario> FilterScenarios(IEnumerable<BenchmarkScenario> scenarios, string[]? tags, string[]? repoFilters)
+    private static IEnumerable<BenchmarkScenario> FilterScenarios(IEnumerable<BenchmarkScenario> scenarios, string[]? tags, Dictionary<string, string?>? repoOptions)
     {
         if (tags is { Length: > 0 })
         {
             scenarios = scenarios.Where(s => tags.Any(t => s.Tags.Contains(t, StringComparer.OrdinalIgnoreCase)));
         }
 
-        if (repoFilters is { Length: > 0 })
+        if (repoOptions is { Count: > 0 })
         {
-            scenarios = scenarios.Where(s => repoFilters.Any(r => $"{s.Repo.Owner}/{s.Repo.Name}".Equals(r, StringComparison.OrdinalIgnoreCase)));
+            scenarios = scenarios.Where(s => repoOptions.ContainsKey($"{s.Repo.Owner}/{s.Repo.Name}"));
         }
 
         return scenarios;
     }
 
     /// <summary>
-    /// Parses --repo values for filtering and optional ref overrides.
-    /// Each value accepts "Owner/Name", "Owner/Name:Ref", or "Name".
-    /// Returns an error message if any repo string is invalid.
+    /// Parses --repo values into a dictionary keyed by "Owner/Name" with optional ref override values.
     /// </summary>
-    private static (string[]? RepoFilters, Dictionary<string, string>? RefOverrides, string? Error) ParseRepoOptions(string[]? repos)
+    private static Dictionary<string, string?>? ParseRepoOptions(string[]? repos)
     {
         if (repos is not { Length: > 0 })
         {
-            return (null, null, null);
+            return null;
         }
 
-        var repoFilters = new List<string>();
-        Dictionary<string, string>? refOverrides = null;
+        var result = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var repo in repos)
         {
-            if (!RepoConfig.TryParseRepoString(repo, out var parsed))
+            if (!RepoConfig.TryParse(repo, out var owner, out var name, out var gitRef))
             {
-                return (null, null, $"Invalid --repo format: '{repo}'. Expected 'Owner/Name:Ref', 'Owner/Name', or 'Name'.");
+                throw new ArgumentException($"Invalid --repo format: '{repo}'. Expected 'Owner/Name' or 'Owner/Name:Ref'.");
             }
 
-            var (owner, name, gitRef) = parsed;
-            var repoFilter = owner != null ? $"{owner}/{name}" : name;
-            repoFilters.Add(repoFilter);
-
-            if (gitRef != null && owner != null)
-            {
-                refOverrides ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                refOverrides[$"{owner}/{name}"] = gitRef;
-            }
+            result[$"{owner}/{name}"] = gitRef;
         }
 
-        return (repoFilters.ToArray(), refOverrides, null);
+        return result;
     }
 
     private static void PrintResult(BenchmarkResult result)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Program.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Program.cs
@@ -98,7 +98,7 @@ public class Program
 
     private static void HandleListCommand(string[]? tags, string? repo)
     {
-        var repoFilter = ParseRepoFilter(repo);
+        var (repoFilter, _) = ParseRepoOption(repo);
         var scenarios = FilterScenarios(ScenarioDiscovery.DiscoverAll(), tags, repoFilter).ToList();
 
         if (scenarios.Count == 0)
@@ -320,29 +320,15 @@ public class Program
 
         if (!string.IsNullOrEmpty(repoFilter))
         {
-            scenarios = scenarios.Where(s => $"{s.Repo.Owner}/{s.Repo.Name}".Equals(repoFilter, StringComparison.OrdinalIgnoreCase)
-                || s.Repo.Name.Equals(repoFilter, StringComparison.OrdinalIgnoreCase));
+            scenarios = scenarios.Where(s => $"{s.Repo.Owner}/{s.Repo.Name}".Equals(repoFilter, StringComparison.OrdinalIgnoreCase));
         }
 
         return scenarios;
     }
 
     /// <summary>
-    /// Parses --repo for the list command (filtering only, ignores ref).
-    /// </summary>
-    private static string? ParseRepoFilter(string? repo)
-    {
-        if (string.IsNullOrEmpty(repo))
-        {
-            return null;
-        }
-
-        var (owner, name, _) = RepoConfig.ParseRepoString(repo);
-        return owner != null ? $"{owner}/{name}" : name;
-    }
-
-    /// <summary>
-    /// Parses --repo for the run command (filtering + optional ref override).
+    /// Parses --repo for filtering and optional ref override.
+    /// Accepts "Owner/Name", "Owner/Name:Ref", or "Name".
     /// </summary>
     private static (string? RepoFilter, Dictionary<string, string>? RefOverrides) ParseRepoOption(string? repo)
     {
@@ -361,23 +347,6 @@ public class Program
             {
                 [$"{owner}/{name}"] = gitRef
             };
-        }
-        else if (gitRef != null)
-        {
-            // Name-only with ref: resolve owner from matching scenarios
-            var matchingScenarios = ScenarioDiscovery.DiscoverAll()
-                .Where(s => s.Repo.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
-                .ToList();
-
-            if (matchingScenarios.Count > 0)
-            {
-                refOverrides = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                foreach (var scenario in matchingScenarios)
-                {
-                    var key = $"{scenario.Repo.Owner}/{scenario.Repo.Name}";
-                    refOverrides.TryAdd(key, gitRef);
-                }
-            }
         }
 
         return (repoFilter, refOverrides);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Program.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Program.cs
@@ -98,7 +98,12 @@ public class Program
 
     private static void HandleListCommand(string[]? tags, string? repo)
     {
-        var (repoFilter, _) = ParseRepoOption(repo);
+        var (repoFilter, _, error) = ParseRepoOption(repo);
+        if (error != null)
+        {
+            Console.WriteLine($"Error: {error}");
+            return;
+        }
         var scenarios = FilterScenarios(ScenarioDiscovery.DiscoverAll(), tags, repoFilter).ToList();
 
         if (scenarios.Count == 0)
@@ -155,7 +160,12 @@ public class Program
         }
 
         // Parse --repo for filtering and optional ref override
-        var (repoFilter, refOverrides) = ParseRepoOption(repo);
+        var (repoFilter, refOverrides, repoError) = ParseRepoOption(repo);
+        if (repoError != null)
+        {
+            Console.WriteLine($"Error: {repoError}");
+            return 1;
+        }
 
         var scenariosToRun = new List<BenchmarkScenario>();
 
@@ -329,15 +339,21 @@ public class Program
     /// <summary>
     /// Parses --repo for filtering and optional ref override.
     /// Accepts "Owner/Name", "Owner/Name:Ref", or "Name".
+    /// Returns an error message if the repo string is invalid.
     /// </summary>
-    private static (string? RepoFilter, Dictionary<string, string>? RefOverrides) ParseRepoOption(string? repo)
+    private static (string? RepoFilter, Dictionary<string, string>? RefOverrides, string? Error) ParseRepoOption(string? repo)
     {
         if (string.IsNullOrEmpty(repo))
         {
-            return (null, null);
+            return (null, null, null);
         }
 
-        var (owner, name, gitRef) = RepoConfig.ParseRepoString(repo);
+        if (!RepoConfig.TryParseRepoString(repo, out var parsed))
+        {
+            return (null, null, $"Invalid --repo format: '{repo}'. Expected 'Owner/Name:Ref', 'Owner/Name', or 'Name'.");
+        }
+
+        var (owner, name, gitRef) = parsed;
         var repoFilter = owner != null ? $"{owner}/{name}" : name;
 
         Dictionary<string, string>? refOverrides = null;
@@ -349,7 +365,7 @@ public class Program
             };
         }
 
-        return (repoFilter, refOverrides);
+        return (repoFilter, refOverrides, null);
     }
 
     private static void PrintResult(BenchmarkResult result)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Program.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Program.cs
@@ -19,7 +19,7 @@ public class Program
         // list command
         var listCommand = new Command("list", "List all available scenarios");
         var listTagOption = new Option<string[]>("--tag") { Description = "Filter scenarios by tag (can be specified multiple times)", AllowMultipleArgumentsPerToken = true };
-        var listRepoOption = new Option<string?>("--repo") { Description = "Filter scenarios by repository (e.g., Azure/azure-rest-api-specs)" };
+        var listRepoOption = new Option<string?>("--repo") { Description = "Filter scenarios by repository (e.g., Azure/azure-rest-api-specs or Azure/azure-rest-api-specs:branch)" };
         listCommand.Options.Add(listTagOption);
         listCommand.Options.Add(listRepoOption);
         listCommand.SetAction((parseResult, _) =>
@@ -47,9 +47,7 @@ public class Program
         var reportOption = new Option<bool>("--report") { Description = "Generate a markdown report after the run completes" };
         var outputOption = new Option<string?>("--output") { Description = "Output file path for the report (used with --report)" };
         var tagOption = new Option<string[]>("--tag") { Description = "Filter scenarios by tag (can be specified multiple times)", AllowMultipleArgumentsPerToken = true };
-        var repoOption = new Option<string?>("--repo") { Description = "Filter scenarios by repository (e.g., Azure/azure-rest-api-specs)" };
-        var authoringSpecRepoOption = new Option<string?>("--authoring-spec-repo") { Description = "The repository containing the authoring skill to override (e.g. Azure/azure-rest-api-specs or Azure/azure-rest-api-specs:<branch>)" };
-        var authoringSkillPathOption = new Option<string?>("--authoring-skill-path") { Description = "The filesystem path of the authoring skill directory to be used." };
+        var repoOption = new Option<string?>("--repo") { Description = "Filter scenarios by repository. Append :ref to override the branch (e.g., Azure/azure-rest-api-specs:my-branch)" };
 
         runCommand.Arguments.Add(nameArgument);
         runCommand.Options.Add(allOption);
@@ -61,8 +59,6 @@ public class Program
         runCommand.Options.Add(outputOption);
         runCommand.Options.Add(tagOption);
         runCommand.Options.Add(repoOption);
-        runCommand.Options.Add(authoringSpecRepoOption);
-        runCommand.Options.Add(authoringSkillPathOption);
 
         runCommand.SetAction(async (parseResult, _) =>
         {
@@ -76,9 +72,7 @@ public class Program
             var output = parseResult.GetValue(outputOption);
             var tags = parseResult.GetValue(tagOption);
             var repo = parseResult.GetValue(repoOption);
-            var authoringSpecRepo = parseResult.GetValue(authoringSpecRepoOption);
-            var authoringSkillPath = parseResult.GetValue(authoringSkillPathOption);
-            return await HandleRunCommand(name, all, tags, repo, model, cleanup, verbose, parallel, authoringSpecRepo, authoringSkillPath, report, output);
+            return await HandleRunCommand(name, all, tags, repo, model, cleanup, verbose, parallel, report, output);
         });
         rootCommand.Subcommands.Add(runCommand);
 
@@ -104,7 +98,8 @@ public class Program
 
     private static void HandleListCommand(string[]? tags, string? repo)
     {
-        var scenarios = FilterScenarios(ScenarioDiscovery.DiscoverAll(), tags, repo).ToList();
+        var repoFilter = ParseRepoFilter(repo);
+        var scenarios = FilterScenarios(ScenarioDiscovery.DiscoverAll(), tags, repoFilter).ToList();
 
         if (scenarios.Count == 0)
         {
@@ -131,7 +126,7 @@ public class Program
         Console.WriteLine($"\nTotal: {scenarios.Count} scenario(s)");
     }
 
-    private static async Task<int> HandleRunCommand(string? name, bool all, string[]? tags, string? repo, string? model, CleanupPolicy cleanup, bool verbose, int parallel, string? authoringSpecRepo, string? authoringSkillPath, bool report, string? output)
+    private static async Task<int> HandleRunCommand(string? name, bool all, string[]? tags, string? repo, string? model, CleanupPolicy cleanup, bool verbose, int parallel, bool report, string? output)
     {
         if (string.IsNullOrEmpty(name) && !all)
         {
@@ -159,11 +154,14 @@ public class Program
             return 1;
         }
 
+        // Parse --repo for filtering and optional ref override
+        var (repoFilter, refOverrides) = ParseRepoOption(repo);
+
         var scenariosToRun = new List<BenchmarkScenario>();
 
         if (all)
         {
-            scenariosToRun.AddRange(FilterScenarios(ScenarioDiscovery.DiscoverAll(authoringSpecRepo, authoringSkillPath), tags, repo));
+            scenariosToRun.AddRange(FilterScenarios(ScenarioDiscovery.DiscoverAll(), tags, repoFilter));
             if (scenariosToRun.Count == 0)
             {
                 var filters = new List<string>();
@@ -186,12 +184,12 @@ public class Program
         }
         else
         {
-            var scenario = ScenarioDiscovery.FindByName(name!, authoringSpecRepo, authoringSkillPath);
+            var scenario = ScenarioDiscovery.FindByName(name!);
             if (scenario == null)
             {
                 Console.WriteLine($"Error: Scenario '{name}' not found.");
                 Console.WriteLine("\nAvailable scenarios:");
-                foreach (var s in ScenarioDiscovery.DiscoverAll(authoringSpecRepo, authoringSkillPath))
+                foreach (var s in ScenarioDiscovery.DiscoverAll())
                 {
                     Console.WriteLine($"  - {s.Name}");
                 }
@@ -219,13 +217,21 @@ public class Program
             Console.WriteLine("  (overridden via --model flag)");
         }
         Console.WriteLine($"Parallelism: {parallel}");
+        if (refOverrides != null)
+        {
+            foreach (var (repoKey, gitRef) in refOverrides)
+            {
+                Console.WriteLine($"Ref override: {repoKey} → {gitRef}");
+            }
+        }
         Console.WriteLine();
 
         var options = new BenchmarkOptions
         {
             CleanupPolicy = cleanup,
             Model = model,
-            Verbose = verbose
+            Verbose = verbose,
+            RefOverrides = refOverrides
         };
 
         var results = new ConcurrentBag<(BenchmarkScenario Scenario, BenchmarkResult Result)>();
@@ -305,19 +311,76 @@ public class Program
         return resultsList.All(r => r.Result.Passed) ? 0 : 1;
     }
 
-    private static IEnumerable<BenchmarkScenario> FilterScenarios(IEnumerable<BenchmarkScenario> scenarios, string[]? tags, string? repo)
+    private static IEnumerable<BenchmarkScenario> FilterScenarios(IEnumerable<BenchmarkScenario> scenarios, string[]? tags, string? repoFilter)
     {
         if (tags is { Length: > 0 })
         {
             scenarios = scenarios.Where(s => tags.Any(t => s.Tags.Contains(t, StringComparer.OrdinalIgnoreCase)));
         }
 
-        if (!string.IsNullOrEmpty(repo))
+        if (!string.IsNullOrEmpty(repoFilter))
         {
-            scenarios = scenarios.Where(s => $"{s.Repo.Owner}/{s.Repo.Name}".Equals(repo, StringComparison.OrdinalIgnoreCase));
+            scenarios = scenarios.Where(s => $"{s.Repo.Owner}/{s.Repo.Name}".Equals(repoFilter, StringComparison.OrdinalIgnoreCase)
+                || s.Repo.Name.Equals(repoFilter, StringComparison.OrdinalIgnoreCase));
         }
 
         return scenarios;
+    }
+
+    /// <summary>
+    /// Parses --repo for the list command (filtering only, ignores ref).
+    /// </summary>
+    private static string? ParseRepoFilter(string? repo)
+    {
+        if (string.IsNullOrEmpty(repo))
+        {
+            return null;
+        }
+
+        var (owner, name, _) = RepoConfig.ParseRepoString(repo);
+        return owner != null ? $"{owner}/{name}" : name;
+    }
+
+    /// <summary>
+    /// Parses --repo for the run command (filtering + optional ref override).
+    /// </summary>
+    private static (string? RepoFilter, Dictionary<string, string>? RefOverrides) ParseRepoOption(string? repo)
+    {
+        if (string.IsNullOrEmpty(repo))
+        {
+            return (null, null);
+        }
+
+        var (owner, name, gitRef) = RepoConfig.ParseRepoString(repo);
+        var repoFilter = owner != null ? $"{owner}/{name}" : name;
+
+        Dictionary<string, string>? refOverrides = null;
+        if (gitRef != null && owner != null)
+        {
+            refOverrides = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [$"{owner}/{name}"] = gitRef
+            };
+        }
+        else if (gitRef != null)
+        {
+            // Name-only with ref: resolve owner from matching scenarios
+            var matchingScenarios = ScenarioDiscovery.DiscoverAll()
+                .Where(s => s.Repo.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (matchingScenarios.Count > 0)
+            {
+                refOverrides = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var scenario in matchingScenarios)
+                {
+                    var key = $"{scenario.Repo.Owner}/{scenario.Repo.Name}";
+                    refOverrides.TryAdd(key, gitRef);
+                }
+            }
+        }
+
+        return (repoFilter, refOverrides);
     }
 
     private static void PrintResult(BenchmarkResult result)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Program.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Program.cs
@@ -19,14 +19,14 @@ public class Program
         // list command
         var listCommand = new Command("list", "List all available scenarios");
         var listTagOption = new Option<string[]>("--tag") { Description = "Filter scenarios by tag (can be specified multiple times)", AllowMultipleArgumentsPerToken = true };
-        var listRepoOption = new Option<string?>("--repo") { Description = "Filter scenarios by repository (e.g., Azure/azure-rest-api-specs or Azure/azure-rest-api-specs:branch)" };
+        var listRepoOption = new Option<string[]>("--repo") { Description = "Filter scenarios by repository (can be specified multiple times, e.g., Azure/azure-rest-api-specs or Azure/azure-rest-api-specs:branch)", AllowMultipleArgumentsPerToken = true };
         listCommand.Options.Add(listTagOption);
         listCommand.Options.Add(listRepoOption);
         listCommand.SetAction((parseResult, _) =>
         {
             var tags = parseResult.GetValue(listTagOption);
-            var repo = parseResult.GetValue(listRepoOption);
-            HandleListCommand(tags, repo);
+            var repos = parseResult.GetValue(listRepoOption);
+            HandleListCommand(tags, repos);
             return Task.FromResult(0);
         });
         rootCommand.Subcommands.Add(listCommand);
@@ -47,7 +47,7 @@ public class Program
         var reportOption = new Option<bool>("--report") { Description = "Generate a markdown report after the run completes" };
         var outputOption = new Option<string?>("--output") { Description = "Output file path for the report (used with --report)" };
         var tagOption = new Option<string[]>("--tag") { Description = "Filter scenarios by tag (can be specified multiple times)", AllowMultipleArgumentsPerToken = true };
-        var repoOption = new Option<string?>("--repo") { Description = "Filter scenarios by repository. Append :ref to override the branch (e.g., Azure/azure-rest-api-specs:my-branch)" };
+        var repoOption = new Option<string[]>("--repo") { Description = "Filter scenarios by repository (can be specified multiple times). Append :ref to override the branch (e.g., Azure/azure-rest-api-specs:my-branch)", AllowMultipleArgumentsPerToken = true };
 
         runCommand.Arguments.Add(nameArgument);
         runCommand.Options.Add(allOption);
@@ -71,8 +71,8 @@ public class Program
             var report = parseResult.GetValue(reportOption);
             var output = parseResult.GetValue(outputOption);
             var tags = parseResult.GetValue(tagOption);
-            var repo = parseResult.GetValue(repoOption);
-            return await HandleRunCommand(name, all, tags, repo, model, cleanup, verbose, parallel, report, output);
+            var repos = parseResult.GetValue(repoOption);
+            return await HandleRunCommand(name, all, tags, repos, model, cleanup, verbose, parallel, report, output);
         });
         rootCommand.Subcommands.Add(runCommand);
 
@@ -96,15 +96,15 @@ public class Program
         return await rootCommand.Parse(args).InvokeAsync();
     }
 
-    private static void HandleListCommand(string[]? tags, string? repo)
+    private static void HandleListCommand(string[]? tags, string[]? repos)
     {
-        var (repoFilter, _, error) = ParseRepoOption(repo);
+        var (repoFilters, _, error) = ParseRepoOptions(repos);
         if (error != null)
         {
             Console.WriteLine($"Error: {error}");
             return;
         }
-        var scenarios = FilterScenarios(ScenarioDiscovery.DiscoverAll(), tags, repoFilter).ToList();
+        var scenarios = FilterScenarios(ScenarioDiscovery.DiscoverAll(), tags, repoFilters).ToList();
 
         if (scenarios.Count == 0)
         {
@@ -131,7 +131,7 @@ public class Program
         Console.WriteLine($"\nTotal: {scenarios.Count} scenario(s)");
     }
 
-    private static async Task<int> HandleRunCommand(string? name, bool all, string[]? tags, string? repo, string? model, CleanupPolicy cleanup, bool verbose, int parallel, bool report, string? output)
+    private static async Task<int> HandleRunCommand(string? name, bool all, string[]? tags, string[]? repos, string? model, CleanupPolicy cleanup, bool verbose, int parallel, bool report, string? output)
     {
         if (string.IsNullOrEmpty(name) && !all)
         {
@@ -147,7 +147,7 @@ public class Program
             return 1;
         }
 
-        if ((tags is { Length: > 0 } || repo != null) && !all)
+        if ((tags is { Length: > 0 } || repos is { Length: > 0 }) && !all)
         {
             Console.WriteLine("Error: --tag and --repo can only be used with --all");
             return 1;
@@ -160,7 +160,7 @@ public class Program
         }
 
         // Parse --repo for filtering and optional ref override
-        var (repoFilter, refOverrides, repoError) = ParseRepoOption(repo);
+        var (repoFilters, refOverrides, repoError) = ParseRepoOptions(repos);
         if (repoError != null)
         {
             Console.WriteLine($"Error: {repoError}");
@@ -171,7 +171,7 @@ public class Program
 
         if (all)
         {
-            scenariosToRun.AddRange(FilterScenarios(ScenarioDiscovery.DiscoverAll(), tags, repoFilter));
+            scenariosToRun.AddRange(FilterScenarios(ScenarioDiscovery.DiscoverAll(), tags, repoFilters));
             if (scenariosToRun.Count == 0)
             {
                 var filters = new List<string>();
@@ -180,9 +180,9 @@ public class Program
                     filters.Add($"tag(s): {string.Join(", ", tags)}");
                 }
 
-                if (repo != null)
+                if (repos is { Length: > 0 })
                 {
-                    filters.Add($"repo: {repo}");
+                    filters.Add($"repo(s): {string.Join(", ", repos)}");
                 }
 
                 var message = filters.Count > 0
@@ -321,51 +321,55 @@ public class Program
         return resultsList.All(r => r.Result.Passed) ? 0 : 1;
     }
 
-    private static IEnumerable<BenchmarkScenario> FilterScenarios(IEnumerable<BenchmarkScenario> scenarios, string[]? tags, string? repoFilter)
+    private static IEnumerable<BenchmarkScenario> FilterScenarios(IEnumerable<BenchmarkScenario> scenarios, string[]? tags, string[]? repoFilters)
     {
         if (tags is { Length: > 0 })
         {
             scenarios = scenarios.Where(s => tags.Any(t => s.Tags.Contains(t, StringComparer.OrdinalIgnoreCase)));
         }
 
-        if (!string.IsNullOrEmpty(repoFilter))
+        if (repoFilters is { Length: > 0 })
         {
-            scenarios = scenarios.Where(s => $"{s.Repo.Owner}/{s.Repo.Name}".Equals(repoFilter, StringComparison.OrdinalIgnoreCase));
+            scenarios = scenarios.Where(s => repoFilters.Any(r => $"{s.Repo.Owner}/{s.Repo.Name}".Equals(r, StringComparison.OrdinalIgnoreCase)));
         }
 
         return scenarios;
     }
 
     /// <summary>
-    /// Parses --repo for filtering and optional ref override.
-    /// Accepts "Owner/Name", "Owner/Name:Ref", or "Name".
-    /// Returns an error message if the repo string is invalid.
+    /// Parses --repo values for filtering and optional ref overrides.
+    /// Each value accepts "Owner/Name", "Owner/Name:Ref", or "Name".
+    /// Returns an error message if any repo string is invalid.
     /// </summary>
-    private static (string? RepoFilter, Dictionary<string, string>? RefOverrides, string? Error) ParseRepoOption(string? repo)
+    private static (string[]? RepoFilters, Dictionary<string, string>? RefOverrides, string? Error) ParseRepoOptions(string[]? repos)
     {
-        if (string.IsNullOrEmpty(repo))
+        if (repos is not { Length: > 0 })
         {
             return (null, null, null);
         }
 
-        if (!RepoConfig.TryParseRepoString(repo, out var parsed))
-        {
-            return (null, null, $"Invalid --repo format: '{repo}'. Expected 'Owner/Name:Ref', 'Owner/Name', or 'Name'.");
-        }
-
-        var (owner, name, gitRef) = parsed;
-        var repoFilter = owner != null ? $"{owner}/{name}" : name;
-
+        var repoFilters = new List<string>();
         Dictionary<string, string>? refOverrides = null;
-        if (gitRef != null && owner != null)
+
+        foreach (var repo in repos)
         {
-            refOverrides = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            if (!RepoConfig.TryParseRepoString(repo, out var parsed))
             {
-                [$"{owner}/{name}"] = gitRef
-            };
+                return (null, null, $"Invalid --repo format: '{repo}'. Expected 'Owner/Name:Ref', 'Owner/Name', or 'Name'.");
+            }
+
+            var (owner, name, gitRef) = parsed;
+            var repoFilter = owner != null ? $"{owner}/{name}" : name;
+            repoFilters.Add(repoFilter);
+
+            if (gitRef != null && owner != null)
+            {
+                refOverrides ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                refOverrides[$"{owner}/{name}"] = gitRef;
+            }
         }
 
-        return (repoFilter, refOverrides, null);
+        return (repoFilters.ToArray(), refOverrides, null);
     }
 
     private static void PrintResult(BenchmarkResult result)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/README.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/README.md
@@ -68,8 +68,26 @@ dotnet run -- report /path/to/logs --output report.md
 |--------|-------------|---------|
 | `--model <model>` | Model to use for agent execution | `claude-opus-4.5` |
 | `--cleanup <policy>` | Cleanup policy: `always`, `never`, `on-success` | `on-success` |
+| `--repo <repo>` | Filter by repository. Append `:ref` to override the branch (see below) | — |
+| `--tag <tag>` | Filter scenarios by tag (repeatable) | — |
 | `--report` | Generate a markdown report after the run completes | `false` |
 | `--output <path>` | Output file path for the report (report command only) | `report.md` in log dir |
+| `--parallel <n>` | Max concurrent scenarios | `1` |
+| `--verbose` | Show agent activity during execution | `false` |
+
+### Branch Overrides for CI / PR Testing
+
+By default, every scenario clones its repository at `main`. When running benchmarks for a pull request, use `--repo Owner/Name:branch` to override the ref:
+
+```sh
+# Run all scenarios targeting azure-rest-api-specs, but use the PR branch instead of main
+dotnet run -- run --all --repo Azure/azure-rest-api-specs:feature/my-pr
+
+# Filter only — no branch override (existing behavior)
+dotnet run -- run --all --repo Azure/azure-rest-api-specs
+```
+
+The override applies to every matching `RepoConfig` in the selected scenarios (including `TargetRepos`).
 
 ### Environment Variables
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/README.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/README.md
@@ -68,8 +68,8 @@ dotnet run -- report /path/to/logs --output report.md
 |--------|-------------|---------|
 | `--model <model>` | Model to use for agent execution | `claude-opus-4.5` |
 | `--cleanup <policy>` | Cleanup policy: `always`, `never`, `on-success` | `on-success` |
-| `--repo <repo>` | Filter by repository. Append `:ref` to override the branch (see below) | — |
-| `--tag <tag>` | Filter scenarios by tag (repeatable) | — |
+| `--repo <repo>` | Filter by repository (when used with `run`, requires `--all`; also supported with `list`). Append `:ref` to override the branch (see below) | — |
+| `--tag <tag>` | Filter scenarios by tag (repeatable; when used with `run`, requires `--all`; also supported with `list`) | — |
 | `--report` | Generate a markdown report after the run completes | `false` |
 | `--output <path>` | Output file path for the report (report command only) | `report.md` in log dir |
 | `--parallel <n>` | Max concurrent scenarios | `1` |


### PR DESCRIPTION
- Logic left in place just removed it from being a flag passed into the CLI and placed it inside of `TestCases.json`
- `---repo` now lets you pass in the reference to replicate the behavior done inside of `authoringSpecRepoOption`