### PR TITLE
Benchmarks fix reporting going over token count

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/SessionExecutor.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/SessionExecutor.cs
@@ -76,13 +76,11 @@ public class SessionExecutor : IDisposable
                             ? input.Timestamp - startTs
                             : null;
 
-                        bool isMcpTool = input.ToolName.Contains("azsdk_", StringComparison.OrdinalIgnoreCase);
-
                         toolCalls.Add(new ToolCallRecord
                         {
                             ToolName = input.ToolName,
-                            ToolArgs = isMcpTool ? input.ToolArgs : null,
-                            ToolResult = isMcpTool ? input.ToolResult : null,
+                            ToolArgs = input.ToolArgs,
+                            ToolResult = input.ToolResult,
                             DurationMs = durationMs,
                         });
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/SessionExecutor.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/SessionExecutor.cs
@@ -76,17 +76,14 @@ public class SessionExecutor : IDisposable
                             ? input.Timestamp - startTs
                             : null;
 
-                        var mcpServerName = input.ToolName.Contains("__")
-                            ? input.ToolName.Split("__", 2)[0]
-                            : null;
+                        bool isMcpTool = input.ToolName.Contains("azsdk_", StringComparison.OrdinalIgnoreCase);
 
                         toolCalls.Add(new ToolCallRecord
                         {
                             ToolName = input.ToolName,
-                            ToolArgs = input.ToolArgs,
-                            ToolResult = input.ToolResult,
+                            ToolArgs = isMcpTool ? input.ToolArgs : null,
+                            ToolResult = isMcpTool ? input.ToolResult : null,
                             DurationMs = durationMs,
-                            McpServerName = mcpServerName,
                         });
 
                         return Task.FromResult<PostToolUseHookOutput?>(null);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/Workspace.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/Workspace.cs
