### PR TITLE
[spec-gen-sdk] Added new tests

### DIFF
--- a/tools/spec-gen-sdk/test/automation/workflow.test.ts
+++ b/tools/spec-gen-sdk/test/automation/workflow.test.ts
@@ -595,6 +595,34 @@ describe('workflow', () => {
       expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('not provided'));
     });
 
+    it('should generate SDK successfully when sdkReleaseType is undefined', async () => {
+      mockWorkflowContext.config.sdkReleaseType = undefined;
+      mockWorkflowContext.specConfigPath = 'test/tspconfig.yaml';
+      vi.mocked(workflowCallGenerateScript).mockResolvedValue({
+        status: 'succeeded',
+        generateInput: {
+          specFolder: 'spec',
+          headSha: 'sha123',
+          repoHttpsUrl: 'https://github.com/test/repo',
+          changedFiles: [],
+          runMode: 'test',
+          installInstructionInput: {
+            isPublic: true,
+            downloadUrlPrefix: '',
+            downloadCommandTemplate: 'downloadCommand',
+          },
+        },
+        generateOutput: {
+          packages: [{ packageName: 'test-package', path: ['test'], result: 'succeeded' }],
+        },
+      });
+
+      await workflowGenerateSdk(mockWorkflowContext);
+
+      expect(workflowCallGenerateScript).toHaveBeenCalledWith(mockWorkflowContext, [], [], ['test']);
+      expect(mockWorkflowContext.handledPackages).toHaveLength(1);
+    });
+
     it('should process all packages sequentially', async () => {
       vi.mocked(workflowCallGenerateScript).mockResolvedValue({
         status: 'succeeded',

--- a/tools/spec-gen-sdk/test/automation/workflowHelpers.test.ts
+++ b/tools/spec-gen-sdk/test/automation/workflowHelpers.test.ts
@@ -110,6 +110,66 @@ describe('workflowHelpers', () => {
         []
       )).rejects.toThrow('generateScript is not configured');
     });
+
+    it('should pass sdkReleaseType as undefined in generateInput when not provided', async () => {
+      mockContext.config.sdkReleaseType = undefined;
+
+      const mockGenerateOutput = {
+        packages: [
+          {
+            packageName: 'test-package',
+            path: ['path/to/package'],
+            result: 'succeeded'
+          }
+        ]
+      };
+
+      vi.spyOn(fsUtils, 'writeTmpJsonFile').mockImplementation(() => undefined);
+      vi.spyOn(fsUtils, 'deleteTmpJsonFile').mockImplementation(() => undefined);
+      vi.spyOn(fsUtils, 'readTmpJsonFile').mockReturnValue(mockGenerateOutput);
+      vi.spyOn(runScript, 'runSdkAutoCustomScript').mockResolvedValue('succeeded');
+
+      const result = await workflowCallGenerateScript(
+        mockContext,
+        ['file1.tsp'],
+        [],
+        ['project1']
+      );
+
+      expect(result.status).toBe('succeeded');
+      const writtenInput = vi.mocked(fsUtils.writeTmpJsonFile).mock.calls[0][2] as any;
+      expect(writtenInput.sdkReleaseType).toBeUndefined();
+    });
+
+    it('should pass sdkReleaseType in generateInput when provided as stable', async () => {
+      mockContext.config.sdkReleaseType = 'stable';
+
+      const mockGenerateOutput = {
+        packages: [
+          {
+            packageName: 'test-package',
+            path: ['path/to/package'],
+            result: 'succeeded'
+          }
+        ]
+      };
+
+      vi.spyOn(fsUtils, 'writeTmpJsonFile').mockImplementation(() => undefined);
+      vi.spyOn(fsUtils, 'deleteTmpJsonFile').mockImplementation(() => undefined);
+      vi.spyOn(fsUtils, 'readTmpJsonFile').mockReturnValue(mockGenerateOutput);
+      vi.spyOn(runScript, 'runSdkAutoCustomScript').mockResolvedValue('succeeded');
+
+      const result = await workflowCallGenerateScript(
+        mockContext,
+        ['file1.tsp'],
+        [],
+        ['project1']
+      );
+
+      expect(result.status).toBe('succeeded');
+      const writtenInput = vi.mocked(fsUtils.writeTmpJsonFile).mock.calls[0][2] as any;
+      expect(writtenInput.sdkReleaseType).toBe('stable');
+    });
   });
 
   describe('workflowDetectChangedPackages', () => {


### PR DESCRIPTION
This pull request adds new test cases to improve coverage for handling the `sdkReleaseType` configuration in the SDK generation workflow. The main focus is to ensure that the workflow correctly passes `sdkReleaseType` as either `undefined` or a specific value, and that SDK generation proceeds as expected in both scenarios.

**Test coverage improvements:**

* Added a test to verify that SDK generation succeeds when `sdkReleaseType` is `undefined`, and that the workflow processes the expected packages (`workflow.test.ts`).
* Added tests to confirm that `sdkReleaseType` is correctly passed as `undefined` or as `'stable'` in the `generateInput` when invoking the script (`workflowHelpers.test.ts`).