### PR TITLE
Fix Validate-AzsdkCodeOwner to paginate org membership API call

### DIFF
--- a/tools/github/scripts/Validate-AzsdkCodeOwner.ps1
+++ b/tools/github/scripts/Validate-AzsdkCodeOwner.ps1
@@ -13,7 +13,7 @@ $hasPermissions = $false
 
 # Verify that the user exists and has the correct public
 # organization memberships.
-$orgResponse = (gh api "https://api.github.com/users/$UserName/orgs")
+$orgResponse = (gh api "https://api.github.com/users/$UserName/orgs" --paginate)
 $orgs = $orgResponse | ConvertFrom-Json | Select-Object -Expand login -ErrorAction Ignore
 
 # Validate that the user has the required public organization memberships.


### PR DESCRIPTION
The `gh api` call to fetch user org memberships was missing the `--paginate` flag. Without it, users with 30+ public orgs could have results truncated, potentially missing Microsoft or Azure from later pages and causing false negative validation results.