### PR TITLE
[CODEOWNERS] Add support for sections

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CodeownersGenerateHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CodeownersGenerateHelperTests.cs
@@ -161,7 +161,7 @@ public class CodeownersGenerateHelperTests
         var data = new WorkItemDataBuilder()
             .AddOwner("aidev", out var ownerId)
             .AddLabel("AI", out var labelId)
-            .AddPRLabelOwner(out _, repoPath: "sdk/ai", relatedTo: [ownerId, labelId])
+            .AddPRLabelOwner(out _, repoPath: "sdk/ai/", relatedTo: [ownerId, labelId])
             .Build();
 
         var packageLookup = new Dictionary<string, RepoPackage>(StringComparer.OrdinalIgnoreCase);
@@ -174,6 +174,31 @@ public class CodeownersGenerateHelperTests
         Assert.Multiple(() =>
         {
             Assert.That(entries[0].PathExpression, Is.EqualTo("/sdk/ai/"));
+            Assert.That(entries[0].SourceOwners, Does.Contain("aidev"));
+            Assert.That(entries[0].PRLabels, Does.Contain("AI"));
+        });
+    }
+
+    [Test]
+    public void BuildCodeownersEntries_CreatesPathEntryForFile()
+    {
+        // Arrange: Label Owner with RepoPath but not linked to any package
+        var data = new WorkItemDataBuilder()
+            .AddOwner("aidev", out var ownerId)
+            .AddLabel("AI", out var labelId)
+            .AddPRLabelOwner(out _, repoPath: "sdk/ai/file.txt", relatedTo: [ownerId, labelId])
+            .Build();
+
+        var packageLookup = new Dictionary<string, RepoPackage>(StringComparer.OrdinalIgnoreCase);
+
+        // Act
+        var entries = InvokeBuildCodeownersEntries(data, packageLookup);
+
+        // Assert
+        Assert.That(entries, Has.Count.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(entries[0].PathExpression, Is.EqualTo("/sdk/ai/file.txt"));
             Assert.That(entries[0].SourceOwners, Does.Contain("aidev"));
             Assert.That(entries[0].PRLabels, Does.Contain("AI"));
         });

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CodeownersManagementHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CodeownersManagementHelperTests.cs
@@ -805,7 +805,7 @@ public class CodeownersManagementHelperTests
                 It.IsAny<int>(), It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<WorkItem> { labelWiRaw });
 
-        var result = await _helper.FindOrCreateLabelOwnerAsync("Azure/azure-sdk-for-net", OwnerType.ServiceOwner, null, [labelWi], default);
+        var result = await _helper.FindOrCreateLabelOwnerAsync("Azure/azure-sdk-for-net", OwnerType.ServiceOwner, null, [labelWi], "Client Libraries", default);
 
         Assert.That(result.WorkItemId, Is.EqualTo(55));
         _mockDevOps.Verify(d => d.CreateWorkItemAsync(It.IsAny<WorkItemBase>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()), Times.Never);
@@ -835,7 +835,7 @@ public class CodeownersManagementHelperTests
                 It.IsAny<WorkItemBase>(), "Label Owner", "Service Owner: Storage", It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(createdLoWi);
 
-        var result = await _helper.FindOrCreateLabelOwnerAsync("Azure/azure-sdk-for-net", OwnerType.ServiceOwner, null, [expectedLabelWi], default);
+        var result = await _helper.FindOrCreateLabelOwnerAsync("Azure/azure-sdk-for-net", OwnerType.ServiceOwner, null, [expectedLabelWi], "Client Libraries", default);
 
         Assert.That(result.WorkItemId, Is.EqualTo(99));
         _mockDevOps.Verify(d => d.CreateWorkItemAsync(It.IsAny<WorkItemBase>(), "Label Owner", "Service Owner: Storage", It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()), Times.Once);
@@ -856,7 +856,7 @@ public class CodeownersManagementHelperTests
                 It.IsAny<WorkItemBase>(), "Label Owner", "Service Owner: Storage", It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(createdLoWi);
 
-        var result = await _helper.FindOrCreateLabelOwnerAsync("Azure/azure-sdk-for-net", OwnerType.ServiceOwner, null, [labelWi], default);
+        var result = await _helper.FindOrCreateLabelOwnerAsync("Azure/azure-sdk-for-net", OwnerType.ServiceOwner, null, [labelWi], "Client Libraries", default);
 
         Assert.That(result.WorkItemId, Is.EqualTo(77));
         _mockDevOps.Verify(d => d.CreateWorkItemAsync(It.IsAny<WorkItemBase>(), "Label Owner", "Service Owner: Storage", It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()), Times.Once);
@@ -877,7 +877,7 @@ public class CodeownersManagementHelperTests
                 It.IsAny<WorkItemBase>(), "Label Owner", "Service Owner: sdk/service/", It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(createdLoWi);
 
-        var result = await _helper.FindOrCreateLabelOwnerAsync("Azure/azure-sdk-for-net", OwnerType.ServiceOwner, "sdk/service/", [labelWi], default);
+        var result = await _helper.FindOrCreateLabelOwnerAsync("Azure/azure-sdk-for-net", OwnerType.ServiceOwner, "sdk/service/", [labelWi], "Client Libraries", default);
 
         Assert.That(result.WorkItemId, Is.EqualTo(88));
     }
