### PR TITLE
Add script to analyze/update github actions tag references in a repository

### DIFF
--- a/eng/scripts/Pin-GitHubActions.ps1
+++ b/eng/scripts/Pin-GitHubActions.ps1
@@ -149,9 +149,14 @@ foreach ($group in ($unpinned | Group-Object File)) {
         $newLine = $oldLine -replace "(?<pre>uses:\s*$([regex]::Escape($r.Action)))@$([regex]::Escape($r.Ref))", "`${pre}@$sha"
         if ($newLine -ne $oldLine) {
             $lines[$idx] = $newLine
-            # Insert comment on the line above, matching indentation
+            $comment = "# SHA corresponds to $($r.Action)@$($r.Ref)"
             $indent = if ($oldLine -match '^(\s*)') { $Matches[1] } else { '' }
-            $lines.Insert($idx, "$indent# SHA corresponds to $($r.Action)@$($r.Ref)")
+            # Update existing comment above if present, otherwise insert
+            if ($idx -gt 0 -and $lines[$idx - 1] -match '^\s*# SHA corresponds to') {
+                $lines[$idx - 1] = "$indent$comment"
+            } else {
+                $lines.Insert($idx, "$indent$comment")
+            }
             $changed = $true
             $fixed++
         }


### PR DESCRIPTION
```
⇉ ⇉ ⇉ ./eng/scripts/Pin-GitHubActions.ps1  -Fix

=== GitHub owned ===
  [pinned] actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  (.github/workflows/copilot-setup-steps.yml:17)
  [pinned] actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  (.github/workflows/copilot-setup-steps.yml:20)
  [pinned] actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  (.github/workflows/eng-common-tsp-client-test.yml:31)
  [pinned] actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  (.github/workflows/eng-common-tsp-client-test.yml:41)
  [pinned] actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  (.github/workflows/eng-common-tsp-client-test.yml:76)
  [pinned] actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  (.github/workflows/eng-common-tsp-client-test.yml:85)
  [pinned] actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  (.github/workflows/eng-common-tsp-client-test.yml:95)
  [pinned] actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  (.github/workflows/eng-common-tsp-client-test.yml:105)
  [pinned] actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  (.github/workflows/eng-common-tsp-client-test.yml:115)
  [pinned] actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  (.github/workflows/eng-common-tsp-client-test.yml:125)
  [pinned] actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  (.github/workflows/event-processor.yml:112)
  [pinned] actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  (.github/workflows/post-apiview.yml:23)
  [pinned] actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  (.github/workflows/scheduled-event-processor.yml:127)
  [pinned] actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  (.github/workflows/skill-eval.yml:22)
  [pinned] actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  (.github/workflows/skill-eval.yml:58)
  [pinned] actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  (.github/workflows/skill-eval.yml:70)
  [pinned] actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  (.github/workflows/skill-eval.yml:125)
  [pinned] actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  (.github/workflows/test-login-to-github.yml:19)
  [pinned] actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  (.github/workflows/test-login-to-github.yml:60)
  [pinned] actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  (.github/workflows/tsp-client-tests.yml:33)
  [pinned] actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  (.github/workflows/tsp-client-tests.yml:41)

=== Azure/ repo owned ===
  [pinned] azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5  (.github/workflows/event-processor.yml:36)
  [TAG] azure/azure-sdk-actions@main  (.github/workflows/event.yml:23)
  [pinned] Azure/setup-azd@c495e71ba59e44bfaaac10a32c8ee90d191ca4a3  (.github/workflows/skill-eval.yml:26)
  [pinned] Azure/setup-azd@c495e71ba59e44bfaaac10a32c8ee90d191ca4a3  (.github/workflows/skill-eval.yml:98)
  [pinned] azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5  (.github/workflows/test-login-to-github.yml:22)
  [pinned] azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5  (.github/workflows/test-login-to-github.yml:63)

=== local ===
  [local] (local)@./eng/common/actions/login-to-github  (.github/workflows/test-login-to-github.yml:28)
  [local] (local)@./eng/common/actions/login-to-github  (.github/workflows/test-login-to-github.yml:69)

1 unpinned reference(s) found.
  Resolving azure/azure-sdk-actions@main ... f6b1a0e4a4856f7ac4767149ec7a74f0f8191e64

Fixed 1 reference(s).
```