### PR TITLE
Fix multi-line Maven description issue

### DIFF
--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
@@ -555,13 +555,19 @@ public class JavaASTAnalyser implements Analyser {
             configurationLine.addContextEndTokens();
         }
 
+        String sanitizedName = sanitizeMavenText(mavenPom.getName());
+        String sanitizedDescription = sanitizeMavenText(mavenPom.getDescription());
+
+        // Skip diff as the change in Maven name and description is not significant
+        // and will not require a reviewer to approve the change
+
         // Maven name
-        MiscUtils.tokeniseMavenKeyValue(mavenLine, "name", mavenPom.getName())
-                .addProperty(PROPERTY_MAVEN_NAME, mavenPom.getName());
+        MiscUtils.tokeniseMavenKeyValue(mavenLine, "name", sanitizedName, true)
+                .addProperty(PROPERTY_MAVEN_NAME, sanitizedName);
 
         // Maven description
-        MiscUtils.tokeniseMavenKeyValue(mavenLine, "description", mavenPom.getDescription())
-                .addProperty(PROPERTY_MAVEN_DESCRIPTION, mavenPom.getDescription());
+        MiscUtils.tokeniseMavenKeyValue(mavenLine, "description", sanitizedDescription, true)
+                .addProperty(PROPERTY_MAVEN_DESCRIPTION, sanitizedDescription);
 
         // dependencies
         ReviewLine dependenciesLine = mavenLine.addChildLine()
@@ -595,7 +601,24 @@ public class JavaASTAnalyser implements Analyser {
         mavenLine.addContextEndTokens();
     }
 
+    /**
+     * Sanitizes the input Maven text by replacing carriage return and newline characters
+     * with their corresponding encoded representations. Only new lines are encoded, as
+     * APIView does not support multi-line tokens.
+     *
+     * @param mavenText the input text to be sanitized; can be null
+     * @return the sanitized text with carriage return replaced by %0D and newline replaced by %0A,
+     * or null if the input mavenText is null
+     */
+    private static String sanitizeMavenText(String mavenText) {
+        if (mavenText == null) {
+            return null;
+        }
 
+        return mavenText
+            .replace("\r", "%0D")
+            .replace("\n", "%0A");
+    }
 
     /************************************************************************************************
      *


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-tools/issues/14891

This pull request improves how Maven POM metadata is handled in the Java AST analyzer by introducing sanitization for the Maven `name` and `description` fields. This ensures that any carriage return or newline characters are properly encoded, preventing issues with multi-line tokens in APIView.

**Enhancements to Maven POM metadata handling:**

* Added a new `sanitizeMavenText` method to encode carriage return (`\r`) and newline (`\n`) characters as `%0D` and `%0A` in Maven metadata fields, ensuring compatibility with APIView's single-line token requirement.
* Updated the tokenization of Maven `name` and `description` fields to use the sanitized values, preventing multi-line issues and ensuring consistent property assignment.