### PR TITLE
[AVC] Add average confidence score to metrics

### DIFF
--- a/packages/python-packages/apiview-copilot/src/_metrics.py
+++ b/packages/python-packages/apiview-copilot/src/_metrics.py
@@ -26,6 +26,7 @@ METRICS_COMMENT_FIELDS = [
     "IsResolved",
     "Upvotes",
     "Downvotes",
+    "ConfidenceScore",
 ]
 
 
@@ -56,6 +57,13 @@ class MetricsSegment:
     implicit_good_ai_comment_count: Optional[int] = None
     implicit_bad_ai_comment_count: Optional[int] = None
     neutral_ai_comment_count: Optional[int] = None
+
+    # Average confidence scores per category (None when no confidence scores available)
+    avg_confidence_upvoted: Optional[float] = None
+    avg_confidence_downvoted: Optional[float] = None
+    avg_confidence_deleted: Optional[float] = None
+    avg_confidence_implicit_good: Optional[float] = None
+    avg_confidence_implicit_bad: Optional[float] = None
 
     # Dimension (e.g., {"language": "python"}) or {} for "All"
     dimension: Dict[str, str] = field(default_factory=dict)
@@ -249,22 +257,43 @@ def _build_metrics_segment(
     implicit_bad_count = 0
     neutral_count = 0
 
+    # Accumulate confidence scores per category
+    scores_upvoted: list[float] = []
+    scores_downvoted: list[float] = []
+    scores_deleted: list[float] = []
+    scores_implicit_good: list[float] = []
+    scores_implicit_bad: list[float] = []
+
     for c in all_ai_comments:
+        score = c.get("ConfidenceScore")
         if c.get("IsDeleted"):
             deleted_count += 1
+            if score is not None:
+                scores_deleted.append(score)
         elif c.get("Downvotes"):
             # Any downvote trumps upvotes
             downvoted_count += 1
+            if score is not None:
+                scores_downvoted.append(score)
         elif c.get("Upvotes"):
             upvoted_count += 1
+            if score is not None:
+                scores_upvoted.append(score)
         elif c.get("IsResolved"):
             implicit_good_count += 1
+            if score is not None:
+                scores_implicit_good.append(score)
         elif c.get("APIRevisionId") in approved_revision_ids:
             # In approved revision, not resolved, no votes = implicit bad
             implicit_bad_count += 1
+            if score is not None:
+                scores_implicit_bad.append(score)
         else:
             # In unapproved revision, not resolved, no votes = neutral
             neutral_count += 1
+
+    def _avg(scores: list[float]) -> Optional[float]:
+        return sum(scores) / len(scores) if scores else None
 
     metrics.total_ai_comment_count = len(all_ai_comments)
     metrics.deleted_ai_comment_count = deleted_count
@@ -273,6 +302,12 @@ def _build_metrics_segment(
     metrics.implicit_good_ai_comment_count = implicit_good_count
     metrics.implicit_bad_ai_comment_count = implicit_bad_count
     metrics.neutral_ai_comment_count = neutral_count
+
+    metrics.avg_confidence_upvoted = _avg(scores_upvoted)
+    metrics.avg_confidence_downvoted = _avg(scores_downvoted)
+    metrics.avg_confidence_deleted = _avg(scores_deleted)
+    metrics.avg_confidence_implicit_good = _avg(scores_implicit_good)
+    metrics.avg_confidence_implicit_bad = _avg(scores_implicit_bad)
 
     return metrics
 
@@ -344,6 +379,12 @@ def _build_metrics_report(data: Dict[str, MetricsSegment]) -> dict:
                     _calculate_rate(segment.implicit_bad_ai_comment_count, segment.total_ai_comment_count)
                 ),
                 "neutral_count": segment.neutral_ai_comment_count,
+                # Average confidence scores per category
+                "avg_confidence_good": fmt(segment.avg_confidence_upvoted) if segment.avg_confidence_upvoted is not None else None,
+                "avg_confidence_bad": fmt(segment.avg_confidence_downvoted) if segment.avg_confidence_downvoted is not None else None,
+                "avg_confidence_deleted": fmt(segment.avg_confidence_deleted) if segment.avg_confidence_deleted is not None else None,
+                "avg_confidence_implicit_good": fmt(segment.avg_confidence_implicit_good) if segment.avg_confidence_implicit_good is not None else None,
+                "avg_confidence_implicit_bad": fmt(segment.avg_confidence_implicit_bad) if segment.avg_confidence_implicit_bad is not None else None,
             },
             "comment_makeup": {
                 "human_comment_count_without_copilot": segment.human_comment_count_without_ai,

--- a/packages/python-packages/apiview-copilot/tests/__init__.py
+++ b/packages/python-packages/apiview-copilot/tests/__init__.py
@@ -1,0 +1,5 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------

--- a/packages/python-packages/apiview-copilot/tests/metrics_test.py
+++ b/packages/python-packages/apiview-copilot/tests/metrics_test.py
@@ -143,6 +143,11 @@ class TestMetrics:
             "implicit_bad_count": 0,
             "implicit_bad": 0.0,
             "neutral_count": 0,
+            "avg_confidence_good": None,
+            "avg_confidence_bad": None,
+            "avg_confidence_deleted": None,
+            "avg_confidence_implicit_good": None,
+            "avg_confidence_implicit_bad": None,
         }
 
         cm = overall["comment_makeup"]
