### PR TITLE
Remove alwaysAuth

### DIFF
--- a/eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+++ b/eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
@@ -21,7 +21,7 @@ steps:
       New-Item -Path $parentFolder -ItemType Directory | Out-Null
     }
 
-    $content = "registry=${{ parameters.registryUrl }}`n`nalways-auth=true"
+    $content = "registry=${{ parameters.registryUrl }}"
     $content | Out-File '${{ parameters.npmrcPath }}'
   displayName: 'Create .npmrc'
   condition: ${{ parameters.CustomCondition }}


### PR DESCRIPTION
always-auth will be deprecated soon.
Requires testing across pipelines using `create-authenticated-npmrc.yml` - will update this pr with passing tests.