### PR TITLE
Fix sample translation to preserve source directory structure

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/Samples/SampleTranslatorToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/Samples/SampleTranslatorToolTests.cs
@@ -12,7 +12,6 @@ using Azure.Sdk.Tools.Cli.Telemetry;
 using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 using Azure.Sdk.Tools.Cli.Tests.Mocks.Services;
 using Azure.Sdk.Tools.Cli.Tools.Package.Samples;
-using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Tools.Package.Samples;
@@ -167,6 +166,17 @@ public class SampleTranslatorDirectoryStructureTests
     private Mock<LanguageService> _mockTargetLanguageService;
     private SampleTranslatorTool _tool;
     private List<LanguageService> _languageServices;
+    private readonly List<TempDirectory> _tempDirs = [];
+
+    [TearDown]
+    public void TearDown()
+    {
+        foreach (var temp in _tempDirs)
+        {
+            temp.Dispose();
+        }
+        _tempDirs.Clear();
+    }
 
     [SetUp]
     public void Setup()
@@ -324,6 +334,36 @@ public class SampleTranslatorDirectoryStructureTests
     }
 
     [Test]
+    public async Task TranslateSamples_AmbiguousFilenameFallback_SkipsSample()
+    {
+        var (sourcePackagePath, targetPackagePath, targetSamplesDir) = await CreateFakePackagesAsync(
+            sourceSamples: new Dictionary<string, string>
+            {
+                ["v1/client.go"] = "package v1\nfunc New() {}",
+                ["v2/client.go"] = "package v2\nfunc New() {}",
+            });
+
+        // AI returns just the filename (ambiguous — matches both v1/client.go and v2/client.go)
+        _copilotAgentRunnerMock
+            .Setup(m => m.RunAsync(It.IsAny<CopilotAgent<List<TranslatedSample>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TranslatedSample>
+            {
+                new("client.go", "client.py", "class Client: pass"),
+            });
+
+        var result = await _tool.TranslateSamplesAsync(sourcePackagePath, targetPackagePath, overwrite: true);
+
+        Assert.That(result.OperationStatus, Is.EqualTo(Status.Succeeded));
+        // The ambiguous sample should be skipped — no file written
+        Assert.That(File.Exists(Path.Combine(targetSamplesDir, "v1", "client.py")), Is.False,
+            "Ambiguous filename-only match should not write to v1/");
+        Assert.That(File.Exists(Path.Combine(targetSamplesDir, "v2", "client.py")), Is.False,
+            "Ambiguous filename-only match should not write to v2/");
+        Assert.That(File.Exists(Path.Combine(targetSamplesDir, "client.py")), Is.False,
+            "Ambiguous filename-only match should not write to root either");
+    }
+
+    [Test]
     public async Task TranslateSamples_PromptContainsRelativePaths()
     {
         var (sourcePackagePath, targetPackagePath, _) = await CreateFakePackagesAsync(
@@ -388,6 +428,7 @@ public class SampleTranslatorDirectoryStructureTests
     {
         // Source repo (Go)
         var sourceTemp = TempDirectory.Create("azure-sdk-for-go-source");
+        _tempDirs.Add(sourceTemp);
         var sourceRepoRoot = sourceTemp.DirectoryPath;
         await GitTestHelper.GitInitAsync(sourceRepoRoot);
         var sourceRelativePath = Path.Combine("sdk", "storage", "azblob");
@@ -426,6 +467,7 @@ public class SampleTranslatorDirectoryStructureTests
 
         // Target repo (Python)
         var targetTemp = TempDirectory.Create("azure-sdk-for-python-target");
+        _tempDirs.Add(targetTemp);
         var targetRepoRoot = targetTemp.DirectoryPath;
         await GitTestHelper.GitInitAsync(targetRepoRoot);
         var targetRelativePath = Path.Combine("sdk", "storage", "azure-storage-blob");

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/Samples/SampleTranslatorToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/Samples/SampleTranslatorToolTests.cs
@@ -4,9 +4,15 @@
 using Azure.Sdk.Tools.Cli.Commands;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.CopilotAgents;
+using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Services;
 using Azure.Sdk.Tools.Cli.Services.Languages;
+using Azure.Sdk.Tools.Cli.Services.Languages.Samples;
+using Azure.Sdk.Tools.Cli.Telemetry;
 using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
+using Azure.Sdk.Tools.Cli.Tests.Mocks.Services;
 using Azure.Sdk.Tools.Cli.Tools.Package.Samples;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Tools.Package.Samples;
@@ -141,5 +147,331 @@ public class SampleTranslatorToolTests
         // Missing --to option  
         var parseResult3 = command.Parse("--from /source/path");
         Assert.That(parseResult3.Errors, Is.Not.Empty);
+    }
+}
+
+/// <summary>
+/// Tests for directory structure preservation during sample translation.
+/// These tests verify that translated samples are written to the same relative
+/// subdirectory structure as the source samples.
+/// </summary>
+[TestFixture]
+public class SampleTranslatorDirectoryStructureTests
+{
+    private TestLogger<SampleTranslatorTool> _logger;
+    private OutputHelper _outputHelper;
+    private Mock<ICopilotAgentRunner> _copilotAgentRunnerMock;
+    private Mock<IGitHelper> _mockGitHelper;
+    private Mock<ITelemetryService> _telemetryServiceMock;
+    private Mock<LanguageService> _mockSourceLanguageService;
+    private Mock<LanguageService> _mockTargetLanguageService;
+    private SampleTranslatorTool _tool;
+    private List<LanguageService> _languageServices;
+
+    [SetUp]
+    public void Setup()
+    {
+        _logger = new TestLogger<SampleTranslatorTool>();
+        _outputHelper = new OutputHelper();
+        _copilotAgentRunnerMock = new Mock<ICopilotAgentRunner>();
+        _telemetryServiceMock = new Mock<ITelemetryService>();
+        _mockGitHelper = new Mock<IGitHelper>();
+
+        var fileHelper = new FileHelper(new TestLogger<FileHelper>());
+
+        _mockSourceLanguageService = new Mock<LanguageService>();
+        _mockSourceLanguageService.Setup(ls => ls.Language).Returns(SdkLanguage.Go);
+        _mockSourceLanguageService.Setup(ls => ls.SampleLanguageContext).Returns(new GoSampleLanguageContext(fileHelper));
+
+        _mockTargetLanguageService = new Mock<LanguageService>();
+        _mockTargetLanguageService.Setup(ls => ls.Language).Returns(SdkLanguage.Python);
+        _mockTargetLanguageService.Setup(ls => ls.SampleLanguageContext).Returns(new PythonSampleLanguageContext(fileHelper));
+
+        _languageServices = [_mockSourceLanguageService.Object, _mockTargetLanguageService.Object];
+
+        _tool = new SampleTranslatorTool(
+            _copilotAgentRunnerMock.Object,
+            _logger,
+            _mockGitHelper.Object,
+            _languageServices);
+        _tool.Initialize(_outputHelper, _telemetryServiceMock.Object, new MockUpgradeService());
+    }
+
+    [Test]
+    public async Task TranslateSamples_PreservesSubdirectoryStructure()
+    {
+        var (sourcePackagePath, targetPackagePath, targetSamplesDir) = await CreateFakePackagesAsync(
+            sourceSamples: new Dictionary<string, string>
+            {
+                ["sync/create_blob.go"] = "package main\nfunc CreateBlob() {}",
+                ["async/create_blob.go"] = "package main\nfunc CreateBlobAsync() {}",
+            });
+
+        _copilotAgentRunnerMock
+            .Setup(m => m.RunAsync(It.IsAny<CopilotAgent<List<TranslatedSample>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TranslatedSample>
+            {
+                new("sync/create_blob.go", "create_blob.py", "def create_blob(): pass"),
+                new("async/create_blob.go", "create_blob_async.py", "async def create_blob(): pass"),
+            });
+
+        var result = await _tool.TranslateSamplesAsync(sourcePackagePath, targetPackagePath, overwrite: true);
+
+        Assert.That(result.OperationStatus, Is.EqualTo(Status.Succeeded));
+        Assert.That(File.Exists(Path.Combine(targetSamplesDir, "sync", "create_blob.py")), Is.True,
+            "Translated file should be in sync/ subdirectory");
+        Assert.That(File.Exists(Path.Combine(targetSamplesDir, "async", "create_blob_async.py")), Is.True,
+            "Translated file should be in async/ subdirectory");
+    }
+
+    [Test]
+    public async Task TranslateSamples_PreservesNestedSubdirectoryStructure()
+    {
+        var (sourcePackagePath, targetPackagePath, targetSamplesDir) = await CreateFakePackagesAsync(
+            sourceSamples: new Dictionary<string, string>
+            {
+                ["level1/level2/deep_sample.go"] = "package main\nfunc Deep() {}",
+            });
+
+        _copilotAgentRunnerMock
+            .Setup(m => m.RunAsync(It.IsAny<CopilotAgent<List<TranslatedSample>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TranslatedSample>
+            {
+                new("level1/level2/deep_sample.go", "deep_sample.py", "def deep(): pass"),
+            });
+
+        var result = await _tool.TranslateSamplesAsync(sourcePackagePath, targetPackagePath, overwrite: true);
+
+        Assert.That(result.OperationStatus, Is.EqualTo(Status.Succeeded));
+        Assert.That(File.Exists(Path.Combine(targetSamplesDir, "level1", "level2", "deep_sample.py")), Is.True,
+            "Translated file should preserve nested subdirectory structure");
+    }
+
+    [Test]
+    public async Task TranslateSamples_RootLevelSamples_WrittenToOutputRoot()
+    {
+        var (sourcePackagePath, targetPackagePath, targetSamplesDir) = await CreateFakePackagesAsync(
+            sourceSamples: new Dictionary<string, string>
+            {
+                ["simple_sample.go"] = "package main\nfunc Simple() {}",
+            });
+
+        _copilotAgentRunnerMock
+            .Setup(m => m.RunAsync(It.IsAny<CopilotAgent<List<TranslatedSample>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TranslatedSample>
+            {
+                new("simple_sample.go", "simple_sample.py", "def simple(): pass"),
+            });
+
+        var result = await _tool.TranslateSamplesAsync(sourcePackagePath, targetPackagePath, overwrite: true);
+
+        Assert.That(result.OperationStatus, Is.EqualTo(Status.Succeeded));
+        Assert.That(File.Exists(Path.Combine(targetSamplesDir, "simple_sample.py")), Is.True,
+            "Root-level sample should be written to target samples directory root");
+    }
+
+    [Test]
+    public async Task TranslateSamples_SameNameDifferentDirs_BothPreserved()
+    {
+        var (sourcePackagePath, targetPackagePath, targetSamplesDir) = await CreateFakePackagesAsync(
+            sourceSamples: new Dictionary<string, string>
+            {
+                ["v1/client.go"] = "package v1\nfunc New() {}",
+                ["v2/client.go"] = "package v2\nfunc New() {}",
+            });
+
+        _copilotAgentRunnerMock
+            .Setup(m => m.RunAsync(It.IsAny<CopilotAgent<List<TranslatedSample>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TranslatedSample>
+            {
+                new("v1/client.go", "client.py", "class ClientV1: pass"),
+                new("v2/client.go", "client.py", "class ClientV2: pass"),
+            });
+
+        var result = await _tool.TranslateSamplesAsync(sourcePackagePath, targetPackagePath, overwrite: true);
+
+        Assert.That(result.OperationStatus, Is.EqualTo(Status.Succeeded));
+        var v1File = Path.Combine(targetSamplesDir, "v1", "client.py");
+        var v2File = Path.Combine(targetSamplesDir, "v2", "client.py");
+        Assert.That(File.Exists(v1File), Is.True, "v1/client.py should exist");
+        Assert.That(File.Exists(v2File), Is.True, "v2/client.py should exist");
+        Assert.That(await File.ReadAllTextAsync(v1File), Does.Contain("ClientV1"));
+        Assert.That(await File.ReadAllTextAsync(v2File), Does.Contain("ClientV2"));
+    }
+
+    [Test]
+    public async Task TranslateSamples_FallbackToFilenameLookup_StillWorks()
+    {
+        var (sourcePackagePath, targetPackagePath, targetSamplesDir) = await CreateFakePackagesAsync(
+            sourceSamples: new Dictionary<string, string>
+            {
+                ["subdir/unique_sample.go"] = "package main\nfunc Unique() {}",
+            });
+
+        // AI returns just the filename without the relative path (backward compatibility)
+        _copilotAgentRunnerMock
+            .Setup(m => m.RunAsync(It.IsAny<CopilotAgent<List<TranslatedSample>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TranslatedSample>
+            {
+                new("unique_sample.go", "unique_sample.py", "def unique(): pass"),
+            });
+
+        var result = await _tool.TranslateSamplesAsync(sourcePackagePath, targetPackagePath, overwrite: true);
+
+        Assert.That(result.OperationStatus, Is.EqualTo(Status.Succeeded));
+        Assert.That(File.Exists(Path.Combine(targetSamplesDir, "subdir", "unique_sample.py")), Is.True,
+            "Filename-only fallback should still place file in correct subdirectory");
+    }
+
+    [Test]
+    public async Task TranslateSamples_PromptContainsRelativePaths()
+    {
+        var (sourcePackagePath, targetPackagePath, _) = await CreateFakePackagesAsync(
+            sourceSamples: new Dictionary<string, string>
+            {
+                ["sync/sample.go"] = "package main\nfunc Sync() {}",
+                ["async/sample.go"] = "package main\nfunc Async() {}",
+            });
+
+        CopilotAgent<List<TranslatedSample>>? capturedAgent = null;
+        _copilotAgentRunnerMock
+            .Setup(m => m.RunAsync(It.IsAny<CopilotAgent<List<TranslatedSample>>>(), It.IsAny<CancellationToken>()))
+            .Callback<CopilotAgent<List<TranslatedSample>>, CancellationToken>((agent, _) => capturedAgent = agent)
+            .ReturnsAsync(new List<TranslatedSample>
+            {
+                new("sync/sample.go", "sample.py", "def sync(): pass"),
+                new("async/sample.go", "sample_async.py", "async def sample(): pass"),
+            });
+
+        await _tool.TranslateSamplesAsync(sourcePackagePath, targetPackagePath, overwrite: true);
+
+        Assert.That(capturedAgent, Is.Not.Null, "Copilot agent should have been invoked");
+        Assert.That(capturedAgent!.Instructions, Does.Contain($"sync{Path.DirectorySeparatorChar}sample.go").Or.Contains("sync/sample.go"),
+            "Prompt should contain relative path including subdirectory for sync sample");
+        Assert.That(capturedAgent.Instructions, Does.Contain($"async{Path.DirectorySeparatorChar}sample.go").Or.Contains("async/sample.go"),
+            "Prompt should contain relative path including subdirectory for async sample");
+    }
+
+    [Test]
+    public async Task TranslateSamples_MixedRootAndSubdirSamples_AllPreserved()
+    {
+        var (sourcePackagePath, targetPackagePath, targetSamplesDir) = await CreateFakePackagesAsync(
+            sourceSamples: new Dictionary<string, string>
+            {
+                ["root_sample.go"] = "package main\nfunc Root() {}",
+                ["advanced/nested_sample.go"] = "package main\nfunc Nested() {}",
+            });
+
+        _copilotAgentRunnerMock
+            .Setup(m => m.RunAsync(It.IsAny<CopilotAgent<List<TranslatedSample>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TranslatedSample>
+            {
+                new("root_sample.go", "root_sample.py", "def root(): pass"),
+                new("advanced/nested_sample.go", "nested_sample.py", "def nested(): pass"),
+            });
+
+        var result = await _tool.TranslateSamplesAsync(sourcePackagePath, targetPackagePath, overwrite: true);
+
+        Assert.That(result.OperationStatus, Is.EqualTo(Status.Succeeded));
+        Assert.That(File.Exists(Path.Combine(targetSamplesDir, "root_sample.py")), Is.True,
+            "Root-level sample should be in target root");
+        Assert.That(File.Exists(Path.Combine(targetSamplesDir, "advanced", "nested_sample.py")), Is.True,
+            "Subdirectory sample should preserve its directory");
+    }
+
+    /// <summary>
+    /// Creates fake source and target package repos for testing translation.
+    /// Source package is Go, target package is Python.
+    /// </summary>
+    private async Task<(string sourcePackagePath, string targetPackagePath, string targetSamplesDir)> CreateFakePackagesAsync(
+        Dictionary<string, string> sourceSamples)
+    {
+        // Source repo (Go)
+        var sourceTemp = TempDirectory.Create("azure-sdk-for-go-source");
+        var sourceRepoRoot = sourceTemp.DirectoryPath;
+        await GitTestHelper.GitInitAsync(sourceRepoRoot);
+        var sourceRelativePath = Path.Combine("sdk", "storage", "azblob");
+        var sourcePackagePath = Path.Combine(sourceRepoRoot, sourceRelativePath);
+        var sourceSamplesDir = Path.Combine(sourcePackagePath, "samples");
+        Directory.CreateDirectory(sourceSamplesDir);
+
+        // Write source sample files in their subdirectory structure
+        foreach (var (relativePath, content) in sourceSamples)
+        {
+            var fullPath = Path.Combine(sourceSamplesDir, relativePath.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+            await File.WriteAllTextAsync(fullPath, content);
+        }
+
+        // Write minimal Go source for context loading
+        File.WriteAllText(Path.Combine(sourcePackagePath, "client.go"), "package azblob\nfunc noop() {}\n");
+        var sourceEngScripts = Path.Combine(sourceRepoRoot, "eng", "scripts");
+        Directory.CreateDirectory(sourceEngScripts);
+        File.WriteAllText(Path.Combine(sourceEngScripts, "Language-Settings.ps1"), "$Language = 'Go'\n");
+
+        _mockSourceLanguageService
+            .Setup(m => m.GetPackageInfo(It.Is<string>(p => p.Contains(sourceRepoRoot)), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PackageInfo
+            {
+                RelativePath = sourceRelativePath,
+                RepoRoot = sourceRepoRoot,
+                SamplesDirectory = sourceSamplesDir,
+                Language = SdkLanguage.Go,
+                PackageName = "sdk/storage/azblob",
+                PackagePath = sourcePackagePath,
+                PackageVersion = "1.0.0",
+                SdkType = SdkType.Dataplane,
+                ServiceName = "storage"
+            });
+
+        // Target repo (Python)
+        var targetTemp = TempDirectory.Create("azure-sdk-for-python-target");
+        var targetRepoRoot = targetTemp.DirectoryPath;
+        await GitTestHelper.GitInitAsync(targetRepoRoot);
+        var targetRelativePath = Path.Combine("sdk", "storage", "azure-storage-blob");
+        var targetPackagePath = Path.Combine(targetRepoRoot, targetRelativePath);
+        var targetSamplesDir = Path.Combine(targetPackagePath, "samples");
+        Directory.CreateDirectory(targetSamplesDir);
+
+        // Write minimal Python source for context loading
+        var pythonSrc = Path.Combine(targetPackagePath, "azure", "storage", "blob");
+        Directory.CreateDirectory(pythonSrc);
+        File.WriteAllText(Path.Combine(pythonSrc, "__init__.py"), "# Azure Storage Blob client");
+        File.WriteAllText(Path.Combine(targetPackagePath, "setup.py"), "from setuptools import setup; setup(name='azure-storage-blob', version='1.0.0')");
+        var targetEngScripts = Path.Combine(targetRepoRoot, "eng", "scripts");
+        Directory.CreateDirectory(targetEngScripts);
+        File.WriteAllText(Path.Combine(targetEngScripts, "Language-Settings.ps1"), "$Language = 'Python'\n");
+
+        _mockTargetLanguageService
+            .Setup(m => m.GetPackageInfo(It.Is<string>(p => p.Contains(targetRepoRoot)), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PackageInfo
+            {
+                RelativePath = targetRelativePath,
+                RepoRoot = targetRepoRoot,
+                SamplesDirectory = targetSamplesDir,
+                Language = SdkLanguage.Python,
+                PackageName = "azure-storage-blob",
+                PackagePath = targetPackagePath,
+                PackageVersion = "1.0.0",
+                SdkType = SdkType.Dataplane,
+                ServiceName = "storage"
+            });
+
+        // Configure git helper to resolve language services
+        _mockGitHelper.Setup(g => g.DiscoverRepoRootAsync(
+                It.Is<string>(p => p.Contains(sourceRepoRoot)), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sourceRepoRoot);
+        _mockGitHelper.Setup(g => g.GetRepoNameAsync(
+                It.Is<string>(p => p.Contains(sourceRepoRoot)), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("azure-sdk-for-go");
+
+        _mockGitHelper.Setup(g => g.DiscoverRepoRootAsync(
+                It.Is<string>(p => p.Contains(targetRepoRoot)), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(targetRepoRoot);
+        _mockGitHelper.Setup(g => g.GetRepoNameAsync(
+                It.Is<string>(p => p.Contains(targetRepoRoot)), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("azure-sdk-for-python");
+
+        return (sourcePackagePath, targetPackagePath, targetSamplesDir);
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
@@ -13,7 +13,7 @@
     <WarningsAsErrors>CA2254</WarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AssemblyName>azsdk</AssemblyName>
-    <VersionPrefix>0.6.5</VersionPrefix>
+    <VersionPrefix>0.6.6</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <!-- Package metadata -->

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.6.6 (Unreleased)
+
+### Bugs Fixed
+
+- Fixed sample translation to preserve source directory structure when writing translated files
+
 ## 0.6.5 (2026-03-27)
 
 ### Features Added

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/Samples/SampleTranslatorTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/Samples/SampleTranslatorTool.cs
@@ -350,16 +350,18 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package.Samples
         {
             var batchList = batch.ToList();
             logger.LogInformation("Translating batch of {count} samples to {targetLanguage}", batchList.Count, targetLanguage);
-            var originalsByName = batchList.ToDictionary(
-                sample => Path.GetFileName(sample.FilePath),
+            var fullSourceSamplesPath = Path.GetFullPath(sourceSamplesPath);
+            var originalsByRelativePath = batchList.ToDictionary(
+                sample => Path.GetRelativePath(fullSourceSamplesPath, sample.FilePath),
                 sample => sample,
-                StringComparer.Ordinal);
+                StringComparer.OrdinalIgnoreCase);
 
-            // Build samples context for the batch
+            // Build samples context for the batch, including relative paths so the AI preserves directory structure
             var samplesContext = new StringBuilder();
             foreach (var sample in batchList)
             {
-                samplesContext.AppendLine($"## Source Sample: {Path.GetFileName(sample.FilePath)} ({sample.SourceLanguage})");
+                var relativePath = Path.GetRelativePath(fullSourceSamplesPath, sample.FilePath);
+                samplesContext.AppendLine($"## Source Sample: {relativePath} ({sample.SourceLanguage})");
                 samplesContext.AppendLine("```");
                 samplesContext.AppendLine(sample.Content);
                 samplesContext.AppendLine("```");
@@ -389,11 +391,12 @@ SOURCE SAMPLES TO TRANSLATE:
 {samplesContext}
 
 For each source sample, provide a translation with:
-1. Original filename
+1. Original file path (the relative path exactly as shown in the '## Source Sample:' headers above, e.g. 'subfolder/sample_name.ext')
 2. Appropriate new filename for {targetLanguage} (following naming conventions)
 3. Translated code content
 
 Return a JSON array of objects with 'OriginalFileName', 'TranslatedFileName', and 'Content' properties.
+The 'OriginalFileName' must be the relative file path exactly as shown in the source sample headers (e.g. 'subfolder/sample_name.ext', not just 'sample_name.ext').
 ";
 
             logger.LogDebug("Enhanced prompt prepared with {contextLength} characters of context", targetPackageContext.Length);
@@ -428,17 +431,30 @@ Return a JSON array of objects with 'OriginalFileName', 'TranslatedFileName', an
                     continue;
                 }
 
-                // Find the original source file to get its directory structure
-                var lookupKey = Path.GetFileName(translatedSample.OriginalFileName);
-                if (!originalsByName.TryGetValue(lookupKey, out var originalSample))
+                // Find the original source file by matching the relative path returned by the AI
+                var lookupKey = translatedSample.OriginalFileName
+                    .Replace('\\', Path.DirectorySeparatorChar)
+                    .Replace('/', Path.DirectorySeparatorChar);
+
+                if (!originalsByRelativePath.TryGetValue(lookupKey, out var originalSample))
                 {
-                    logger.LogWarning("Could not find original sample file for: {original}",
-                        translatedSample.OriginalFileName);
-                    continue;
+                    // Fallback: try matching by filename only for backwards compatibility
+                    var fileName = Path.GetFileName(lookupKey);
+                    originalSample = originalsByRelativePath.Values.FirstOrDefault(
+                        s => string.Equals(Path.GetFileName(s.FilePath), fileName, StringComparison.OrdinalIgnoreCase));
+                    if (originalSample != null)
+                    {
+                        logger.LogDebug("Matched translated sample '{original}' to source file by filename fallback", translatedSample.OriginalFileName);
+                    }
+                    else
+                    {
+                        logger.LogWarning("Could not find original sample file for: {original}",
+                            translatedSample.OriginalFileName);
+                        continue;
+                    }
                 }
 
                 // Calculate the relative path from the source samples directory
-                var fullSourceSamplesPath = Path.GetFullPath(sourceSamplesPath);
                 var relativePath = Path.GetRelativePath(fullSourceSamplesPath, originalSample.FilePath);
                 var relativeDir = Path.GetDirectoryName(relativePath) ?? "";
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/Samples/SampleTranslatorTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/Samples/SampleTranslatorTool.cs
@@ -438,18 +438,32 @@ The 'OriginalFileName' must be the relative file path exactly as shown in the so
 
                 if (!originalsByRelativePath.TryGetValue(lookupKey, out var originalSample))
                 {
-                    // Fallback: try matching by filename only for backwards compatibility
+                    // Fallback: try matching by filename only for backwards compatibility.
+                    // If multiple matches are found, treat as ambiguous and skip to avoid writing to the wrong path.
                     var fileName = Path.GetFileName(lookupKey);
-                    originalSample = originalsByRelativePath.Values.FirstOrDefault(
-                        s => string.Equals(Path.GetFileName(s.FilePath), fileName, StringComparison.OrdinalIgnoreCase));
-                    if (originalSample != null)
+                    var filenameMatches = originalsByRelativePath.Values
+                        .Where(s => string.Equals(Path.GetFileName(s.FilePath), fileName, StringComparison.OrdinalIgnoreCase))
+                        .ToList();
+
+                    if (filenameMatches.Count == 1)
                     {
+                        originalSample = filenameMatches[0];
                         logger.LogDebug("Matched translated sample '{original}' to source file by filename fallback", translatedSample.OriginalFileName);
                     }
-                    else
+                    else if (filenameMatches.Count == 0)
                     {
                         logger.LogWarning("Could not find original sample file for: {original}",
                             translatedSample.OriginalFileName);
+                        continue;
+                    }
+                    else
+                    {
+                        logger.LogWarning(
+                            "Ambiguous filename-only match for translated sample: {original}. Found {count} source files named '{fileName}'. " +
+                            "Please disambiguate by providing a relative path.",
+                            translatedSample.OriginalFileName,
+                            filenameMatches.Count,
+                            fileName);
                         continue;
                     }
                 }


### PR DESCRIPTION
## Problem

The sample translator lost directory context when translating samples in subdirectories. The lookup dictionary was keyed by filename only, causing collisions for same-named files in different directories (e.g. `sync/create.py` and `async/create.py`). The AI prompt also only included filenames, preventing the model from returning path information.

## Fix

- Key the lookup dictionary by **relative path** from the samples root instead of filename
- Include **relative paths** in the AI prompt and instruct the model to return them as `OriginalFileName`
- Use **relative path matching** with a filename-only fallback for backward compatibility

## Tests

Added 7 new tests covering:
- Subdirectory structure preservation
- Nested directory paths
- Same-named files in different subdirectories
- Filename-only fallback (backward compatibility)
- Prompt contains relative paths
- Mixed root and subdirectory samples