@@ -279,6 +284,11 @@ class TestMetrics:
             "implicit_bad_count": 0,
             "implicit_bad": 0.0,
             "neutral_count": 0,
+            "avg_confidence_good": None,
+            "avg_confidence_bad": None,
+            "avg_confidence_deleted": None,
+            "avg_confidence_implicit_good": None,
+            "avg_confidence_implicit_bad": None,
         }
         assert java_cq == {
             "ai_comment_count": 1,
@@ -294,6 +304,11 @@ class TestMetrics:
             "implicit_bad_count": 0,
             "implicit_bad": 0.0,
             "neutral_count": 0,
+            "avg_confidence_good": None,
+            "avg_confidence_bad": None,
+            "avg_confidence_deleted": None,
+            "avg_confidence_implicit_good": None,
+            "avg_confidence_implicit_bad": None,
         }
         assert py_cm == {
             "human_comment_count_without_copilot": 0,
@@ -429,6 +444,11 @@ class TestMetrics:
             "implicit_bad_count": 1,
             "implicit_bad": 1.0,
             "neutral_count": 0,
+            "avg_confidence_good": None,
+            "avg_confidence_bad": None,
+            "avg_confidence_deleted": None,
+            "avg_confidence_implicit_good": None,
+            "avg_confidence_implicit_bad": None,
         }
         assert py_cm == {
             "human_comment_count_without_copilot": 0,
@@ -1211,3 +1231,181 @@ class TestMetrics:
             + cq["neutral_count"]
         )
         assert total_from_categories == cq["ai_comment_count"]
