### PR TITLE
Add support for adding and removing teams

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CodeownersManagementHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CodeownersManagementHelperTests.cs
@@ -28,6 +28,7 @@ public class CodeownersManagementHelperTests
         _mockDevOps = new Mock<IDevOpsService>();
         _mockTeamUserCache = new Mock<ITeamUserCache>();
         _mockTeamUserCache.Setup(c => c.GetUsersForTeam(It.IsAny<string>())).Returns(new List<string>());
+        _mockTeamUserCache.Setup(c => c.TeamUserDict).Returns(new Dictionary<string, List<string>>(StringComparer.InvariantCultureIgnoreCase));
         _mockGitHub = new Mock<IGitHubService>();
         _helper = new CodeownersManagementHelper(
             new TestLogger<CodeownersManagementHelper>(),
@@ -1547,12 +1548,34 @@ public class CodeownersManagementHelperTests
     {
         var alias = "Azure/my-cached-team";
         _mockTeamUserCache
-            .Setup(c => c.GetUsersForTeam(alias))
-            .Returns(new List<string> { "user1", "user2" });
+            .Setup(c => c.TeamUserDict)
+            .Returns(new Dictionary<string, List<string>>(StringComparer.InvariantCultureIgnoreCase)
+            {
+                { "my-cached-team", new List<string> { "user1", "user2" } }
+            });
 
         Assert.DoesNotThrowAsync(() => _helper.ThrowIfInvalidTeamAlias(alias, CancellationToken.None));
 
         // Should not call GitHub API when found in cache
+        _mockGitHub.Verify(
+            g => g.GetTeamByNameAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Test]
+    public void ThrowIfInvalidTeamAlias_FoundInCache_EmptyTeam_DoesNotThrow()
+    {
+        var alias = "Azure/azure-sdk-partners";
+        _mockTeamUserCache
+            .Setup(c => c.TeamUserDict)
+            .Returns(new Dictionary<string, List<string>>(StringComparer.InvariantCultureIgnoreCase)
+            {
+                { "azure-sdk-partners", new List<string>() }
+            });
+
+        Assert.DoesNotThrowAsync(() => _helper.ThrowIfInvalidTeamAlias(alias, CancellationToken.None));
+
+        // Should not call GitHub API when the team key exists in the cache, even with zero members
         _mockGitHub.Verify(
             g => g.GetTeamByNameAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
@@ -1675,5 +1698,82 @@ public class CodeownersManagementHelperTests
 
         Assert.ThrowsAsync<Octokit.NotFoundException>(
             () => _helper.ThrowIfInvalidTeamAlias(alias, CancellationToken.None));
+    }
+
+    [Test]
+    public void ThrowIfInvalidTeamAlias_AtPrefixed_FoundInCache_DoesNotThrow()
+    {
+        var alias = "@Azure/azure-sdk-eng";
+        _mockTeamUserCache
+            .Setup(c => c.TeamUserDict)
+            .Returns(new Dictionary<string, List<string>>(StringComparer.InvariantCultureIgnoreCase)
+            {
+                { "azure-sdk-eng", new List<string> { "engineer1", "engineer2" } }
+            });
+
+        Assert.DoesNotThrowAsync(() => _helper.ThrowIfInvalidTeamAlias(alias, CancellationToken.None));
+
+        // Should not call GitHub API when found in cache
+        _mockGitHub.Verify(
+            g => g.GetTeamByNameAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Test]
+    public void ThrowIfInvalidTeamAlias_AtPrefixed_NotInCache_ValidatesViaGitHub()
+    {
+        var alias = "@Azure/azure-sdk-release";
+        var parentTeam = CreateTeam("azure-sdk-write");
+        var childTeam = CreateTeam("azure-sdk-release", parent: parentTeam);
+
+        _mockGitHub
+            .Setup(g => g.GetTeamByNameAsync("Azure", "azure-sdk-release", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(childTeam);
+        _mockGitHub
+            .Setup(g => g.GetTeamByNameAsync("Azure", "azure-sdk-write", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(parentTeam);
+
+        Assert.DoesNotThrowAsync(() => _helper.ThrowIfInvalidTeamAlias(alias, CancellationToken.None));
+        _mockGitHub.Verify(g => g.GetTeamByNameAsync("Azure", "azure-sdk-release", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public void ThrowIfInvalidTeamAlias_EmptyTeamName_Throws()
+    {
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            () => _helper.ThrowIfInvalidTeamAlias("Azure/", CancellationToken.None));
+        Assert.That(ex!.Message, Does.Contain("Both the organization and team name must be non-empty"));
+    }
+
+    [Test]
+    public void ThrowIfInvalidTeamAlias_EmptyOrgName_Throws()
+    {
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            () => _helper.ThrowIfInvalidTeamAlias("/azure-sdk-core", CancellationToken.None));
+        Assert.That(ex!.Message, Does.Contain("Both the organization and team name must be non-empty"));
+    }
+
+    [Test]
+    public void ThrowIfInvalidTeamAlias_AtPrefixedEmptyOrg_Throws()
+    {
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            () => _helper.ThrowIfInvalidTeamAlias("@/azure-sdk-tooling", CancellationToken.None));
+        Assert.That(ex!.Message, Does.Contain("Both the organization and team name must be non-empty"));
+    }
+
+    [Test]
+    public void ThrowIfInvalidTeamAlias_NonAzureOrg_Throws()
+    {
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            () => _helper.ThrowIfInvalidTeamAlias("contoso/azure-sdk-storage", CancellationToken.None));
+        Assert.That(ex!.Message, Does.Contain("Only teams in the 'Azure' organization are supported"));
+    }
+
+    [Test]
+    public void ThrowIfInvalidTeamAlias_AtPrefixedNonAzureOrg_Throws()
+    {
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            () => _helper.ThrowIfInvalidTeamAlias("@microsoft/azure-sdk-infra", CancellationToken.None));
+        Assert.That(ex!.Message, Does.Contain("Only teams in the 'Azure' organization are supported"));
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CodeownersManagementHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CodeownersManagementHelperTests.cs
@@ -10,6 +10,7 @@ using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 using Azure.Sdk.Tools.CodeownersUtils.Caches;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
 using Moq;
+using Octokit;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Helpers;
 
@@ -18,6 +19,7 @@ public class CodeownersManagementHelperTests
 {
     private Mock<IDevOpsService> _mockDevOps;
     private Mock<ITeamUserCache> _mockTeamUserCache;
+    private Mock<IGitHubService> _mockGitHub;
     private CodeownersManagementHelper _helper;
 
     [SetUp]
@@ -26,10 +28,12 @@ public class CodeownersManagementHelperTests
         _mockDevOps = new Mock<IDevOpsService>();
         _mockTeamUserCache = new Mock<ITeamUserCache>();
         _mockTeamUserCache.Setup(c => c.GetUsersForTeam(It.IsAny<string>())).Returns(new List<string>());
+        _mockGitHub = new Mock<IGitHubService>();
         _helper = new CodeownersManagementHelper(
             new TestLogger<CodeownersManagementHelper>(),
             _mockDevOps.Object,
-            _mockTeamUserCache.Object
+            _mockTeamUserCache.Object,
+            _mockGitHub.Object
         );
     }
 
@@ -1511,5 +1515,165 @@ public class CodeownersManagementHelperTests
         // Should remove from labelOwner1 (which has label1), not labelOwner2
         _mockDevOps.Verify(d => d.RemoveWorkItemRelationAsync(labelOwner1Id, "related", ownerId, It.IsAny<CancellationToken>()), Times.Once);
         _mockDevOps.Verify(d => d.RemoveWorkItemRelationAsync(labelOwner2Id, "related", It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ========================
+    // ThrowIfInvalidTeamAlias tests
+    // ========================
+
+    private static Team CreateTeam(string slug, Team? parent = null)
+    {
+        return new Team(
+            url: $"https://api.github.com/orgs/Azure/teams/{slug}",
+            htmlUrl: $"https://github.com/orgs/Azure/teams/{slug}",
+            id: slug.GetHashCode(),
+            nodeId: $"T_{slug.GetHashCode()}",
+            slug: slug,
+            name: slug,
+            description: "",
+            privacy: TeamPrivacy.Closed,
+            permission: "push",
+            teamRepositoryPermissions: null,
+            membersCount: 1,
+            reposCount: 0,
+            organization: null,
+            parent: parent,
+            ldapDistinguishedName: null
+        );
+    }
+
+    [Test]
+    public void ThrowIfInvalidTeamAlias_FoundInCache_DoesNotThrow()
+    {
+        var alias = "Azure/my-cached-team";
+        _mockTeamUserCache
+            .Setup(c => c.GetUsersForTeam(alias))
+            .Returns(new List<string> { "user1", "user2" });
+
+        Assert.DoesNotThrowAsync(() => _helper.ThrowIfInvalidTeamAlias(alias, CancellationToken.None));
+
+        // Should not call GitHub API when found in cache
+        _mockGitHub.Verify(
+            g => g.GetTeamByNameAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Test]
+    public void ThrowIfInvalidTeamAlias_NotInCache_DirectlyIsAzureSdkWrite_DoesNotThrow()
+    {
+        var alias = "Azure/azure-sdk-write";
+        var team = CreateTeam("azure-sdk-write");
+
+        _mockGitHub
+            .Setup(g => g.GetTeamByNameAsync("Azure", "azure-sdk-write", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(team);
+
+        Assert.DoesNotThrowAsync(() => _helper.ThrowIfInvalidTeamAlias(alias, CancellationToken.None));
+        _mockGitHub.Verify(g => g.GetTeamByNameAsync("Azure", "azure-sdk-write", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public void ThrowIfInvalidTeamAlias_NotInCache_ParentIsAzureSdkWrite_DoesNotThrow()
+    {
+        var alias = "Azure/my-child-team";
+        var parentTeam = CreateTeam("azure-sdk-write");
+        var childTeam = CreateTeam("my-child-team", parent: parentTeam);
+
+        _mockGitHub
+            .Setup(g => g.GetTeamByNameAsync("Azure", "my-child-team", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(childTeam);
+        _mockGitHub
+            .Setup(g => g.GetTeamByNameAsync("Azure", "azure-sdk-write", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(parentTeam);
+
+        Assert.DoesNotThrowAsync(() => _helper.ThrowIfInvalidTeamAlias(alias, CancellationToken.None));
+        _mockGitHub.Verify(g => g.GetTeamByNameAsync("Azure", "my-child-team", It.IsAny<CancellationToken>()), Times.Once);
+        _mockGitHub.Verify(g => g.GetTeamByNameAsync("Azure", "azure-sdk-write", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public void ThrowIfInvalidTeamAlias_NotInCache_GrandparentIsAzureSdkWrite_DoesNotThrow()
+    {
+        var alias = "Azure/deep-child-team";
+        var azureSdkWrite = CreateTeam("azure-sdk-write");
+        var midTeam = CreateTeam("mid-team", parent: azureSdkWrite);
+        var deepChild = CreateTeam("deep-child-team", parent: midTeam);
+
+        _mockGitHub
+            .Setup(g => g.GetTeamByNameAsync("Azure", "deep-child-team", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(deepChild);
+        _mockGitHub
+            .Setup(g => g.GetTeamByNameAsync("Azure", "mid-team", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(midTeam);
+        _mockGitHub
+            .Setup(g => g.GetTeamByNameAsync("Azure", "azure-sdk-write", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(azureSdkWrite);
+
+        Assert.DoesNotThrowAsync(() => _helper.ThrowIfInvalidTeamAlias(alias, CancellationToken.None));
+        _mockGitHub.Verify(g => g.GetTeamByNameAsync("Azure", "deep-child-team", It.IsAny<CancellationToken>()), Times.Once);
+        _mockGitHub.Verify(g => g.GetTeamByNameAsync("Azure", "mid-team", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public void ThrowIfInvalidTeamAlias_NotInCache_NotDescendantOfAzureSdkWrite_Throws()
+    {
+        var alias = "Azure/unrelated-team";
+        var unrelatedTeam = CreateTeam("unrelated-team", parent: null);
+
+        _mockGitHub
+            .Setup(g => g.GetTeamByNameAsync("Azure", "unrelated-team", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(unrelatedTeam);
+
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            () => _helper.ThrowIfInvalidTeamAlias(alias, CancellationToken.None));
+        Assert.That(ex!.Message, Does.Contain("is not a child of 'azure-sdk-write'"));
+    }
+
+    [Test]
+    public void ThrowIfInvalidTeamAlias_NotInCache_ParentChainDoesNotReachAzureSdkWrite_Throws()
+    {
+        var alias = "Azure/wrong-tree-team";
+        var otherRoot = CreateTeam("other-root", parent: null);
+        var wrongTreeTeam = CreateTeam("wrong-tree-team", parent: otherRoot);
+
+        _mockGitHub
+            .Setup(g => g.GetTeamByNameAsync("Azure", "wrong-tree-team", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(wrongTreeTeam);
+        _mockGitHub
+            .Setup(g => g.GetTeamByNameAsync("Azure", "other-root", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(otherRoot);
+
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            () => _helper.ThrowIfInvalidTeamAlias(alias, CancellationToken.None));
+        Assert.That(ex!.Message, Does.Contain("is not a child of 'azure-sdk-write'"));
+    }
+
+    [Test]
+    public void ThrowIfInvalidTeamAlias_InvalidFormat_MultipleSlashes_Throws()
+    {
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            () => _helper.ThrowIfInvalidTeamAlias("Azure/sub/team", CancellationToken.None));
+        Assert.That(ex!.Message, Does.Contain("Team aliases must be in the format '<org>/<team>' with exactly one '/'"));
+    }
+
+    [Test]
+    public void ThrowIfInvalidTeamAlias_NoSlash_Throws()
+    {
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            () => _helper.ThrowIfInvalidTeamAlias("just-a-name", CancellationToken.None));
+        Assert.That(ex!.Message, Does.Contain("Team aliases must be in the format '<org>/<team>' with exactly one '/'"));
+    }
+
+    [Test]
+    public void ThrowIfInvalidTeamAlias_NotInCache_NotFoundOnGitHub_Throws()
+    {
+        var alias = "Azure/nonexistent-team";
+
+        _mockGitHub
+            .Setup(g => g.GetTeamByNameAsync("Azure", "nonexistent-team", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Octokit.NotFoundException("Not Found", System.Net.HttpStatusCode.NotFound));
+
+        Assert.ThrowsAsync<Octokit.NotFoundException>(
+            () => _helper.ThrowIfInvalidTeamAlias(alias, CancellationToken.None));
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockGitHubService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockGitHubService.cs
@@ -356,5 +356,10 @@ namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
             var emptyResult = new SearchCodeResult(0, false, new List<SearchCode>());
             return Task.FromResult(emptyResult);
         }
+
+        public Task<Team> GetTeamByNameAsync(string org, string teamSlug, CancellationToken ct)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Config/CodeownersToolsTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Config/CodeownersToolsTests.cs
@@ -1,5 +1,4 @@
 using Moq;
-using Octokit;
 
 using Azure.Sdk.Tools.Cli.Services;
 using Azure.Sdk.Tools.Cli.Helpers;
@@ -7,10 +6,9 @@ using Azure.Sdk.Tools.Cli.Models.AzureDevOps;
 using Azure.Sdk.Tools.Cli.Models.Responses;
 using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 using Azure.Sdk.Tools.Cli.Tests.Mocks.Services;
-using Azure.Sdk.Tools.Cli.Tools.EngSys;
 using Azure.Sdk.Tools.Cli.Tools.Config;
 using Azure.Sdk.Tools.Cli.Models.Responses.Codeowners;
-using Azure.Sdk.Tools.Cli.Configuration;
+using Azure.Sdk.Tools.CodeownersUtils.Caches;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Tools.Config
 {
@@ -23,6 +21,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.Config
         private Mock<ICodeownersGenerateHelper> _mockcodeownersGenerateHelper;
         private Mock<ICodeownersManagementHelper> _mockCodeownersManagement;
         private Mock<IDevOpsService> _mockDevOps;
+        private Mock<ITeamUserCache> _mockTeamUserCache;
 
         private CodeownersTool _tool;
 
@@ -35,6 +34,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.Config
             _mockGitHelper = new Mock<IGitHelper>();
             _mockCodeownersManagement = new Mock<ICodeownersManagementHelper>();
             _mockDevOps = new Mock<IDevOpsService>();
+            _mockTeamUserCache = new Mock<ITeamUserCache>();
+            _mockTeamUserCache.Setup(c => c.GetUsersForTeam(It.IsAny<string>())).Returns(new List<string>());
 
             _tool = new CodeownersTool(
                 _mockGithub,
@@ -44,7 +45,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.Config
                 _mockcodeownersGenerateHelper.Object,
                 _mockGitHelper.Object,
                 _mockCodeownersManagement.Object,
-                _mockDevOps.Object
+                _mockDevOps.Object,
+                _mockTeamUserCache.Object
             );
         }
 
@@ -138,5 +140,6 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.Config
 
             Assert.That(result.ToString(), Does.Contain("Could not infer repository"));
         }
+
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Config/CodeownersToolsTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Config/CodeownersToolsTests.cs
@@ -45,8 +45,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.Config
                 _mockcodeownersGenerateHelper.Object,
                 _mockGitHelper.Object,
                 _mockCodeownersManagement.Object,
-                _mockDevOps.Object,
-                _mockTeamUserCache.Object
+                _mockDevOps.Object
             );
         }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CodeownersManagementHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CodeownersManagementHelper.cs
@@ -415,22 +415,37 @@ public class CodeownersManagementHelper(
     /// </summary>
     public async Task ThrowIfInvalidTeamAlias(string alias, CancellationToken ct)
     {
-        if (alias.Count(c => c == '/') != 1)
+        var normalizedAlias = NormalizeGitHubAlias(alias);
+
+        if (normalizedAlias.Count(c => c == '/') != 1)
         {
             throw new InvalidOperationException(
                 $"Invalid team alias '{alias}'. Team aliases must be in the format '<org>/<team>' with exactly one '/'.");
         }
 
         // Extract the team name without the org prefix for cache lookup
-        var parts = alias.Split('/', StringSplitOptions.TrimEntries);
+        var parts = normalizedAlias.Split('/', StringSplitOptions.TrimEntries);
         var org = parts[0];
         var teamSlug = parts[1];
 
-        // Check if the team exists in the TeamUserCache (populated from azure-sdk-write blob)
-        var usersForTeam = teamUserCache.GetUsersForTeam(alias);
-        if (usersForTeam.Count > 0)
+        if (string.IsNullOrEmpty(org) || string.IsNullOrEmpty(teamSlug))
         {
-            logger.LogInformation("Team '{Alias}' found in TeamUserCache with {Count} members", alias, usersForTeam.Count);
+            throw new InvalidOperationException(
+                $"Invalid team alias '{alias}'. Both the organization and team name must be non-empty.");
+        }
+
+        if (!string.Equals(org, "Azure", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Invalid team alias '{alias}'. Only teams in the 'Azure' organization are supported.");
+        }
+
+        // Check if the team exists in the TeamUserDict (populated from azure-sdk-write blob).
+        // Use ContainsKey rather than GetUsersForTeam so that teams with zero members
+        // are still accepted — empty-team validation happens later during the release gate.
+        if (teamUserCache.TeamUserDict.ContainsKey(teamSlug))
+        {
+            logger.LogInformation("Team '{Alias}' found in TeamUserCache", alias);
             return;
         }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CodeownersManagementHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CodeownersManagementHelper.cs
@@ -9,6 +9,7 @@ using Azure.Sdk.Tools.Cli.Services;
 using Azure.Sdk.Tools.CodeownersUtils.Caches;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
 using Azure.Sdk.Tools.Cli.Configuration;
+using Octokit;
 
 namespace Azure.Sdk.Tools.Cli.Helpers;
 
@@ -34,7 +35,8 @@ public static class OwnerTypeExtensions
 public class CodeownersManagementHelper(
     ILogger<CodeownersManagementHelper> logger,
     IDevOpsService devOpsService,
-    ITeamUserCache teamUserCache
+    ITeamUserCache teamUserCache,
+    IGitHubService githubService
 ) : ICodeownersManagementHelper
 {
     public async Task<CodeownersViewResponse> GetViewByUser(string alias, string? repo, CancellationToken ct)
@@ -405,6 +407,64 @@ public class CodeownersManagementHelper(
         };
         var created = await devOpsService.CreateWorkItemAsync(labelOwnerWi, "Label Owner", title, ct: ct);
         return WorkItemMappers.MapToLabelOwnerWorkItem(created);
+    }
+
+    /// <summary>
+    /// Throws <see cref="InvalidOperationException"/> if the team alias is not in the expected
+    /// format or does not descend from the azure-sdk-write team.
+    /// </summary>
+    public async Task ThrowIfInvalidTeamAlias(string alias, CancellationToken ct)
+    {
+        if (alias.Count(c => c == '/') != 1)
+        {
+            throw new InvalidOperationException(
+                $"Invalid team alias '{alias}'. Team aliases must be in the format '<org>/<team>' with exactly one '/'.");
+        }
+
+        // Extract the team name without the org prefix for cache lookup
+        var parts = alias.Split('/', StringSplitOptions.TrimEntries);
+        var org = parts[0];
+        var teamSlug = parts[1];
+
+        // Check if the team exists in the TeamUserCache (populated from azure-sdk-write blob)
+        var usersForTeam = teamUserCache.GetUsersForTeam(alias);
+        if (usersForTeam.Count > 0)
+        {
+            logger.LogInformation("Team '{Alias}' found in TeamUserCache with {Count} members", alias, usersForTeam.Count);
+            return;
+        }
+
+        logger.LogInformation("Team '{Alias}' not found in TeamUserCache, verifying via GitHub API", alias);
+
+        // Fetch the team from GitHub
+        var team = await githubService.GetTeamByNameAsync(org, teamSlug, ct);
+
+        // Walk the parent chain to verify the team is under azure-sdk-write.
+        // The loop is bounded by MaxParentDepth to prevent infinite loops.
+        const int MaxParentDepth = 20;
+        const string AzureSdkWriteTeamSlug = "azure-sdk-write";
+
+        var current = team;
+        for (int depth = 0; depth < MaxParentDepth; depth++)
+        {
+            if (string.Equals(current.Slug, AzureSdkWriteTeamSlug, StringComparison.OrdinalIgnoreCase))
+            {
+                logger.LogInformation("Team '{Alias}' is a descendant of '{Parent}'", alias, AzureSdkWriteTeamSlug);
+                return;
+            }
+
+            if (current.Parent == null)
+            {
+                break;
+            }
+
+            // Re-fetch the parent team to get the complete object with its own Parent populated.
+            current = await githubService.GetTeamByNameAsync(org, current.Parent.Slug, ct);
+        }
+
+        throw new InvalidOperationException(
+            $"GitHub team '{alias}' is not a child of '{AzureSdkWriteTeamSlug}'. " +
+            $"Only teams that descend from '{AzureSdkWriteTeamSlug}' can be added as CODEOWNERS.");
     }
 
     // ========================

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/ICodeownersManagementHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/ICodeownersManagementHelper.cs
@@ -35,4 +35,7 @@ public interface ICodeownersManagementHelper
     Task<CodeownersModifyResponse> RemoveOwnersFromPackage(OwnerWorkItem[] owners, string packageName, string repo, CancellationToken ct);
     Task<CodeownersModifyResponse> RemoveLabelsFromPackage(LabelWorkItem[] labels, string packageName, string repo, CancellationToken ct);
     Task<CodeownersModifyResponse> RemoveOwnersFromLabelsAndPath(OwnerWorkItem[] owners, LabelWorkItem[] labels, string repo, string path, OwnerType ownerType, CancellationToken ct);
+
+    // Validation
+    Task ThrowIfInvalidTeamAlias(string alias, CancellationToken ct);
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/GitHubService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/GitHubService.cs
@@ -122,6 +122,7 @@ namespace Azure.Sdk.Tools.Cli.Services
         public Task<HashSet<string>?> GetPublicOrgMembership(string username, CancellationToken ct);
         public Task<bool> HasWritePermission(string owner, string repo, string username, CancellationToken ct);
         public Task<Octokit.SearchCodeResult> SearchFilesAsync(string searchQuery, CancellationToken ct);
+        public Task<Team> GetTeamByNameAsync(string org, string teamSlug, CancellationToken ct);
     }
 
     // We enforce cancellation token usage broadly via an analyzer across this codebase,
@@ -700,6 +701,11 @@ namespace Azure.Sdk.Tools.Cli.Services
         {
             var searchRequest = new Octokit.SearchCodeRequest(searchQuery);
             return await gitHubClient.Search.SearchCode(searchRequest);
+        }
+
+        public async Task<Team> GetTeamByNameAsync(string org, string teamSlug, CancellationToken ct)
+        {
+            return await gitHubClient.Organization.Team.GetByName(org, teamSlug);
         }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
@@ -11,6 +11,7 @@ using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Models.Codeowners;
 using Azure.Sdk.Tools.Cli.Models.Responses.Codeowners;
 using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.CodeownersUtils.Caches;
 using Azure.Sdk.Tools.CodeownersUtils.Editing;
 using Azure.Sdk.Tools.CodeownersUtils.Parsing;
 using Azure.Sdk.Tools.CodeownersUtils.Utils;
@@ -117,6 +118,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
         private readonly ICodeownersManagementHelper codeownersManagementHelper;
         private readonly IGitHelper gitHelper;
         private readonly IDevOpsService devOpsService;
+        private readonly ITeamUserCache teamUserCache;
 
         // URL constants
         private const string azureWriteTeamsBlobUrl = "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/azure-sdk-write-teams-blob";
@@ -176,7 +178,8 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
             ICodeownersGenerateHelper codeownersGenerateHelper,
             IGitHelper gitHelper,
             ICodeownersManagementHelper codeownersManagementHelper,
-            IDevOpsService devOpsService
+            IDevOpsService devOpsService,
+            ITeamUserCache teamUserCache
         )
         {
             this.githubService = githubService;
@@ -186,6 +189,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
             this.codeownersManagementHelper = codeownersManagementHelper;
             this.gitHelper = gitHelper;
             this.devOpsService = devOpsService;
+            this.teamUserCache = teamUserCache;
 
             CodeownersUtils.Utils.Log.Configure(loggerFactory);
         }
@@ -652,6 +656,13 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
             var ownerWorkItems = new List<OwnerWorkItem>();
             foreach (var alias in ownerAliases)
             {
+                var isTeamAlias = IsTeamAlias(alias);
+                if (isTeamAlias)
+                {
+                    await codeownersManagementHelper.ThrowIfInvalidTeamAlias(alias, ct);
+                }
+
+                // Owner work items exist for both individual and teams
                 var existing = await codeownersManagementHelper.FindOwnerByGitHubAlias(alias, ct);
                 if (existing != null)
                 {
@@ -659,11 +670,14 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
                     continue;
                 }
 
-                var validation = await codeownersValidatorHelper.ValidateCodeOwnerAsync(alias, verbose: false, ct: ct);
-                if (!validation.IsValidCodeOwner)
+                if (!isTeamAlias)
                 {
-                    throw new InvalidOperationException(
-                        $"GitHub user '{alias}' is not a valid Azure SDK code owner: {validation.Message}");
+                    var validation = await codeownersValidatorHelper.ValidateCodeOwnerAsync(alias, verbose: false, ct: ct);
+                    if (!validation.IsValidCodeOwner)
+                    {
+                        throw new InvalidOperationException(
+                            $"GitHub user '{alias}' is not a valid Azure SDK code owner: {validation.Message}");
+                    }
                 }
 
                 var ownerWi = new OwnerWorkItem { GitHubAlias = alias };
@@ -686,6 +700,14 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
                 labelWorkItems.Add(labelWorkItem);
             }
             return labelWorkItems.ToArray();
+        }
+
+        /// <summary>
+        /// Determines whether an alias is a team reference (contains a '/' separator, e.g. "azure/my-team").
+        /// </summary>
+        private static bool IsTeamAlias(string alias)
+        {
+            return alias.Contains('/');
         }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
@@ -118,7 +118,6 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
         private readonly ICodeownersManagementHelper codeownersManagementHelper;
         private readonly IGitHelper gitHelper;
         private readonly IDevOpsService devOpsService;
-        private readonly ITeamUserCache teamUserCache;
 
         // URL constants
         private const string azureWriteTeamsBlobUrl = "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/azure-sdk-write-teams-blob";
@@ -178,8 +177,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
             ICodeownersGenerateHelper codeownersGenerateHelper,
             IGitHelper gitHelper,
             ICodeownersManagementHelper codeownersManagementHelper,
-            IDevOpsService devOpsService,
-            ITeamUserCache teamUserCache
+            IDevOpsService devOpsService
         )
         {
             this.githubService = githubService;
@@ -189,7 +187,6 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
             this.codeownersManagementHelper = codeownersManagementHelper;
             this.gitHelper = gitHelper;
             this.devOpsService = devOpsService;
-            this.teamUserCache = teamUserCache;
 
             CodeownersUtils.Utils.Log.Configure(loggerFactory);
         }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
@@ -11,7 +11,6 @@ using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Models.Codeowners;
 using Azure.Sdk.Tools.Cli.Models.Responses.Codeowners;
 using Azure.Sdk.Tools.Cli.Services;
-using Azure.Sdk.Tools.CodeownersUtils.Caches;
 using Azure.Sdk.Tools.CodeownersUtils.Editing;
 using Azure.Sdk.Tools.CodeownersUtils.Parsing;
 using Azure.Sdk.Tools.CodeownersUtils.Utils;


### PR DESCRIPTION
Adds support for specifying teams in `--github-user` ... This is useful for adding GitHub managed teams. 

Teams are valid if they are children of `azure-sdk-write` 