@@ -1133,7 +1133,7 @@ public class CodeownersManagementHelperTests
         var owners = new[] { new OwnerWorkItem { WorkItemId = ownerId, GitHubAlias = "user1" } };
         var labels = new[] { new LabelWorkItem { WorkItemId = labelId, LabelName = "Storage" } };
 
-        var result = await _helper.AddOwnersAndLabelsToPath(owners, labels, "Azure/azure-sdk-for-net", "/sdk/storage", OwnerType.ServiceOwner, default);
+        var result = await _helper.AddOwnersAndLabelsToPath(owners, labels, "Azure/azure-sdk-for-net", "/sdk/storage", OwnerType.ServiceOwner, "Client Libraries", default);
 
         Assert.That(result.ResponseError, Is.Null);
         Assert.That(result.View, Is.Not.Null);
@@ -1170,7 +1170,7 @@ public class CodeownersManagementHelperTests
         var owners = new[] { new OwnerWorkItem { WorkItemId = ownerId, GitHubAlias = "user1" } };
         var labels = new[] { new LabelWorkItem { WorkItemId = labelId, LabelName = "Storage" } };
 
-        var result = await _helper.AddOwnersAndLabelsToPath(owners, labels, "Azure/azure-sdk-for-net", "/sdk/storage", OwnerType.ServiceOwner, default);
+        var result = await _helper.AddOwnersAndLabelsToPath(owners, labels, "Azure/azure-sdk-for-net", "/sdk/storage", OwnerType.ServiceOwner, "Client Libraries", default);
 
         Assert.That(result.ResponseError, Is.Null);
         Assert.That(result.View, Is.Not.Null);
@@ -1213,7 +1213,7 @@ public class CodeownersManagementHelperTests
         };
         var labels = new[] { new LabelWorkItem { WorkItemId = labelId, LabelName = "Storage" } };
 
-        var result = await _helper.AddOwnersAndLabelsToPath(owners, labels, "Azure/azure-sdk-for-net", "/sdk/storage", OwnerType.ServiceOwner, default);
+        var result = await _helper.AddOwnersAndLabelsToPath(owners, labels, "Azure/azure-sdk-for-net", "/sdk/storage", OwnerType.ServiceOwner, "Client Libraries", default);
 
         Assert.That(result.ResponseError, Is.Null);
         Assert.That(result.View, Is.Not.Null);
@@ -1254,7 +1254,7 @@ public class CodeownersManagementHelperTests
         var owners = new[] { new OwnerWorkItem { WorkItemId = ownerId, GitHubAlias = "user1" } };
         var labels = new[] { new LabelWorkItem { WorkItemId = labelId, LabelName = "Storage" } };
 
-        var result = await _helper.AddOwnersAndLabelsToPath(owners, labels, "Azure/azure-sdk-for-net", "/sdk/newpath", OwnerType.ServiceOwner, default);
+        var result = await _helper.AddOwnersAndLabelsToPath(owners, labels, "Azure/azure-sdk-for-net", "/sdk/newpath", OwnerType.ServiceOwner, "Client Libraries", default);
 
         Assert.That(result.ResponseError, Is.Null);
         Assert.That(result.View, Is.Not.Null);
@@ -1311,7 +1311,7 @@ public class CodeownersManagementHelperTests
             new LabelWorkItem { WorkItemId = label2Id, LabelName = "Blobs" }
         };
 
-        var result = await _helper.AddOwnersAndLabelsToPath(owners, labels, "Azure/azure-sdk-for-net", "/sdk/storage", OwnerType.ServiceOwner, default);
+        var result = await _helper.AddOwnersAndLabelsToPath(owners, labels, "Azure/azure-sdk-for-net", "/sdk/storage", OwnerType.ServiceOwner, "Client Libraries", default);
 
         Assert.That(result.ResponseError, Is.Null);
         Assert.That(result.View, Is.Not.Null);
@@ -1336,7 +1336,7 @@ public class CodeownersManagementHelperTests
         var owners = new[] { new OwnerWorkItem { WorkItemId = 10, GitHubAlias = "user1" } };
         var labels = new[] { new LabelWorkItem { WorkItemId = 20, LabelName = "Storage" } };
 
-        var result = await _helper.RemoveOwnersFromLabelsAndPath(owners, labels, "Azure/azure-sdk-for-net", "/sdk/nopath", OwnerType.ServiceOwner, default);
+        var result = await _helper.RemoveOwnersFromLabelsAndPath(owners, labels, "Azure/azure-sdk-for-net", "/sdk/nopath", OwnerType.ServiceOwner, "Client Libraries", default);
 
         Assert.That(result.ResponseError, Does.Contain("No Label Owner work item found for path '/sdk/nopath'"));
     }
@@ -1377,7 +1377,7 @@ public class CodeownersManagementHelperTests
         var owners = new[] { new OwnerWorkItem { WorkItemId = ownerId, GitHubAlias = "user1" } };
         var labels = new[] { new LabelWorkItem { WorkItemId = labelId, LabelName = "Storage" } };
 
-        var result = await _helper.RemoveOwnersFromLabelsAndPath(owners, labels, "Azure/azure-sdk-for-net", "/sdk/storage", OwnerType.ServiceOwner, default);
+        var result = await _helper.RemoveOwnersFromLabelsAndPath(owners, labels, "Azure/azure-sdk-for-net", "/sdk/storage", OwnerType.ServiceOwner, "Client Libraries", default);
 
         Assert.That(result.ResponseError, Is.Null);
         _mockDevOps.Verify(d => d.RemoveWorkItemRelationAsync(labelOwnerWiId, "related", ownerId, It.IsAny<CancellationToken>()), Times.Once);
