### PR TITLE
Make repo loading optional for scenario in benchmark

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/BenchmarkRunner.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/BenchmarkRunner.cs
@@ -38,12 +38,21 @@ public class BenchmarkRunner : IDisposable
 
         try
         {
-            // Apply ref overrides to repo config
-            var repo = ApplyRefOverride(scenario.Repo, options.RefOverrides);
+            // Apply ref overrides to repo config and prepare workspace
+            if (scenario.Repo is not null)
+            {
+                var repo = ApplyRefOverride(scenario.Repo, options.RefOverrides);
 
-            // 1. Environment Setup - prepare workspace
-            Console.WriteLine($"[Benchmark] Preparing workspace for {scenario.Name}...");
-            workspace = await _workspaceManager.PrepareAsync(repo, scenario.Name);
+                // 1. Environment Setup - prepare workspace
+                Console.WriteLine($"[Benchmark] Preparing workspace for {scenario.Name}...");
+                workspace = await _workspaceManager.PrepareAsync(repo, scenario.Name);
+            }
+            else
+            {
+                // 1. Environment Setup - prepare empty workspace (no repo clone)
+                Console.WriteLine($"[Benchmark] Preparing empty workspace for {scenario.Name}...");
+                workspace = await _workspaceManager.PrepareEmptyAsync(scenario.Name);
+            }
 
             // 2. Run scenario setup (if any)
             Console.WriteLine($"[Benchmark] Running scenario setup...");

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/WorkspaceManager.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/WorkspaceManager.cs
@@ -68,6 +68,28 @@ public class WorkspaceManager
     }
 
     /// <summary>
+    /// Prepares an empty workspace with a bare git repository (no repo clone).
+    /// Useful for scenarios that don't require a pre-existing repository.
+    /// </summary>
+    /// <param name="scenarioId">A unique identifier for the benchmark scenario.</param>
+    /// <returns>A <see cref="Workspace"/> instance pointing to the prepared directory.</returns>
+    public async Task<Workspace> PrepareEmptyAsync(string scenarioId)
+    {
+        var runId = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss-fff");
+        var workspaceRoot = Path.Combine(_workspacePath, scenarioId, runId);
+        var repoName = "workspace";
+        var repoPath = Path.Combine(workspaceRoot, repoName);
+        Directory.CreateDirectory(repoPath);
+
+        // Initialize an empty git repo so workspace git operations work
+        await RunGitCommandAsync(repoPath, "init");
+
+        SetupWorkspaceEnvironment();
+
+        return new Workspace(workspaceRoot, repoName);
+    }
+
+    /// <summary>
     /// Cleans up a workspace based on the specified policy and execution result.
     /// </summary>
     /// <param name="workspace">The workspace to clean up.</param>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/WorkspaceManager.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Infrastructure/WorkspaceManager.cs
@@ -81,9 +81,6 @@ public class WorkspaceManager
         var repoPath = Path.Combine(workspaceRoot, repoName);
         Directory.CreateDirectory(repoPath);
 
-        // Initialize an empty git repo so workspace git operations work
-        await RunGitCommandAsync(repoPath, "init");
-
         SetupWorkspaceEnvironment();
 
         return new Workspace(workspaceRoot, repoName);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Program.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Program.cs
@@ -248,7 +248,7 @@ public class Program
             {
                 Console.WriteLine($"Running scenario: {scenario.Name}");
                 Console.WriteLine($"Description: {scenario.Description}");
-                Console.WriteLine($"Target repo: {scenario.Repo.CloneUrl}");
+                Console.WriteLine($"Target repo: {scenario.Repo?.CloneUrl ?? "(empty workspace)"}");
                 Console.WriteLine();
             }
             // override authoring skill path if specified for authoring scenarios
@@ -328,7 +328,7 @@ public class Program
 
         if (repoOptions is { Count: > 0 })
         {
-            scenarios = scenarios.Where(s => repoOptions.ContainsKey($"{s.Repo.Owner}/{s.Repo.Name}"));
+            scenarios = scenarios.Where(s => s.Repo is not null && repoOptions.ContainsKey($"{s.Repo.Owner}/{s.Repo.Name}"));
         }
 
         return scenarios;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/BenchmarkScenario.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Benchmarks/Scenarios/BenchmarkScenario.cs
@@ -34,8 +34,9 @@ public abstract class BenchmarkScenario
 
     /// <summary>
     /// Gets the configuration for the home repository where the agent will run.
+    /// When null, the workspace is initialized as an empty git repository.
     /// </summary>
-    public abstract RepoConfig Repo { get; }
+    public virtual RepoConfig? Repo => null;
 
     // === MULTI-REPO (optional) ===
 


### PR DESCRIPTION
Currently loading a repo is required. Make it optional and set up empty workspace if repo config does not exist. 