### PR TITLE
[DRAFT] CODEOWNERS check package release in data model

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/TestData/TestPrompts.json
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/TestData/TestPrompts.json
@@ -138,6 +138,10 @@
     { "toolName": "azsdk_update_release_plan", "prompt": "Update TypeSpec project in release plan", "category": "all" },
     { "toolName": "azsdk_typespec_delegate_apiview_feedback", "prompt": "Help me fix these comments: https://spa.apiview.dev/review/c375391d5ab9419f83e3bdsfas9asdfadf2e?activeApiRevisionId=fc2a4adfasdfasdagae3w3hhtd", "category": "all" },
     { "toolName": "azsdk_typespec_delegate_apiview_feedback", "prompt": "Fix this feedback: https://spa.apiview.dev/review/c375391d5ab9419f83e3bdsfas9asdfadf2e?activeApiRevisionId=fc2a4adfasdfasdagae3w3hhtd", "category": "all" },
-    { "toolName": "azsdk_typespec_delegate_apiview_feedback", "prompt": "Create an issue and assign to copilot to fix this: https://spa.apiview.dev/review/adfaset5391d5ab9419f83e3bds9asdfadf2e?activeApiRevisionId=adf34adfasadastasdagae3w3hhtd", "category": "all" }
+    { "toolName": "azsdk_typespec_delegate_apiview_feedback", "prompt": "Create an issue and assign to copilot to fix this: https://spa.apiview.dev/review/adfaset5391d5ab9419f83e3bds9asdfadf2e?activeApiRevisionId=adf34adfasadastasdagae3w3hhtd", "category": "all" },
+
+    { "toolName": "azsdk_engsys_codeowner_check_package_owners", "prompt": "Check if my package has sufficient code owners", "category": "all" },
+    { "toolName": "azsdk_engsys_codeowner_check_package_owners", "prompt": "Validate the code owner configuration for my package", "category": "all" },
+    { "toolName": "azsdk_engsys_codeowner_check_package_owners", "prompt": "Does my package meet the code owner requirements to release?", "category": "all" }
   ]
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CodeownersManagementHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CodeownersManagementHelperTests.cs
@@ -1955,11 +1955,10 @@ public class CodeownersManagementHelperTests
                 MakeLabelWorkItem(labelId, "TestLabel")
             ]);
 
-        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None));
 
-        Assert.That(result.PackageWorkItem!.Owners!.Count, Is.LessThan(2));
-        Assert.That(result.PackageWorkItem!.Owners!.Count, Is.EqualTo(1));
-        Assert.That(result.Pass, Is.False);
+        Assert.That(ex!.Message, Does.Contain("has 1 unique individual owner(s) but requires at least 2"));
     }
 
     // Test 4:No owners → triggers path fallback
@@ -2025,11 +2024,10 @@ public class CodeownersManagementHelperTests
         ]);
         SetupLabelOwnerQuery("Service Owner", repo, []);
 
-        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None));
 
-        Assert.That(result.PackageWorkItem!.Owners!.Count, Is.GreaterThanOrEqualTo(2));
-        Assert.That(result.PrLabels, Is.Null);
-        Assert.That(result.Pass, Is.False);
+        Assert.That(ex!.Message, Does.Contain("has no PR labels assigned"));
     }
 
     // Test 6: Insufficient service owners (only 1 individual)
@@ -2057,11 +2055,10 @@ public class CodeownersManagementHelperTests
                 MakeLabelWorkItem(labelId, "TestLabel")
             ]);
 
-        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None));
 
-        Assert.That(result.ServiceOwners!.Owners!.Count, Is.LessThan(2));
-        Assert.That(result.ServiceOwners!.Owners!.Count, Is.EqualTo(1));
-        Assert.That(result.Pass, Is.False);
+        Assert.That(ex!.Message, Does.Contain("has 1 unique individual(s) but requires at least 2"));
     }
 
     // Test 7:No service owner has labels that are a superset of package labels
@@ -2080,10 +2077,10 @@ public class CodeownersManagementHelperTests
 
         SetupLabelOwnerQuery("Service Owner", repo, []);
 
-        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None));
 
-        Assert.That(result.ServiceOwners, Is.Null);
-        Assert.That(result.Pass, Is.False);
+        Assert.That(ex!.Message, Does.Contain("No Service Owner Label Owner found"));
     }
 
     // Test 8:Team expansion counts individuals — 1 team with 3 members satisfies 2-owner requirement
@@ -2224,10 +2221,10 @@ public class CodeownersManagementHelperTests
                 MakeLabelWorkItem(label2Id, "LabelB")
             ]);
 
-        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None));
 
-        Assert.That(result.ServiceOwners, Is.Null);
-        Assert.That(result.Pass, Is.False);
+        Assert.That(ex!.Message, Does.Contain("No Service Owner Label Owner found whose labels are a superset of [LabelA, LabelB]"));
     }
 
     // Test 12:Multiple package versions — uses latest
@@ -2286,10 +2283,11 @@ public class CodeownersManagementHelperTests
         ]);
         SetupLabelOwnerQuery("Service Owner", repo, []);
 
-        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
+        // user1 appears both individually and in team — dedup should count as 1, which is < 2 required
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None));
 
-        // user1 appears both individually and in team — should count as 1
-        Assert.That(result.PackageWorkItem!.Owners!.SelectMany(o => o.Members ?? [o.GitHubAlias]).Distinct(StringComparer.OrdinalIgnoreCase).Count(), Is.EqualTo(1));
+        Assert.That(ex!.Message, Does.Contain("has 1 unique individual owner(s) but requires at least 2"));
     }
 
     // Test 14: Fallback — both PR Label and Service Owner pass
@@ -2372,11 +2370,10 @@ public class CodeownersManagementHelperTests
         // Still need SO query for complete check
         SetupLabelOwnerQuery("Service Owner", repo, []);
 
-        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None));
 
-        Assert.That(result.PathOwners!.Owners!.Count, Is.LessThan(2));
-        Assert.That(result.PathOwners!.Owners!.Count, Is.EqualTo(1));
-        Assert.That(result.Pass, Is.False);
+        Assert.That(ex!.Message, Does.Contain("has 1 unique individual(s) but requires at least 2"));
     }
 
     // Test 16: Fallback — Service Owners insufficient
@@ -2419,12 +2416,10 @@ public class CodeownersManagementHelperTests
                 MakeLabelWorkItem(prLabelId, "FallbackLabel")
             ]);
 
-        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None));
 
-        Assert.That(result.PathOwners!.Owners!.Count, Is.GreaterThanOrEqualTo(2));
-        Assert.That(result.ServiceOwners!.Owners!.Count, Is.LessThan(2));
-        Assert.That(result.ServiceOwners!.Owners!.Count, Is.EqualTo(1));
-        Assert.That(result.Pass, Is.False);
+        Assert.That(ex!.Message, Does.Contain("has 1 unique individual(s) but requires at least 2"));
     }
 
     // Test 17: Fallback — no matching paths
@@ -2445,10 +2440,10 @@ public class CodeownersManagementHelperTests
         var prLabelLo = MakeLabelOwnerWorkItem(500, "PR Label", repo, "/sdk/other/");
         SetupLabelOwnerQuery("PR Label", repo, [prLabelLo]);
 
-        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None));
 
-        Assert.That(result.PathOwners, Is.Null);
-        Assert.That(result.Pass, Is.False);
+        Assert.That(ex!.Message, Does.Contain("no PR Label Label Owner has a path matching"));
     }
 
     // Test 18: Fallback — glob match
@@ -2644,10 +2639,10 @@ public class CodeownersManagementHelperTests
                 MakeLabelWorkItem(prLabel2Id, "LabelB")
             ]);
 
-        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None));
 
-        Assert.That(result.ServiceOwners, Is.Null);
-        Assert.That(result.Pass, Is.False);
+        Assert.That(ex!.Message, Does.Contain("No Service Owner Label Owner found whose labels are a superset of [LabelA, LabelB]"));
     }
 
     // Test 22:Fallback — same people as PR Label and Service Owners

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CodeownersManagementHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CodeownersManagementHelperTests.cs
@@ -1909,11 +1909,12 @@ public class CodeownersManagementHelperTests
 
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
 
-        Assert.That(result.AllPassed, Is.True);
-        Assert.That(result.ValidationPath, Is.EqualTo("Package"));
-        Assert.That(result.OwnerCheck!.Passed, Is.True);
-        Assert.That(result.PrLabelCheck!.Passed, Is.True);
-        Assert.That(result.ServiceOwnerCheck!.Passed, Is.True);
+        Assert.That(result.Pass, Is.True);
+        Assert.That(result.PackageWorkItem!.Owners!.Count, Is.GreaterThanOrEqualTo(2));
+        Assert.That(result.PrLabels, Is.Not.Null);
+        Assert.That(result.PrLabels!, Is.Not.Empty);
+        Assert.That(result.ServiceOwners, Is.Not.Null);
+        Assert.That(result.ServiceOwners!.Owners!.Count, Is.GreaterThanOrEqualTo(2));
         Assert.That(result.ExitCode, Is.EqualTo(0));
     }
 
@@ -1926,7 +1927,7 @@ public class CodeownersManagementHelperTests
         var result = await _helper.CheckPackageOwners("NonExistent.Pkg", "sdk/test", "Azure/azure-sdk-for-net", CancellationToken.None);
 
         Assert.That(result.ResponseError, Does.Contain("No Package work item found"));
-        Assert.That(result.AllPassed, Is.False);
+        Assert.That(result.Pass, Is.False);
         Assert.That(result.ExitCode, Is.EqualTo(1));
     }
 
@@ -1956,13 +1957,12 @@ public class CodeownersManagementHelperTests
 
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
 
-        Assert.That(result.ValidationPath, Is.EqualTo("Package"));
-        Assert.That(result.OwnerCheck!.Passed, Is.False);
-        Assert.That(result.OwnerCheck.Actual, Is.EqualTo(1));
-        Assert.That(result.AllPassed, Is.False);
+        Assert.That(result.PackageWorkItem!.Owners!.Count, Is.LessThan(2));
+        Assert.That(result.PackageWorkItem!.Owners!.Count, Is.EqualTo(1));
+        Assert.That(result.Pass, Is.False);
     }
 
-    // Test 4: No owners → triggers path fallback
+    // Test 4:No owners → triggers path fallback
     [Test]
     public async Task CheckPackageOwners_NoOwners_TriggersPathFallback()
     {
@@ -2005,14 +2005,13 @@ public class CodeownersManagementHelperTests
 
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
 
-        Assert.That(result.ValidationPath, Is.EqualTo("PathFallback"));
-        Assert.That(result.PathFallbackCheck, Is.Not.Null);
-        Assert.That(result.PathFallbackCheck!.PrLabelOwnerCheck!.Passed, Is.True);
-        Assert.That(result.PathFallbackCheck!.ServiceOwnerCheck!.Passed, Is.True);
-        Assert.That(result.AllPassed, Is.True);
+        Assert.That(result.PathOwners!.Owners!.Count, Is.GreaterThanOrEqualTo(2));
+        Assert.That(result.ServiceOwners, Is.Not.Null);
+        Assert.That(result.ServiceOwners!.Owners!.Count, Is.GreaterThanOrEqualTo(2));
+        Assert.That(result.Pass, Is.True);
     }
 
-    // Test 5: Package has owners but no PR labels
+    // Test 5:Package has owners but no PR labels
     [Test]
     public async Task CheckPackageOwners_NoPrLabel_Fails()
     {
@@ -2028,10 +2027,9 @@ public class CodeownersManagementHelperTests
 
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
 
-        Assert.That(result.ValidationPath, Is.EqualTo("Package"));
-        Assert.That(result.OwnerCheck!.Passed, Is.True);
-        Assert.That(result.PrLabelCheck!.Passed, Is.False);
-        Assert.That(result.AllPassed, Is.False);
+        Assert.That(result.PackageWorkItem!.Owners!.Count, Is.GreaterThanOrEqualTo(2));
+        Assert.That(result.PrLabels, Is.Null);
+        Assert.That(result.Pass, Is.False);
     }
 
     // Test 6: Insufficient service owners (only 1 individual)
@@ -2061,12 +2059,12 @@ public class CodeownersManagementHelperTests
 
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
 
-        Assert.That(result.ServiceOwnerCheck!.Passed, Is.False);
-        Assert.That(result.ServiceOwnerCheck.Actual, Is.EqualTo(1));
-        Assert.That(result.AllPassed, Is.False);
+        Assert.That(result.ServiceOwners!.Owners!.Count, Is.LessThan(2));
+        Assert.That(result.ServiceOwners!.Owners!.Count, Is.EqualTo(1));
+        Assert.That(result.Pass, Is.False);
     }
 
-    // Test 7: No service owner has labels that are a superset of package labels
+    // Test 7:No service owner has labels that are a superset of package labels
     [Test]
     public async Task CheckPackageOwners_NoServiceOwners_Fails()
     {
@@ -2084,11 +2082,11 @@ public class CodeownersManagementHelperTests
 
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
 
-        Assert.That(result.ServiceOwnerCheck!.Passed, Is.False);
-        Assert.That(result.AllPassed, Is.False);
+        Assert.That(result.ServiceOwners, Is.Null);
+        Assert.That(result.Pass, Is.False);
     }
 
-    // Test 8: Team expansion counts individuals — 1 team with 3 members satisfies 2-owner requirement
+    // Test 8:Team expansion counts individuals — 1 team with 3 members satisfies 2-owner requirement
     [Test]
     public async Task CheckPackageOwners_TeamExpansion_CountsIndividuals()
     {
@@ -2119,9 +2117,9 @@ public class CodeownersManagementHelperTests
 
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
 
-        Assert.That(result.OwnerCheck!.Passed, Is.True);
-        Assert.That(result.OwnerCheck.Actual, Is.EqualTo(3));
-        Assert.That(result.AllPassed, Is.True);
+        Assert.That(result.PackageWorkItem!.Owners, Is.Not.Null);
+        Assert.That(result.PackageWorkItem!.Owners!.SelectMany(o => o.Members ?? [o.GitHubAlias]).Distinct(StringComparer.OrdinalIgnoreCase).Count(), Is.EqualTo(3));
+        Assert.That(result.Pass, Is.True);
     }
 
     // Test 9: Team expansion for service owners
@@ -2153,9 +2151,9 @@ public class CodeownersManagementHelperTests
 
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
 
-        Assert.That(result.ServiceOwnerCheck!.Passed, Is.True);
-        Assert.That(result.ServiceOwnerCheck.Actual, Is.EqualTo(3));
-        Assert.That(result.AllPassed, Is.True);
+        Assert.That(result.ServiceOwners, Is.Not.Null);
+        Assert.That(result.ServiceOwners!.Owners!.SelectMany(o => o.Members ?? [o.GitHubAlias]).Distinct(StringComparer.OrdinalIgnoreCase).Count(), Is.EqualTo(3));
+        Assert.That(result.Pass, Is.True);
     }
 
     // Test 10: Multiple labels — Service Owner must have all labels (superset)
@@ -2190,11 +2188,12 @@ public class CodeownersManagementHelperTests
 
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
 
-        Assert.That(result.ServiceOwnerCheck!.Passed, Is.True);
-        Assert.That(result.AllPassed, Is.True);
+        Assert.That(result.ServiceOwners, Is.Not.Null);
+        Assert.That(result.ServiceOwners!.Owners!.Count, Is.GreaterThanOrEqualTo(2));
+        Assert.That(result.Pass, Is.True);
     }
 
-    // Test 11: Fragmented service owners — multiple SO records collectively cover labels but no single one does
+    // Test 11:Fragmented service owners — multiple SO records collectively cover labels but no single one does
     [Test]
     public async Task CheckPackageOwners_FragmentedServiceOwners_Fails()
     {
@@ -2227,11 +2226,11 @@ public class CodeownersManagementHelperTests
 
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
 
-        Assert.That(result.ServiceOwnerCheck!.Passed, Is.False);
-        Assert.That(result.AllPassed, Is.False);
+        Assert.That(result.ServiceOwners, Is.Null);
+        Assert.That(result.Pass, Is.False);
     }
 
-    // Test 12: Multiple package versions — uses latest
+    // Test 12:Multiple package versions — uses latest
     [Test]
     public async Task CheckPackageOwners_MultiplePackageVersions_UsesLatestByName()
     {
@@ -2264,8 +2263,8 @@ public class CodeownersManagementHelperTests
 
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
 
-        Assert.That(result.AllPassed, Is.True);
-        Assert.That(result.OwnerCheck!.Actual, Is.EqualTo(2));
+        Assert.That(result.Pass, Is.True);
+        Assert.That(result.PackageWorkItem!.Owners!.Count, Is.EqualTo(2));
     }
 
     // Test 13: Overlapping owners — same user in team + individual doesn't double-count
@@ -2290,8 +2289,7 @@ public class CodeownersManagementHelperTests
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
 
         // user1 appears both individually and in team — should count as 1
-        Assert.That(result.OwnerCheck!.Actual, Is.EqualTo(1));
-        Assert.That(result.OwnerCheck.Passed, Is.False);
+        Assert.That(result.PackageWorkItem!.Owners!.SelectMany(o => o.Members ?? [o.GitHubAlias]).Distinct(StringComparer.OrdinalIgnoreCase).Count(), Is.EqualTo(1));
     }
 
     // Test 14: Fallback — both PR Label and Service Owner pass
@@ -2338,10 +2336,10 @@ public class CodeownersManagementHelperTests
 
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
 
-        Assert.That(result.ValidationPath, Is.EqualTo("PathFallback"));
-        Assert.That(result.AllPassed, Is.True);
-        Assert.That(result.PathFallbackCheck!.PrLabelOwnerCheck!.Passed, Is.True);
-        Assert.That(result.PathFallbackCheck.ServiceOwnerCheck!.Passed, Is.True);
+        Assert.That(result.Pass, Is.True);
+        Assert.That(result.PathOwners!.Owners!.Count, Is.GreaterThanOrEqualTo(2));
+        Assert.That(result.ServiceOwners, Is.Not.Null);
+        Assert.That(result.ServiceOwners!.Owners!.Count, Is.GreaterThanOrEqualTo(2));
     }
 
     // Test 15: Fallback — PR Label owners insufficient
@@ -2376,9 +2374,9 @@ public class CodeownersManagementHelperTests
 
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
 
-        Assert.That(result.PathFallbackCheck!.PrLabelOwnerCheck!.Passed, Is.False);
-        Assert.That(result.PathFallbackCheck.PrLabelOwnerCheck.Actual, Is.EqualTo(1));
-        Assert.That(result.AllPassed, Is.False);
+        Assert.That(result.PathOwners!.Owners!.Count, Is.LessThan(2));
+        Assert.That(result.PathOwners!.Owners!.Count, Is.EqualTo(1));
+        Assert.That(result.Pass, Is.False);
     }
 
     // Test 16: Fallback — Service Owners insufficient
@@ -2423,10 +2421,10 @@ public class CodeownersManagementHelperTests
 
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
 
-        Assert.That(result.PathFallbackCheck!.PrLabelOwnerCheck!.Passed, Is.True);
-        Assert.That(result.PathFallbackCheck.ServiceOwnerCheck!.Passed, Is.False);
-        Assert.That(result.PathFallbackCheck.ServiceOwnerCheck.Actual, Is.EqualTo(1));
-        Assert.That(result.AllPassed, Is.False);
+        Assert.That(result.PathOwners!.Owners!.Count, Is.GreaterThanOrEqualTo(2));
+        Assert.That(result.ServiceOwners!.Owners!.Count, Is.LessThan(2));
+        Assert.That(result.ServiceOwners!.Owners!.Count, Is.EqualTo(1));
+        Assert.That(result.Pass, Is.False);
     }
 
     // Test 17: Fallback — no matching paths
@@ -2449,9 +2447,8 @@ public class CodeownersManagementHelperTests
 
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
 
-        Assert.That(result.ValidationPath, Is.EqualTo("PathFallback"));
-        Assert.That(result.PathFallbackCheck!.PrLabelOwnerCheck!.Passed, Is.False);
-        Assert.That(result.AllPassed, Is.False);
+        Assert.That(result.PathOwners, Is.Null);
+        Assert.That(result.Pass, Is.False);
     }
 
     // Test 18: Fallback — glob match
@@ -2498,8 +2495,8 @@ public class CodeownersManagementHelperTests
 
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/contoso/Azure.Contoso.WidgetManager", repo, CancellationToken.None);
 
-        Assert.That(result.AllPassed, Is.True);
-        Assert.That(result.PathFallbackCheck!.PrLabelOwnerCheck!.MatchedPath, Is.EqualTo("/sdk/contoso/"));
+        Assert.That(result.Pass, Is.True);
+        Assert.That(result.PathOwners!.Owners!.Count, Is.GreaterThanOrEqualTo(2));
     }
 
     // Test 19: Fallback — multiple matching PR Label owners, uses last by path
