### PR TITLE
[azsdk] Only install azsdk when there is a new version

### DIFF
--- a/eng/common/mcp/azure-sdk-mcp.ps1
+++ b/eng/common/mcp/azure-sdk-mcp.ps1
@@ -112,7 +112,7 @@ if ($azsdkCmd) {
         if ($localVersion.old_version -eq $localVersion.new_version) {
             log "Version up to date at $($localVersion.old_version)"
             if ($Run) {
-                $proc = Start-Process -PassThru -WorkingDirectory $RunDirectory -FilePath $azsdkCmd.Source -ArgumentList 'mcp' -NoNewWindow -Wait
+                $proc = Start-Process -PassThru -WorkingDirectory $RunDirectory -FilePath $azsdkCmd.Path -ArgumentList 'mcp' -NoNewWindow -Wait
                 exit $proc.ExitCode
             }
             exit 0

--- a/eng/common/mcp/azure-sdk-mcp.ps1
+++ b/eng/common/mcp/azure-sdk-mcp.ps1
@@ -4,8 +4,6 @@
 #Requires -PSEdition Core
 
 param(
-    [string]$FileName = 'Azure.Sdk.Tools.Cli',
-    [string]$Package = 'azsdk',
     [string]$Version, # Default to latest
     [string]$InstallDirectory = '',
     [string]$Repository = 'Azure/azure-sdk-tools',
@@ -15,10 +13,13 @@ param(
     [switch]$UpdatePathInProfile
 )
 
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference = 'Stop'
 . (Join-Path $PSScriptRoot '..' 'scripts' 'Helpers' 'AzSdkTool-Helpers.ps1')
 
 $toolInstallDirectory = $InstallDirectory ? $InstallDirectory : (Get-CommonInstallDirectory)
+
+$packageName = 'azsdk'
+$packageFileName = 'Azure.Sdk.Tools.Cli'
 
 $mcpMode = $Run
 
@@ -104,12 +105,15 @@ $guid = [System.Guid]::NewGuid()
 $tempInstallDirectory = Join-Path $tmp "azsdk-install-$($guid)"
 
 # If already installed, use first class version mechanism
-$azsdkCmd = Get-Command -ErrorAction SilentlyContinue 'azsdk'
-if ($azsdkCmd -and !$Version -and !$InstallDirectory) {
-    $upgrade = azsdk upgrade --check --output json | out-string
+$azsdkCmd = Get-Command -ErrorAction SilentlyContinue $packageName
+if ($azsdkCmd -and !$InstallDirectory) {
+    $ErrorActionPreference = "Stop"
+    $upgrade = & $packageName upgrade --check --output json | out-string
     if (!$LASTEXITCODE) {
+        $ErrorActionPreference = 'Ignore'
         $localVersion = $upgrade | ConvertFrom-Json -AsHashtable
-        if ($localVersion.old_version -eq $localVersion.new_version) {
+        $ErrorActionPreference = 'Stop'
+        if ($localVersion.old_version -and $localVersion.old_version -eq ($Version ? $Version : $localVersion.new_version)) {
             log "Version up to date at $($localVersion.old_version)"
             if ($Run) {
                 $proc = Start-Process -PassThru -WorkingDirectory $RunDirectory -FilePath $azsdkCmd.Path -ArgumentList 'mcp' -NoNewWindow -Wait
@@ -127,8 +131,8 @@ if ($mcpMode) {
         # output from the inner function as json-rpc
         $tempExe = Install-Standalone-Tool `
             -Version $Version `
-            -FileName $FileName `
-            -Package $Package `
+            -FileName $packageFileName `
+            -Package $packageName `
             -Directory $tempInstallDirectory `
             -Repository $Repository `
             *>&1
@@ -144,8 +148,8 @@ if ($mcpMode) {
 else {
     $tempExe = Install-Standalone-Tool `
         -Version $Version `
-        -FileName $FileName `
-        -Package $Package `
+        -FileName $packageFileName `
+        -Package $packageName `
         -Directory $tempInstallDirectory `
         -Repository $Repository `
 
@@ -182,7 +186,7 @@ if (Test-Path $tempInstallDirectory) {
 }
 
 if ($updateSucceeded) {
-    log "Executable $package is installed at $exeDestination"
+    log "Executable $packageName is installed at $exeDestination"
 }
 if (!$UpdatePathInProfile) {
     log -warn "To add the tool to PATH for new shell sessions, re-run with -UpdatePathInProfile to modify the shell profile file."
@@ -193,5 +197,6 @@ else {
 }
 
 if ($Run) {
-    Start-Process -WorkingDirectory $RunDirectory -FilePath $exeDestination -ArgumentList 'mcp' -NoNewWindow -Wait
+    $proc = Start-Process -PassThru -WorkingDirectory $RunDirectory -FilePath $exeDestination -ArgumentList 'mcp' -NoNewWindow -Wait
+    exit $proc.ExitCode
 }

--- a/eng/common/mcp/azure-sdk-mcp.ps1
+++ b/eng/common/mcp/azure-sdk-mcp.ps1
@@ -105,7 +105,7 @@ $tempInstallDirectory = Join-Path $tmp "azsdk-install-$($guid)"
 
 # If already installed, use first class version mechanism
 $azsdkCmd = Get-Command -ErrorAction SilentlyContinue 'azsdk'
-if ($azsdkCmd) {
+if ($azsdkCmd -and !$Version -and !$InstallDirectory) {
     $upgrade = azsdk upgrade --check --output json | out-string
     if (!$LASTEXITCODE) {
         $localVersion = $upgrade | ConvertFrom-Json -AsHashtable

--- a/eng/common/mcp/azure-sdk-mcp.ps1
+++ b/eng/common/mcp/azure-sdk-mcp.ps1
@@ -103,6 +103,24 @@ $tmp = $env:TEMP ? $env:TEMP : [System.IO.Path]::GetTempPath()
 $guid = [System.Guid]::NewGuid()
 $tempInstallDirectory = Join-Path $tmp "azsdk-install-$($guid)"
 
+# If already installed, use first class version mechanism
+$azsdkCmd = Get-Command -ErrorAction SilentlyContinue 'azsdk'
+if ($azsdkCmd) {
+    $upgrade = azsdk upgrade --check --output json | out-string
+    if (!$LASTEXITCODE) {
+        $localVersion = $upgrade | ConvertFrom-Json -AsHashtable
+        if ($localVersion.old_version -eq $localVersion.new_version) {
+            log "Version up to date at $($localVersion.old_version)"
+            if ($Run) {
+                $proc = Start-Process -PassThru -WorkingDirectory $RunDirectory -FilePath $azsdkCmd.Source -ArgumentList 'mcp' -NoNewWindow -Wait
+                exit $proc.ExitCode
+            }
+            exit 0
+        }
+        log "Version not up to date at " + $localVersion.old_version
+    }
+}
+
 if ($mcpMode) {
     try {
         # Swallow all output and re-log so we can wrap any
@@ -175,5 +193,5 @@ else {
 }
 
 if ($Run) {
-    Start-Process -WorkingDirectory $RunDirectory -FilePath $exeDestination -ArgumentList 'start' -NoNewWindow -Wait
+    Start-Process -WorkingDirectory $RunDirectory -FilePath $exeDestination -ArgumentList 'mcp' -NoNewWindow -Wait
 }


### PR DESCRIPTION
Only install azsdk when there is a new version. This also relegates the update checking to the `azsdk upgrade --check` command. We could also utilize `azsdk upgrade` instead of the powershell helpers, but the upgrade command has a two-phase install process (to avoid file locking) that would require putting a sleep in the script.