@@ -1413,7 +1413,7 @@ public class CodeownersManagementHelperTests
         var owners = new[] { new OwnerWorkItem { WorkItemId = ownerId, GitHubAlias = "user1" } };
         var labels = new[] { new LabelWorkItem { WorkItemId = labelId, LabelName = "Storage" } };
 
-        var result = await _helper.RemoveOwnersFromLabelsAndPath(owners, labels, "Azure/azure-sdk-for-net", "/sdk/storage", OwnerType.ServiceOwner, default);
+        var result = await _helper.RemoveOwnersFromLabelsAndPath(owners, labels, "Azure/azure-sdk-for-net", "/sdk/storage", OwnerType.ServiceOwner, "Client Libraries", default);
 
         Assert.That(result.ResponseError, Is.Null);
         Assert.That(result.View, Is.Not.Null);
@@ -1461,7 +1461,7 @@ public class CodeownersManagementHelperTests
         };
         var labels = new[] { new LabelWorkItem { WorkItemId = labelId, LabelName = "Storage" } };
 
-        var result = await _helper.RemoveOwnersFromLabelsAndPath(owners, labels, "Azure/azure-sdk-for-net", "/sdk/storage", OwnerType.ServiceOwner, default);
+        var result = await _helper.RemoveOwnersFromLabelsAndPath(owners, labels, "Azure/azure-sdk-for-net", "/sdk/storage", OwnerType.ServiceOwner, "Client Libraries", default);
 
         Assert.That(result.ResponseError, Is.Null);
         Assert.That(result.View, Is.Not.Null);
@@ -1510,7 +1510,7 @@ public class CodeownersManagementHelperTests
         var owners = new[] { new OwnerWorkItem { WorkItemId = ownerId, GitHubAlias = "user1" } };
         var labels = new[] { new LabelWorkItem { WorkItemId = label1Id, LabelName = "Storage" } };
 
-        var result = await _helper.RemoveOwnersFromLabelsAndPath(owners, labels, "Azure/azure-sdk-for-net", "/sdk/storage", OwnerType.ServiceOwner, default);
+        var result = await _helper.RemoveOwnersFromLabelsAndPath(owners, labels, "Azure/azure-sdk-for-net", "/sdk/storage", OwnerType.ServiceOwner, "Client Libraries", default);
 
         Assert.That(result.ResponseError, Is.Null);
         // Should remove from labelOwner1 (which has label1), not labelOwner2

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CodeownersManagementHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CodeownersManagementHelperTests.cs
@@ -90,7 +90,8 @@ public class CodeownersManagementHelperTests
         {
             { "Custom.LabelType", labelType },
             { "Custom.Repository", repository },
-            { "Custom.RepoPath", repoPath }
+            { "Custom.RepoPath", repoPath },
+            { "Custom.Section", "" }
         }, relatedIds);
 
     // ========================
@@ -110,7 +111,7 @@ public class CodeownersManagementHelperTests
         }
     }
 
-    private static void AssertLabelOwner(LabelOwnerResponse lo, string expectedRepo, string expectedPath, string[]? expectedOwners = null, string[]? expectedLabels = null)
+    private static void AssertLabelOwner(LabelOwnerResponse lo, string expectedRepo, string expectedPath, string[]? expectedOwners = null, string[]? expectedLabels = null, string? expectedSection = null)
     {
         Assert.That(lo.Repo, Is.EqualTo(expectedRepo));
         Assert.That(lo.Path, Is.EqualTo(expectedPath));
@@ -121,6 +122,10 @@ public class CodeownersManagementHelperTests
         if (expectedLabels != null)
         {
             Assert.That(lo.Labels, Is.EquivalentTo(expectedLabels));
+        }
+        if (expectedSection != null)
+        {
+            Assert.That(lo.Section, Is.EqualTo(expectedSection));
         }
     }
 
@@ -456,6 +461,46 @@ public class CodeownersManagementHelperTests
         Assert.That(result.Packages, Is.Null); // GetViewByPath returns no packages
         Assert.That(result.PathBasedLabelOwners, Has.Count.EqualTo(1));
         AssertLabelOwner(result.PathBasedLabelOwners![0], "Azure/azure-sdk-for-net", "/sdk/storage", ["owner2"], ["Storage"]);
+    }
+
+    [Test]
+    public async Task GetViewByPath_ReturnsSectionInResponse()
+    {
+        var loId = 1;
+        var ownerId = 10;
+        var labelId = 11;
+
+        var loWi = MakeWorkItem(loId, "Label Owner", new Dictionary<string, object>
+        {
+            { "Custom.LabelType", "Service Owner" },
+            { "Custom.Repository", "Azure/azure-sdk-for-net" },
+            { "Custom.RepoPath", "/sdk/storage" },
+            { "Custom.Section", "Test Section" }
+        }, ownerId, labelId);
+
+        _mockDevOps.Setup(d => d.FetchWorkItemsPagedAsync(
+                It.Is<string>(q => q.Contains("/sdk/storage")),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                WorkItemExpand.Relations, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<WorkItem> { loWi });
+
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(ownerId) && ids.Contains(labelId)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<WorkItem>
+            {
+                MakeOwnerWorkItem(ownerId, "owner2"),
+                MakeLabelWorkItem(labelId, "Storage")
+            });
+
+        var result = await _helper.GetViewByPath("/sdk/storage", null, CancellationToken.None);
+
+        Assert.That(result.ResponseError, Is.Null);
+        Assert.That(result.PathBasedLabelOwners, Has.Count.EqualTo(1));
+        AssertLabelOwner(result.PathBasedLabelOwners![0], "Azure/azure-sdk-for-net", "/sdk/storage",
+            expectedOwners: ["owner2"], expectedLabels: ["Storage"], expectedSection: "Test Section");
     }
 
     [Test]