@@ -181,7 +181,7 @@ public class Workspace : IDisposable
         TokenUsage? tokenUsage = null,
         string? error = null)
     {
-        var log = new
+        var log = new BenchmarkLog
         {
             Scenario = scenarioName,
             Timestamp = DateTime.UtcNow.ToString("o"),
@@ -190,8 +190,8 @@ public class Workspace : IDisposable
             Error = error,
             Validation = validation,
             TokenUsage = tokenUsage,
-            ToolCalls = toolCalls,
-            Messages = messages,
+            ToolCalls = toolCalls.ToList(),
+            Messages = messages.ToList(),
             GitDiff = gitDiff
         };
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/WorkspaceManager.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/WorkspaceManager.cs
@@ -286,5 +286,6 @@ public class WorkspaceManager
     {
         // Force test mode for the tools.
         Environment.SetEnvironmentVariable("AZSDKTOOLS_AGENT_TESTING", "true");
+        Environment.SetEnvironmentVariable("AZSDKTOOLS_COLLECT_TELEMETRY", "false");
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Models/BenchmarkLog.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Models/BenchmarkLog.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Sdk.Tools.Cli.Benchmarks.Models;
+
+/// <summary>
+/// Represents the benchmark execution log written to benchmark-log.json.
+/// </summary>
+public class BenchmarkLog
+{
+    public string Scenario { get; set; } = "";
+    public string Timestamp { get; set; } = "";
+    public string Duration { get; set; } = "";
+    public bool Passed { get; set; }
+    public string? Error { get; set; }
+    public ValidationSummary? Validation { get; set; }
+    public TokenUsage? TokenUsage { get; set; }
+    public List<ToolCallRecord> ToolCalls { get; set; } = [];
+    public List<object> Messages { get; set; } = [];
+    public string? GitDiff { get; set; }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Models/ToolCallRecord.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Models/ToolCallRecord.cs
@@ -25,9 +25,6 @@ public class ToolCallRecord
     /// <summary>Gets the tool call duration in milliseconds, or null if unavailable.</summary>
     public double? DurationMs { get; init; }
 
-    /// <summary>Gets the MCP server name extracted from the tool name prefix, or null.</summary>
-    public string? McpServerName { get; init; }
-
     /// <summary>
     /// Gets the tool arguments as a string-keyed dictionary of JsonElements.
     /// Returns an empty dictionary if args are null or not a JSON object.

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Reporting/ReportGenerator.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Reporting/ReportGenerator.cs
@@ -78,7 +78,15 @@ public class ReportGenerator
         var logsJson = await Task.WhenAll(
             logFiles.Select(f => File.ReadAllTextAsync(f, cancellationToken)));
 
-        var combinedData = $"[{string.Join(",\n", logsJson)}]";
+        var logs = logsJson
+            .Select(j => JsonSerializer.Deserialize<BenchmarkLog>(j, JsonOptions)!)
+            .Select(log =>
+            {
+                log.ToolCalls = SimplifyToolCalls(log.ToolCalls);
+                return log;
+            });
+
+        var combinedData = JsonSerializer.Serialize(logs, JsonOptions);
         return await CallLlmAsync(BuildPrompt(combinedData, "Benchmark Log Data (JSON Array)"), cancellationToken);
     }
 
@@ -192,4 +200,14 @@ public class ReportGenerator
 
         return File.ReadAllText(templatePath);
     }
+
+    private static bool IsDetailedTool(string toolName) =>
+        toolName.Contains("azsdk", StringComparison.OrdinalIgnoreCase)
+        || toolName.Equals("skill", StringComparison.OrdinalIgnoreCase);
+
+    private static List<ToolCallRecord> SimplifyToolCalls(List<ToolCallRecord> toolCalls) =>
+        toolCalls.Select(tc => IsDetailedTool(tc.ToolName)
+            ? tc
+            : new ToolCallRecord { ToolName = tc.ToolName }
+        ).ToList();
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Reporting/ReportGenerator.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Reporting/ReportGenerator.cs
@@ -85,7 +85,7 @@ public class ReportGenerator
     }
 
     private async Task<string> GenerateInBatchesAsync(
-        IEnumerable<BenchmarkLog> items, string dataLabel, CancellationToken cancellationToken)
+        IEnumerable<object> items, string dataLabel, CancellationToken cancellationToken)
     {
         string report = string.Empty;
         foreach (var batch in items.Chunk(BatchSize))

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Reporting/ReportGenerator.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Reporting/ReportGenerator.cs
@@ -83,6 +83,8 @@ public class ReportGenerator
             .Select(log =>
             {
                 log.ToolCalls = SimplifyToolCalls(log.ToolCalls);
+                log.Messages = []; // to reduce how much tokens we spend making a report.
+                log.GitDiff = null;
                 return log;
             });
 
@@ -175,14 +177,11 @@ public class ReportGenerator
             TotalTokenUsage = totalUsage,
             Scenarios = results.Select((r, i) => new
             {
-                Index = i + 1,
                 r.Scenario.Name,
                 r.Scenario.Description,
-                r.Scenario.Tags,
                 r.Scenario.Prompt,
-                Repo = r.Scenario.Repo.CloneUrl,
-                r.Result,
-                r.Result.TokenUsage
+                r.Scenario.Repo.CloneUrl,
+                r.Result
             }).ToList()
         };
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Reporting/ReportGenerator.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Reporting/ReportGenerator.cs
@@ -17,6 +17,7 @@ public class ReportGenerator
 {
     private const string DefaultModel = "claude-sonnet-4.5";
     private const string TemplateFileName = "report-template.md";
+    private const int BatchSize = 9;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -57,8 +58,8 @@ public class ReportGenerator
         string agentModel,
         CancellationToken cancellationToken = default)
     {
-        var dataJson = JsonSerializer.Serialize(BuildReportData(results, runName, agentModel), JsonOptions);
-        return await CallLlmAsync(BuildPrompt(dataJson, "Benchmark Data (JSON)"), cancellationToken);
+        var items = results.Select(r => BuildReportData(r, runName, agentModel)).ToList();
+        return await GenerateInBatchesAsync(items, "Benchmark Data (JSON)", cancellationToken);
     }
 
     /// <summary>
@@ -78,29 +79,38 @@ public class ReportGenerator
         var logsJson = await Task.WhenAll(
             logFiles.Select(f => File.ReadAllTextAsync(f, cancellationToken)));
 
-        var logs = logsJson
-            .Select(j => JsonSerializer.Deserialize<BenchmarkLog>(j, JsonOptions)!)
-            .Select(log =>
-            {
-                log.ToolCalls = SimplifyToolCalls(log.ToolCalls);
-                log.Messages = []; // to reduce how much tokens we spend making a report.
-                log.GitDiff = null;
-                return log;
-            });
+        var items = logsJson.Select(j => SimplifyLog(JsonSerializer.Deserialize<BenchmarkLog>(j, JsonOptions)!));
 
-        var combinedData = JsonSerializer.Serialize(logs, JsonOptions);
-        return await CallLlmAsync(BuildPrompt(combinedData, "Benchmark Log Data (JSON Array)"), cancellationToken);
+        return await GenerateInBatchesAsync(items, "Benchmark Log Data (JSON Array)", cancellationToken);
     }
 