+
+    @patch("src._metrics.get_active_reviews")
+    def test_avg_confidence_score_per_category(self, mock_get_reviews):
+        """Test that average confidence scores are computed correctly per category."""
+        review1 = ActiveReviewMetadata(
+            review_id="review1",
+            name="azure-storage-blob",
+            language="Python",
+            revisions=[
+                ActiveRevisionMetadata(
+                    revision_ids=["rev1"],
+                    package_version="1.0.0",
+                    approval="2026-01-06T00:00:00Z",
+                    has_copilot_review=True,
+                    version_type="GA",
+                ),
+                ActiveRevisionMetadata(
+                    revision_ids=["rev2"],
+                    package_version="2.0.0",
+                    approval=None,  # Unapproved
+                    has_copilot_review=True,
+                    version_type="GA",
+                ),
+            ],
+        )
+
+        comments = [
+            # Good (upvoted) with confidence scores
+            {
+                "id": "c1",
+                "ReviewId": "review1",
+                "APIRevisionId": "rev1",
+                "CommentSource": "AIGenerated",
+                "Upvotes": ["user1"],
+                "Downvotes": [],
+                "ConfidenceScore": 0.8,
+            },
+            {
+                "id": "c2",
+                "ReviewId": "review1",
+                "APIRevisionId": "rev1",
+                "CommentSource": "AIGenerated",
+                "Upvotes": ["user2"],
+                "Downvotes": [],
+                "ConfidenceScore": 0.6,
+            },
+            # Bad (downvoted) with confidence score
+            {
+                "id": "c3",
+                "ReviewId": "review1",
+                "APIRevisionId": "rev1",
+                "CommentSource": "AIGenerated",
+                "Upvotes": [],
+                "Downvotes": ["user1"],
+                "ConfidenceScore": 0.3,
+            },
+            # Deleted with confidence score
+            {
+                "id": "c4",
+                "ReviewId": "review1",
+                "APIRevisionId": "rev1",
+                "CommentSource": "AIGenerated",
+                "IsDeleted": True,
+                "ConfidenceScore": 0.5,
+            },
+            # Implicit good (resolved, no votes)
+            {
+                "id": "c5",
+                "ReviewId": "review1",
+                "APIRevisionId": "rev1",
+                "CommentSource": "AIGenerated",
+                "IsResolved": True,
+                "ConfidenceScore": 0.7,
+            },
+            # Implicit bad (approved, unresolved, no votes)
+            {
+                "id": "c6",
+                "ReviewId": "review1",
+                "APIRevisionId": "rev1",
+                "CommentSource": "AIGenerated",
+                "ConfidenceScore": 0.4,
+            },
+            # Neutral (unapproved) - should not have avg reported
+            {
+                "id": "c7",
+                "ReviewId": "review1",
+                "APIRevisionId": "rev2",
+                "CommentSource": "AIGenerated",
+                "ConfidenceScore": 0.9,
+            },
+        ]
+
+        mock_get_reviews.return_value = ([review1], comments)
+
+        report = metrics.get_metrics_report("2026-01-01", "2026-01-31", environment="test")
+        cq = report["metrics"]["Python"]["comment_quality"]
+
+        assert cq["good_count"] == 2
+        assert cq["bad_count"] == 1
+        assert cq["deleted_count"] == 1
+        assert cq["implicit_good_count"] == 1
+        assert cq["implicit_bad_count"] == 1
+        assert cq["neutral_count"] == 1
+
+        # Average confidence: (0.8 + 0.6) / 2 = 0.7
+        assert cq["avg_confidence_good"] == 0.7
+        # Average confidence: 0.3 / 1 = 0.3
+        assert cq["avg_confidence_bad"] == 0.3
+        # Average confidence: 0.5 / 1 = 0.5
+        assert cq["avg_confidence_deleted"] == 0.5
+        # Average confidence: 0.7 / 1 = 0.7
+        assert cq["avg_confidence_implicit_good"] == 0.7
+        # Average confidence: 0.4 / 1 = 0.4
+        assert cq["avg_confidence_implicit_bad"] == 0.4
+
+    @patch("src._metrics.get_active_reviews")
+    def test_avg_confidence_score_missing_scores_omitted(self, mock_get_reviews):
+        """Test that comments without ConfidenceScore are omitted from average, not treated as 0."""
+        review1 = ActiveReviewMetadata(
+            review_id="review1",
+            name="azure-storage-blob",
+            language="Python",
+            revisions=[
+                ActiveRevisionMetadata(
+                    revision_ids=["rev1"],
+                    package_version="1.0.0",
+                    approval="2026-01-06T00:00:00Z",
+                    has_copilot_review=True,
+                    version_type="GA",
+                )
+            ],
+        )
+
+        comments = [
+            # Good with score
+            {
+                "id": "c1",
+                "ReviewId": "review1",
+                "APIRevisionId": "rev1",
+                "CommentSource": "AIGenerated",
+                "Upvotes": ["user1"],
+                "Downvotes": [],
+                "ConfidenceScore": 0.8,
+            },
+            # Good WITHOUT score - should be omitted from avg, not treated as 0
+            {
+                "id": "c2",
+                "ReviewId": "review1",
+                "APIRevisionId": "rev1",
+                "CommentSource": "AIGenerated",
+                "Upvotes": ["user2"],
+                "Downvotes": [],
+                # No ConfidenceScore field
+            },
+            # Bad with no score at all
+            {
+                "id": "c3",
+                "ReviewId": "review1",
+                "APIRevisionId": "rev1",
+                "CommentSource": "AIGenerated",
+                "Upvotes": [],
+                "Downvotes": ["user1"],
+                # No ConfidenceScore
+            },
+        ]
+
+        mock_get_reviews.return_value = ([review1], comments)
+
+        report = metrics.get_metrics_report("2026-01-01", "2026-01-31", environment="test")
+        cq = report["metrics"]["Python"]["comment_quality"]
+
+        assert cq["good_count"] == 2
+        assert cq["bad_count"] == 1
+
+        # Avg good should be 0.8 (only c1 has a score), NOT (0.8 + 0) / 2 = 0.4
+        assert cq["avg_confidence_good"] == 0.8
+        # Avg bad should be None (no scores available)
+        assert cq["avg_confidence_bad"] is None


### PR DESCRIPTION
Closes https://github.com/Azure/azure-sdk-tools/issues/14971

The metrics report now includes a calculation of the average "confidence score" for each quality "bucket":
- good
- bad
- implicit good
- implicit bad
- deleted

The intent is to see if confidence scores are a reliable discriminator between good and bad comments. 