@@ -796,7 +841,7 @@ public class CodeownersManagementHelperTests
         var labelWi = new LabelWorkItem { WorkItemId = labelId, LabelName = "Storage" };
 
         _mockDevOps.Setup(d => d.FetchWorkItemsPagedAsync(
-                It.Is<string>(q => q.Contains("'Label Owner'") && q.Contains("Azure/azure-sdk-for-net") && q.Contains("Service Owner")),
+                It.Is<string>(q => q.Contains("'Label Owner'") && q.Contains("Azure/azure-sdk-for-net") && q.Contains("Service Owner") && q.Contains("Custom.Section") && q.Contains("Client Libraries")),
                 It.IsAny<int>(), It.IsAny<int>(), It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<WorkItem> { loWi });
 
@@ -821,7 +866,7 @@ public class CodeownersManagementHelperTests
         var expectedLabelWi = new LabelWorkItem { WorkItemId = expectedLabelId, LabelName = "Storage" };
 
         _mockDevOps.Setup(d => d.FetchWorkItemsPagedAsync(
-                It.Is<string>(q => q.Contains("'Label Owner'") && q.Contains("Azure/azure-sdk-for-net") && q.Contains("Service Owner")),
+                It.Is<string>(q => q.Contains("'Label Owner'") && q.Contains("Azure/azure-sdk-for-net") && q.Contains("Service Owner") && q.Contains("Custom.Section") && q.Contains("Client Libraries")),
                 It.IsAny<int>(), It.IsAny<int>(), It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<WorkItem> { loWi });
 
@@ -847,7 +892,7 @@ public class CodeownersManagementHelperTests
         var labelWi = new LabelWorkItem { WorkItemId = 100, LabelName = "Storage" };
 
         _mockDevOps.Setup(d => d.FetchWorkItemsPagedAsync(
-                It.Is<string>(q => q.Contains("'Label Owner'") && q.Contains("Azure/azure-sdk-for-net")),
+                It.Is<string>(q => q.Contains("'Label Owner'") && q.Contains("Azure/azure-sdk-for-net") && q.Contains("Custom.Section") && q.Contains("Client Libraries")),
                 It.IsAny<int>(), It.IsAny<int>(), It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<WorkItem>());
 
@@ -868,7 +913,7 @@ public class CodeownersManagementHelperTests
         var labelWi = new LabelWorkItem { WorkItemId = 100, LabelName = "Storage" };
 
         _mockDevOps.Setup(d => d.FetchWorkItemsPagedAsync(
-                It.Is<string>(q => q.Contains("'Label Owner'") && q.Contains("sdk/service/")),
+                It.Is<string>(q => q.Contains("'Label Owner'") && q.Contains("sdk/service/") && q.Contains("Custom.Section") && q.Contains("Client Libraries")),
                 It.IsAny<int>(), It.IsAny<int>(), It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<WorkItem>());
 
@@ -1138,6 +1183,10 @@ public class CodeownersManagementHelperTests
         Assert.That(result.ResponseError, Is.Null);
         Assert.That(result.View, Is.Not.Null);
         _mockDevOps.Verify(d => d.CreateWorkItemRelationAsync(labelOwnerWiId, "related", ownerId, It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
+        // Verify FindOrCreateLabelOwnerAsync included section in WIQL query
+        _mockDevOps.Verify(d => d.FetchWorkItemsPagedAsync(
+            It.Is<string>(q => q.Contains("Custom.Section") && q.Contains("Client Libraries")),
+            It.IsAny<int>(), It.IsAny<int>(), It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
     }
 
     [Test]
@@ -1329,7 +1378,7 @@ public class CodeownersManagementHelperTests
     public async Task RemoveOwnersFromLabelsAndPath_NoLabelOwnerFound_ReturnsError()
     {
         _mockDevOps.Setup(d => d.FetchWorkItemsPagedAsync(
-                It.Is<string>(q => q.Contains("'Label Owner'") && q.Contains("/sdk/nopath")),
+                It.Is<string>(q => q.Contains("'Label Owner'") && q.Contains("/sdk/nopath") && q.Contains("Custom.Section") && q.Contains("Client Libraries")),
                 It.IsAny<int>(), It.IsAny<int>(), WorkItemExpand.Relations, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<WorkItem>());
 
@@ -1381,6 +1430,10 @@ public class CodeownersManagementHelperTests
 
         Assert.That(result.ResponseError, Is.Null);
         _mockDevOps.Verify(d => d.RemoveWorkItemRelationAsync(labelOwnerWiId, "related", ownerId, It.IsAny<CancellationToken>()), Times.Once);
+        // Verify QueryLabelOwnersByPath included section in WIQL query
+        _mockDevOps.Verify(d => d.FetchWorkItemsPagedAsync(
+            It.Is<string>(q => q.Contains("Custom.Section") && q.Contains("Client Libraries")),
+            It.IsAny<int>(), It.IsAny<int>(), It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
     }
 
     [Test]
@@ -1418,6 +1471,10 @@ public class CodeownersManagementHelperTests
         Assert.That(result.ResponseError, Is.Null);
         Assert.That(result.View, Is.Not.Null);
         _mockDevOps.Verify(d => d.RemoveWorkItemRelationAsync(It.IsAny<int>(), "related", It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        // Verify QueryLabelOwnersByPath included section in WIQL query
+        _mockDevOps.Verify(d => d.FetchWorkItemsPagedAsync(
+            It.Is<string>(q => q.Contains("Custom.Section") && q.Contains("Client Libraries")),
+            It.IsAny<int>(), It.IsAny<int>(), It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
     }
 
     [Test]
@@ -1467,6 +1524,10 @@ public class CodeownersManagementHelperTests
         Assert.That(result.View, Is.Not.Null);
         _mockDevOps.Verify(d => d.RemoveWorkItemRelationAsync(labelOwnerWiId, "related", owner1Id, It.IsAny<CancellationToken>()), Times.Once);
         _mockDevOps.Verify(d => d.RemoveWorkItemRelationAsync(labelOwnerWiId, "related", owner2Id, It.IsAny<CancellationToken>()), Times.Never);
+        // Verify QueryLabelOwnersByPath included section in WIQL query
+        _mockDevOps.Verify(d => d.FetchWorkItemsPagedAsync(
+            It.Is<string>(q => q.Contains("Custom.Section") && q.Contains("Client Libraries")),
+            It.IsAny<int>(), It.IsAny<int>(), It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
     }
 
     [Test]
@@ -1516,6 +1577,10 @@ public class CodeownersManagementHelperTests
         // Should remove from labelOwner1 (which has label1), not labelOwner2
         _mockDevOps.Verify(d => d.RemoveWorkItemRelationAsync(labelOwner1Id, "related", ownerId, It.IsAny<CancellationToken>()), Times.Once);
         _mockDevOps.Verify(d => d.RemoveWorkItemRelationAsync(labelOwner2Id, "related", It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        // Verify QueryLabelOwnersByPath included section in WIQL query
+        _mockDevOps.Verify(d => d.FetchWorkItemsPagedAsync(
+            It.Is<string>(q => q.Contains("Custom.Section") && q.Contains("Client Libraries")),
+            It.IsAny<int>(), It.IsAny<int>(), It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
     }
 
     // ========================

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 0.6.6 (Unreleased)
+## 0.6.6 (2026-04-01)
 
 ### Features Added
+
+- Added support for CODEOWNERS "Section" in Label Owners (defaults to "Client Libraries")
 
 ### Breaking Changes
 
@@ -11,6 +13,8 @@
 - Fixed sample translation to preserve source directory structure when writing translated files
 
 ### Other Changes
+
+- CODEOWNERS generator supports file paths and doesn't assume all paths are directories
 
 ## 0.6.5 (2026-03-27)
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -6,8 +6,6 @@
 
 - Added support for CODEOWNERS "Section" in Label Owners (defaults to "Client Libraries")
 
-### Breaking Changes
-
 ### Bugs Fixed
 
 - Fixed sample translation to preserve source directory structure when writing translated files

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CodeownersGenerateHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CodeownersGenerateHelper.cs
@@ -238,7 +238,7 @@ public class CodeownersGenerateHelper(
         var serviceLevelPathEntries = new Dictionary<string, CodeownersEntry>(StringComparer.OrdinalIgnoreCase);
         foreach (var lo in unlinkedLabelOwners.Where(lo => !string.IsNullOrEmpty(lo.RepoPath)))
         {
-            string pathExpression = "/" + lo.RepoPath.TrimStart('/').TrimEnd('/') + "/";
+            string pathExpression = "/" + lo.RepoPath.TrimStart('/');
 
             var sourceOwners = lo.Owners
                 .Select(o => o.GitHubAlias)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CodeownersManagementHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CodeownersManagementHelper.cs
@@ -85,7 +85,7 @@ public class CodeownersManagementHelper(
 
     public async Task<CodeownersViewResponse> GetViewByPath(string path, string? repo, CancellationToken ct)
     {
-        var labelOwners = await QueryLabelOwnersByPath(path, repo, ct);
+        var labelOwners = await QueryLabelOwnersByPath(path, repo, null, ct);
         await HydrateLabelOwners(labelOwners, ct);
 
         return new CodeownersViewResponse([], labelOwners);
@@ -233,7 +233,7 @@ public class CodeownersManagementHelper(
         return labelOwners;
     }
 
-    private async Task<List<LabelOwnerWorkItem>> QueryLabelOwnersByPath(string path, string? repo, CancellationToken ct)
+    private async Task<List<LabelOwnerWorkItem>> QueryLabelOwnersByPath(string path, string? repo, string? section, CancellationToken ct)
     {
         var escapedPath = string.IsNullOrEmpty(path) ? string.Empty : path.Replace("'", "''");
         var query = $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{Constants.AZURE_SDK_DEVOPS_RELEASE_PROJECT}' AND [System.WorkItemType] = 'Label Owner' AND [Custom.RepoPath] = '{escapedPath}'";
@@ -241,6 +241,11 @@ public class CodeownersManagementHelper(
         {
             var escapedRepo = repo.Replace("'", "''");
             query += $" AND [Custom.Repository] = '{escapedRepo}'";
+        }
+        if (!string.IsNullOrEmpty(section))
+        {
+            var escapedSection = section.Replace("'", "''");
+            query += $" AND [Custom.Section] = '{escapedSection}'";
         }
         var rawWorkItems = await devOpsService.FetchWorkItemsPagedAsync(query, expand: WorkItemExpand.Relations, ct: ct);
         return rawWorkItems.Select(WorkItemMappers.MapToLabelOwnerWorkItem).ToList();
@@ -359,6 +364,7 @@ public class CodeownersManagementHelper(
         OwnerType ownerType,
         string? repoPath,
         LabelWorkItem[] labelWorkItems,
+        string section,
         CancellationToken ct
     ) {
         var labelTypeString = ownerType.ToWorkItemString();
@@ -367,12 +373,14 @@ public class CodeownersManagementHelper(
         var escapedRepo = repo.Replace("'", "''");
         var escapedLabelType = labelTypeString.Replace("'", "''");
         var escapedPath = normalizedPath.Replace("'", "''");
+        var escapedSection = section.Replace("'", "''");
 
         var query = $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{Constants.AZURE_SDK_DEVOPS_RELEASE_PROJECT}'" +
                     $" AND [System.WorkItemType] = 'Label Owner'" +
                     $" AND [Custom.Repository] = '{escapedRepo}'" +
                     $" AND [Custom.LabelType] = '{escapedLabelType}'" +
-                    $" AND [Custom.RepoPath] = '{escapedPath}'";
+                    $" AND [Custom.RepoPath] = '{escapedPath}'" +
+                    $" AND [Custom.Section] = '{escapedSection}'";
 
         var workItems = await devOpsService.FetchWorkItemsPagedAsync(query, expand: WorkItemExpand.Relations, ct: ct);
         if (workItems.Count > 0)
@@ -403,7 +411,8 @@ public class CodeownersManagementHelper(
         {
             LabelType = labelTypeString,
             Repository = repo,
-            RepoPath = normalizedPath
+            RepoPath = normalizedPath,
+            Section = section
         };
         var created = await devOpsService.CreateWorkItemAsync(labelOwnerWi, "Label Owner", title, ct: ct);
         return WorkItemMappers.MapToLabelOwnerWorkItem(created);
@@ -548,9 +557,10 @@ public class CodeownersManagementHelper(
         string repo,
         string path,
         OwnerType ownerType,
+        string section,
         CancellationToken ct
     ) {
-        var labelOwnerWi = await FindOrCreateLabelOwnerAsync(repo, ownerType, path, labels, ct);
+        var labelOwnerWi = await FindOrCreateLabelOwnerAsync(repo, ownerType, path, labels, section, ct);
 
         foreach (var labelWi in labels)
         {
@@ -651,9 +661,10 @@ public class CodeownersManagementHelper(
         string repo,
         string path,
         OwnerType ownerType,
+        string section,
         CancellationToken ct
     ) {
-        var labelOwners = await QueryLabelOwnersByPath(path, repo, ct);
+        var labelOwners = await QueryLabelOwnersByPath(path, repo, section, ct);
         if (labelOwners.Count == 0)
         {
             return new CodeownersModifyResponse { ResponseError = $"No Label Owner work item found for path '{path}'." };

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/ICodeownersManagementHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/ICodeownersManagementHelper.cs
@@ -20,6 +20,7 @@ public interface ICodeownersManagementHelper
         OwnerType ownerType,
         string? repoPath,
         LabelWorkItem[] labelWorkItems,
+        string section,
         CancellationToken ct
     );
 
@@ -29,12 +30,12 @@ public interface ICodeownersManagementHelper
     // Add scenarios
     Task<CodeownersModifyResponse> AddOwnersToPackage(OwnerWorkItem[] owners, string packageName, string repo, CancellationToken ct);
     Task<CodeownersModifyResponse> AddLabelsToPackage(LabelWorkItem[] labels, string packageName, string repo, CancellationToken ct);
-    Task<CodeownersModifyResponse> AddOwnersAndLabelsToPath(OwnerWorkItem[] owners, LabelWorkItem[] labels, string repo, string path, OwnerType ownerType, CancellationToken ct);
+    Task<CodeownersModifyResponse> AddOwnersAndLabelsToPath(OwnerWorkItem[] owners, LabelWorkItem[] labels, string repo, string path, OwnerType ownerType, string section, CancellationToken ct);
 
     // Remove scenarios
     Task<CodeownersModifyResponse> RemoveOwnersFromPackage(OwnerWorkItem[] owners, string packageName, string repo, CancellationToken ct);
     Task<CodeownersModifyResponse> RemoveLabelsFromPackage(LabelWorkItem[] labels, string packageName, string repo, CancellationToken ct);
-    Task<CodeownersModifyResponse> RemoveOwnersFromLabelsAndPath(OwnerWorkItem[] owners, LabelWorkItem[] labels, string repo, string path, OwnerType ownerType, CancellationToken ct);
+    Task<CodeownersModifyResponse> RemoveOwnersFromLabelsAndPath(OwnerWorkItem[] owners, LabelWorkItem[] labels, string repo, string path, OwnerType ownerType, string section, CancellationToken ct);
 
     // Validation
     Task ThrowIfInvalidTeamAlias(string alias, CancellationToken ct);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AzureDevOps/LabelOwnerWorkItem.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AzureDevOps/LabelOwnerWorkItem.cs
@@ -19,6 +19,9 @@ public class LabelOwnerWorkItem : WorkItemBase
     [FieldName("Custom.RepoPath")]
     public string RepoPath { get; set; } = string.Empty;
 
+    [FieldName("Custom.Section")]
+    public string Section { get; set; } = string.Empty;
+
     /// <summary>
     /// IDs of related work items (populated from work item relations).
     /// </summary>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Codeowners/WorkItemMappers.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Codeowners/WorkItemMappers.cs
@@ -62,6 +62,7 @@ public static class WorkItemMappers
             LabelType = wi.GetFieldValue("Custom.LabelType"),
             Repository = wi.GetFieldValue("Custom.Repository"),
             RepoPath = wi.GetFieldValue("Custom.RepoPath"),
+            Section = wi.GetFieldValue("Custom.Section"),
             RelatedIds = ExtractRelatedIds(wi)
         };
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Codeowners/CodeownersViewResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Codeowners/CodeownersViewResponse.cs
@@ -91,6 +91,7 @@ public class LabelOwnerResponse
         Repo = labelOwnerWorkItem.Repository;
         Path = labelOwnerWorkItem.RepoPath;
         Type = labelOwnerWorkItem.LabelType;
+        Section = string.IsNullOrEmpty(labelOwnerWorkItem.Section) ? null : labelOwnerWorkItem.Section;
         Owners = owners.Count > 0 ? owners : null;
         Labels = labels.Count > 0 ? labels : null;
     }
@@ -109,6 +110,10 @@ public class LabelOwnerResponse
     [JsonPropertyName("type")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Type { get; set; }
+
+    [JsonPropertyName("section")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Section { get; set; }
 
     [JsonPropertyName("owners")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -156,6 +161,7 @@ public class CodeownersViewResponse : CommandResponse
         {
             PathBasedLabelOwners = pathBased.Select(labelOwner => new LabelOwnerResponse(labelOwner))
                 .OrderBy(lo => lo.Repo, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(lo => lo.Section, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(lo => lo.Path, StringComparer.OrdinalIgnoreCase)
                 .ToList();
         }
@@ -164,6 +170,7 @@ public class CodeownersViewResponse : CommandResponse
         {
             PathlessLabelOwners = pathless.Select(labelOwner => new LabelOwnerResponse(labelOwner))
                 .OrderBy(lo => lo.Repo, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(lo => lo.Section, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(lo => string.Join("|", lo.Labels ?? []), StringComparer.OrdinalIgnoreCase)
                 .ToList();
         }
@@ -198,21 +205,30 @@ public class CodeownersViewResponse : CommandResponse
                 .OrderBy(rg => rg.Key, StringComparer.OrdinalIgnoreCase))
             {
                 sb.AppendLine($"  Repo: {repoGroup.Key}");
-                foreach (var pathGroup in repoGroup
-                    .GroupBy(lo => lo.Path, StringComparer.OrdinalIgnoreCase)
-                    .OrderBy(pg => pg.Key, StringComparer.OrdinalIgnoreCase))
+                foreach (var sectionGroup in repoGroup
+                    .GroupBy(lo => lo.Section ?? "", StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(sg => sg.Key, StringComparer.OrdinalIgnoreCase))
                 {
-                    sb.AppendLine($"    Path: {pathGroup.Key}");
-                    foreach (var lo in pathGroup)
+                    if (!string.IsNullOrEmpty(sectionGroup.Key))
                     {
-                        sb.AppendLine($"      Type: {lo.Type} [{lo.WorkItemId}]");
-                        if (lo.Owners?.Count > 0)
+                        sb.AppendLine($"    Section: {sectionGroup.Key}");
+                    }
+                    foreach (var pathGroup in sectionGroup
+                        .GroupBy(lo => lo.Path, StringComparer.OrdinalIgnoreCase)
+                        .OrderBy(pg => pg.Key, StringComparer.OrdinalIgnoreCase))
+                    {
+                        sb.AppendLine($"      Path: {pathGroup.Key}");
+                        foreach (var lo in pathGroup)
                         {
-                            sb.AppendLine($"        Owners: {FormatOwnersList(lo.Owners)}");
-                        }
-                        if (lo.Labels?.Count > 0)
-                        {
-                            sb.AppendLine($"        Labels: {string.Join(", ", lo.Labels)}");
+                            sb.AppendLine($"        Type: {lo.Type} [{lo.WorkItemId}]");
+                            if (lo.Owners?.Count > 0)
+                            {
+                                sb.AppendLine($"          Owners: {FormatOwnersList(lo.Owners)}");
+                            }
+                            if (lo.Labels?.Count > 0)
+                            {
+                                sb.AppendLine($"          Labels: {string.Join(", ", lo.Labels)}");
+                            }
                         }
                     }
                 }
@@ -227,13 +243,22 @@ public class CodeownersViewResponse : CommandResponse
                 .OrderBy(rg => rg.Key, StringComparer.OrdinalIgnoreCase))
             {
                 sb.AppendLine($"  Repo: {repoGroup.Key}");
-                foreach (var lo in repoGroup)
+                foreach (var sectionGroup in repoGroup
+                    .GroupBy(lo => lo.Section ?? "", StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(sg => sg.Key, StringComparer.OrdinalIgnoreCase))
                 {
-                    sb.AppendLine($"    Labels: {string.Join(", ", lo.Labels ?? [])} [{lo.WorkItemId}]");
-                    sb.AppendLine($"      Type: {lo.Type}");
-                    if (lo.Owners?.Count > 0)
+                    if (!string.IsNullOrEmpty(sectionGroup.Key))
                     {
-                        sb.AppendLine($"      Owners: {FormatOwnersList(lo.Owners)}");
+                        sb.AppendLine($"    Section: {sectionGroup.Key}");
+                    }
+                    foreach (var lo in sectionGroup)
+                    {
+                        sb.AppendLine($"      Labels: {string.Join(", ", lo.Labels ?? [])} [{lo.WorkItemId}]");
+                        sb.AppendLine($"        Type: {lo.Type}");
+                        if (lo.Owners?.Count > 0)
+                        {
+                            sb.AppendLine($"          Owners: {FormatOwnersList(lo.Owners)}");
+                        }
                     }
                 }
             }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
@@ -517,7 +517,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
             OwnerType ownerType,
             string? path = null,
             string? repo = null,
-            string section = null,
+            string section = "Client Libraries",
             CancellationToken ct = default
         )
         {
@@ -598,7 +598,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
             OwnerType ownerType,
             string? path = null,
             string? repo = null,
-            string section = null,
+            string section = "Client Libraries",
             CancellationToken ct = default
         )
         {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
@@ -604,7 +604,6 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
         {
             try
             {
-                // System.Diagnostics.Debugger.Launch();
                 repo = await ResolveRepo(repo, ct);
                 return await codeownersManagementHelper.RemoveOwnersFromLabelsAndPath(
                     await GetOwnerWorkItems(githubUsers, ct),

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
@@ -210,7 +210,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
             },
             new(addLabelOwnerCommandName, "Add owner(s) to a label and optional path")
             {
-                multipleGithubUserOption, labelsOption, pathOption, ownerTypeOption, optionalRepoOption,
+                multipleGithubUserOption, labelsOption, pathOption, ownerTypeOption, optionalRepoOption, sectionOption,
             },
             new(removeCodeownersToPackageCommandName, "Remove source owner(s) from a package")
             {
@@ -222,7 +222,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
             },
             new(removeLabelOwnerCommandName, "Remove owner(s) from a label and optional path")
             {
-                multipleGithubUserOption, labelsOption, pathOption, ownerTypeOption, optionalRepoOption,
+                multipleGithubUserOption, labelsOption, pathOption, ownerTypeOption, optionalRepoOption, sectionOption,
             },
             new(exportSectionCommandName, "Export one or more named sections from a CODEOWNERS file")
             {
@@ -278,7 +278,8 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
                 var ownerType = parseResult.GetValue(ownerTypeOption);
                 var path = parseResult.GetValue(pathOption);
                 var repo = parseResult.GetValue(optionalRepoOption);
-                return await AddLabelOwner(users!, labels!, ownerType!, path, repo, ct);
+                var section = parseResult.GetValue(sectionOption);
+                return await AddLabelOwner(users!, labels!, ownerType!, path, repo, section, ct);
             }
 
             if (command == removeCodeownersToPackageCommandName)
@@ -304,7 +305,8 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
                 var ownerType = parseResult.GetValue(ownerTypeOption);
                 var path = parseResult.GetValue(pathOption);
                 var repo = parseResult.GetValue(optionalRepoOption);
-                return await RemoveLabelOwner(users!, labels!, ownerType!, path, repo, ct);
+                var section = parseResult.GetValue(sectionOption);
+                return await RemoveLabelOwner(users!, labels!, ownerType!, path, repo, section, ct);
             }
 
             if (command == exportSectionCommandName)
@@ -515,6 +517,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
             OwnerType ownerType,
             string? path = null,
             string? repo = null,
+            string section = null,
             CancellationToken ct = default
         )
         {
@@ -527,6 +530,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
                     repo,
                     path,
                     ownerType,
+                    section,
                     ct
                 );
             }
@@ -594,11 +598,13 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
             OwnerType ownerType,
             string? path = null,
             string? repo = null,
+            string section = null,
             CancellationToken ct = default
         )
         {
             try
             {
+                // System.Diagnostics.Debugger.Launch();
                 repo = await ResolveRepo(repo, ct);
                 return await codeownersManagementHelper.RemoveOwnersFromLabelsAndPath(
                     await GetOwnerWorkItems(githubUsers, ct),
@@ -606,6 +612,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
                     repo,
                     path,
                     ownerType,
+                    section,
                     ct
                 );
             }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
@@ -523,6 +523,10 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
         {
             try
             {
+                if (string.IsNullOrEmpty(section))
+                {
+                    throw new ArgumentException("Section name must be provided", nameof(section));
+                }
                 repo = await ResolveRepo(repo, ct);
                 return await codeownersManagementHelper.AddOwnersAndLabelsToPath(
                     await FindOrCreateOwnerWorkItems(githubUsers, ct),
@@ -604,6 +608,10 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
         {
             try
             {
+                if (string.IsNullOrEmpty(section))
+                {
+                    throw new ArgumentException("Section name must be provided", nameof(section));
+                }
                 repo = await ResolveRepo(repo, ct);
                 return await codeownersManagementHelper.RemoveOwnersFromLabelsAndPath(
                     await GetOwnerWorkItems(githubUsers, ct),


### PR DESCRIPTION
Adds support for specifying sections when viewing/creating/removing label owners. This helps sort Management and Client packages in their respective sections of the CODEOWNERS file.