-    private string BuildPrompt(string dataJson, string dataLabel)
+    private async Task<string> GenerateInBatchesAsync(
+        IEnumerable<BenchmarkLog> items, string dataLabel, CancellationToken cancellationToken)
+    {
+        string report = string.Empty;
+        foreach (var batch in items.Chunk(BatchSize))
+        {
+            var dataJson = JsonSerializer.Serialize(batch, JsonOptions);
+            report = await CallLlmAsync(BuildPrompt(dataJson, dataLabel, report), cancellationToken);
+        }
+        return report;
+    }
+
+    private string BuildPrompt(string dataJson, string dataLabel, string existingReport = "")
     {
         return $"""
             Generate a benchmark report using the template and data below.
-            Fill in every section of the template based on the provided data.
+            If an existing report is provided, merge the new data into it — keep all existing
+            per-scenario sections, add new ones, and update aggregate statistics. Otherwise,
+            create a fresh report from the template.
             
             ## Report Template
             
             {_template}
+            
+            ## Existing Report
+            
+            {(string.IsNullOrEmpty(existingReport) ? "None" : existingReport)}
             
             ## {dataLabel}
             
@@ -108,7 +118,7 @@ public class ReportGenerator
             {dataJson}
             ```
             
-            Generate the complete report now. Output only the filled-in markdown, no other text.
+            Output only the filled-in markdown, no other text.
             """;
     }
 
@@ -152,37 +162,20 @@ public class ReportGenerator
     }
 
     private static object BuildReportData(
-        IReadOnlyList<(BenchmarkScenario Scenario, BenchmarkResult Result)> results,
+        (BenchmarkScenario Scenario, BenchmarkResult Result) result,
         string runName,
         string agentModel)
     {
-        var totalUsage = new TokenUsage();
-        foreach (var (_, result) in results)
-        {
-            if (result.TokenUsage != null)
-            {
-                totalUsage.Add(result.TokenUsage);
-            } 
-        }
-
         return new
         {
             RunName = runName,
             Model = agentModel,
             TestDate = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss UTC"),
-            TotalScenarios = results.Count,
-            TotalPassed = results.Count(r => r.Result.Passed),
-            TotalFailed = results.Count(r => !r.Result.Passed),
-            TotalDurationSeconds = results.Sum(r => r.Result.Duration.TotalSeconds),
-            TotalTokenUsage = totalUsage,
-            Scenarios = results.Select((r, i) => new
-            {
-                r.Scenario.Name,
-                r.Scenario.Description,
-                r.Scenario.Prompt,
-                r.Scenario.Repo.CloneUrl,
-                r.Result
-            }).ToList()
+            result.Scenario.Name,
+            result.Scenario.Description,
+            result.Scenario.Prompt,
+            result.Scenario.Repo.CloneUrl,
+            result.Result
         };
     }
 
@@ -198,6 +191,14 @@ public class ReportGenerator
         }
 
         return File.ReadAllText(templatePath);
+    }
+
+    private static BenchmarkLog SimplifyLog(BenchmarkLog log)
+    {
+        log.ToolCalls = SimplifyToolCalls(log.ToolCalls);
+        log.Messages = [];
+        log.GitDiff = null;
+        return log;
     }
 
     private static bool IsDetailedTool(string toolName) =>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Reporting/ReportGenerator.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Reporting/ReportGenerator.cs
@@ -208,6 +208,9 @@ public class ReportGenerator
     private static List<ToolCallRecord> SimplifyToolCalls(List<ToolCallRecord> toolCalls) =>
         toolCalls.Select(tc => IsDetailedTool(tc.ToolName)
             ? tc
-            : new ToolCallRecord { ToolName = tc.ToolName }
+            : new ToolCallRecord { 
+                ToolName = tc.ToolName,
+                DurationMs = tc.DurationMs
+            }
         ).ToList();
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/GitHub/GetPrLinkCurrentBranchScenario.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/GitHub/GetPrLinkCurrentBranchScenario.cs
@@ -36,7 +36,6 @@ public class GetPrLinkCurrentBranchScenario : BenchmarkScenario
     /// <inheritdoc />
     public override string Prompt => """
         What's the status of the spec PR in my current branch? Only check the status once.
-        My setup has already been verified, do not run azsdk_verify_setup.
         The repository root is the relative path ./azure-rest-api-specs.
         """;
 