@@ -2549,9 +2546,8 @@ public class CodeownersManagementHelperTests
 
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/sub/Azure.Test.Pkg", repo, CancellationToken.None);
 
-        Assert.That(result.AllPassed, Is.True);
-        Assert.That(result.PathFallbackCheck!.PrLabelOwnerCheck!.MatchedPath, Is.EqualTo("/sdk/test/sub/"));
-        Assert.That(result.PathFallbackCheck.PrLabelOwnerCheck.Labels, Does.Contain("SpecificLabel"));
+        Assert.That(result.Pass, Is.True);
+        Assert.That(result.PrLabels, Does.Contain("SpecificLabel"));
     }
 
     // Test 20: Fallback — multiple labels, Service Owner must be superset
@@ -2600,7 +2596,7 @@ public class CodeownersManagementHelperTests
 
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
 
-        Assert.That(result.AllPassed, Is.True);
+        Assert.That(result.Pass, Is.True);
     }
 
     // Test 21: Fallback — fragmented service owners fail
@@ -2650,11 +2646,11 @@ public class CodeownersManagementHelperTests
 
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
 
-        Assert.That(result.PathFallbackCheck!.ServiceOwnerCheck!.Passed, Is.False);
-        Assert.That(result.AllPassed, Is.False);
+        Assert.That(result.ServiceOwners, Is.Null);
+        Assert.That(result.Pass, Is.False);
     }
 
-    // Test 22: Fallback — same people as PR Label and Service Owners
+    // Test 22:Fallback — same people as PR Label and Service Owners
     [Test]
     public async Task CheckPackageOwners_Fallback_SameOwnersForBothTypes()
     {
@@ -2689,7 +2685,7 @@ public class CodeownersManagementHelperTests
 
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
 
-        Assert.That(result.AllPassed, Is.True);
+        Assert.That(result.Pass, Is.True);
     }
 
     // Test 23: Fallback — Service Owner is pathless but still valid
@@ -2736,8 +2732,9 @@ public class CodeownersManagementHelperTests
 
         var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
 
-        Assert.That(result.AllPassed, Is.True);
-        Assert.That(result.PathFallbackCheck!.ServiceOwnerCheck!.Passed, Is.True);
+        Assert.That(result.Pass, Is.True);
+        Assert.That(result.ServiceOwners, Is.Not.Null);
+        Assert.That(result.ServiceOwners!.Owners!.Count, Is.GreaterThanOrEqualTo(2));
     }
 
     // NormalizePath static helper tests

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CodeownersManagementHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CodeownersManagementHelperTests.cs
@@ -1841,4 +1841,912 @@ public class CodeownersManagementHelperTests
             () => _helper.ThrowIfInvalidTeamAlias("@microsoft/azure-sdk-infra", CancellationToken.None));
         Assert.That(ex!.Message, Does.Contain("Only teams in the 'Azure' organization are supported"));
     }
