### PR TITLE
[APIView] Diagnostic comments incorrectly show related comments across multiple API revisions

### DIFF
--- a/src/dotnet/APIView/APIViewUnitTests/DiagnosticCommentServiceTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/DiagnosticCommentServiceTests.cs
@@ -405,7 +405,7 @@ public class DiagnosticCommentServiceTests
 
 
     [Fact]
-    public async Task SyncDiagnosticCommentsAsync_SameDiagnosticTextAcrossRevisions_ProducesMatchingCorrelationIds()
+    public async Task SyncDiagnosticCommentsAsync_SameDiagnosticTextAcrossRevisions_ProducesDifferentCorrelationIds()
     {
         DiagnosticCommentService service = CreateService(out Mock<ICosmosCommentsRepository> commentsRepoMock);
 
@@ -426,7 +426,7 @@ public class DiagnosticCommentServiceTests
 
         Assert.Equal(2, upsertedComments.Count);
         Assert.NotEqual(upsertedComments[0].Id, upsertedComments[1].Id); // different comments (different targets)
-        Assert.Equal(upsertedComments[0].CorrelationId, upsertedComments[1].CorrelationId); // but same correlation
+        Assert.NotEqual(upsertedComments[0].CorrelationId, upsertedComments[1].CorrelationId); // different revisions → different correlation
     }
 
     [Fact]

--- a/src/dotnet/APIView/APIViewWeb/Managers/DiagnosticCommentService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/DiagnosticCommentService.cs
@@ -120,7 +120,7 @@ public class DiagnosticCommentService : IDiagnosticCommentService
                 IsResolved = false,
                 ResolutionLocked = false,
                 CommentType = CommentType.APIRevision,
-                CorrelationId = GenerateDiagnosticHash(string.Empty, diagnostic.Text)
+                CorrelationId = GenerateDiagnosticHash(apiRevisionId, diagnostic.Text)
             };
 
             await _commentsRepository.UpsertCommentAsync(comment);


### PR DESCRIPTION
follow up of: https://github.com/Azure/azure-sdk-tools/pull/14798

This is not impacting production as this hasn't being released 

When a diagnostic comment has a `correlationId` (used to link related comments across API elements), the "related comments" feature was grouping diagnostics from **all revisions** together — not just the current one.

This is wrong for diagnostics because they are generated per-revision (e.g., from a linter or static analysis run against a specific revision). A diagnostic in revision A sharing a `correlationId` with one in revision B are not meaningfully "related" in the context of a single review; they're independent findings on different snapshots of the API.