@@ -48,7 +47,6 @@ public class GetPrLinkCurrentBranchScenario : BenchmarkScenario
             expectedToolCalls:
             [
                 new ExpectedToolCall("azsdk_get_pull_request_link_for_current_branch")
-            ],
-            forbiddenToolNames: ["azsdk_verify_setup"])
+            ])
     ];
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/GitHub/GetPrLinkCurrentBranchScenario.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/GitHub/GetPrLinkCurrentBranchScenario.cs
@@ -47,6 +47,7 @@ public class GetPrLinkCurrentBranchScenario : BenchmarkScenario
             expectedToolCalls:
             [
                 new ExpectedToolCall("azsdk_get_pull_request_link_for_current_branch")
-            ])
+            ],
+            optionalToolNames: ["azsdk_verify_setup"])
     ];
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/Pipeline/CheckSdkGenerationStatusScenario.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/Pipeline/CheckSdkGenerationStatusScenario.cs
@@ -52,6 +52,7 @@ public class CheckSdkGenerationStatusScenario : BenchmarkScenario
                     {
                         ["buildId"] = 5513110
                     })
-            ])
+            ],
+            optionalToolNames: ["azsdk_verify_setup"])
     ];
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/Pipeline/CheckSdkGenerationStatusScenario.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/Pipeline/CheckSdkGenerationStatusScenario.cs
@@ -38,7 +38,6 @@ public class CheckSdkGenerationStatusScenario : BenchmarkScenario
     /// <inheritdoc />
     public override string Prompt => """
         Check the SDK generation pipeline status for build ID 5513110.
-        My setup has already been verified, do not run azsdk_verify_setup.
         """;
 
     /// <inheritdoc />
@@ -53,7 +52,6 @@ public class CheckSdkGenerationStatusScenario : BenchmarkScenario
                     {
                         ["buildId"] = 5513110
                     })
-            ],
-            forbiddenToolNames: ["azsdk_verify_setup"])
+            ])
     ];
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/ReleasePlan/CreateReleasePlanScenario.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/ReleasePlan/CreateReleasePlanScenario.cs
@@ -62,6 +62,7 @@ public class CreateReleasePlanScenario : BenchmarkScenario
                         ["specPullRequestUrl"] = "https://github.com/Azure/azure-rest-api-specs/pull/38387",
                         ["sdkReleaseType"] = "beta"
                     })
-            ])
+            ],
+            optionalToolNames: ["azsdk_verify_setup"])
     ];
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/ReleasePlan/CreateReleasePlanScenario.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/ReleasePlan/CreateReleasePlanScenario.cs
@@ -35,7 +35,7 @@ public class CreateReleasePlanScenario : BenchmarkScenario
     /// <inheritdoc />
     public override string Prompt => """
         Create a release plan for the Contoso Widget Manager, no need to get it afterwards only create.
-        My setup has already been verified, do not run azsdk_verify_setup. Here is all the context you need:
+        Here is all the context you need:
         TypeSpec project located at "specification/contosowidgetmanager/Contoso.WidgetManager".
         Use service tree ID "a7f2b8e4-9c1d-4a3e-b6f9-2d8e5a7c3b1f",
         product tree ID "f1a8c5d2-6e4b-4f7a-9c2d-8b5e1f3a6c9e",
@@ -62,7 +62,6 @@ public class CreateReleasePlanScenario : BenchmarkScenario
                         ["specPullRequestUrl"] = "https://github.com/Azure/azure-rest-api-specs/pull/38387",
                         ["sdkReleaseType"] = "beta"
                     })
-            ],
-            forbiddenToolNames: ["azsdk_verify_setup"])
+            ])
     ];
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/ReleasePlan/LinkNamespaceApprovalIssueScenario.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/ReleasePlan/LinkNamespaceApprovalIssueScenario.cs
@@ -36,7 +36,6 @@ public class LinkNamespaceApprovalIssueScenario : BenchmarkScenario
     /// <inheritdoc />
     public override string Prompt => """
         Link namespace approval issue https://github.com/Azure/azure-sdk/issues/1234 to release plan 12345.