+
+    // ========================
+    // CheckPackageOwners tests
+    // ========================
+
+    /// <summary>
+    /// Sets up FetchWorkItemsPagedAsync to return label owners by type and repo.
+    /// </summary>
+    private void SetupLabelOwnerQuery(string labelType, string repo, List<WorkItem> results)
+    {
+        _mockDevOps.Setup(d => d.FetchWorkItemsPagedAsync(
+                It.Is<string>(q => q.Contains("'Label Owner'") && q.Contains($"'{labelType}'") && q.Contains(repo)),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                WorkItemExpand.Relations, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(results);
+    }
+
+    private void SetupPackageQuery(string packageName, List<WorkItem> results)
+    {
+        _mockDevOps.Setup(d => d.FetchWorkItemsPagedAsync(
+                It.Is<string>(q => q.Contains("'Package'") && q.Contains(packageName)),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(results);
+    }
+
+    private void SetupHydration(List<int> expectedIds, List<WorkItem> results)
+    {
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => expectedIds.All(id => ids.Contains(id))),
+                It.IsAny<int>(),
+                It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(results);
+    }
+
+    // Test 1: Primary path — all checks pass
+    [Test]
+    public async Task CheckPackageOwners_AllChecksPass()
+    {
+        const int pkgId = 100, owner1Id = 201, owner2Id = 202, labelId = 301, soId = 400;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        // Package with 2 owners + 1 label
+        SetupPackageQuery("Azure.Test.Pkg", [MakePackageWorkItem(pkgId, "Azure.Test.Pkg", relatedIds: [owner1Id, owner2Id, labelId])]);
+        // Hydrate package -> owners + label
+        SetupHydration([owner1Id, owner2Id, labelId], [
+            MakeOwnerWorkItem(owner1Id, "user1"),
+            MakeOwnerWorkItem(owner2Id, "user2"),
+            MakeLabelWorkItem(labelId, "TestLabel")
+        ]);
+        // Service Owner Label Owner with superset labels and 2 owners
+        var soWi = MakeLabelOwnerWorkItem(soId, "Service Owner", repo, "", owner1Id, owner2Id, labelId);
+        SetupLabelOwnerQuery("Service Owner", repo, [soWi]);
+        // Hydrate SO -> owners + labels
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(owner1Id) && ids.Contains(owner2Id) && ids.Contains(labelId)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(owner1Id, "user1"),
+                MakeOwnerWorkItem(owner2Id, "user2"),
+                MakeLabelWorkItem(labelId, "TestLabel")
+            ]);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
+
+        Assert.That(result.AllPassed, Is.True);
+        Assert.That(result.ValidationPath, Is.EqualTo("Package"));
+        Assert.That(result.OwnerCheck!.Passed, Is.True);
+        Assert.That(result.PrLabelCheck!.Passed, Is.True);
+        Assert.That(result.ServiceOwnerCheck!.Passed, Is.True);
+        Assert.That(result.ExitCode, Is.EqualTo(0));
+    }
+
+    // Test 2: Package not found
+    [Test]
+    public async Task CheckPackageOwners_PackageNotFound_ReturnsError()
+    {
+        SetupPackageQuery("NonExistent.Pkg", []);
+
+        var result = await _helper.CheckPackageOwners("NonExistent.Pkg", "sdk/test", "Azure/azure-sdk-for-net", CancellationToken.None);
+
+        Assert.That(result.ResponseError, Does.Contain("No Package work item found"));
+        Assert.That(result.AllPassed, Is.False);
+        Assert.That(result.ExitCode, Is.EqualTo(1));
+    }
+
+    // Test 3: Insufficient owners (1 owner < 2 required) — no fallback
+    [Test]
+    public async Task CheckPackageOwners_InsufficientOwners_Fails()
+    {
+        const int pkgId = 100, ownerId = 201, labelId = 301, soId = 400;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        SetupPackageQuery("Azure.Test.Pkg", [MakePackageWorkItem(pkgId, "Azure.Test.Pkg", relatedIds: [ownerId, labelId])]);
+        SetupHydration([ownerId, labelId], [
+            MakeOwnerWorkItem(ownerId, "user1"),
+            MakeLabelWorkItem(labelId, "TestLabel")
+        ]);
+        // Service Owner
+        var soWi = MakeLabelOwnerWorkItem(soId, "Service Owner", repo, "", ownerId, labelId);
+        SetupLabelOwnerQuery("Service Owner", repo, [soWi]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(ownerId) && ids.Contains(labelId)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(ownerId, "user1"),
+                MakeLabelWorkItem(labelId, "TestLabel")
+            ]);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
+
+        Assert.That(result.ValidationPath, Is.EqualTo("Package"));
+        Assert.That(result.OwnerCheck!.Passed, Is.False);
+        Assert.That(result.OwnerCheck.Actual, Is.EqualTo(1));
+        Assert.That(result.AllPassed, Is.False);
+    }
+
+    // Test 4: No owners → triggers path fallback
+    [Test]
+    public async Task CheckPackageOwners_NoOwners_TriggersPathFallback()
+    {
+        const int pkgId = 100, labelId = 301;
+        const int prLabelLoId = 500, prOwner1Id = 601, prOwner2Id = 602, prLabelLabelId = 701;
+        const int soId = 800, soOwner1Id = 901, soOwner2Id = 902;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        // Package with no owners
+        SetupPackageQuery("Azure.Test.Pkg", [MakePackageWorkItem(pkgId, "Azure.Test.Pkg", relatedIds: [labelId])]);
+        SetupHydration([labelId], [MakeLabelWorkItem(labelId, "TestLabel")]);
+
+        // PR Label Label Owner matching path
+        var prLabelLo = MakeLabelOwnerWorkItem(prLabelLoId, "PR Label", repo, "/sdk/test/", prOwner1Id, prOwner2Id, prLabelLabelId);
+        SetupLabelOwnerQuery("PR Label", repo, [prLabelLo]);
+
+        // Hydrate PR Label Label Owner
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(prOwner1Id) && ids.Contains(prOwner2Id) && ids.Contains(prLabelLabelId)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(prOwner1Id, "prUser1"),
+                MakeOwnerWorkItem(prOwner2Id, "prUser2"),
+                MakeLabelWorkItem(prLabelLabelId, "PrLabel1")
+            ]);
+
+        // Service Owner matching labels
+        var soWi = MakeLabelOwnerWorkItem(soId, "Service Owner", repo, "", soOwner1Id, soOwner2Id, prLabelLabelId);
+        SetupLabelOwnerQuery("Service Owner", repo, [soWi]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(soOwner1Id) && ids.Contains(soOwner2Id) && ids.Contains(prLabelLabelId)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(soOwner1Id, "soUser1"),
+                MakeOwnerWorkItem(soOwner2Id, "soUser2"),
+                MakeLabelWorkItem(prLabelLabelId, "PrLabel1")
+            ]);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
+
+        Assert.That(result.ValidationPath, Is.EqualTo("PathFallback"));
+        Assert.That(result.PathFallbackCheck, Is.Not.Null);
+        Assert.That(result.PathFallbackCheck!.PrLabelOwnerCheck!.Passed, Is.True);
+        Assert.That(result.PathFallbackCheck!.ServiceOwnerCheck!.Passed, Is.True);
+        Assert.That(result.AllPassed, Is.True);
+    }
+
+    // Test 5: Package has owners but no PR labels
+    [Test]
+    public async Task CheckPackageOwners_NoPrLabel_Fails()
+    {
+        const int pkgId = 100, owner1Id = 201, owner2Id = 202;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        SetupPackageQuery("Azure.Test.Pkg", [MakePackageWorkItem(pkgId, "Azure.Test.Pkg", relatedIds: [owner1Id, owner2Id])]);
+        SetupHydration([owner1Id, owner2Id], [
+            MakeOwnerWorkItem(owner1Id, "user1"),
+            MakeOwnerWorkItem(owner2Id, "user2"),
+        ]);
+        SetupLabelOwnerQuery("Service Owner", repo, []);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
+
+        Assert.That(result.ValidationPath, Is.EqualTo("Package"));
+        Assert.That(result.OwnerCheck!.Passed, Is.True);
+        Assert.That(result.PrLabelCheck!.Passed, Is.False);
+        Assert.That(result.AllPassed, Is.False);
+    }
+
+    // Test 6: Insufficient service owners (only 1 individual)
+    [Test]
+    public async Task CheckPackageOwners_InsufficientServiceOwners_Fails()
+    {
+        const int pkgId = 100, owner1Id = 201, owner2Id = 202, labelId = 301, soId = 400, soOwnerId = 501;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        SetupPackageQuery("Azure.Test.Pkg", [MakePackageWorkItem(pkgId, "Azure.Test.Pkg", relatedIds: [owner1Id, owner2Id, labelId])]);
+        SetupHydration([owner1Id, owner2Id, labelId], [
+            MakeOwnerWorkItem(owner1Id, "user1"),
+            MakeOwnerWorkItem(owner2Id, "user2"),
+            MakeLabelWorkItem(labelId, "TestLabel")
+        ]);
+
+        var soWi = MakeLabelOwnerWorkItem(soId, "Service Owner", repo, "", soOwnerId, labelId);
+        SetupLabelOwnerQuery("Service Owner", repo, [soWi]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(soOwnerId) && ids.Contains(labelId)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(soOwnerId, "soUser1"),
+                MakeLabelWorkItem(labelId, "TestLabel")
+            ]);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
+
+        Assert.That(result.ServiceOwnerCheck!.Passed, Is.False);
+        Assert.That(result.ServiceOwnerCheck.Actual, Is.EqualTo(1));
+        Assert.That(result.AllPassed, Is.False);
+    }
+
+    // Test 7: No service owner has labels that are a superset of package labels
+    [Test]
+    public async Task CheckPackageOwners_NoServiceOwners_Fails()
+    {
+        const int pkgId = 100, owner1Id = 201, owner2Id = 202, labelId = 301;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        SetupPackageQuery("Azure.Test.Pkg", [MakePackageWorkItem(pkgId, "Azure.Test.Pkg", relatedIds: [owner1Id, owner2Id, labelId])]);
+        SetupHydration([owner1Id, owner2Id, labelId], [
+            MakeOwnerWorkItem(owner1Id, "user1"),
+            MakeOwnerWorkItem(owner2Id, "user2"),
+            MakeLabelWorkItem(labelId, "TestLabel")
+        ]);
+
+        SetupLabelOwnerQuery("Service Owner", repo, []);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
+
+        Assert.That(result.ServiceOwnerCheck!.Passed, Is.False);
+        Assert.That(result.AllPassed, Is.False);
+    }
+
+    // Test 8: Team expansion counts individuals — 1 team with 3 members satisfies 2-owner requirement
+    [Test]
+    public async Task CheckPackageOwners_TeamExpansion_CountsIndividuals()
+    {
+        const int pkgId = 100, teamOwnerId = 201, labelId = 301, soId = 400, so1Id = 501, so2Id = 502;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        SetupPackageQuery("Azure.Test.Pkg", [MakePackageWorkItem(pkgId, "Azure.Test.Pkg", relatedIds: [teamOwnerId, labelId])]);
+
+        // Team owner with 3 expanded members
+        _mockTeamUserCache.Setup(c => c.GetUsersForTeam("azure/test-team")).Returns(["member1", "member2", "member3"]);
+
+        SetupHydration([teamOwnerId, labelId], [
+            MakeOwnerWorkItem(teamOwnerId, "azure/test-team"),
+            MakeLabelWorkItem(labelId, "TestLabel")
+        ]);
+
+        var soWi = MakeLabelOwnerWorkItem(soId, "Service Owner", repo, "", so1Id, so2Id, labelId);
+        SetupLabelOwnerQuery("Service Owner", repo, [soWi]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(so1Id) && ids.Contains(so2Id) && ids.Contains(labelId)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(so1Id, "soUser1"),
+                MakeOwnerWorkItem(so2Id, "soUser2"),
+                MakeLabelWorkItem(labelId, "TestLabel")
+            ]);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
+
+        Assert.That(result.OwnerCheck!.Passed, Is.True);
+        Assert.That(result.OwnerCheck.Actual, Is.EqualTo(3));
+        Assert.That(result.AllPassed, Is.True);
+    }
+
+    // Test 9: Team expansion for service owners
+    [Test]
+    public async Task CheckPackageOwners_TeamExpansion_ServiceOwners()
+    {
+        const int pkgId = 100, owner1Id = 201, owner2Id = 202, labelId = 301, soId = 400, soTeamId = 501;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        SetupPackageQuery("Azure.Test.Pkg", [MakePackageWorkItem(pkgId, "Azure.Test.Pkg", relatedIds: [owner1Id, owner2Id, labelId])]);
+        SetupHydration([owner1Id, owner2Id, labelId], [
+            MakeOwnerWorkItem(owner1Id, "user1"),
+            MakeOwnerWorkItem(owner2Id, "user2"),
+            MakeLabelWorkItem(labelId, "TestLabel")
+        ]);
+
+        _mockTeamUserCache.Setup(c => c.GetUsersForTeam("azure/so-team")).Returns(["soMember1", "soMember2", "soMember3"]);
+
+        var soWi = MakeLabelOwnerWorkItem(soId, "Service Owner", repo, "", soTeamId, labelId);
+        SetupLabelOwnerQuery("Service Owner", repo, [soWi]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(soTeamId) && ids.Contains(labelId)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(soTeamId, "azure/so-team"),
+                MakeLabelWorkItem(labelId, "TestLabel")
+            ]);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
+
+        Assert.That(result.ServiceOwnerCheck!.Passed, Is.True);
+        Assert.That(result.ServiceOwnerCheck.Actual, Is.EqualTo(3));
+        Assert.That(result.AllPassed, Is.True);
+    }
+
+    // Test 10: Multiple labels — Service Owner must have all labels (superset)
+    [Test]
+    public async Task CheckPackageOwners_MultipleLabels_ServiceOwnerSupersetRequired()
+    {
+        const int pkgId = 100, owner1Id = 201, owner2Id = 202, label1Id = 301, label2Id = 302;
+        const int soId = 400, soOwner1Id = 501, soOwner2Id = 502;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        SetupPackageQuery("Azure.Test.Pkg", [MakePackageWorkItem(pkgId, "Azure.Test.Pkg", relatedIds: [owner1Id, owner2Id, label1Id, label2Id])]);
+        SetupHydration([owner1Id, owner2Id, label1Id, label2Id], [
+            MakeOwnerWorkItem(owner1Id, "user1"),
+            MakeOwnerWorkItem(owner2Id, "user2"),
+            MakeLabelWorkItem(label1Id, "LabelA"),
+            MakeLabelWorkItem(label2Id, "LabelB")
+        ]);
+
+        // Service Owner has both labels
+        var soWi = MakeLabelOwnerWorkItem(soId, "Service Owner", repo, "", soOwner1Id, soOwner2Id, label1Id, label2Id);
+        SetupLabelOwnerQuery("Service Owner", repo, [soWi]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(soOwner1Id) && ids.Contains(soOwner2Id) && ids.Contains(label1Id) && ids.Contains(label2Id)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(soOwner1Id, "soUser1"),
+                MakeOwnerWorkItem(soOwner2Id, "soUser2"),
+                MakeLabelWorkItem(label1Id, "LabelA"),
+                MakeLabelWorkItem(label2Id, "LabelB")
+            ]);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
+
+        Assert.That(result.ServiceOwnerCheck!.Passed, Is.True);
+        Assert.That(result.AllPassed, Is.True);
+    }
+
+    // Test 11: Fragmented service owners — multiple SO records collectively cover labels but no single one does
+    [Test]
+    public async Task CheckPackageOwners_FragmentedServiceOwners_Fails()
+    {
+        const int pkgId = 100, owner1Id = 201, owner2Id = 202, label1Id = 301, label2Id = 302;
+        const int so1Id = 400, so2Id = 401, soOwner1Id = 501, soOwner2Id = 502;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        SetupPackageQuery("Azure.Test.Pkg", [MakePackageWorkItem(pkgId, "Azure.Test.Pkg", relatedIds: [owner1Id, owner2Id, label1Id, label2Id])]);
+        SetupHydration([owner1Id, owner2Id, label1Id, label2Id], [
+            MakeOwnerWorkItem(owner1Id, "user1"),
+            MakeOwnerWorkItem(owner2Id, "user2"),
+            MakeLabelWorkItem(label1Id, "LabelA"),
+            MakeLabelWorkItem(label2Id, "LabelB")
+        ]);
+
+        // SO 1 has LabelA only, SO 2 has LabelB only
+        var so1Wi = MakeLabelOwnerWorkItem(so1Id, "Service Owner", repo, "", soOwner1Id, soOwner2Id, label1Id);
+        var so2Wi = MakeLabelOwnerWorkItem(so2Id, "Service Owner", repo, "", soOwner1Id, soOwner2Id, label2Id);
+        SetupLabelOwnerQuery("Service Owner", repo, [so1Wi, so2Wi]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(soOwner1Id) && ids.Contains(soOwner2Id)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(soOwner1Id, "soUser1"),
+                MakeOwnerWorkItem(soOwner2Id, "soUser2"),
+                MakeLabelWorkItem(label1Id, "LabelA"),
+                MakeLabelWorkItem(label2Id, "LabelB")
+            ]);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
+
+        Assert.That(result.ServiceOwnerCheck!.Passed, Is.False);
+        Assert.That(result.AllPassed, Is.False);
+    }
+
+    // Test 12: Multiple package versions — uses latest
+    [Test]
+    public async Task CheckPackageOwners_MultiplePackageVersions_UsesLatestByName()
+    {
+        const int pkg1Id = 100, pkg2Id = 101, owner1Id = 201, owner2Id = 202, labelId = 301;
+        const int soId = 400, soOwner1Id = 501, soOwner2Id = 502;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        // Two versions of same package: 1.0 and 2.0
+        SetupPackageQuery("Azure.Test.Pkg", [
+            MakePackageWorkItem(pkg1Id, "Azure.Test.Pkg", version: "1.0", relatedIds: []),
+            MakePackageWorkItem(pkg2Id, "Azure.Test.Pkg", version: "2.0", relatedIds: [owner1Id, owner2Id, labelId])
+        ]);
+        SetupHydration([owner1Id, owner2Id, labelId], [
+            MakeOwnerWorkItem(owner1Id, "user1"),
+            MakeOwnerWorkItem(owner2Id, "user2"),
+            MakeLabelWorkItem(labelId, "TestLabel")
+        ]);
+
+        var soWi = MakeLabelOwnerWorkItem(soId, "Service Owner", repo, "", soOwner1Id, soOwner2Id, labelId);
+        SetupLabelOwnerQuery("Service Owner", repo, [soWi]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(soOwner1Id) && ids.Contains(soOwner2Id) && ids.Contains(labelId)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(soOwner1Id, "soUser1"),
+                MakeOwnerWorkItem(soOwner2Id, "soUser2"),
+                MakeLabelWorkItem(labelId, "TestLabel")
+            ]);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
+
+        Assert.That(result.AllPassed, Is.True);
+        Assert.That(result.OwnerCheck!.Actual, Is.EqualTo(2));
+    }
+
+    // Test 13: Overlapping owners — same user in team + individual doesn't double-count
+    [Test]
+    public async Task CheckPackageOwners_OverlappingOwners_Deduplication()
+    {
+        const int pkgId = 100, indivOwnerId = 201, teamOwnerId = 202, labelId = 301;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        SetupPackageQuery("Azure.Test.Pkg", [MakePackageWorkItem(pkgId, "Azure.Test.Pkg", relatedIds: [indivOwnerId, teamOwnerId, labelId])]);
+
+        // Team contains same user as individual owner
+        _mockTeamUserCache.Setup(c => c.GetUsersForTeam("azure/test-team")).Returns(["user1"]);
+
+        SetupHydration([indivOwnerId, teamOwnerId, labelId], [
+            MakeOwnerWorkItem(indivOwnerId, "user1"),
+            MakeOwnerWorkItem(teamOwnerId, "azure/test-team"),
+            MakeLabelWorkItem(labelId, "TestLabel")
+        ]);
+        SetupLabelOwnerQuery("Service Owner", repo, []);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test", repo, CancellationToken.None);
+
+        // user1 appears both individually and in team — should count as 1
+        Assert.That(result.OwnerCheck!.Actual, Is.EqualTo(1));
+        Assert.That(result.OwnerCheck.Passed, Is.False);
+    }
+
+    // Test 14: Fallback — both PR Label and Service Owner pass
+    [Test]
+    public async Task CheckPackageOwners_Fallback_BothPrLabelAndServiceOwnerPass()
+    {
+        const int pkgId = 100;
+        const int prLabelLoId = 500, prOwner1Id = 601, prOwner2Id = 602, prLabelId = 701;
+        const int soId = 800, soOwner1Id = 901, soOwner2Id = 902;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        // Package with no owners
+        SetupPackageQuery("Azure.Test.Pkg", [MakePackageWorkItem(pkgId, "Azure.Test.Pkg", relatedIds: [])]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => !ids.Any()),
+                It.IsAny<int>(),
+                It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var prLabelLo = MakeLabelOwnerWorkItem(prLabelLoId, "PR Label", repo, "/sdk/test/", prOwner1Id, prOwner2Id, prLabelId);
+        SetupLabelOwnerQuery("PR Label", repo, [prLabelLo]);
+
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(prOwner1Id) && ids.Contains(prOwner2Id) && ids.Contains(prLabelId)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(prOwner1Id, "prUser1"),
+                MakeOwnerWorkItem(prOwner2Id, "prUser2"),
+                MakeLabelWorkItem(prLabelId, "FallbackLabel")
+            ]);
+
+        var soWi = MakeLabelOwnerWorkItem(soId, "Service Owner", repo, "", soOwner1Id, soOwner2Id, prLabelId);
+        SetupLabelOwnerQuery("Service Owner", repo, [soWi]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(soOwner1Id) && ids.Contains(soOwner2Id) && ids.Contains(prLabelId)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(soOwner1Id, "soUser1"),
+                MakeOwnerWorkItem(soOwner2Id, "soUser2"),
+                MakeLabelWorkItem(prLabelId, "FallbackLabel")
+            ]);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
+
+        Assert.That(result.ValidationPath, Is.EqualTo("PathFallback"));
+        Assert.That(result.AllPassed, Is.True);
+        Assert.That(result.PathFallbackCheck!.PrLabelOwnerCheck!.Passed, Is.True);
+        Assert.That(result.PathFallbackCheck.ServiceOwnerCheck!.Passed, Is.True);
+    }
+
+    // Test 15: Fallback — PR Label owners insufficient
+    [Test]
+    public async Task CheckPackageOwners_Fallback_PrLabelOwnersInsufficient()
+    {
+        const int pkgId = 100;
+        const int prLabelLoId = 500, prOwnerId = 601, prLabelId = 701;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        SetupPackageQuery("Azure.Test.Pkg", [MakePackageWorkItem(pkgId, "Azure.Test.Pkg", relatedIds: [])]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => !ids.Any()),
+                It.IsAny<int>(),
+                It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var prLabelLo = MakeLabelOwnerWorkItem(prLabelLoId, "PR Label", repo, "/sdk/test/", prOwnerId, prLabelId);
+        SetupLabelOwnerQuery("PR Label", repo, [prLabelLo]);
+
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(prOwnerId) && ids.Contains(prLabelId)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(prOwnerId, "prUser1"),
+                MakeLabelWorkItem(prLabelId, "FallbackLabel")
+            ]);
+
+        // Still need SO query for complete check
+        SetupLabelOwnerQuery("Service Owner", repo, []);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
+
+        Assert.That(result.PathFallbackCheck!.PrLabelOwnerCheck!.Passed, Is.False);
+        Assert.That(result.PathFallbackCheck.PrLabelOwnerCheck.Actual, Is.EqualTo(1));
+        Assert.That(result.AllPassed, Is.False);
+    }
+
+    // Test 16: Fallback — Service Owners insufficient
+    [Test]
+    public async Task CheckPackageOwners_Fallback_ServiceOwnersInsufficient()
+    {
+        const int pkgId = 100;
+        const int prLabelLoId = 500, prOwner1Id = 601, prOwner2Id = 602, prLabelId = 701;
+        const int soId = 800, soOwnerId = 901;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        SetupPackageQuery("Azure.Test.Pkg", [MakePackageWorkItem(pkgId, "Azure.Test.Pkg", relatedIds: [])]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => !ids.Any()),
+                It.IsAny<int>(),
+                It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var prLabelLo = MakeLabelOwnerWorkItem(prLabelLoId, "PR Label", repo, "/sdk/test/", prOwner1Id, prOwner2Id, prLabelId);
+        SetupLabelOwnerQuery("PR Label", repo, [prLabelLo]);
+
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(prOwner1Id) && ids.Contains(prOwner2Id) && ids.Contains(prLabelId)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(prOwner1Id, "prUser1"),
+                MakeOwnerWorkItem(prOwner2Id, "prUser2"),
+                MakeLabelWorkItem(prLabelId, "FallbackLabel")
+            ]);
+
+        var soWi = MakeLabelOwnerWorkItem(soId, "Service Owner", repo, "", soOwnerId, prLabelId);
+        SetupLabelOwnerQuery("Service Owner", repo, [soWi]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(soOwnerId) && ids.Contains(prLabelId)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(soOwnerId, "soUser1"),
+                MakeLabelWorkItem(prLabelId, "FallbackLabel")
+            ]);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
+
+        Assert.That(result.PathFallbackCheck!.PrLabelOwnerCheck!.Passed, Is.True);
+        Assert.That(result.PathFallbackCheck.ServiceOwnerCheck!.Passed, Is.False);
+        Assert.That(result.PathFallbackCheck.ServiceOwnerCheck.Actual, Is.EqualTo(1));
+        Assert.That(result.AllPassed, Is.False);
+    }
+
+    // Test 17: Fallback — no matching paths
+    [Test]
+    public async Task CheckPackageOwners_Fallback_NoMatchingPaths()
+    {
+        const int pkgId = 100;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        SetupPackageQuery("Azure.Test.Pkg", [MakePackageWorkItem(pkgId, "Azure.Test.Pkg", relatedIds: [])]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => !ids.Any()),
+                It.IsAny<int>(),
+                It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        // PR Label Label Owner with non-matching path
+        var prLabelLo = MakeLabelOwnerWorkItem(500, "PR Label", repo, "/sdk/other/");
+        SetupLabelOwnerQuery("PR Label", repo, [prLabelLo]);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
+
+        Assert.That(result.ValidationPath, Is.EqualTo("PathFallback"));
+        Assert.That(result.PathFallbackCheck!.PrLabelOwnerCheck!.Passed, Is.False);
+        Assert.That(result.AllPassed, Is.False);
+    }
+
+    // Test 18: Fallback — glob match
+    [Test]
+    public async Task CheckPackageOwners_Fallback_GlobMatch()
+    {
+        const int pkgId = 100;
+        const int prLabelLoId = 500, prOwner1Id = 601, prOwner2Id = 602, prLabelId = 701;
+        const int soId = 800, soOwner1Id = 901, soOwner2Id = 902;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        SetupPackageQuery("Azure.Test.Pkg", [MakePackageWorkItem(pkgId, "Azure.Test.Pkg", relatedIds: [])]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => !ids.Any()),
+                It.IsAny<int>(),
+                It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        // PR Label Label Owner with glob path /sdk/contoso/
+        var prLabelLo = MakeLabelOwnerWorkItem(prLabelLoId, "PR Label", repo, "/sdk/contoso/", prOwner1Id, prOwner2Id, prLabelId);
+        SetupLabelOwnerQuery("PR Label", repo, [prLabelLo]);
+
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(prOwner1Id) && ids.Contains(prOwner2Id) && ids.Contains(prLabelId)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(prOwner1Id, "prUser1"),
+                MakeOwnerWorkItem(prOwner2Id, "prUser2"),
+                MakeLabelWorkItem(prLabelId, "ContosoLabel")
+            ]);
+
+        var soWi = MakeLabelOwnerWorkItem(soId, "Service Owner", repo, "", soOwner1Id, soOwner2Id, prLabelId);
+        SetupLabelOwnerQuery("Service Owner", repo, [soWi]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(soOwner1Id) && ids.Contains(soOwner2Id) && ids.Contains(prLabelId)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(soOwner1Id, "soUser1"),
+                MakeOwnerWorkItem(soOwner2Id, "soUser2"),
+                MakeLabelWorkItem(prLabelId, "ContosoLabel")
+            ]);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/contoso/Azure.Contoso.WidgetManager", repo, CancellationToken.None);
+
+        Assert.That(result.AllPassed, Is.True);
+        Assert.That(result.PathFallbackCheck!.PrLabelOwnerCheck!.MatchedPath, Is.EqualTo("/sdk/contoso/"));
+    }
+
+    // Test 19: Fallback — multiple matching PR Label owners, uses last by path
+    [Test]
+    public async Task CheckPackageOwners_Fallback_MultipleMatchingPrLabelOwners_UsesLastByPath()
+    {
+        const int pkgId = 100;
+        const int prLo1Id = 500, prLo2Id = 501;
+        const int prOwner1Id = 601, prOwner2Id = 602, prLabel1Id = 701, prLabel2Id = 702;
+        const int soId = 800, soOwner1Id = 901, soOwner2Id = 902;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        SetupPackageQuery("Azure.Test.Pkg", [MakePackageWorkItem(pkgId, "Azure.Test.Pkg", relatedIds: [])]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => !ids.Any()),
+                It.IsAny<int>(),
+                It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        // Two PR Label Label Owners, both matching. /sdk/test/ (broader) and /sdk/test/sub/ (more specific)
+        var prLo1 = MakeLabelOwnerWorkItem(prLo1Id, "PR Label", repo, "/sdk/test/", prOwner1Id, prLabel1Id);
+        var prLo2 = MakeLabelOwnerWorkItem(prLo2Id, "PR Label", repo, "/sdk/test/sub/", prOwner1Id, prOwner2Id, prLabel2Id);
+        SetupLabelOwnerQuery("PR Label", repo, [prLo1, prLo2]);
+
+        // Hydrate the selected (last by path = /sdk/test/sub/) PR Label Label Owner
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(prOwner1Id) && ids.Contains(prOwner2Id) && ids.Contains(prLabel2Id)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(prOwner1Id, "prUser1"),
+                MakeOwnerWorkItem(prOwner2Id, "prUser2"),
+                MakeLabelWorkItem(prLabel2Id, "SpecificLabel")
+            ]);
+
+        var soWi = MakeLabelOwnerWorkItem(soId, "Service Owner", repo, "", soOwner1Id, soOwner2Id, prLabel2Id);
+        SetupLabelOwnerQuery("Service Owner", repo, [soWi]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(soOwner1Id) && ids.Contains(soOwner2Id) && ids.Contains(prLabel2Id)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(soOwner1Id, "soUser1"),
+                MakeOwnerWorkItem(soOwner2Id, "soUser2"),
+                MakeLabelWorkItem(prLabel2Id, "SpecificLabel")
+            ]);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/sub/Azure.Test.Pkg", repo, CancellationToken.None);
+
+        Assert.That(result.AllPassed, Is.True);
+        Assert.That(result.PathFallbackCheck!.PrLabelOwnerCheck!.MatchedPath, Is.EqualTo("/sdk/test/sub/"));
+        Assert.That(result.PathFallbackCheck.PrLabelOwnerCheck.Labels, Does.Contain("SpecificLabel"));
+    }
+
+    // Test 20: Fallback — multiple labels, Service Owner must be superset
+    [Test]
+    public async Task CheckPackageOwners_Fallback_MultipleLabels_ServiceOwnerSupersetRequired()
+    {
+        const int pkgId = 100;
+        const int prLabelLoId = 500, prOwner1Id = 601, prOwner2Id = 602, prLabel1Id = 701, prLabel2Id = 702;
+        const int soId = 800, soOwner1Id = 901, soOwner2Id = 902;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        SetupPackageQuery("Azure.Test.Pkg", [MakePackageWorkItem(pkgId, "Azure.Test.Pkg", relatedIds: [])]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => !ids.Any()),
+                It.IsAny<int>(),
+                It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var prLabelLo = MakeLabelOwnerWorkItem(prLabelLoId, "PR Label", repo, "/sdk/test/", prOwner1Id, prOwner2Id, prLabel1Id, prLabel2Id);
+        SetupLabelOwnerQuery("PR Label", repo, [prLabelLo]);
+
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(prOwner1Id) && ids.Contains(prOwner2Id) && ids.Contains(prLabel1Id) && ids.Contains(prLabel2Id)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(prOwner1Id, "prUser1"),
+                MakeOwnerWorkItem(prOwner2Id, "prUser2"),
+                MakeLabelWorkItem(prLabel1Id, "LabelA"),
+                MakeLabelWorkItem(prLabel2Id, "LabelB")
+            ]);
+
+        // Service Owner has both labels
+        var soWi = MakeLabelOwnerWorkItem(soId, "Service Owner", repo, "", soOwner1Id, soOwner2Id, prLabel1Id, prLabel2Id);
+        SetupLabelOwnerQuery("Service Owner", repo, [soWi]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(soOwner1Id) && ids.Contains(soOwner2Id) && ids.Contains(prLabel1Id) && ids.Contains(prLabel2Id)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(soOwner1Id, "soUser1"),
+                MakeOwnerWorkItem(soOwner2Id, "soUser2"),
+                MakeLabelWorkItem(prLabel1Id, "LabelA"),
+                MakeLabelWorkItem(prLabel2Id, "LabelB")
+            ]);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
+
+        Assert.That(result.AllPassed, Is.True);
+    }
+
+    // Test 21: Fallback — fragmented service owners fail
+    [Test]
+    public async Task CheckPackageOwners_Fallback_FragmentedServiceOwners_Fails()
+    {
+        const int pkgId = 100;
+        const int prLabelLoId = 500, prOwner1Id = 601, prOwner2Id = 602, prLabel1Id = 701, prLabel2Id = 702;
+        const int so1Id = 800, so2Id = 801, soOwner1Id = 901, soOwner2Id = 902;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        SetupPackageQuery("Azure.Test.Pkg", [MakePackageWorkItem(pkgId, "Azure.Test.Pkg", relatedIds: [])]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => !ids.Any()),
+                It.IsAny<int>(),
+                It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var prLabelLo = MakeLabelOwnerWorkItem(prLabelLoId, "PR Label", repo, "/sdk/test/", prOwner1Id, prOwner2Id, prLabel1Id, prLabel2Id);
+        SetupLabelOwnerQuery("PR Label", repo, [prLabelLo]);
+
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(prOwner1Id) && ids.Contains(prOwner2Id) && ids.Contains(prLabel1Id) && ids.Contains(prLabel2Id)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(prOwner1Id, "prUser1"),
+                MakeOwnerWorkItem(prOwner2Id, "prUser2"),
+                MakeLabelWorkItem(prLabel1Id, "LabelA"),
+                MakeLabelWorkItem(prLabel2Id, "LabelB")
+            ]);
+
+        // Fragmented: SO 1 has LabelA only, SO 2 has LabelB only
+        var so1Wi = MakeLabelOwnerWorkItem(so1Id, "Service Owner", repo, "", soOwner1Id, soOwner2Id, prLabel1Id);
+        var so2Wi = MakeLabelOwnerWorkItem(so2Id, "Service Owner", repo, "", soOwner1Id, soOwner2Id, prLabel2Id);
+        SetupLabelOwnerQuery("Service Owner", repo, [so1Wi, so2Wi]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(soOwner1Id) && ids.Contains(soOwner2Id)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(soOwner1Id, "soUser1"),
+                MakeOwnerWorkItem(soOwner2Id, "soUser2"),
+                MakeLabelWorkItem(prLabel1Id, "LabelA"),
+                MakeLabelWorkItem(prLabel2Id, "LabelB")
+            ]);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
+
+        Assert.That(result.PathFallbackCheck!.ServiceOwnerCheck!.Passed, Is.False);
+        Assert.That(result.AllPassed, Is.False);
+    }
+
+    // Test 22: Fallback — same people as PR Label and Service Owners
+    [Test]
+    public async Task CheckPackageOwners_Fallback_SameOwnersForBothTypes()
+    {
+        const int pkgId = 100;
+        const int prLabelLoId = 500, owner1Id = 601, owner2Id = 602, prLabelId = 701;
+        const int soId = 800;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        SetupPackageQuery("Azure.Test.Pkg", [MakePackageWorkItem(pkgId, "Azure.Test.Pkg", relatedIds: [])]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => !ids.Any()),
+                It.IsAny<int>(),
+                It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var prLabelLo = MakeLabelOwnerWorkItem(prLabelLoId, "PR Label", repo, "/sdk/test/", owner1Id, owner2Id, prLabelId);
+        SetupLabelOwnerQuery("PR Label", repo, [prLabelLo]);
+
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(owner1Id) && ids.Contains(owner2Id) && ids.Contains(prLabelId)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(owner1Id, "sharedUser1"),
+                MakeOwnerWorkItem(owner2Id, "sharedUser2"),
+                MakeLabelWorkItem(prLabelId, "SharedLabel")
+            ]);
+
+        // Service Owner has the same owners
+        var soWi = MakeLabelOwnerWorkItem(soId, "Service Owner", repo, "", owner1Id, owner2Id, prLabelId);
+        SetupLabelOwnerQuery("Service Owner", repo, [soWi]);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
+
+        Assert.That(result.AllPassed, Is.True);
+    }
+
+    // Test 23: Fallback — Service Owner is pathless but still valid
+    [Test]
+    public async Task CheckPackageOwners_Fallback_ServiceOwnerPathless()
+    {
+        const int pkgId = 100;
+        const int prLabelLoId = 500, prOwner1Id = 601, prOwner2Id = 602, prLabelId = 701;
+        const int soId = 800, soOwner1Id = 901, soOwner2Id = 902;
+        const string repo = "Azure/azure-sdk-for-net";
+
+        SetupPackageQuery("Azure.Test.Pkg", [MakePackageWorkItem(pkgId, "Azure.Test.Pkg", relatedIds: [])]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => !ids.Any()),
+                It.IsAny<int>(),
+                It.IsAny<WorkItemExpand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var prLabelLo = MakeLabelOwnerWorkItem(prLabelLoId, "PR Label", repo, "/sdk/test/", prOwner1Id, prOwner2Id, prLabelId);
+        SetupLabelOwnerQuery("PR Label", repo, [prLabelLo]);
+
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(prOwner1Id) && ids.Contains(prOwner2Id) && ids.Contains(prLabelId)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(prOwner1Id, "prUser1"),
+                MakeOwnerWorkItem(prOwner2Id, "prUser2"),
+                MakeLabelWorkItem(prLabelId, "TestLabel")
+            ]);
+
+        // Service Owner with no path (pathless) — still matches on labels
+        var soWi = MakeLabelOwnerWorkItem(soId, "Service Owner", repo, "", soOwner1Id, soOwner2Id, prLabelId);
+        SetupLabelOwnerQuery("Service Owner", repo, [soWi]);
+        _mockDevOps.Setup(d => d.GetWorkItemsByIdsAsync(
+                It.Is<IEnumerable<int>>(ids => ids.Contains(soOwner1Id) && ids.Contains(soOwner2Id) && ids.Contains(prLabelId)),
+                It.IsAny<int>(),
+                WorkItemExpand.All, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                MakeOwnerWorkItem(soOwner1Id, "soUser1"),
+                MakeOwnerWorkItem(soOwner2Id, "soUser2"),
+                MakeLabelWorkItem(prLabelId, "TestLabel")
+            ]);
+
+        var result = await _helper.CheckPackageOwners("Azure.Test.Pkg", "sdk/test/Azure.Test.Pkg", repo, CancellationToken.None);
+
+        Assert.That(result.AllPassed, Is.True);
+        Assert.That(result.PathFallbackCheck!.ServiceOwnerCheck!.Passed, Is.True);
+    }
+
+    // NormalizePath static helper tests
+    [TestCase("sdk/test", "/sdk/test")]
+    [TestCase("/sdk/test", "/sdk/test")]
+    [TestCase("sdk\\test", "/sdk/test")]
+    [TestCase("", "")]
+    public void NormalizePath_ReturnsExpected(string input, string expected)
+    {
+        Assert.That(CodeownersManagementHelper.NormalizePath(input), Is.EqualTo(expected));
+    }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Core/ToolPromptCoverageTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Core/ToolPromptCoverageTests.cs
@@ -35,8 +35,7 @@ internal class ToolPromptCoverageTests
         "azsdk_engsys_codeowner_add_package_owner",
         "azsdk_engsys_codeowner_remove_package_owner",
         "azsdk_engsys_codeowner_add_package_label",
