### PR TITLE
Add 'Foundry' to common labels

### DIFF
--- a/tools/github/data/common-labels.csv
+++ b/tools/github/data/common-labels.csv
@@ -142,6 +142,7 @@ Epic,,3E4B9E
 Evaluation,,e99695
 Event Grid,,e99695
 Event Hubs,,e99695
+Foundry,,e99695
 Functions,,e99695
 Graph,,e99695
 Graph.Microsoft,,e99695


### PR DESCRIPTION
Adds the **Foundry** service label to `common-labels.csv` with the standard service label color (`e99695`). Label sync to all repos is in progress.