-        My setup has already been verified, do not run azsdk_verify_setup.
         """;
 
     /// <inheritdoc />
@@ -52,7 +51,6 @@ public class LinkNamespaceApprovalIssueScenario : BenchmarkScenario
                         ["releasePlanWorkItemId"] = 12345,
                         ["namespaceApprovalIssue"] = "https://github.com/Azure/azure-sdk/issues/1234"
                     })
-            ],
-            forbiddenToolNames: ["azsdk_verify_setup"])
+            ])
     ];
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/ReleasePlan/LinkNamespaceApprovalIssueScenario.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/ReleasePlan/LinkNamespaceApprovalIssueScenario.cs
@@ -51,6 +51,7 @@ public class LinkNamespaceApprovalIssueScenario : BenchmarkScenario
                         ["releasePlanWorkItemId"] = 12345,
                         ["namespaceApprovalIssue"] = "https://github.com/Azure/azure-sdk/issues/1234"
                     })
-            ])
+            ],
+            optionalToolNames: ["azsdk_verify_setup"])
     ];
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/TypeSpec/CheckPublicRepoScenario.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/TypeSpec/CheckPublicRepoScenario.cs
@@ -36,7 +36,6 @@ public class CheckPublicRepoScenario : BenchmarkScenario
     /// <inheritdoc />
     public override string Prompt => """
         Check if my TypeSpec project is in the public repo.
-        My setup has already been verified, do not run azsdk_verify_setup.
         Project root: specification/contosowidgetmanager/Contoso.WidgetManager.
         """;
 
@@ -52,7 +51,6 @@ public class CheckPublicRepoScenario : BenchmarkScenario
                     {
                         ["typeSpecProjectPath"] = "specification/contosowidgetmanager/Contoso.WidgetManager"
                     })
-            ],
-            forbiddenToolNames: ["azsdk_verify_setup"])
+            ])
     ];
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/TypeSpec/CheckPublicRepoScenario.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/TypeSpec/CheckPublicRepoScenario.cs
@@ -51,6 +51,7 @@ public class CheckPublicRepoScenario : BenchmarkScenario
                     {
                         ["typeSpecProjectPath"] = "specification/contosowidgetmanager/Contoso.WidgetManager"
                     })
-            ])
+            ],
+            optionalToolNames: ["azsdk_verify_setup"])
     ];
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/TypeSpec/CheckPublicRepoThenValidateScenario.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/TypeSpec/CheckPublicRepoThenValidateScenario.cs
@@ -56,6 +56,7 @@ public class CheckPublicRepoThenValidateScenario : BenchmarkScenario
                     {
                         ["typeSpecProjectPath"] = "specification/contosowidgetmanager/Contoso.WidgetManager"
                     })
-            ])
+            ],
+            optionalToolNames: ["azsdk_verify_setup"])
     ];
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/TypeSpec/CheckPublicRepoThenValidateScenario.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/TypeSpec/CheckPublicRepoThenValidateScenario.cs
@@ -37,7 +37,6 @@ public class CheckPublicRepoThenValidateScenario : BenchmarkScenario
     public override string Prompt => """
         Run TypeSpec validation, then check if the project is in the public repo.
         Project path: specification/contosowidgetmanager/Contoso.WidgetManager.
-        My setup has already been verified, do not run azsdk_verify_setup.
         """;
 
     /// <inheritdoc />
@@ -57,7 +56,6 @@ public class CheckPublicRepoThenValidateScenario : BenchmarkScenario
                     {
                         ["typeSpecProjectPath"] = "specification/contosowidgetmanager/Contoso.WidgetManager"
                     })
-            ],
-            forbiddenToolNames: ["azsdk_verify_setup"])
+            ])
     ];
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/TypeSpec/GetModifiedTypespecProjectsScenario.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/TypeSpec/GetModifiedTypespecProjectsScenario.cs
@@ -51,7 +51,6 @@ public class GetModifiedTypespecProjectsScenario : BenchmarkScenario
     /// <inheritdoc />
     public override string Prompt => """
         List the TypeSpec projects modified in my current branch compared to main.
-        My setup has already been verified, do not run azsdk_verify_setup.
         """;
 
     /// <inheritdoc />
@@ -67,7 +66,6 @@ public class GetModifiedTypespecProjectsScenario : BenchmarkScenario
                         ["repoRootPath"] = "azure-rest-api-specs",
                         ["targetBranch"] = "main"
                     })
-            ],
-            forbiddenToolNames: ["azsdk_verify_setup"])
+            ])
     ];
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/TypeSpec/GetModifiedTypespecProjectsScenario.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/TypeSpec/GetModifiedTypespecProjectsScenario.cs
@@ -66,6 +66,7 @@ public class GetModifiedTypespecProjectsScenario : BenchmarkScenario
                         ["repoRootPath"] = "azure-rest-api-specs",
                         ["targetBranch"] = "main"
                     })
-            ])
+            ],
+            optionalToolNames: ["azsdk_verify_setup"])
     ];
 }


### PR DESCRIPTION
- Benchmarks reports were adding to much information into result and causing rate limiting,
- Avoid telemetry.
- Remove do not verify setup from tests that don't need to avoid it