-        "azsdk_engsys_codeowner_remove_package_label",
-        "azsdk_engsys_codeowner_check_package_owners"
+        "azsdk_engsys_codeowner_remove_package_label"
     };
 
     [Test]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Core/ToolPromptCoverageTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Core/ToolPromptCoverageTests.cs
@@ -35,7 +35,8 @@ internal class ToolPromptCoverageTests
         "azsdk_engsys_codeowner_add_package_owner",
         "azsdk_engsys_codeowner_remove_package_owner",
         "azsdk_engsys_codeowner_add_package_label",
-        "azsdk_engsys_codeowner_remove_package_label"
+        "azsdk_engsys_codeowner_remove_package_label",
+        "azsdk_engsys_codeowner_check_package_owners"
     };
 
     [Test]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CodeownersManagementHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CodeownersManagementHelper.cs
@@ -704,8 +704,8 @@ public class CodeownersManagementHelper(
         string packageName,
         string directoryPath,
         string repo,
-        CancellationToken ct)
-    {
+        CancellationToken ct
+    ) {
         const int requiredOwners = 2;
 
         var response = new CheckPackageOwnersResponse
@@ -741,8 +741,8 @@ public class CodeownersManagementHelper(
         PackageWorkItem packageWi,
         int requiredOwners,
         string repo,
-        CancellationToken ct)
-    {
+        CancellationToken ct
+    ) {
         logger.LogInformation("Validation path: Package (direct owners)");
 
         var uniqueIndividuals = GetUniqueIndividuals(packageWi.Owners);
@@ -800,8 +800,8 @@ public class CodeownersManagementHelper(
         string directoryPath,
         int requiredOwners,
         string repo,
-        CancellationToken ct)
-    {
+        CancellationToken ct
+    ) {
         logger.LogInformation("Validation path: PathFallback (no direct owners on package)");
 
         // Find PR Label type Label Owners whose RepoPath glob matches directoryPath
@@ -889,8 +889,8 @@ public class CodeownersManagementHelper(
         List<string> requiredLabels,
         int requiredOwners,
         string repo,
-        CancellationToken ct)
-    {
+        CancellationToken ct
+    ) {
         if (requiredLabels.Count == 0)
         {
             return null;
@@ -939,8 +939,8 @@ public class CodeownersManagementHelper(
     private async Task<List<LabelOwnerWorkItem>> QueryLabelOwnersByTypeAndRepo(
         string labelType,
         string repo,
-        CancellationToken ct)
-    {
+        CancellationToken ct
+    ) {
         var escapedRepo = repo.Replace("'", "''");
         var escapedLabelType = labelType.Replace("'", "''");
         var query = $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{Constants.AZURE_SDK_DEVOPS_RELEASE_PROJECT}'" +

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CodeownersManagementHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CodeownersManagementHelper.cs
@@ -7,6 +7,7 @@ using Azure.Sdk.Tools.Cli.Models.Codeowners;
 using Azure.Sdk.Tools.Cli.Models.Responses.Codeowners;
 using Azure.Sdk.Tools.Cli.Services;
 using Azure.Sdk.Tools.CodeownersUtils.Caches;
+using Azure.Sdk.Tools.CodeownersUtils.Utils;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
 using Azure.Sdk.Tools.Cli.Configuration;
 using Octokit;
@@ -693,6 +694,281 @@ public class CodeownersManagementHelper(
                 ? await GetViewByLabel(labels.Select(l => l.LabelName).ToArray(), repo, ct)
                 : await GetViewByPath(path, repo, ct)
         };
+    }
+
+    // ========================
+    // Validation: CheckPackageOwners
+    // ========================
+
+    public async Task<CheckPackageOwnersResponse> CheckPackageOwners(
+        string packageName, string directoryPath, string repo, CancellationToken ct)
+    {
+        const int requiredOwners = 2;
+
+        var response = new CheckPackageOwnersResponse
+        {
+            PackageName = packageName,
+            DirectoryPath = directoryPath,
+            Repo = repo
+        };
+
+        // Look up the package
+        var packageWi = await FindPackageByName(packageName, repo, ct);
+        if (packageWi == null)
+        {
+            response.ResponseError = $"No Package work item found for '{packageName}'.";
+            return response;
+        }
+
+        // Hydrate the package (owners + labels)
+        await HydratePackages([packageWi], ct);
+
+        // Count unique individuals from package owners
+        var uniqueIndividuals = GetUniqueIndividuals(packageWi.Owners);
+
+        if (packageWi.Owners.Count > 0)
+        {
+            // Primary path: package has at least 1 owner
+            return await CheckPrimaryPath(response, packageWi, uniqueIndividuals, requiredOwners, repo, ct);
+        }
+
+        // Fallback path: package has 0 owners
+        return await CheckFallbackPath(response, packageWi, directoryPath, requiredOwners, repo, ct);
+    }
+
+    private async Task<CheckPackageOwnersResponse> CheckPrimaryPath(
+        CheckPackageOwnersResponse response,
+        PackageWorkItem packageWi,
+        List<string> uniqueIndividuals,
+        int requiredOwners,
+        string repo,
+        CancellationToken ct)
+    {
+        response.ValidationPath = "Package";
+
+        // Owner check
+        var ownersPassed = uniqueIndividuals.Count >= requiredOwners;
+        response.OwnerCheck = new OwnershipCheck
+        {
+            Passed = ownersPassed,
+            Required = requiredOwners,
+            Actual = uniqueIndividuals.Count,
+            Owners = uniqueIndividuals.Count > 0 ? uniqueIndividuals : null
+        };
+
+        // PR Label check
+        var packageLabels = packageWi.Labels.Select(l => l.LabelName).OrderBy(l => l, StringComparer.OrdinalIgnoreCase).ToList();
+        var prLabelPassed = packageLabels.Count >= 1;
+        response.PrLabelCheck = new PrLabelCheck
+        {
+            Passed = prLabelPassed,
+            Labels = packageLabels.Count > 0 ? packageLabels : null
+        };
+
+        // Service Owner check
+        var serviceOwnerResult = await CheckServiceOwnerCoverage(packageLabels, repo, ct);
+        response.ServiceOwnerCheck = serviceOwnerResult;
+
+        response.AllPassed = ownersPassed && prLabelPassed && serviceOwnerResult.Passed;
+        return response;
+    }
+
+    private async Task<CheckPackageOwnersResponse> CheckFallbackPath(
+        CheckPackageOwnersResponse response,
+        PackageWorkItem packageWi,
+        string directoryPath,
+        int requiredOwners,
+        string repo,
+        CancellationToken ct)
+    {
+        response.ValidationPath = "PathFallback";
+        response.OwnerCheck = new OwnershipCheck
+        {
+            Passed = false,
+            Required = requiredOwners,
+            Actual = 0,
+            Owners = null
+        };
+
+        var fallback = new PathFallbackCheckResult();
+        response.PathFallbackCheck = fallback;
+
+        // Find PR Label type Label Owners whose RepoPath glob matches directoryPath
+        var prLabelLabelOwners = await QueryLabelOwnersByTypeAndRepo("PR Label", repo, ct);
+
+        var normalizedDirectoryPath = NormalizePath(directoryPath);
+
+        var matchingPrLabelOwners = prLabelLabelOwners
+            .Where(lo =>
+            {
+                var normalizedRepoPath = NormalizePath(lo.RepoPath);
+                return !string.IsNullOrEmpty(normalizedRepoPath)
+                    && DirectoryUtils.PathExpressionMatchesTargetPath(normalizedRepoPath, normalizedDirectoryPath);
+            })
+            .ToList();
+
+        if (matchingPrLabelOwners.Count == 0)
+        {
+            fallback.PrLabelOwnerCheck = new PrLabelOwnerCheck
+            {
+                Passed = false,
+                Required = requiredOwners,
+                Actual = 0
+            };
+            response.AllPassed = false;
+            return response;
+        }
+
+        // Sort by normalized path and choose the last one
+        var selectedPrLabelOwner = matchingPrLabelOwners
+            .OrderBy(lo => NormalizePath(lo.RepoPath), StringComparer.Ordinal)
+            .Last();
+
+        // Hydrate the selected PR Label Label Owner
+        await HydrateLabelOwners([selectedPrLabelOwner], ct);
+
+        var prLabelIndividuals = GetUniqueIndividuals(selectedPrLabelOwner.Owners);
+        var prLabelLabels = selectedPrLabelOwner.Labels.Select(l => l.LabelName)
+            .OrderBy(l => l, StringComparer.OrdinalIgnoreCase).ToList();
+        var prLabelOwnersPassed = prLabelIndividuals.Count >= requiredOwners;
+
+        fallback.PrLabelOwnerCheck = new PrLabelOwnerCheck
+        {
+            Passed = prLabelOwnersPassed,
+            Required = requiredOwners,
+            Actual = prLabelIndividuals.Count,
+            Owners = prLabelIndividuals.Count > 0 ? prLabelIndividuals : null,
+            Labels = prLabelLabels.Count > 0 ? prLabelLabels : null,
+            MatchedPath = selectedPrLabelOwner.RepoPath
+        };
+
+        // Service Owner check against the selected PR Label Label Owner's labels
+        var serviceOwnerResult = await CheckServiceOwnerCoverage(prLabelLabels, repo, ct);
+        fallback.ServiceOwnerCheck = serviceOwnerResult;
+
+        response.AllPassed = prLabelOwnersPassed && serviceOwnerResult.Passed;
+        return response;
+    }
+
+    /// <summary>
+    /// Checks that a single Service Owner Label Owner in the repo has labels that are a superset
+    /// of the required labels, and has ≥ 2 unique individuals.
+    /// </summary>
+    private async Task<ServiceOwnerCheck> CheckServiceOwnerCoverage(
+        List<string> requiredLabels, string repo, CancellationToken ct)
+    {
+        const int requiredOwners = 2;
+
+        if (requiredLabels.Count == 0)
+        {
+            return new ServiceOwnerCheck
+            {
+                Passed = false,
+                Required = requiredOwners,
+                Actual = 0,
+                RequiredLabels = null
+            };
+        }
+
+        var serviceOwnerLabelOwners = await QueryLabelOwnersByTypeAndRepo("Service Owner", repo, ct);
+        await HydrateLabelOwners(serviceOwnerLabelOwners, ct);
+
+        var requiredLabelSet = new HashSet<string>(requiredLabels, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var so in serviceOwnerLabelOwners)
+        {
+            var soLabels = so.Labels.Select(l => l.LabelName).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            if (!requiredLabelSet.IsSubsetOf(soLabels))
+            {
+                continue;
+            }
+
+            var soIndividuals = GetUniqueIndividuals(so.Owners);
+            if (soIndividuals.Count >= requiredOwners)
+            {
+                return new ServiceOwnerCheck
+                {
+                    Passed = true,
+                    Required = requiredOwners,
+                    Actual = soIndividuals.Count,
+                    Owners = soIndividuals,
+                    RequiredLabels = requiredLabels,
+                    MatchedLabels = soLabels.OrderBy(l => l, StringComparer.OrdinalIgnoreCase).ToList()
+                };
+            }
+
+            // Found a matching Service Owner but insufficient individuals
+            return new ServiceOwnerCheck
+            {
+                Passed = false,
+                Required = requiredOwners,
+                Actual = soIndividuals.Count,
+                Owners = soIndividuals.Count > 0 ? soIndividuals : null,
+                RequiredLabels = requiredLabels,
+                MatchedLabels = soLabels.OrderBy(l => l, StringComparer.OrdinalIgnoreCase).ToList()
+            };
+        }
+
+        // No matching Service Owner found
+        return new ServiceOwnerCheck
+        {
+            Passed = false,
+            Required = requiredOwners,
+            Actual = 0,
+            RequiredLabels = requiredLabels
+        };
+    }
+
+    /// <summary>
+    /// Gets unique individual GitHub aliases from a list of owners, expanding teams.
+    /// </summary>
+    private static List<string> GetUniqueIndividuals(List<OwnerWorkItem> owners)
+    {
+        var individuals = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var owner in owners)
+        {
+            if (owner.IsGitHubTeam)
+            {
+                foreach (var member in owner.ExpandedMembers)
+                {
+                    individuals.Add(member);
+                }
+            }
+            else
+            {
+                individuals.Add(owner.GitHubAlias);
+            }
+        }
+        return individuals.OrderBy(a => a, StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    private async Task<List<LabelOwnerWorkItem>> QueryLabelOwnersByTypeAndRepo(string labelType, string repo, CancellationToken ct)
+    {
+        var escapedRepo = repo.Replace("'", "''");
+        var escapedLabelType = labelType.Replace("'", "''");
+        var query = $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{Constants.AZURE_SDK_DEVOPS_RELEASE_PROJECT}'" +
+                    $" AND [System.WorkItemType] = 'Label Owner'" +
+                    $" AND [Custom.LabelType] = '{escapedLabelType}'" +
+                    $" AND [Custom.Repository] = '{escapedRepo}'";
+        var rawWorkItems = await devOpsService.FetchWorkItemsPagedAsync(query, expand: WorkItemExpand.Relations, ct: ct);
+        return rawWorkItems.Select(WorkItemMappers.MapToLabelOwnerWorkItem).ToList();
+    }
+
+    /// <summary>
+    /// Normalizes a path to a consistent leading-slash form for glob matching.
+    /// </summary>
+    public static string NormalizePath(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return path;
+        }
+        path = path.Replace('\\', '/');
+        if (!path.StartsWith('/'))
+        {
+            path = "/" + path;
+        }
+        return path;
     }
 
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CodeownersManagementHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CodeownersManagementHelper.cs
@@ -707,9 +707,8 @@ public class CodeownersManagementHelper(
 
         var response = new CheckPackageOwnersResponse
         {
-            PackageName = packageName,
-            DirectoryPath = directoryPath,
-            Repo = repo
+            Package = packageName,
+            Path = directoryPath
         };
 
         // Look up the package
@@ -722,58 +721,77 @@ public class CodeownersManagementHelper(
 
         // Hydrate the package (owners + labels)
         await HydratePackages([packageWi], ct);
-
-        // Count unique individuals from package owners
-        var uniqueIndividuals = GetUniqueIndividuals(packageWi.Owners);
+        response.PackageWorkItem = new PackageResponse(packageWi);
 
         if (packageWi.Owners.Count > 0)
         {
             // Primary path: package has at least 1 owner
-            return await CheckPrimaryPath(response, packageWi, uniqueIndividuals, requiredOwners, repo, ct);
+            return await CheckPackageDirectOwners(response, packageWi, requiredOwners, repo, ct);
         }
 
         // Fallback path: package has 0 owners
-        return await CheckFallbackPath(response, packageWi, directoryPath, requiredOwners, repo, ct);
+        return await CheckPackagePathOwners(response, packageWi, directoryPath, requiredOwners, repo, ct);
     }
 
-    private async Task<CheckPackageOwnersResponse> CheckPrimaryPath(
+    private async Task<CheckPackageOwnersResponse> CheckPackageDirectOwners(
         CheckPackageOwnersResponse response,
         PackageWorkItem packageWi,
-        List<string> uniqueIndividuals,
         int requiredOwners,
         string repo,
         CancellationToken ct)
     {
-        response.ValidationPath = "Package";
+        logger.LogInformation("Validation path: Package (direct owners)");
 
-        // Owner check
+        var uniqueIndividuals = GetUniqueIndividuals(packageWi.Owners);
         var ownersPassed = uniqueIndividuals.Count >= requiredOwners;
-        response.OwnerCheck = new OwnershipCheck
-        {
-            Passed = ownersPassed,
-            Required = requiredOwners,
-            Actual = uniqueIndividuals.Count,
-            Owners = uniqueIndividuals.Count > 0 ? uniqueIndividuals : null
-        };
 
-        // PR Label check
-        var packageLabels = packageWi.Labels.Select(l => l.LabelName).OrderBy(l => l, StringComparer.OrdinalIgnoreCase).ToList();
+        var packageLabels = packageWi.Labels.Select(l => l.LabelName)
+            .OrderBy(l => l, StringComparer.OrdinalIgnoreCase).ToList();
         var prLabelPassed = packageLabels.Count >= 1;
-        response.PrLabelCheck = new PrLabelCheck
+        response.PrLabels = packageLabels.Count > 0 ? packageLabels : null;
+
+        // Find matching Service Owner
+        var matchedServiceOwner = await FindMatchingServiceOwner(packageLabels, requiredOwners, repo, ct);
+        if (matchedServiceOwner != null)
         {
-            Passed = prLabelPassed,
-            Labels = packageLabels.Count > 0 ? packageLabels : null
-        };
+            response.ServiceOwners = new LabelOwnerResponse(matchedServiceOwner);
+        }
 
-        // Service Owner check
-        var serviceOwnerResult = await CheckServiceOwnerCoverage(packageLabels, repo, ct);
-        response.ServiceOwnerCheck = serviceOwnerResult;
+        var serviceOwnerPassed = matchedServiceOwner != null
+            && GetUniqueIndividuals(matchedServiceOwner.Owners).Count >= requiredOwners;
 
-        response.AllPassed = ownersPassed && prLabelPassed && serviceOwnerResult.Passed;
+        response.Pass = ownersPassed && prLabelPassed && serviceOwnerPassed;
+
+        if (!response.Pass)
+        {
+            var reasons = new List<string>();
+            if (!ownersPassed)
+            {
+                reasons.Add($"Package '{packageWi.PackageName}' has {uniqueIndividuals.Count} unique individual owner(s) but requires at least {requiredOwners}.");
+            }
+            if (!prLabelPassed)
+            {
+                reasons.Add($"Package '{packageWi.PackageName}' has no PR labels assigned.");
+            }
+            if (!serviceOwnerPassed)
+            {
+                if (matchedServiceOwner == null)
+                {
+                    reasons.Add($"No Service Owner Label Owner found whose labels are a superset of [{string.Join(", ", packageLabels)}].");
+                }
+                else
+                {
+                    var soIndividuals = GetUniqueIndividuals(matchedServiceOwner.Owners);
+                    reasons.Add($"Service Owner (work item {matchedServiceOwner.WorkItemId}) for labels [{string.Join(", ", packageLabels)}] has {soIndividuals.Count} unique individual(s) but requires at least {requiredOwners}.");
+                }
+            }
+            throw new InvalidOperationException(string.Join(" ", reasons));
+        }
+
         return response;
     }
 
-    private async Task<CheckPackageOwnersResponse> CheckFallbackPath(
+    private async Task<CheckPackageOwnersResponse> CheckPackagePathOwners(
         CheckPackageOwnersResponse response,
         PackageWorkItem packageWi,
         string directoryPath,
@@ -781,17 +799,7 @@ public class CodeownersManagementHelper(
         string repo,
         CancellationToken ct)
     {
-        response.ValidationPath = "PathFallback";
-        response.OwnerCheck = new OwnershipCheck
-        {
-            Passed = false,
-            Required = requiredOwners,
-            Actual = 0,
-            Owners = null
-        };
-
-        var fallback = new PathFallbackCheckResult();
-        response.PathFallbackCheck = fallback;
+        logger.LogInformation("Validation path: PathFallback (no direct owners on package)");
 
         // Find PR Label type Label Owners whose RepoPath glob matches directoryPath
         var prLabelLabelOwners = await QueryLabelOwnersByTypeAndRepo("PR Label", repo, ct);
@@ -809,65 +817,77 @@ public class CodeownersManagementHelper(
 
         if (matchingPrLabelOwners.Count == 0)
         {
-            fallback.PrLabelOwnerCheck = new PrLabelOwnerCheck
-            {
-                Passed = false,
-                Required = requiredOwners,
-                Actual = 0
-            };
-            response.AllPassed = false;
-            return response;
+            logger.LogInformation("No PR Label Label Owner matched the directory path.");
+            response.Pass = false;
+            throw new InvalidOperationException(
+                $"Package '{packageWi.PackageName}' has 0 direct owners and no PR Label Label Owner has a path matching '{directoryPath}'. No fallback path available.");
         }
 
-        // Sort by normalized path and choose the last one
+        // Sort by normalized path and choose the last (most specific) match
         var selectedPrLabelOwner = matchingPrLabelOwners
             .OrderBy(lo => NormalizePath(lo.RepoPath), StringComparer.Ordinal)
             .Last();
 
+        logger.LogInformation("Matched PR Label Label Owner path: {RepoPath}", selectedPrLabelOwner.RepoPath);
+
         // Hydrate the selected PR Label Label Owner
         await HydrateLabelOwners([selectedPrLabelOwner], ct);
+        response.PathOwners = new LabelOwnerResponse(selectedPrLabelOwner);
 
         var prLabelIndividuals = GetUniqueIndividuals(selectedPrLabelOwner.Owners);
+        var ownersPassed = prLabelIndividuals.Count >= requiredOwners;
+
         var prLabelLabels = selectedPrLabelOwner.Labels.Select(l => l.LabelName)
             .OrderBy(l => l, StringComparer.OrdinalIgnoreCase).ToList();
-        var prLabelOwnersPassed = prLabelIndividuals.Count >= requiredOwners;
+        response.PrLabels = prLabelLabels.Count > 0 ? prLabelLabels : null;
 
-        fallback.PrLabelOwnerCheck = new PrLabelOwnerCheck
+        // Find matching Service Owner
+        var matchedServiceOwner = await FindMatchingServiceOwner(prLabelLabels, requiredOwners, repo, ct);
+        if (matchedServiceOwner != null)
         {
-            Passed = prLabelOwnersPassed,
-            Required = requiredOwners,
-            Actual = prLabelIndividuals.Count,
-            Owners = prLabelIndividuals.Count > 0 ? prLabelIndividuals : null,
-            Labels = prLabelLabels.Count > 0 ? prLabelLabels : null,
-            MatchedPath = selectedPrLabelOwner.RepoPath
-        };
+            response.ServiceOwners = new LabelOwnerResponse(matchedServiceOwner);
+        }
 
-        // Service Owner check against the selected PR Label Label Owner's labels
-        var serviceOwnerResult = await CheckServiceOwnerCoverage(prLabelLabels, repo, ct);
-        fallback.ServiceOwnerCheck = serviceOwnerResult;
+        var serviceOwnerPassed = matchedServiceOwner != null
+            && GetUniqueIndividuals(matchedServiceOwner.Owners).Count >= requiredOwners;
 
-        response.AllPassed = prLabelOwnersPassed && serviceOwnerResult.Passed;
+        response.Pass = ownersPassed && serviceOwnerPassed;
+
+        if (!response.Pass)
+        {
+            var reasons = new List<string>();
+            if (!ownersPassed)
+            {
+                reasons.Add($"PR Label Label Owner at path '{selectedPrLabelOwner.RepoPath}' has {prLabelIndividuals.Count} unique individual(s) but requires at least {requiredOwners}.");
+            }
+            if (!serviceOwnerPassed)
+            {
+                if (matchedServiceOwner == null)
+                {
+                    reasons.Add($"No Service Owner Label Owner found whose labels are a superset of [{string.Join(", ", prLabelLabels)}].");
+                }
+                else
+                {
+                    var soIndividuals = GetUniqueIndividuals(matchedServiceOwner.Owners);
+                    reasons.Add($"Service Owner (work item {matchedServiceOwner.WorkItemId}) for labels [{string.Join(", ", prLabelLabels)}] has {soIndividuals.Count} unique individual(s) but requires at least {requiredOwners}.");
+                }
+            }
+            throw new InvalidOperationException(string.Join(" ", reasons));
+        }
+
         return response;
     }
 
     /// <summary>
-    /// Checks that a single Service Owner Label Owner in the repo has labels that are a superset
-    /// of the required labels, and has ≥ 2 unique individuals.
+    /// Finds a single Service Owner Label Owner whose labels are a superset of the required labels.
+    /// Returns the first matching Service Owner (hydrated), or null if none found.
     /// </summary>
-    private async Task<ServiceOwnerCheck> CheckServiceOwnerCoverage(
-        List<string> requiredLabels, string repo, CancellationToken ct)
+    private async Task<LabelOwnerWorkItem?> FindMatchingServiceOwner(
+        List<string> requiredLabels, int requiredOwners, string repo, CancellationToken ct)
     {
-        const int requiredOwners = 2;
-
         if (requiredLabels.Count == 0)
         {
-            return new ServiceOwnerCheck
-            {
-                Passed = false,
-                Required = requiredOwners,
-                Actual = 0,
-                RequiredLabels = null
-            };
+            return null;
         }
 
         var serviceOwnerLabelOwners = await QueryLabelOwnersByTypeAndRepo("Service Owner", repo, ct);
@@ -878,45 +898,13 @@ public class CodeownersManagementHelper(
         foreach (var so in serviceOwnerLabelOwners)
         {
             var soLabels = so.Labels.Select(l => l.LabelName).ToHashSet(StringComparer.OrdinalIgnoreCase);
-            if (!requiredLabelSet.IsSubsetOf(soLabels))
+            if (requiredLabelSet.IsSubsetOf(soLabels))
             {
-                continue;
+                return so;
             }
-
-            var soIndividuals = GetUniqueIndividuals(so.Owners);
-            if (soIndividuals.Count >= requiredOwners)
-            {
-                return new ServiceOwnerCheck
-                {
-                    Passed = true,
-                    Required = requiredOwners,
-                    Actual = soIndividuals.Count,
-                    Owners = soIndividuals,
-                    RequiredLabels = requiredLabels,
-                    MatchedLabels = soLabels.OrderBy(l => l, StringComparer.OrdinalIgnoreCase).ToList()
-                };
-            }
-
-            // Found a matching Service Owner but insufficient individuals
-            return new ServiceOwnerCheck
-            {
-                Passed = false,
-                Required = requiredOwners,
-                Actual = soIndividuals.Count,
-                Owners = soIndividuals.Count > 0 ? soIndividuals : null,
-                RequiredLabels = requiredLabels,
-                MatchedLabels = soLabels.OrderBy(l => l, StringComparer.OrdinalIgnoreCase).ToList()
-            };
         }
 
-        // No matching Service Owner found
-        return new ServiceOwnerCheck
-        {
-            Passed = false,
-            Required = requiredOwners,
-            Actual = 0,
-            RequiredLabels = requiredLabels
-        };
+        return null;
     }
 
     /// <summary>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CodeownersManagementHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CodeownersManagementHelper.cs
@@ -701,7 +701,10 @@ public class CodeownersManagementHelper(
     // ========================
 
     public async Task<CheckPackageOwnersResponse> CheckPackageOwners(
-        string packageName, string directoryPath, string repo, CancellationToken ct)
+        string packageName,
+        string directoryPath,
+        string repo,
+        CancellationToken ct)
     {
         const int requiredOwners = 2;
 
@@ -883,7 +886,10 @@ public class CodeownersManagementHelper(
     /// Returns the first matching Service Owner (hydrated), or null if none found.
     /// </summary>
     private async Task<LabelOwnerWorkItem?> FindMatchingServiceOwner(
-        List<string> requiredLabels, int requiredOwners, string repo, CancellationToken ct)
+        List<string> requiredLabels,
+        int requiredOwners,
+        string repo,
+        CancellationToken ct)
     {
         if (requiredLabels.Count == 0)
         {
@@ -930,7 +936,10 @@ public class CodeownersManagementHelper(
         return individuals.OrderBy(a => a, StringComparer.OrdinalIgnoreCase).ToList();
     }
 
-    private async Task<List<LabelOwnerWorkItem>> QueryLabelOwnersByTypeAndRepo(string labelType, string repo, CancellationToken ct)
+    private async Task<List<LabelOwnerWorkItem>> QueryLabelOwnersByTypeAndRepo(
+        string labelType,
+        string repo,
+        CancellationToken ct)
     {
         var escapedRepo = repo.Replace("'", "''");
         var escapedLabelType = labelType.Replace("'", "''");

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/ICodeownersManagementHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/ICodeownersManagementHelper.cs
@@ -39,4 +39,5 @@ public interface ICodeownersManagementHelper
 
     // Validation
     Task ThrowIfInvalidTeamAlias(string alias, CancellationToken ct);
+    Task<CheckPackageOwnersResponse> CheckPackageOwners(string packageName, string directoryPath, string repo, CancellationToken ct);
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Codeowners/CheckPackageOwnersResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Codeowners/CheckPackageOwnersResponse.cs
@@ -1,0 +1,261 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace Azure.Sdk.Tools.Cli.Models.Responses.Codeowners;
+
+/// <summary>
+/// Result of an individual ownership or label check.
+/// </summary>
+public class OwnershipCheck
+{
+    [JsonPropertyName("passed")]
+    public bool Passed { get; set; }
+
+    [JsonPropertyName("required")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public int Required { get; set; }
+
+    [JsonPropertyName("actual")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public int Actual { get; set; }
+
+    [JsonPropertyName("owners")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? Owners { get; set; }
+}
+
+/// <summary>
+/// Result of a PR label existence check.
+/// </summary>
+public class PrLabelCheck
+{
+    [JsonPropertyName("passed")]
+    public bool Passed { get; set; }
+
+    [JsonPropertyName("labels")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? Labels { get; set; }
+}
+
+/// <summary>
+/// Result of a service owner check including label superset matching.
+/// </summary>
+public class ServiceOwnerCheck
+{
+    [JsonPropertyName("passed")]
+    public bool Passed { get; set; }
+
+    [JsonPropertyName("required")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public int Required { get; set; }
+
+    [JsonPropertyName("actual")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public int Actual { get; set; }
+
+    [JsonPropertyName("owners")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? Owners { get; set; }
+
+    [JsonPropertyName("required_labels")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? RequiredLabels { get; set; }
+
+    [JsonPropertyName("matched_labels")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? MatchedLabels { get; set; }
+}
+
+/// <summary>
+/// Result of the path-based fallback PR Label owner check.
+/// </summary>
+public class PrLabelOwnerCheck
+{
+    [JsonPropertyName("passed")]
+    public bool Passed { get; set; }
+
+    [JsonPropertyName("required")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public int Required { get; set; }
+
+    [JsonPropertyName("actual")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public int Actual { get; set; }
+
+    [JsonPropertyName("owners")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? Owners { get; set; }
+
+    [JsonPropertyName("labels")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? Labels { get; set; }
+
+    [JsonPropertyName("matched_path")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MatchedPath { get; set; }
+}
+
+/// <summary>
+/// Combined result of the path-based fallback checks.
+/// </summary>
+public class PathFallbackCheckResult
+{
+    [JsonPropertyName("pr_label_owner_check")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public PrLabelOwnerCheck? PrLabelOwnerCheck { get; set; }
+
+    [JsonPropertyName("service_owner_check")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ServiceOwnerCheck? ServiceOwnerCheck { get; set; }
+}
+
+/// <summary>
+/// Structured response for the check-package-owners command.
+/// </summary>
+public class CheckPackageOwnersResponse : CommandResponse
+{
+    [JsonPropertyName("package_name")]
+    public string PackageName { get; set; } = string.Empty;
+
+    [JsonPropertyName("directory_path")]
+    public string DirectoryPath { get; set; } = string.Empty;
+
+    [JsonPropertyName("repo")]
+    public string Repo { get; set; } = string.Empty;
+
+    [JsonPropertyName("validation_path")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ValidationPath { get; set; }
+
+    [JsonPropertyName("owner_check")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public OwnershipCheck? OwnerCheck { get; set; }
+
+    [JsonPropertyName("pr_label_check")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public PrLabelCheck? PrLabelCheck { get; set; }
+
+    [JsonPropertyName("service_owner_check")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ServiceOwnerCheck? ServiceOwnerCheck { get; set; }
+
+    [JsonPropertyName("path_fallback_check")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public PathFallbackCheckResult? PathFallbackCheck { get; set; }
+
+    [JsonPropertyName("all_passed")]
+    public bool AllPassed { get; set; }
+
+    public override int ExitCode
+    {
+        get => AllPassed ? 0 : 1;
+        set { }
+    }
+
+    protected override string Format()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"=== Check Package Owners: {PackageName} ===");
+        sb.AppendLine($"  Repo: {Repo}");
+        sb.AppendLine($"  Directory Path: {DirectoryPath}");
+
+        if (ValidationPath != null)
+        {
+            sb.AppendLine($"  Validation Path: {ValidationPath}");
+        }
+
+        if (ValidationPath == "Package")
+        {
+            FormatPrimaryPath(sb);
+        }
+        else if (ValidationPath == "PathFallback")
+        {
+            FormatFallbackPath(sb);
+        }
+
+        sb.AppendLine();
+        sb.AppendLine(AllPassed ? "  Result: PASS" : "  Result: FAIL");
+        return sb.ToString();
+    }
+
+    private void FormatPrimaryPath(StringBuilder sb)
+    {
+        if (OwnerCheck != null)
+        {
+            var status = OwnerCheck.Passed ? "PASS" : "FAIL";
+            sb.AppendLine($"  Package Owners: [{status}] {OwnerCheck.Actual}/{OwnerCheck.Required} unique individuals");
+            if (OwnerCheck.Owners?.Count > 0)
+            {
+                sb.AppendLine($"    Owners: {string.Join(", ", OwnerCheck.Owners)}");
+            }
+        }
+
+        if (PrLabelCheck != null)
+        {
+            var status = PrLabelCheck.Passed ? "PASS" : "FAIL";
+            sb.AppendLine($"  PR Labels: [{status}]");
+            if (PrLabelCheck.Labels?.Count > 0)
+            {
+                sb.AppendLine($"    Labels: {string.Join(", ", PrLabelCheck.Labels)}");
+            }
+        }
+
+        if (ServiceOwnerCheck != null)
+        {
+            FormatServiceOwnerCheck(sb, ServiceOwnerCheck, "  ");
+        }
+    }
+
+    private void FormatFallbackPath(StringBuilder sb)
+    {
+        if (PathFallbackCheck == null)
+        {
+            return;
+        }
+
+        if (PathFallbackCheck.PrLabelOwnerCheck != null)
+        {
+            var check = PathFallbackCheck.PrLabelOwnerCheck;
+            var status = check.Passed ? "PASS" : "FAIL";
+            sb.AppendLine($"  PR Label Owners (path-based): [{status}] {check.Actual}/{check.Required} unique individuals");
+            if (check.MatchedPath != null)
+            {
+                sb.AppendLine($"    Matched Path: {check.MatchedPath}");
+            }
+            if (check.Owners?.Count > 0)
+            {
+                sb.AppendLine($"    Owners: {string.Join(", ", check.Owners)}");
+            }
+            if (check.Labels?.Count > 0)
+            {
+                sb.AppendLine($"    Labels: {string.Join(", ", check.Labels)}");
+            }
+        }
+
+        if (PathFallbackCheck.ServiceOwnerCheck != null)
+        {
+            FormatServiceOwnerCheck(sb, PathFallbackCheck.ServiceOwnerCheck, "  ");
+        }
+    }
+
+    private static void FormatServiceOwnerCheck(StringBuilder sb, ServiceOwnerCheck check, string indent)
+    {
+        var status = check.Passed ? "PASS" : "FAIL";
+        sb.AppendLine($"{indent}Service Owners: [{status}] {check.Actual}/{check.Required} unique individuals");
+        if (check.RequiredLabels?.Count > 0)
+        {
+            sb.AppendLine($"{indent}  Required Labels: {string.Join(", ", check.RequiredLabels)}");
+        }
+        if (check.MatchedLabels?.Count > 0)
+        {
+            sb.AppendLine($"{indent}  Matched Labels: {string.Join(", ", check.MatchedLabels)}");
+        }
+        if (check.Owners?.Count > 0)
+        {
+            sb.AppendLine($"{indent}  Owners: {string.Join(", ", check.Owners)}");
+        }
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Codeowners/CheckPackageOwnersResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Codeowners/CheckPackageOwnersResponse.cs
@@ -7,255 +7,125 @@ using System.Text.Json.Serialization;
 namespace Azure.Sdk.Tools.Cli.Models.Responses.Codeowners;
 
 /// <summary>
-/// Result of an individual ownership or label check.
-/// </summary>
-public class OwnershipCheck
-{
-    [JsonPropertyName("passed")]
-    public bool Passed { get; set; }
-
-    [JsonPropertyName("required")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public int Required { get; set; }
-
-    [JsonPropertyName("actual")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public int Actual { get; set; }
-
-    [JsonPropertyName("owners")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<string>? Owners { get; set; }
-}
-
-/// <summary>
-/// Result of a PR label existence check.
-/// </summary>
-public class PrLabelCheck
-{
-    [JsonPropertyName("passed")]
-    public bool Passed { get; set; }
-
-    [JsonPropertyName("labels")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<string>? Labels { get; set; }
-}
-
-/// <summary>
-/// Result of a service owner check including label superset matching.
-/// </summary>
-public class ServiceOwnerCheck
-{
-    [JsonPropertyName("passed")]
-    public bool Passed { get; set; }
-
-    [JsonPropertyName("required")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public int Required { get; set; }
-
-    [JsonPropertyName("actual")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public int Actual { get; set; }
-
-    [JsonPropertyName("owners")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<string>? Owners { get; set; }
-
-    [JsonPropertyName("required_labels")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<string>? RequiredLabels { get; set; }
-
-    [JsonPropertyName("matched_labels")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<string>? MatchedLabels { get; set; }
-}
-
-/// <summary>
-/// Result of the path-based fallback PR Label owner check.
-/// </summary>
-public class PrLabelOwnerCheck
-{
-    [JsonPropertyName("passed")]
-    public bool Passed { get; set; }
-
-    [JsonPropertyName("required")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public int Required { get; set; }
-
-    [JsonPropertyName("actual")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public int Actual { get; set; }
-
-    [JsonPropertyName("owners")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<string>? Owners { get; set; }
-
-    [JsonPropertyName("labels")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<string>? Labels { get; set; }
-
-    [JsonPropertyName("matched_path")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? MatchedPath { get; set; }
-}
-
-/// <summary>
-/// Combined result of the path-based fallback checks.
-/// </summary>
-public class PathFallbackCheckResult
-{
-    [JsonPropertyName("pr_label_owner_check")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public PrLabelOwnerCheck? PrLabelOwnerCheck { get; set; }
-
-    [JsonPropertyName("service_owner_check")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public ServiceOwnerCheck? ServiceOwnerCheck { get; set; }
-}
-
-/// <summary>
 /// Structured response for the check-package-owners command.
+/// Reuses PackageResponse and LabelOwnerResponse from the view command.
 /// </summary>
 public class CheckPackageOwnersResponse : CommandResponse
 {
-    [JsonPropertyName("package_name")]
-    public string PackageName { get; set; } = string.Empty;
+    [JsonPropertyName("package")]
+    public string Package { get; set; } = string.Empty;
 
-    [JsonPropertyName("directory_path")]
-    public string DirectoryPath { get; set; } = string.Empty;
+    [JsonPropertyName("path")]
+    public string Path { get; set; } = string.Empty;
 
-    [JsonPropertyName("repo")]
-    public string Repo { get; set; } = string.Empty;
+    [JsonPropertyName("pass")]
+    public bool Pass { get; set; }
 
-    [JsonPropertyName("validation_path")]
+    [JsonPropertyName("package_work_item")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ValidationPath { get; set; }
+    public PackageResponse? PackageWorkItem { get; set; }
 
-    [JsonPropertyName("owner_check")]
+    [JsonPropertyName("path_owners")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public OwnershipCheck? OwnerCheck { get; set; }
+    public LabelOwnerResponse? PathOwners { get; set; }
 
-    [JsonPropertyName("pr_label_check")]
+    [JsonPropertyName("pr_labels")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public PrLabelCheck? PrLabelCheck { get; set; }
+    public List<string>? PrLabels { get; set; }
 
-    [JsonPropertyName("service_owner_check")]
+    [JsonPropertyName("service_owners")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public ServiceOwnerCheck? ServiceOwnerCheck { get; set; }
-
-    [JsonPropertyName("path_fallback_check")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public PathFallbackCheckResult? PathFallbackCheck { get; set; }
-
-    [JsonPropertyName("all_passed")]
-    public bool AllPassed { get; set; }
+    public LabelOwnerResponse? ServiceOwners { get; set; }
 
     public override int ExitCode
     {
-        get => AllPassed ? 0 : 1;
+        get => Pass ? 0 : 1;
         set { }
     }
 
     protected override string Format()
     {
         var sb = new StringBuilder();
-        sb.AppendLine($"=== Check Package Owners: {PackageName} ===");
-        sb.AppendLine($"  Repo: {Repo}");
-        sb.AppendLine($"  Directory Path: {DirectoryPath}");
+        sb.AppendLine($"=== Check Package Owners: {Package} ===");
+        sb.AppendLine($"  Path: {Path}");
+        sb.AppendLine();
 
-        if (ValidationPath != null)
+        if (PackageWorkItem != null)
         {
-            sb.AppendLine($"  Validation Path: {ValidationPath}");
+            sb.AppendLine($"  Package: {PackageWorkItem.PackageName} [{PackageWorkItem.WorkItemId}]");
+            if (PackageWorkItem.Owners?.Count > 0)
+            {
+                sb.AppendLine($"    Owners: {FormatOwnersList(PackageWorkItem.Owners)}");
+            }
+            else
+            {
+                sb.AppendLine("    Owners: (none)");
+            }
+            if (PackageWorkItem.Labels?.Count > 0)
+            {
+                sb.AppendLine($"    Labels: {string.Join(", ", PackageWorkItem.Labels)}");
+            }
         }
 
-        if (ValidationPath == "Package")
+        if (PathOwners != null)
         {
-            FormatPrimaryPath(sb);
+            sb.AppendLine();
+            sb.AppendLine($"  Path Owners: [{PathOwners.WorkItemId}]");
+            if (PathOwners.Path != null)
+            {
+                sb.AppendLine($"    Matched Path: {PathOwners.Path}");
+            }
+            if (PathOwners.Owners?.Count > 0)
+            {
+                sb.AppendLine($"    Owners: {FormatOwnersList(PathOwners.Owners)}");
+            }
+            if (PathOwners.Labels?.Count > 0)
+            {
+                sb.AppendLine($"    Labels: {string.Join(", ", PathOwners.Labels)}");
+            }
         }
-        else if (ValidationPath == "PathFallback")
+
+        if (PrLabels?.Count > 0)
         {
-            FormatFallbackPath(sb);
+            sb.AppendLine();
+            sb.AppendLine($"  PR Labels: {string.Join(", ", PrLabels)}");
+        }
+
+        if (ServiceOwners != null)
+        {
+            sb.AppendLine();
+            sb.AppendLine($"  Service Owners: [{ServiceOwners.WorkItemId}]");
+            if (ServiceOwners.Owners?.Count > 0)
+            {
+                sb.AppendLine($"    Owners: {FormatOwnersList(ServiceOwners.Owners)}");
+            }
+            else
+            {
+                sb.AppendLine("    Owners: (none)");
+            }
+            if (ServiceOwners.Labels?.Count > 0)
+            {
+                sb.AppendLine($"    Labels: {string.Join(", ", ServiceOwners.Labels)}");
+            }
         }
 
         sb.AppendLine();
-        sb.AppendLine(AllPassed ? "  Result: PASS" : "  Result: FAIL");
+        sb.AppendLine(Pass ? "  Result: PASS" : "  Result: FAIL");
         return sb.ToString();
     }
 
-    private void FormatPrimaryPath(StringBuilder sb)
+    private static string FormatOwnersList(List<OwnerResponse> owners)
     {
-        if (OwnerCheck != null)
-        {
-            var status = OwnerCheck.Passed ? "PASS" : "FAIL";
-            sb.AppendLine($"  Package Owners: [{status}] {OwnerCheck.Actual}/{OwnerCheck.Required} unique individuals");
-            if (OwnerCheck.Owners?.Count > 0)
-            {
-                sb.AppendLine($"    Owners: {string.Join(", ", OwnerCheck.Owners)}");
-            }
-        }
-
-        if (PrLabelCheck != null)
-        {
-            var status = PrLabelCheck.Passed ? "PASS" : "FAIL";
-            sb.AppendLine($"  PR Labels: [{status}]");
-            if (PrLabelCheck.Labels?.Count > 0)
-            {
-                sb.AppendLine($"    Labels: {string.Join(", ", PrLabelCheck.Labels)}");
-            }
-        }
-
-        if (ServiceOwnerCheck != null)
-        {
-            FormatServiceOwnerCheck(sb, ServiceOwnerCheck, "  ");
-        }
+        return string.Join(", ", owners.Select(FormatOwnerDisplay).OrderBy(s => s, StringComparer.OrdinalIgnoreCase));
     }
 
-    private void FormatFallbackPath(StringBuilder sb)
+    private static string FormatOwnerDisplay(OwnerResponse owner)
     {
-        if (PathFallbackCheck == null)
+        if (owner.Members?.Count > 0)
         {
-            return;
+            return $"{owner.GitHubAlias} ({string.Join(", ", owner.Members)})";
         }
 
-        if (PathFallbackCheck.PrLabelOwnerCheck != null)
-        {
-            var check = PathFallbackCheck.PrLabelOwnerCheck;
-            var status = check.Passed ? "PASS" : "FAIL";
-            sb.AppendLine($"  PR Label Owners (path-based): [{status}] {check.Actual}/{check.Required} unique individuals");
-            if (check.MatchedPath != null)
-            {
-                sb.AppendLine($"    Matched Path: {check.MatchedPath}");
-            }
-            if (check.Owners?.Count > 0)
-            {
-                sb.AppendLine($"    Owners: {string.Join(", ", check.Owners)}");
-            }
-            if (check.Labels?.Count > 0)
-            {
-                sb.AppendLine($"    Labels: {string.Join(", ", check.Labels)}");
-            }
-        }
-
-        if (PathFallbackCheck.ServiceOwnerCheck != null)
-        {
-            FormatServiceOwnerCheck(sb, PathFallbackCheck.ServiceOwnerCheck, "  ");
-        }
-    }
-
-    private static void FormatServiceOwnerCheck(StringBuilder sb, ServiceOwnerCheck check, string indent)
-    {
-        var status = check.Passed ? "PASS" : "FAIL";
-        sb.AppendLine($"{indent}Service Owners: [{status}] {check.Actual}/{check.Required} unique individuals");
-        if (check.RequiredLabels?.Count > 0)
-        {
-            sb.AppendLine($"{indent}  Required Labels: {string.Join(", ", check.RequiredLabels)}");
-        }
-        if (check.MatchedLabels?.Count > 0)
-        {
-            sb.AppendLine($"{indent}  Matched Labels: {string.Join(", ", check.MatchedLabels)}");
-        }
-        if (check.Owners?.Count > 0)
-        {
-            sb.AppendLine($"{indent}  Owners: {string.Join(", ", check.Owners)}");
-        }
+        return owner.GitHubAlias;
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
@@ -147,6 +147,18 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
             Required = false,
         };
 
+        private readonly Option<string> checkPackageOption = new("--package")
+        {
+            Description = "Package name",
+            Required = true,
+        };
+
+        private readonly Option<string> directoryPathOption = new("--directory-path")
+        {
+            Description = "Relative path to the package directory from the repo root",
+            Required = true,
+        };
+
         // Command names
         private const string generateCodeownersCommandName = "generate";
         private const string viewCodeownersCommandName = "view";
@@ -157,6 +169,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
         private const string removeCodeownersToPackageCommandName = "remove-package-owner";
         private const string removeLabelToPackageCommandName = "remove-package-label";
         private const string removeLabelOwnerCommandName = "remove-label-owner";
+        private const string checkPackageOwnersCommandName = "check-package-owners";
 
 
         // MCP Tool Names
@@ -167,6 +180,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
         private const string CodeownerRemovePackageOwnerToolName = "azsdk_engsys_codeowner_remove_package_owner";
         private const string CodeownerRemoveLabelToolName = "azsdk_engsys_codeowner_remove_package_label";
         private const string CodeownerRemoveLabelOwnerToolName = "azsdk_engsys_codeowner_remove_label_owner";
+        private const string CodeownerCheckPackageOwnersToolName = "azsdk_engsys_codeowner_check_package_owners";
 
         public CodeownersTool(
             IGitHubService githubService,
@@ -227,6 +241,10 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
             new(exportSectionCommandName, "Export one or more named sections from a CODEOWNERS file")
             {
                 codeownersPathOption, sectionsOption, outputFilePathOption,
+            },
+            new(checkPackageOwnersCommandName, "Check if a package has sufficient owner information")
+            {
+                checkPackageOption, directoryPathOption, optionalRepoOption,
             }
         ];
 
@@ -315,6 +333,14 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
                 var sections = parseResult.GetValue(sectionsOption);
                 var output = parseResult.GetValue(outputFilePathOption);
                 return await ExportSection(codeownersPath!, sections!, output!, ct);
+            }
+
+            if (command == checkPackageOwnersCommandName)
+            {
+                var package = parseResult.GetValue(checkPackageOption);
+                var directoryPath = parseResult.GetValue(directoryPathOption);
+                var repo = parseResult.GetValue(optionalRepoOption);
+                return await CheckPackageOwners(package!, directoryPath!, repo, ct);
             }
 
             return new DefaultCommandResponse { ResponseError = $"Unknown command: '{command}'" };
@@ -626,6 +652,26 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
             catch (Exception ex)
             {
                 logger.LogError(ex, "Error removing label owner(s)");
+                return new DefaultCommandResponse { ResponseError = ex.Message };
+            }
+        }
+
+        [McpServerTool(Name = CodeownerCheckPackageOwnersToolName), Description("Check if a package has sufficient owner information for PR/release gating. Returns pass/fail for package owners, PR labels, and service owner checks.")]
+        public async Task<CommandResponse> CheckPackageOwners(
+            string package,
+            string directoryPath,
+            string? repo = null,
+            CancellationToken ct = default
+        )
+        {
+            try
+            {
+                repo = await ResolveRepo(repo, ct);
+                return await codeownersManagementHelper.CheckPackageOwners(package, directoryPath, repo, ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error checking package owners");
                 return new DefaultCommandResponse { ResponseError = ex.Message };
             }
         }

--- a/tools/azsdk-cli/docs/specs/7-operations-codeowners-management.spec.md
+++ b/tools/azsdk-cli/docs/specs/7-operations-codeowners-management.spec.md
@@ -1,0 +1,624 @@
+# Spec: 8-Operations - Codeowners Management and GitHub Label Sync
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Definitions](#definitions)
+- [Background / Problem Statement](#background--problem-statement)
+- [Goals and Exceptions/Limitations](#goals-and-exceptionslimitations)
+- [Design Proposal](#design-proposal)
+- [Open Questions](#open-questions)
+- [Success Criteria](#success-criteria)
+- [Agent Prompts](#agent-prompts)
+- [CLI Commands](#cli-commands)
+- [Implementation Plan](#implementation-plan)
+- [Testing Strategy](#testing-strategy)
+- [Metrics/Telemetry](#metricstelemetry)
+- [Documentation Updates](#documentation-updates)
+
+---
+
+## Overview
+
+This spec defines CODEOWNERS-related tooling behavior in `azsdk-cli`.
+
+Scope in this spec:
+
+- `config codeowners` command group and MCP tools implemented in `CodeownersTool`
+- `config github-label` command group and MCP tools implemented in `GitHubLabelsTool`
+- Helper and service dependencies used by those tools
+- Azure DevOps work item data model required by this design
+
+---
+
+## Definitions
+
+- **CODEOWNERS entry**: A parsed ownership record (path expression, owners, labels, and metadata) represented by `CodeownersEntry`.
+- **Pathless entry**: A CODEOWNERS entry with empty path expression, used for service-level ownership metadata grouping. Pathless entries do not have any effect on GitHub's interpretation of a CODEOWNERS file.
+- **Service-level path entry**: A CODEOWNERS entry created from `Label Owner` records that have `Custom.RepoPath`.
+- **Owner work item**: Azure DevOps work item of type `Owner`, keyed by `Custom.GitHubAlias`.
+- **Label work item**: Azure DevOps work item of type `Label`, keyed by `Custom.Label`.
+- **Label Owner work item**: Azure DevOps work item of type `Label Owner`, carrying repository/path/role metadata and related owner/label links.
+- **Repository filter**: Optional repo input that narrows package and label-owner results in view and modify operations.
+
+---
+
+## Background / Problem Statement
+
+CODEOWNERS files describe ownership and responsibilities for code in Azure SDK repositories. Those files represent owners across team and organization boundaries which may become invalid over time. To prevent confusion and keep an accurate record of ownership, package and service ownership data should be tracked in a durable system, and ownership updates should be easier and part of the release process.
+
+### Current State
+
+Main user personas:
+
+- SDK contributor: owns code in SDK repositories and is responsible for maintenance.
+- SDK triage: routes issues to appropriate owners; accurate owners reduce routing delays.
+
+Current workflow: ownership information is manually maintained, and triage automation routes issues using deterministic rules.
+
+Specific friction points this spec resolves:
+
+- Simplify ownership updates from the perspective of SDK contributors.
+- Reduce triage friction by keeping ownership data up to date in the right locations, including CODEOWNERS for PR review.
+
+### Why This Matters
+
+Ensure accurate information goes into CODEOWNERS and triage automation has reliable ownership data for issue routing.
+
+---
+
+## Goals and Exceptions/Limitations
+
+### Goals
+
+- [ ] Import existing data into Azure DevOps work items and use that as the source of truth.
+- [ ] Enable service teams to use `azsdk` tools to update ownership information.
+- [ ] Require a minimum set of valid codeowners.
+- [ ] Automate CODEOWNERS validation.
+- [ ] Automate email notifications for invalid owners.
+- [ ] Prevent PRs from being merged or packages from being released when CODEOWNERS are invalid.
+- [ ] Migrate the triage system to use the new ownership source of truth.
+
+### Exceptions and Limitations
+
+- The codeowners management flow does not model or require explicit `Service`/`Product` links for label-owner operations.
+- `RemoveOwnersFromLabelsAndPath` expects exactly one matching `Label Owner` record for `(repo, path, section, ownerType, label set)` and uses `Single(...)`; duplicate candidates can throw.
+- Team owner validation supports only aliases in `Azure/<team>` format and requires the team to descend from `azure-sdk-write`.
+- `GitHubLableWorkItem` type name contains a legacy spelling (`Lable`) in code and responses.
+
+---
+
+## Design Proposal
+
+### Design Overview
+
+Two command groups are documented:
+
+- `config codeowners`: view, generate, export-section, add/remove package owners, add/remove package labels, add/remove label owners on optional path scope.
+- `config github-label`: check/create service labels in GitHub CSV and sync service labels to Azure DevOps `Label` work items.
+
+### Command and Tool Surface
+
+`CodeownersTool` commands:
+
+- `generate` (no MCP)
+- `view`
+- `add-package-owner`
+- `add-package-label`
+- `add-label-owner`
+- `remove-package-owner`
+- `remove-package-label`
+- `remove-label-owner`
+- `export-section` (no MCP)
+
+`CodeownersTool` MCP tools:
+
+- `azsdk_engsys_codeowner_view`
+- `azsdk_engsys_codeowner_add_package_owner`
+- `azsdk_engsys_codeowner_add_package_label`
+- `azsdk_engsys_codeowner_add_label_owner`
+- `azsdk_engsys_codeowner_remove_package_owner`
+- `azsdk_engsys_codeowner_remove_package_label`
+- `azsdk_engsys_codeowner_remove_label_owner`
+
+`GitHubLabelsTool` commands:
+
+- `check`
+- `create`
+- `sync-ado` (no MCP)
+
+`GitHubLabelsTool` MCP tools:
+
+- `azsdk_check_service_label`
+- `azsdk_create_service_label`
+
+### Data Model
+
+#### Work Item Types
+
+| Work Item Type | Required/Queried Fields | Notes |
+|----------------|-------------------------|-------|
+| `Package` | `Custom.Package`, `Custom.PackageVersionMajorMinor`, `Custom.Language`, `Custom.PackageType`, `Custom.PackageDisplayName`, `Custom.GroupId`, `Custom.PackageRepoPath` | Package queries can be constrained by language derived from repo. Latest package version is selected per package name. |
+| `Owner` | `Custom.GitHubAlias` | Alias is normalized (`trim`, remove `@`) before lookup for both groups and individual users. |
+| `Label` | `Custom.Label` | Used both for package label links and service label sync. Kept up to date with common-labels.csv using `github-label sync-ado` |
+| `Label Owner` | `Custom.LabelType`, `Custom.Repository`, `Custom.RepoPath`, `Custom.Section` | Related links carry owner and label associations. |
+
+#### Relation Types
+
+| Relation Type | Usage |
+|---------------|-------|
+| `System.LinkTypes.Related` | Relation type for codeowners mapping/hydration (`ExtractRelatedIds`) and add/remove operations (`CreateWorkItemRelationAsync(..., "related", ...)`). |
+
+Hierarchy links are not used by codeowners management/generation logic.
+
+#### Entity Relationship Diagram
+
+```mermaid
+flowchart LR
+  Package[Package\nCustom.Package\nCustom.PackageVersionMajorMinor]
+  Owner[Owner\nCustom.GitHubAlias]
+  Label[Label\nCustom.Label]
+  LabelOwner[Label Owner\nCustom.Repository\nCustom.LabelType\nCustom.RepoPath\nCustom.Section]
+
+  Package --- Owner
+  Package --- Label
+  Package --- LabelOwner
+
+  LabelOwner --- Owner
+  LabelOwner --- Label
+```
+
+#### Example Relationship Diagram
+
+```mermaid
+flowchart LR
+  subgraph Owners
+    O1[Owner: owner1]
+    O2[Owner: owner2]
+    O3[Owner: owner3]
+  end
+
+  subgraph Labels
+    L1[Label: Contoso]
+    L2[Label: Storage]
+  end
+
+  subgraph Packages
+    P1[Package\nAzure.Contoso.WidgetManager]
+  end
+
+  subgraph LabelOwners
+    LO1[Label Owner\nLabel Type: Service Owners]
+  end
+
+  P1 ---|owner| O1
+  P1 ---|owner| O2
+  P1 ---|label| L1
+
+  LO1 ---|owner| O2
+  LO1 ---|owner| O3
+  LO1 ---|label| L1
+```
+
+#### Example CODEOWNERS Output
+
+> [!NOTE]
+> The example rendered CODEOWNERS is a snapshot in time. The only relevant syntax to GitHub's view of CODEOWNERS is the un-commented line. The commented lines are handled by parser tooling in the azure-sdk-tools repo.
+
+```text
+# PRLabel: %Contoso
+/sdk/contoso/Azure.Contoso.WidgetManager/    @owner1 @owner2
+
+# ServiceLabel: %Contoso
+# ServiceOwners: @owner2 @owner3
+```
+
+In this example, `Storage` exists as a label entity but is not attached to the package or label-owner entry, so it does not appear in the CODEOWNERS lines above.
+
+#### Identity and Matching Rules
+
+| Entity/Operation | Matching Rule |
+|------------------|---------------|
+| Owner lookup | `Custom.GitHubAlias == normalizedAlias` |
+| Label lookup | `Custom.Label == label` |
+| Package lookup | `Custom.Package == packageName` (+ optional language filter), then latest by `Custom.PackageVersionMajorMinor` |
+| Label Owner find/create | Filter by `Custom.Repository + Custom.LabelType + Custom.RepoPath + Custom.Section`, then choose candidate whose linked label ID set exactly equals requested label ID set; otherwise create new |
+
+#### OwnerType Mapping
+
+`OwnerType` enum values map to `Custom.LabelType` string values as follows:
+
+| Enum | Stored String |
+|------|---------------|
+| `ServiceOwner` | `Service Owner` |
+| `AzSdkOwner` | `Azure SDK Owner` |
+| `PrLabel` | `PR Label` |
+
+#### Generated CODEOWNERS Projection Rules
+
+- Package entries are generated from selecting the latest `Package` work item by version and hydrated related owners/labels/label-owners.
+- Service-level path entries are generated from unlinked `Label Owner` records with non-empty `RepoPath`.
+- Pathless metadata entries are grouped by service-label set from unlinked `Label Owner` records with empty `RepoPath`.
+- Original owner collections are preserved in generated `CodeownersEntry` via:
+  - `OriginalSourceOwners`
+  - `OriginalServiceOwners`
+  - `OriginalAzureSdkOwners`
+- Entries are sorted by:
+  - Entries with paths and without paths
+  - Primary label (labels are sorted alphabetically)
+  - Path
+
+Sorting has the effect of grouping similar service-level entries together with package entires sorting later than service-level entries. (e.g. `/sdk/contoso` comes before `/sdk/contoso/widget-manager`)
+
+Sorting is implemented in `CodeownersEntrySorter.cs`.
+
+#### GitHub Service Label Sync Model
+
+- Service labels are read from `eng/common/docs/common-labels.csv` in `Azure/azure-sdk-tools`.
+- Service labels are detected by color code `e99695`.
+- Sync target: Azure DevOps `Label` work item with `Custom.Label`.
+- Sync reports:
+  - duplicate CSV labels
+  - duplicate ADO label work items
+  - orphaned ADO labels not present in CSV
+
+### High-Level Flow
+
+```text
+CodeownersTool
+  -> resolves repo and arguments
+  -> delegates view/add/remove/generate/export logic to helpers
+  -> helpers query/update Azure DevOps via IDevOpsService
+  -> helpers query/validate GitHub identities or teams via IGitHubService
+
+GitHubLabelsTool
+  -> reads common-labels.csv from GitHub
+  -> checks/creates service label PRs OR syncs labels to ADO Label work items
+```
+
+### Cross-Language Considerations
+
+| Language | Approach | Notes |
+|----------|----------|-------|
+| .NET | Same ownership data model and command surface. | Ownership rendering should stay consistent across languages. |
+| Java | Same ownership data model and command surface. | Package identity handling includes Java Group ID support. |
+| JavaScript | Same ownership data model and command surface. | Ownership rendering should stay consistent across languages. |
+| Python | Same ownership data model and command surface. | Ownership rendering should stay consistent across languages. |
+| Go | Same ownership data model and command surface. | Ownership rendering should stay consistent across languages. |
+
+---
+
+## Open Questions
+
+- [ ] **Management Plane owner handling and release**: How should management fallback ownership be sorted and enforced when label-based sorting can place `%Mgmt` entries in the middle of the Management Libraries section?
+  - Context: Management plane packages should sort after client packages so client ownership applies broadly and management ownership applies narrowly. Current sorting includes label-based ordering, which can move `/%**/*Management*/` fallback entries away from the intended top of the management section.
+  - Options:
+    - Keep label-based sorting as-is and introduce an explicit management fallback priority rule.
+    - Add section-aware sort precedence so fallback entries are always first within Management Libraries.
+    - Introduce a dedicated fallback metadata marker and update renderer/sorter to respect it.
+
+```codeowners
+####################
+# Client Libraries
+####################
+
+# Top level owner for a service (management libraries are overridden down below)
+
+# PRLabel: %AI Model Inference %AI Projects
+/sdk/ai/    @dargilco @glharper @nick863 @trangevi @trrwilson
+
+# Client package-specific owner
+
+# PRLabel: %AI Model Inference
+/sdk/ai/Azure.AI.Inference/    @dargilco @glharper @trangevi
+...
+
+####################
+# Management Libraries
+####################
+
+# Fallback owners first, but after owners in Client Libraries
+
+# PRLabel: %Mgmt
+/**/*Management*/    @ArcturusZhang @ArthurMa1978
+
+
+# Then package-specific owners
+
+# PRLabel: %API Center %Mgmt
+/sdk/apicenter/Azure.ResourceManager.ApiCenter/    @ArcturusZhang @ArthurMa1978
+...
+```
+
+---
+
+## Success Criteria
+
+This feature/tool is complete when:
+
+- [ ] Service teams can use AzSDK Tools MCP to update CODEOWNERS-backed ownership data ([Issue #12917](https://github.com/Azure/azure-sdk-tools/issues/12917)).
+- [ ] The CODEOWNERS file is editable by tooling and protected against manual drift.
+- [ ] CODEOWNERS file sections are generated from the data model.
+- [ ] PRs and releases are blocked for packages that do not have owner information.
+
+---
+
+## Agent Prompts
+
+### View codeowners by package
+
+**Prompt:**
+
+```text
+Show me CODEOWNERS associations for package azure-ai-vision-imageanalysis in Azure/azure-sdk-for-net.
+```
+
+**Expected Agent Activity:**
+
+1. Call `azsdk_engsys_codeowner_view` with `package` and optional `repo`.
+2. Return package owners/labels and related label-owner groupings.
+
+### Add package owners
+
+**Prompt:**
+
+```text
+Add @alice and Azure/my-team as source owners for package azure-ai-foo in Azure/azure-sdk-for-python.
+```
+
+**Expected Agent Activity:**
+
+1. Resolve/validate owner aliases.
+2. Create owner work items if missing (with validation rules).
+3. Link owners to package via related relations.
+4. Return updated view.
+
+### Add path-scoped label owners
+
+**Prompt:**
+
+```text
+Add @alice as a PR Label owner for labels service-attention and needs-team-attention on path sdk/contoso/ in Azure/azure-sdk-for-net section Client Libraries.
+```
+
+**Expected Agent Activity:**
+
+1. Resolve owner and label work items.
+2. Find or create matching `Label Owner` work item by repo/path/section/label type + label set.
+3. Link owner/labels.
+4. Return updated view by path.
+
+### Check service label
+
+**Prompt:**
+
+```text
+Check whether the service label azure-openai exists.
+```
+
+**Expected Agent Activity:**
+
+1. Read common-labels CSV from GitHub.
+2. Check for existing service label by color code.
+3. Check open PRs for in-review state.
+4. Return status (`Exists`, `DoesNotExist`, `NotAServiceLabel`, or `InReview`).
+
+---
+
+## CLI Commands
+
+Command details are documented in a template-compatible format for representative operations below. The remaining command examples in this section follow the same shape.
+
+### Check service label
+
+**Command:**
+
+```bash
+azsdk config github-label check azure-openai
+```
+
+**Options:**
+
+- `<label-name>`: Service label name to check in the common-labels source.
+
+**Expected Output:**
+
+```text
+Exists | DoesNotExist | NotAServiceLabel | InReview
+```
+
+**Error Cases:**
+
+```text
+Error: Unable to read service label source or query open PR state.
+```
+
+### Add package owner(s)
+
+**Command:**
+
+```bash
+azsdk config codeowners add-package-owner --github-user alice --github-user Azure/my-team --package azure-ai-foo --repo Azure/azure-sdk-for-python
+```
+
+**Options:**
+
+- `--github-user <alias>`: GitHub user or team alias; repeatable.
+- `--package <package-name>`: Target package name.
+- `--repo <owner/name>`: Optional repository filter.
+
+**Expected Output:**
+
+```text
+Owners linked to package successfully.
+Updated ownership view returned.
+```
+
+**Error Cases:**
+
+```text
+Error: One or more owner aliases are invalid or do not satisfy validation requirements.
+```
+
+### View by package
+
+```bash
+azsdk config codeowners view --package azure-ai-foo --repo Azure/azure-sdk-for-python
+```
+
+### View by label(s)
+
+```bash
+azsdk config codeowners view --label service-attention --label needs-team-attention --repo Azure/azure-sdk-for-net
+```
+
+### Add package owner(s)
+
+```bash
+azsdk config codeowners add-package-owner --github-user alice --github-user Azure/my-team --package azure-ai-foo --repo Azure/azure-sdk-for-python
+```
+
+### Add package label(s)
+
+```bash
+azsdk config codeowners add-package-label --label service-attention --package azure-ai-foo --repo Azure/azure-sdk-for-net
+```
+
+### Add label owner(s) on path
+
+```bash
+azsdk config codeowners add-label-owner --github-user alice --label service-attention --owner-type pr-label --path sdk/contoso/ --section "Client Libraries" --repo Azure/azure-sdk-for-net
+```
+
+### Remove package owner(s)
+
+```bash
+azsdk config codeowners remove-package-owner --github-user alice --package azure-ai-foo --repo Azure/azure-sdk-for-python
+```
+
+### Remove package label(s)
+
+```bash
+azsdk config codeowners remove-package-label --label service-attention --package azure-ai-foo --repo Azure/azure-sdk-for-net
+```
+
+### Remove label owner(s) on path
+
+```bash
+azsdk config codeowners remove-label-owner --github-user alice --label service-attention --owner-type pr-label --path sdk/contoso/ --section "Client Libraries" --repo Azure/azure-sdk-for-net
+```
+
+### Export CODEOWNERS section(s)
+
+```bash
+azsdk config codeowners export-section --codeowners-path .github/CODEOWNERS --section "Client Libraries" --output-file out/CODEOWNERS.client
+```
+
+### Check/create service label
+
+```bash
+azsdk config github-label check azure-openai
+azsdk config github-label create azure-openai --link https://learn.microsoft.com/azure/ai-services/openai/
+```
+
+### Sync service labels to ADO label work items
+
+```bash
+azsdk config github-label sync-ado --dry-run
+azsdk config github-label sync-ado
+```
+
+---
+
+## Implementation Plan
+
+### Phase 1: Data Model
+
+- Milestone: Create DevOps work items as the source of truth, normalize existing CODEOWNERS data, and render CODEOWNERS from the data model.
+- Timeline: TBD
+- Dependencies: Azure DevOps work item schema readiness and migration scripts.
+
+### Phase 2: Render and Enforce
+
+- Milestone: Onboard repositories for rendering, build MCP/CLI tools for data updates, block manual CODEOWNERS edits, update docs/agent skills, and block releases for packages without owner information.
+- Timeline: TBD
+- Dependencies: Phase 1 completion and repository onboarding agreements.
+
+### Phase 3: Validation and Notification
+
+- Milestone: Validate data model entries and eject invalid entries, populate internal contact information, ingest service owner data from Dataverse, and send notifications for packages missing owner data.
+- Timeline: TBD
+- Dependencies: Dataverse integration and notification channel definitions.
+
+### Phase 4: Data Model Migration
+
+- Milestone: Migrate dependent tooling (for example Event Processor) to the work item data model and remove metadata comments from CODEOWNERS while keeping label-owner data publicly accessible.
+- Timeline: TBD
+- Dependencies: Phase 2 and Phase 3 stabilization.
+
+
+### Code Dependency Summary
+
+The following dependency map defines the required dependencies across `CodeownersTool`, `GitHubLabelsTool`, and their helper/service layers.
+
+| Dependency | Type | Used By | Purpose |
+|------------|------|---------|---------|
+| `System.CommandLine` | External library | `CodeownersTool`, `GitHubLabelsTool` | Command and option/argument definitions for CLI subcommands. |
+| `ModelContextProtocol.Server` | External library | `CodeownersTool`, `GitHubLabelsTool` | MCP tool registration via `[McpServerToolType]` and `[McpServerTool]`. |
+| `Octokit` | External library | `GitHubService`, `CodeownersValidatorHelper` | GitHub API operations (users, org membership, teams, PR search/create, repo content). |
+| Azure DevOps client SDK (`Microsoft.TeamFoundation.*`, `Microsoft.VisualStudio.Services.*`) | External library | `DevOpsService`, `CodeownersManagementHelper`, `CodeownersGenerateHelper`, `GitHubLabelsTool` | WIQL queries, work item create/update, and relation management in Azure DevOps. |
+| `Azure.Sdk.Tools.CodeownersUtils` (`Parsing`, `Utils`, `Caches`) | Internal project dependency | `CodeownersTool`, `CodeownersGenerateHelper`, `CodeownersManagementHelper` | CODEOWNERS section parsing, entry sorting/formatting, and team membership cache support. |
+| `IGitHubService` / `GitHubService` | Internal service | Both tool groups + validators/helpers | Wrapper over GitHub auth/API calls. |
+| `IDevOpsService` / `DevOpsService` | Internal service | Both tool groups + management/generation helpers | Wrapper over Azure DevOps work item and relation operations. |
+| `ICodeownersManagementHelper` | Internal helper | `CodeownersTool` | View/add/remove behavior for package owners, package labels, and label-owner path records. |
+| `ICodeownersGenerateHelper` | Internal helper | `CodeownersTool` | Generates CODEOWNERS section content from Azure DevOps + repo package metadata. |
+| `ICodeownersValidatorHelper` | Internal helper | `CodeownersTool` | Validates individual GitHub users as Azure SDK code owners before owner WI creation. |
+| `IGitHelper` | Internal helper | `CodeownersTool` | Repo root/repo full name discovery. |
+| `IPowershellHelper` | Internal helper | `CodeownersGenerateHelper` | Runs `eng/common/scripts/common.ps1` to resolve package metadata in repo. |
+| `ITeamUserCache` | Internal cache | `CodeownersManagementHelper` | Team alias validation and team-member expansion for views. |
+| `LabelHelper` | Internal utility | `GitHubLabelsTool` | Service-label CSV parsing, normalization, duplicate detection, and insertion. |
+
+
+
+---
+
+## Testing Strategy
+
+- Unit tests for data model rendering, updating, and validation.
+- Unit tests for command behavior and helper interactions in:
+  - `Azure.Sdk.Tools.Cli.Tests/Tools/Config/CodeownersToolsTests.cs`
+  - `Azure.Sdk.Tools.Cli.Tests/Helpers/CodeownersManagementHelperTests.cs`
+- Data-model-sensitive coverage should include:
+  - owner/label/package lookup semantics
+  - label-owner find/create uniqueness rules
+  - add/remove relation behavior
+  - service label sync duplicate/orphan detection
+
+Constraints and risks:
+
+- It is difficult to accurately emulate Azure DevOps Work Item APIs outside Azure DevOps.
+- Functional tests against a test Azure DevOps instance can be unstable, especially when executed in parallel.
+
+---
+
+## Metrics/Telemetry
+
+No special metrics collection at this time. The design continues to rely on structured logging (`ILogger`) for operational diagnostics.
+
+### Privacy Considerations
+
+Owner data is not private information; it is already present in plain text in Azure SDK repositories, and write access metadata is publicly accessible via GitHub APIs. API calls require authentication, and credential handling remains encapsulated in helper methods rather than this spec's feature logic.
+
+---
+
+## Documentation Updates
+
+Documentation updated:
+
+- [Agent Skills](https://github.com/Azure/azure-sdk-for-net/blob/main/.github/skills/owners/SKILL.md)
+- [EngHub docs](https://aka.ms/azsdk/codeowners) describing agent process, linked from pipelines when blocked.
+
+As code is edited, the agent should make the following updates:
+
+- Keep command examples synchronized with option names in `CodeownersTool` and `GitHubLabelsTool`.
+- Keep work item field tables synchronized with mapper/query code.

--- a/tools/azsdk-cli/docs/specs/7-operations-codeowners-management.spec.md
+++ b/tools/azsdk-cli/docs/specs/7-operations-codeowners-management.spec.md
@@ -94,7 +94,7 @@ Ensure accurate information goes into CODEOWNERS and triage automation has relia
 
 Two command groups are documented:
 
-- `config codeowners`: view, generate, export-section, add/remove package owners, add/remove package labels, add/remove label owners on optional path scope.
+- `config codeowners`: view, generate, export-section, add/remove package owners, add/remove package labels, add/remove label owners on optional path scope, and check-package-owners validation for CI gating.
 - `config github-label`: check/create service labels in GitHub CSV and sync service labels to Azure DevOps `Label` work items.
 
 ### Command and Tool Surface
@@ -110,6 +110,7 @@ Two command groups are documented:
 - `remove-package-label`
 - `remove-label-owner`
 - `export-section` (no MCP)
+- `check-package-owners`
 
 `CodeownersTool` MCP tools:
 
@@ -120,6 +121,7 @@ Two command groups are documented:
 - `azsdk_engsys_codeowner_remove_package_owner`
 - `azsdk_engsys_codeowner_remove_package_label`
 - `azsdk_engsys_codeowner_remove_label_owner`
+- `azsdk_engsys_codeowner_check_package_owners`
 
 `GitHubLabelsTool` commands:
 
@@ -286,6 +288,75 @@ GitHubLabelsTool
 | Python | Same ownership data model and command surface. | Ownership rendering should stay consistent across languages. |
 | Go | Same ownership data model and command surface. | Ownership rendering should stay consistent across languages. |
 
+### Feature Area: Check Package Owners
+
+The `check-package-owners` command validates that a package has sufficient ownership data for CI gating (blocking PRs and releases). It returns a structured pass/fail result with exit code 0 (pass) or 1 (fail).
+
+#### Validation Rules
+
+Two paths to validity — **Package-level** (primary) and **Path-based fallback**:
+
+##### Primary Path: Package-Level Ownership
+
+If the Package work item has one or more direct owners, use this path. All three checks must pass:
+
+1. **Package Owners ≥ 2 unique individuals**: The Package work item must have at least 2 unique individual GitHub users as owners. Teams are expanded via `ITeamUserCache`. If the package has 1 or more owners but fewer than 2 unique individuals, the check **fails** (no fallback to the path-based path).
+2. **Has PR Label**: The Package work item must have at least 1 linked Label.
+3. **Service Owners ≥ 2 unique individuals**: There must exist a `Label Owner` work item of type `Service Owner` in the same repo whose linked labels are a **superset** of all the package's PR labels, and whose owners (after team expansion) include at least 2 unique individuals.
+
+Service Owner coverage must come from a **single** `Label Owner` record with a label superset. If coverage is split across multiple records such that no single record covers the full required label set, the check fails. Cleanup of fragmented Label Owner data is out of scope for this command (see Open Questions).
+
+##### Fallback Path: Path-Based Label Owner Ownership
+
+If the package has **zero direct owners**, fall back to checking `Label Owner` records whose `RepoPath` glob expression matches the package's `directoryPath`. Glob matching uses `DirectoryUtils.PathExpressionMatchesTargetPath` from `Azure.Sdk.Tools.CodeownersUtils`.
+
+Before path comparison, normalize both `Label Owner`.`RepoPath` and `directoryPath` to a single leading-slash form (e.g., `sdk/contoso` → `/sdk/contoso`).
+
+The fallback check proceeds in two steps:
+
+1. **PR Label owners ≥ 2 unique individuals**: Find `Label Owner` work items of type `PR Label` whose `RepoPath` glob matches `directoryPath`. If multiple match, sort by normalized `RepoPath` and choose the **last** matching `Label Owner`. That selected Label Owner must have ≥ 2 unique individuals (after team expansion). Only the selected Label Owner's linked labels become the required PR label set.
+2. **Service Owners ≥ 2 unique individuals with matching labels**: Find a `Label Owner` work item of type `Service Owner` whose linked labels are a **superset** of the required PR label set from the selected PR Label Label Owner (no path restriction — can be pathless or have any path). That Service Owner must have ≥ 2 unique individuals (after team expansion).
+
+The PR Label and Service Owner individual sets **can overlap**. A successful fallback path also satisfies the "has PR label" requirement.
+
+##### Decision Tree
+
+```text
+Package has any direct owners?
+  YES (≥ 1) → Check ≥ 2 unique individuals (fail if < 2, no fallback)
+               → Check PR label(s) exist on Package
+               → Check a single Service Owner Label Owner exists in repo
+                 whose labels ⊇ all PR labels AND has ≥ 2 unique individuals
+  NO (0)   → Find PR Label type Label Owners where RepoPath glob matches directoryPath
+              → Sort matching PR Label Label Owners by normalized path, choose last
+              → Use selected PR Label Label Owner's labels as the required PR label set
+              → Check selected PR Label owners have ≥ 2 unique individuals
+              → Check a single Service Owner Label Owner exists
+                whose labels ⊇ the selected PR Label Label Owner's labels
+                AND has ≥ 2 unique individuals
+                (Service Owners do NOT need to match the path)
+```
+
+#### Package Lookup
+
+Package lookup is by `Custom.Package` name + repo. When multiple Package work items match, select the latest version using `Custom.PackageVersionMajorMinor` via `WorkItemMappers.GetLatestPackageVersions`.
+
+#### Response Model
+
+`CheckPackageOwnersResponse` inherits from `CommandResponse` and includes:
+
+- `PackageName` (string)
+- `DirectoryPath` (string)
+- `Repo` (string)
+- `ValidationPath` (string) — `"Package"` or `"PathFallback"` indicating which path was used
+- `OwnerCheck` — `{ passed, required, actual, owners[] }`
+- `PrLabelCheck` — `{ passed, labels[] }` (Package path only)
+- `ServiceOwnerCheck` — `{ passed, required, actual, owners[], requiredLabels[], matchedLabels[] }`
+- `PathFallbackCheck` — `{ prLabelOwnerCheck, serviceOwnerCheck }` (fallback path only)
+- `AllPassed` (bool)
+
+Formatted text output shows each check with PASS/FAIL and details.
+
 ---
 
 ## Open Questions
@@ -329,6 +400,10 @@ GitHubLabelsTool
 /sdk/apicenter/Azure.ResourceManager.ApiCenter/    @ArcturusZhang @ArthurMa1978
 ...
 ```
+
+- [ ] **Label Owner canonicalization / cleanup**: How should tooling detect and clean up fragmented or overlapping `Label Owner` records when rendered ownership can appear valid in aggregate, but future enforcement may intentionally require a single canonical `Label Owner` record (for example, one `Service Owner` record whose labels cover the full required set)?
+  - Context: Current rendering logic can flatten or group `Label Owner` data in ways that make multiple records look equivalent to one canonical record. A future validator/check feature may intentionally reject that non-canonical shape rather than aggregating across records.
+  - Proposed direction: Treat cleanup and normalization of non-canonical `Label Owner` data as future validator work rather than part of the current CRUD/rendering flows.
 
 ---
 
@@ -402,6 +477,20 @@ Check whether the service label azure-openai exists.
 2. Check for existing service label by color code.
 3. Check open PRs for in-review state.
 4. Return status (`Exists`, `DoesNotExist`, `NotAServiceLabel`, or `InReview`).
+
+### Check package owners
+
+**Prompt:**
+
+```text
+Check whether package azure-ai-vision-imageanalysis in Azure/azure-sdk-for-net at path sdk/ai/Azure.AI.Vision.ImageAnalysis has valid ownership for release.
+```
+
+**Expected Agent Activity:**
+
+1. Call `azsdk_engsys_codeowner_check_package_owners` with `package`, `directoryPath`, and optional `repo`.
+2. Evaluate validation path (package-level or path-based fallback).
+3. Return structured pass/fail result with details on each ownership check.
 
 ---
 
@@ -528,6 +617,61 @@ azsdk config github-label sync-ado --dry-run
 azsdk config github-label sync-ado
 ```
 
+### Check package owners
+
+**Command:**
+
+```bash
+azsdk config codeowners check-package-owners --package azure-ai-foo --directory-path sdk/ai/Azure.AI.Foo --repo Azure/azure-sdk-for-net
+```
+
+**Options:**
+
+- `--package <package-name>` (required): Package name (maps to `Custom.Package` work item field).
+- `--directory-path <relative-path>` (required): Relative path from repo root to the package directory (e.g., `sdk/contoso/Azure.Contoso.WidgetManager`).
+- `--repo <owner/repo>` (optional): Repository in `owner/repo` format. Auto-resolved from git if omitted.
+
+**Expected Output (pass):**
+
+```text
+Validation Path: Package
+
+  Owner Check:       PASS (2 of 2 required) — owner1, owner2
+  PR Label Check:    PASS — Contoso
+  Service Owner Check: PASS (2 of 2 required) — owner2, owner3
+
+All checks passed.
+```
+
+**Expected Output (fail — insufficient owners):**
+
+```text
+Validation Path: Package
+
+  Owner Check:       FAIL (1 of 2 required) — owner1
+
+Not all checks passed.
+```
+
+**Expected Output (fallback path pass):**
+
+```text
+Validation Path: PathFallback
+
+  PR Label Owner Check:    PASS (2 of 2 required) — owner1, owner2 (labels: Contoso)
+  Service Owner Check:     PASS (2 of 2 required) — owner2, owner3 (matched labels: Contoso)
+
+All checks passed.
+```
+
+**Error Cases:**
+
+```text
+Error: Package 'azure-ai-nonexistent' not found in repo 'Azure/azure-sdk-for-net'.
+```
+
+Exit code: 0 if all checks pass, 1 if any check fails.
+
 ---
 
 ## Implementation Plan
@@ -567,7 +711,7 @@ The following dependency map defines the required dependencies across `Codeowner
 | `ModelContextProtocol.Server` | External library | `CodeownersTool`, `GitHubLabelsTool` | MCP tool registration via `[McpServerToolType]` and `[McpServerTool]`. |
 | `Octokit` | External library | `GitHubService`, `CodeownersValidatorHelper` | GitHub API operations (users, org membership, teams, PR search/create, repo content). |
 | Azure DevOps client SDK (`Microsoft.TeamFoundation.*`, `Microsoft.VisualStudio.Services.*`) | External library | `DevOpsService`, `CodeownersManagementHelper`, `CodeownersGenerateHelper`, `GitHubLabelsTool` | WIQL queries, work item create/update, and relation management in Azure DevOps. |
-| `Azure.Sdk.Tools.CodeownersUtils` (`Parsing`, `Utils`, `Caches`) | Internal project dependency | `CodeownersTool`, `CodeownersGenerateHelper`, `CodeownersManagementHelper` | CODEOWNERS section parsing, entry sorting/formatting, and team membership cache support. |
+| `Azure.Sdk.Tools.CodeownersUtils` (`Parsing`, `Utils`, `Caches`) | Internal project dependency | `CodeownersTool`, `CodeownersGenerateHelper`, `CodeownersManagementHelper` | CODEOWNERS section parsing, entry sorting/formatting, team membership cache support, and path glob matching via `DirectoryUtils.PathExpressionMatchesTargetPath` for `check-package-owners` fallback validation. |
 | `IGitHubService` / `GitHubService` | Internal service | Both tool groups + validators/helpers | Wrapper over GitHub auth/API calls. |
 | `IDevOpsService` / `DevOpsService` | Internal service | Both tool groups + management/generation helpers | Wrapper over Azure DevOps work item and relation operations. |
 | `ICodeownersManagementHelper` | Internal helper | `CodeownersTool` | View/add/remove behavior for package owners, package labels, and label-owner path records. |
@@ -593,6 +737,11 @@ The following dependency map defines the required dependencies across `Codeowner
   - label-owner find/create uniqueness rules
   - add/remove relation behavior
   - service label sync duplicate/orphan detection
+- `check-package-owners` validation coverage should include:
+  - Primary path: all checks pass, insufficient owners (< 2 unique individuals with ≥ 1 direct owner — no fallback), missing PR labels, insufficient or missing service owners, fragmented service owner label coverage across multiple Label Owner records
+  - Fallback path: both PR Label and Service Owner checks pass, insufficient PR Label owners, insufficient Service Owners, no matching paths, glob path matching, multiple matching PR Label Label Owners (sorted by normalized path, last selected), fragmented service owner label coverage, pathless Service Owner matches
+  - Team expansion: team owners expanded to count unique individuals, deduplication of overlapping team and individual owners
+  - Package resolution: latest version selected by `Custom.PackageVersionMajorMinor` when multiple Package work items match
 
 Constraints and risks:
 

--- a/tools/azsdk-cli/plan.md
+++ b/tools/azsdk-cli/plan.md
@@ -1,0 +1,202 @@
+# Plan: `check-package-owners` Command
+
+## Problem Statement
+
+The spec requires: "PRs and releases are blocked for packages that do not have owner information." We need a CLI command that validates a package's codeowners data in Azure DevOps and returns a pass/fail result usable by CI pipelines to block PRs/releases.
+
+## Command
+
+```bash
+azsdk config codeowners check-package-owners --package <name> --directory-path <relative-path> [--repo <owner/repo>]
+```
+
+- `--package` (required): Package name (maps to `Custom.Package` work item field).
+- `--directory-path` (required): Relative path from repo root to the package directory (e.g., `sdk/contoso/Azure.Contoso.WidgetManager`).
+- `--repo` (optional): Repository in `owner/repo` format. Auto-resolved from git if omitted.
+- MCP tool: `azsdk_engsys_codeowner_check_package_owners`
+
+## Validation Rules
+
+Two paths to validity — **Package-level** (primary) and **Path-based fallback**:
+
+### Primary Path: Package-Level Ownership
+
+If the Package work item has sufficient direct owners, use this path. All three checks must pass:
+
+1. **Package Owners ≥ 2 unique individuals**: The Package work item must have at least 2 unique individual GitHub users as owners. Teams are expanded via `ITeamUserCache`. If the package has 1 or more owners but fewer than 2 unique individuals, the check **fails** (no fallback).
+2. **Has PR Label**: The Package work item must have at least 1 linked Label.
+3. **Service Owners ≥ 2 unique individuals**: There must exist a `Label Owner` work item of type `Service Owner` in the same repo whose linked labels are a **superset** of all the package's PR labels, and whose owners (after team expansion) include at least 2 unique individuals.
+
+If Service Owner coverage is split across multiple `Label Owner` records such that rendering or human inspection might imply equivalent coverage, but no **single** `Service Owner` record has labels covering the full required set, the check **fails**. Cleanup/canonicalization of that data shape is out of scope for this command and belongs in a future validator feature.
+
+### Fallback Path: Path-Based Label Owner Ownership
+
+If the package has **zero direct owners**, fall back to checking Label Owners whose `RepoPath` glob expression matches the package's `directoryPath`. Glob matching uses `DirectoryUtils.PathExpressionMatchesTargetPath` from `Azure.Sdk.Tools.CodeownersUtils`.
+
+Before path comparison, normalize both `Label Owner`.`RepoPath` and `directoryPath` to a single leading-slash form (for example, `sdk/contoso` -> `/sdk/contoso`).
+
+The check proceeds in two steps for **at least one label**:
+
+1. **PR Label owners ≥ 2 unique individuals**: Find `Label Owner` work items of type `PR Label` whose `RepoPath` glob matches `directoryPath`. If multiple PR Label Label Owners match, sort them by normalized `RepoPath` and choose the last matching `Label Owner` as the required PR Label source. That selected Label Owner must have ≥ 2 unique individuals (after team expansion), and only that selected Label Owner's linked labels become the required PR label set.
+2. **Service Owners ≥ 2 unique individuals with matching labels**: Find a `Label Owner` work item of type `Service Owner` whose linked labels are a **superset** of the required PR label set from the selected PR Label Label Owner (no path restriction — can be pathless or have any path). That Service Owner must have ≥ 2 unique individuals (after team expansion).
+
+The PR Label and Service Owner sets **can be the same people**. If the fallback path succeeds (matching PR Label owners found with a label satisfies the "has PR label" requirement too).
+
+### Summary Decision Tree
+
+```
+Package has any direct owners?
+  YES (≥ 1) → Check ≥ 2 unique individuals (fail if < 2, no fallback)
+               → Check PR label(s) exist on Package
+               → Check a single Service Owner Label Owner exists in repo
+                 whose labels ⊇ all PR labels AND has ≥ 2 unique individuals
+  NO (0)   → Find PR Label type Label Owners where RepoPath glob matches directoryPath
+              → Sort matching PR Label Label Owners by normalized path and choose the last one
+              → Use that selected PR Label Label Owner's labels as the required PR label set
+              → Check selected PR Label owners have ≥ 2 unique individuals
+              → Check a single Service Owner Label Owner exists
+                whose labels ⊇ the selected PR Label Label Owner's labels AND has ≥ 2 unique individuals
+                (Service Owners do NOT need to match the path)
+```
+
+Team expansion uses the existing `ITeamUserCache` infrastructure.
+
+> **Note:** All ownership data is determined from the Azure DevOps work item data model (Package, Owner, Label, Label Owner work items and their relations), not from parsing the CODEOWNERS file directly. See [Spec: Codeowners Management](docs/specs/7-operations-codeowners-management.spec.md) for the full data model definition.
+
+## Proposed Approach
+
+### 1. Response Model — `CheckPackageOwnersResponse`
+
+New file: `Models/Responses/Codeowners/CheckPackageOwnersResponse.cs`
+
+A structured response inheriting from `CommandResponse` with:
+- `PackageName` (string)
+- `DirectoryPath` (string)
+- `Repo` (string)
+- `ValidationPath` (string) — `"Package"` or `"PathFallback"` indicating which path was used
+- `OwnerCheck` — sub-object: `{ passed, required, actual, owners[] }`
+- `PrLabelCheck` — sub-object: `{ passed, labels[] }` (only in Package path)
+- `ServiceOwnerCheck` — sub-object: `{ passed, required, actual, owners[], requiredLabels[], matchedLabels[] }` (primary and fallback paths)
+- `PathFallbackCheck` — sub-object: `{ prLabelOwnerCheck: { passed, required, actual, owners[], labels[] }, serviceOwnerCheck: { passed, required, actual, owners[], requiredLabels[], matchedLabels[] } }` (only in fallback path)
+- `AllPassed` (bool) — summary
+
+Prefer shared nested check models to avoid duplicating the same payload shape in multiple places, but only collapse fields if the resulting response stays straightforward to read in both JSON and formatted text output.
+
+Exit code: 0 if all pass, 1 if any fail.
+
+Formatted text output shows each check with PASS/FAIL and details.
+
+### 2. Helper Method — `ICodeownersManagementHelper.CheckPackageOwners`
+
+New method on the existing interface + implementation in `CodeownersManagementHelper`:
+
+```csharp
+Task<CheckPackageOwnersResponse> CheckPackageOwners(
+    string packageName, string directoryPath, string repo, CancellationToken ct);
+```
+
+Logic:
+1. Look up Package work items by name + repo (consistent with existing `FindPackageByName` logic). If multiple matches exist, select the latest version using `Custom.PackageVersionMajorMinor` via `WorkItemMappers.GetLatestPackageVersions`.
+2. If not found, return error response.
+3. Hydrate the package to get owners and labels.
+4. **Owner check**: Expand team owners via `ITeamUserCache`, collect distinct individual aliases, check count ≥ 2.
+5. **If owners ≥ 1 (primary path — fail if < 2, no fallback)**:
+   - **PR Label check**: Check that `package.Labels.Count >= 1`.
+   - **Service Owner check**: Query `Label Owner` work items of type `Service Owner` in the repo. Find one whose linked labels are a superset of all the package's PR labels. Hydrate, expand teams, check ≥ 2 unique individuals. Do not aggregate coverage across multiple Service Owner records.
+6. **If owners == 0 (fallback path)**:
+   - Query `Label Owner` work items of type `PR Label` in the repo. Filter to those whose `RepoPath` glob matches `directoryPath` using `DirectoryUtils.PathExpressionMatchesTargetPath`.
+   - Sort the matching PR Label Label Owners by normalized `RepoPath` and choose the last matching Label Owner.
+   - Hydrate the selected PR Label Label Owner to get its owners and labels. Expand teams, check ≥ 2 unique individuals.
+   - Use the selected PR Label Label Owner's linked labels as the required PR label set. Do not union labels across multiple matching PR Label Label Owners.
+   - Query `Label Owner` work items of type `Service Owner` in the repo. Find one whose linked labels are a superset of the required PR label set (no path restriction). Hydrate, expand teams, check ≥ 2 unique individuals. Do not aggregate coverage across multiple Service Owner records.
+   - If both checks pass, the fallback passes.
+
+### 3. Command Registration in `CodeownersTool`
+
+Add to `GetCommands()`:
+- New command `check-package-owners` with a new required `checkPackageOption`, a new required `directoryPathOption`, and `optionalRepoOption`.
+
+Add to `HandleCommand()`:
+- Route to new `CheckPackageOwners` method that calls `ResolveRepo` then delegates to the helper.
+
+### 4. `checkPackageOption` and `directoryPath` option
+
+New required option in `CodeownersTool` for this command only:
+```csharp
+private readonly Option<string> checkPackageOption = new("--package")
+{
+    Description = "Package name",
+    Required = true,
+};
+```
+
+New option in `CodeownersTool`:
+```csharp
+private readonly Option<string> directoryPathOption = new("--directory-path")
+{
+    Description = "Relative path to the package directory from the repo root",
+    Required = true,
+};
+```
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `Models/Responses/Codeowners/CheckPackageOwnersResponse.cs` | **New** — Response model |
+| `Helpers/ICodeownersManagementHelper.cs` | Add `CheckPackageOwners` method to interface |
+| `Helpers/CodeownersManagementHelper.cs` | Implement `CheckPackageOwners` |
+| `Tools/Config/CodeownersTool.cs` | Add command, option, routing, and public method |
+| `Tests/Helpers/CodeownersManagementHelperTests.cs` | Helper-level tests |
+
+## Testing Strategy
+
+### Unit Tests — Helper Level (`CodeownersManagementHelperTests.cs`)
+
+Tests for `CheckPackageOwners` with mocked `IDevOpsService` and `ITeamUserCache`:
+
+**Primary Path Tests:**
+
+| # | Test | Scenario |
+|---|------|----------|
+| 1 | `CheckPackageOwners_AllChecksPass` | Package has 2+ owners, 1+ label, and one Service Owner Label Owner whose labels ⊇ all package PR labels and whose owners expand to ≥ 2 individuals |
+| 2 | `CheckPackageOwners_PackageNotFound_ReturnsError` | No matching package work item |
+| 3 | `CheckPackageOwners_InsufficientOwners_Fails` | Package has 1 owner (< 2 unique individuals) → fails immediately, no fallback |
+| 4 | `CheckPackageOwners_NoOwners_TriggersPathFallback` | Package has 0 owners → falls to path-based check |
+| 5 | `CheckPackageOwners_NoPrLabel_Fails` | Package has 2+ owners but no labels → PrLabelCheck fails |
+| 6 | `CheckPackageOwners_InsufficientServiceOwners_Fails` | Matching Service Owner Label Owner has only 1 individual |
+| 7 | `CheckPackageOwners_NoServiceOwners_Fails` | No Service Owner Label Owner has labels ⊇ package's PR labels |
+| 8 | `CheckPackageOwners_TeamExpansion_CountsIndividuals` | 1 team owner with 3 members satisfies 2-owner requirement |
+| 9 | `CheckPackageOwners_TeamExpansion_ServiceOwners` | 1 team-type service owner with 3 members satisfies 2-service-owner requirement |
+| 10 | `CheckPackageOwners_MultipleLabels_ServiceOwnerSupersetRequired` | Package has 2 PR labels; Service Owner must have both labels on a single Label Owner record to pass |
+| 11 | `CheckPackageOwners_FragmentedServiceOwners_Fails` | Multiple Service Owner Label Owner records collectively cover the labels, but no single record has the full label superset → fails |
+| 12 | `CheckPackageOwners_MultiplePackageVersions_UsesLatestByName` | Multiple Package work items match by name; helper selects the one with the latest `Custom.PackageVersionMajorMinor` |
+| 13 | `CheckPackageOwners_OverlappingOwners_Deduplication` | Same user in team + individual doesn't double-count |
+**Path-Based Fallback Tests:**
+
+| # | Test | Scenario |
+|---|------|----------|
+| 14 | `CheckPackageOwners_Fallback_BothPrLabelAndServiceOwnerPass` | No package owners, but the selected path-matching PR Label Label Owner and a matching Service Owner Label Owner each have ≥ 2 individuals → passes |
+| 15 | `CheckPackageOwners_Fallback_PrLabelOwnersInsufficient` | A PR Label path match is selected, but its owners expand to < 2 individuals → fails |
+| 16 | `CheckPackageOwners_Fallback_ServiceOwnersInsufficient` | The selected PR Label path match is valid, but the matching single Service Owner record has < 2 individuals → fails |
+| 17 | `CheckPackageOwners_Fallback_NoMatchingPaths` | No PR Label type Label Owners have paths matching directoryPath → fails |
+| 18 | `CheckPackageOwners_Fallback_GlobMatch` | Label Owner path is a glob (e.g., `/sdk/contoso/`) that matches `sdk/contoso/Azure.Contoso.WidgetManager` |
+| 19 | `CheckPackageOwners_Fallback_MultipleMatchingPrLabelOwners_UsesLastByPath` | Multiple PR Label Label Owners match the path; helper sorts them by normalized path, chooses the last one, and uses only that record's labels |
+| 20 | `CheckPackageOwners_Fallback_MultipleLabels_ServiceOwnerSupersetRequired` | The selected PR Label Label Owner has labels ["A", "B"]; Service Owner must have both labels on a single Label Owner record to pass |
+| 21 | `CheckPackageOwners_Fallback_FragmentedServiceOwners_Fails` | Multiple Service Owner Label Owner records collectively cover the labels from the selected PR Label Label Owner, but no single record has the full label superset → fails |
+| 22 | `CheckPackageOwners_Fallback_SameOwnersForBothTypes` | Same individuals are PR Label owners and Service Owners → passes |
+| 23 | `CheckPackageOwners_Fallback_ServiceOwnerPathless` | Service Owner for the selected PR Label Label Owner's label set has no RepoPath (pathless) but still satisfies the check → passes |
+
+## Notes
+
+- The command has both CLI and MCP bindings (`[McpServerTool]` with name `azsdk_engsys_codeowner_check_package_owners`).
+- Team expansion reuses the existing `ITeamUserCache` / `ExpandTeamOwners` pattern already in `CodeownersManagementHelper`.
+- Package lookup for this command is by package name + repo only.
+- The `directoryPath` parameter is used as the target path for glob matching against Label Owner `RepoPath` in the path-based fallback.
+- When multiple Package work items match by package name + repo, resolve to the latest package version using `Custom.PackageVersionMajorMinor`, consistent with existing package lookup behavior.
+- Normalize `directoryPath` and Label Owner `RepoPath` to a consistent leading-slash form before glob matching.
+- When multiple PR Label Label Owners match the fallback path, sort them by normalized path and use the last matching Label Owner as the required PR Label source rather than unioning labels across all matches.
+- Glob matching uses `DirectoryUtils.PathExpressionMatchesTargetPath` from the existing `Azure.Sdk.Tools.CodeownersUtils` project reference.
+- Service Owner coverage is intentionally evaluated against a single `Label Owner` record with a label superset; cleanup of fragmented-but-equivalent Label Owner data is future validator work rather than part of this command.
+- Exit code behavior (0 = pass, 1 = fail) makes this directly usable as a CI gate step.
+- When the primary path is used (package has ≥ 2 owners), the response includes `ValidationPath = "Package"`. When the fallback is used, `ValidationPath = "PathFallback"`.


### PR DESCRIPTION
Checks the data model for owners on the package, a PR label for the package, and service owners for the label. If more than 2 unique owners for package and 2 unique owners for service label (package and service label owners can be the same), pass. If not, fail. 