### PR TITLE
Support Rust in azsdk-cli package build tool

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/ProgressReporterTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/ProgressReporterTests.cs
@@ -147,7 +147,7 @@ public class ProgressReporterTests
 
     private static async Task DelayWithRetry<T>(List<T> counter, int maxRetries)
     {
-        var timeout = TimeSpan.FromMilliseconds(100);
+        var timeout = TimeSpan.FromMilliseconds(500);
         var sw = Stopwatch.StartNew();
         while (counter.Count < maxRetries && sw.Elapsed < timeout)
         {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/RustLanguageServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/RustLanguageServiceTests.cs
@@ -53,13 +53,13 @@ public class RustLanguageServiceTests
     }
 
     /// <summary>
-    /// Sets up the mock process helper to return a successful cargo read-manifest response.
+    /// Sets up the mock process helper to return a successful cargo metadata response.
     /// </summary>
-    private void SetupCargoReadManifest(string name, string version)
+    private void SetupCargoMetadata(string name, string version)
     {
-        var json = JsonSerializer.Serialize(new { name, version });
+        var json = JsonSerializer.Serialize(new { packages = new[] { new { name, version } } });
         _mockProcessHelper
-            .Setup(x => x.Run(It.Is<ProcessOptions>(o => o.Args.Contains("read-manifest")), It.IsAny<CancellationToken>()))
+            .Setup(x => x.Run(It.Is<ProcessOptions>(o => o.Args.Contains("metadata")), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, json)] });
     }
 
@@ -217,7 +217,7 @@ public class RustLanguageServiceTests
             .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_tempDirectory.DirectoryPath);
 
-        SetupCargoReadManifest("azure_core", "0.34.0");
+        SetupCargoMetadata("azure_core", "0.34.0");
 
         // Act
         var info = await _service.GetPackageInfo(packageDir);
@@ -236,19 +236,19 @@ public class RustLanguageServiceTests
     [Test]
     public async Task GetPackageInfo_MgmtPackage_ReturnsMgmtSdkType()
     {
-        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "resourcemanager", "azure_mgmt_compute");
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "compute", "azure_resourcemanager_compute");
         Directory.CreateDirectory(packageDir);
-        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), "[package]\nname = \"azure_mgmt_compute\"\n");
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), "[package]\nname = \"azure_resourcemanager_compute\"\n");
 
         _mockGitHelper
             .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_tempDirectory.DirectoryPath);
 
-        SetupCargoReadManifest("azure_mgmt_compute", "0.1.0");
+        SetupCargoMetadata("azure_resourcemanager_compute", "0.1.0");
 
         var info = await _service.GetPackageInfo(packageDir);
 
-        Assert.That(info.PackageName, Is.EqualTo("azure_mgmt_compute"));
+        Assert.That(info.PackageName, Is.EqualTo("azure_resourcemanager_compute"));
         Assert.That(info.SdkTypeString, Is.EqualTo("mgmt"));
     }
 
@@ -267,7 +267,7 @@ public class RustLanguageServiceTests
         Assert.That(info.PackageName, Is.Null);
         Assert.That(info.PackageVersion, Is.Null);
         Assert.That(info.Language, Is.EqualTo(SdkLanguage.Rust));
-        // cargo read-manifest should NOT be called when Cargo.toml is missing
+        // cargo metadata should NOT be called when Cargo.toml is missing
         _mockProcessHelper.Verify(
             x => x.Run(It.IsAny<ProcessOptions>(), It.IsAny<CancellationToken>()),
             Times.Never);
@@ -276,17 +276,17 @@ public class RustLanguageServiceTests
     [Test]
     public async Task GetPackageInfo_WithReadmeAndChangelog_SetsPathsCorrectly()
     {
-        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "storage", "azure_storage_blobs");
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "storage", "azure_storage_blob");
         Directory.CreateDirectory(packageDir);
-        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), "[package]\nname = \"azure_storage_blobs\"\n");
-        File.WriteAllText(Path.Combine(packageDir, "README.md"), "# Azure Storage Blobs");
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), "[package]\nname = \"azure_storage_blob\"\n");
+        File.WriteAllText(Path.Combine(packageDir, "README.md"), "# Azure Storage Blob");
         File.WriteAllText(Path.Combine(packageDir, "CHANGELOG.md"), "## 0.2.0\n- Initial release");
 
         _mockGitHelper
             .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_tempDirectory.DirectoryPath);
 
-        SetupCargoReadManifest("azure_storage_blobs", "0.2.0");
+        SetupCargoMetadata("azure_storage_blob", "0.2.0");
 
         var info = await _service.GetPackageInfo(packageDir);
 
@@ -295,7 +295,7 @@ public class RustLanguageServiceTests
     }
 
     [Test]
-    public async Task GetPackageInfo_CargoReadManifestFails_ReturnsEmptyPackageInfo()
+    public async Task GetPackageInfo_CargoMetadataFails_ReturnsEmptyPackageInfo()
     {
         var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "core", "azure_core_macros");
         Directory.CreateDirectory(packageDir);
@@ -307,8 +307,8 @@ public class RustLanguageServiceTests
 
         // Simulate cargo failing (e.g., workspace root not found)
         _mockProcessHelper
-            .Setup(x => x.Run(It.Is<ProcessOptions>(o => o.Args.Contains("read-manifest")), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ProcessResult { ExitCode = 101, OutputDetails = [(StdioLevel.StandardError, "error: failed to read manifest")] });
+            .Setup(x => x.Run(It.Is<ProcessOptions>(o => o.Args.Contains("metadata")), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessResult { ExitCode = 101, OutputDetails = [(StdioLevel.StandardError, "error: failed to parse manifest")] });
 
         var info = await _service.GetPackageInfo(packageDir);
 
@@ -318,7 +318,7 @@ public class RustLanguageServiceTests
 
     #endregion
 
-    #region GetPackageInfo - cargo read-manifest edge cases
+    #region GetPackageInfo - cargo metadata edge cases
 
     [Test]
     public async Task GetPackageInfo_PreReleaseVersion_ExtractsCorrectly()
@@ -331,7 +331,7 @@ public class RustLanguageServiceTests
             .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_tempDirectory.DirectoryPath);
 
-        SetupCargoReadManifest("azure_core", "1.2.3-beta.1");
+        SetupCargoMetadata("azure_core", "1.2.3-beta.1");
 
         var info = await _service.GetPackageInfo(packageDir);
 
@@ -341,7 +341,7 @@ public class RustLanguageServiceTests
     [Test]
     public async Task GetPackageInfo_CargoOutputWithExtraFields_ParsesCorrectly()
     {
-        // cargo read-manifest returns many fields; ensure we extract just name and version
+        // cargo metadata returns many fields; ensure we extract just name and version
         var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "test", "my_crate");
         Directory.CreateDirectory(packageDir);
         File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), "[package]\nname = \"my_crate\"\n");
@@ -352,17 +352,20 @@ public class RustLanguageServiceTests
 
         var fullJson = JsonSerializer.Serialize(new
         {
-            name = "my_crate",
-            version = "0.1.0",
-            id = "my_crate 0.1.0 (path+file:///tmp/sdk/test/my_crate)",
-            license = "MIT",
-            description = "A test crate",
-            edition = "2021",
-            dependencies = new[] { new { name = "serde", version = "1.0" } }
+            packages = new[] { new
+            {
+                name = "my_crate",
+                version = "0.1.0",
+                id = "my_crate 0.1.0 (path+file:///tmp/sdk/test/my_crate)",
+                license = "MIT",
+                description = "A test crate",
+                edition = "2021",
+                dependencies = new[] { new { name = "serde", version = "1.0" } }
+            }}
         });
 
         _mockProcessHelper
-            .Setup(x => x.Run(It.Is<ProcessOptions>(o => o.Args.Contains("read-manifest")), It.IsAny<CancellationToken>()))
+            .Setup(x => x.Run(It.Is<ProcessOptions>(o => o.Args.Contains("metadata")), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, fullJson)] });
 
         var info = await _service.GetPackageInfo(packageDir);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/RustLanguageServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/RustLanguageServiceTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Diagnostics;
 using System.Text.Json;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/RustLanguageServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/RustLanguageServiceTests.cs
@@ -52,11 +52,17 @@ public class RustLanguageServiceTests
         _tempDirectory.Dispose();
     }
 
+    #region Language Identity
+
     [Test]
     public void Language_ReturnsRust()
     {
         Assert.That(_service.Language, Is.EqualTo(SdkLanguage.Rust));
     }
+
+    #endregion
+
+    #region BuildAsync Tests
 
     [Test]
     public async Task BuildAsync_EmptyPath_ReturnsFailure()
@@ -79,7 +85,6 @@ public class RustLanguageServiceTests
     [Test]
     public async Task BuildAsync_MissingBuildScript_ReturnsFailure()
     {
-        // Arrange - repo root exists but no build script
         var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "mypackage");
         Directory.CreateDirectory(packageDir);
 
@@ -87,10 +92,8 @@ public class RustLanguageServiceTests
             .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_tempDirectory.DirectoryPath);
 
-        // Act
         var (success, errorMessage, _) = await _service.BuildAsync(packageDir);
 
-        // Assert
         Assert.That(success, Is.False);
         Assert.That(errorMessage, Does.Contain("Build script not found"));
     }
@@ -98,7 +101,6 @@ public class RustLanguageServiceTests
     [Test]
     public async Task BuildAsync_ScriptExists_ExecutesPowershell()
     {
-        // Arrange - create the package dir and the build script
         var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "mypackage");
         Directory.CreateDirectory(packageDir);
         var scriptDir = Path.Combine(_tempDirectory.DirectoryPath, "eng", "scripts");
@@ -113,10 +115,8 @@ public class RustLanguageServiceTests
             .Setup(x => x.Run(It.IsAny<PowershellOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Build succeeded")] });
 
-        // Act
         var (success, errorMessage, _) = await _service.BuildAsync(packageDir);
 
-        // Assert
         Assert.That(success, Is.True);
         Assert.That(errorMessage, Is.Null);
         _mockPowershellHelper.Verify(x => x.Run(
@@ -129,7 +129,6 @@ public class RustLanguageServiceTests
     [Test]
     public async Task BuildAsync_ScriptFails_ReturnsFailure()
     {
-        // Arrange
         var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "mypackage");
         Directory.CreateDirectory(packageDir);
         var scriptDir = Path.Combine(_tempDirectory.DirectoryPath, "eng", "scripts");
@@ -144,10 +143,8 @@ public class RustLanguageServiceTests
             .Setup(x => x.Run(It.IsAny<PowershellOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardOutput, "compilation error")] });
 
-        // Act
         var (success, errorMessage, _) = await _service.BuildAsync(packageDir);
 
-        // Assert
         Assert.That(success, Is.False);
         Assert.That(errorMessage, Does.Contain("Build failed with exit code 1"));
         Assert.That(errorMessage, Does.Contain("compilation error"));
@@ -156,7 +153,6 @@ public class RustLanguageServiceTests
     [Test]
     public async Task BuildAsync_DiscoverRepoRootFails_ReturnsFailure()
     {
-        // Arrange
         var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "mypackage");
         Directory.CreateDirectory(packageDir);
 
@@ -164,10 +160,8 @@ public class RustLanguageServiceTests
             .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(string.Empty);
 
-        // Act
         var (success, errorMessage, _) = await _service.BuildAsync(packageDir);
 
-        // Assert
         Assert.That(success, Is.False);
         Assert.That(errorMessage, Does.Contain("Failed to discover local sdk repo"));
     }
@@ -175,7 +169,6 @@ public class RustLanguageServiceTests
     [Test]
     public async Task BuildAsync_DoesNotUseSpecGenSdkConfig()
     {
-        // Arrange - verify Rust doesn't call specGenSdkConfigHelper
         var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "mypackage");
         Directory.CreateDirectory(packageDir);
         var scriptDir = Path.Combine(_tempDirectory.DirectoryPath, "eng", "scripts");
@@ -190,12 +183,182 @@ public class RustLanguageServiceTests
             .Setup(x => x.Run(It.IsAny<PowershellOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "ok")] });
 
-        // Act
         await _service.BuildAsync(packageDir);
 
-        // Assert - specGenSdkConfigHelper should never be called for Rust builds
         _mockSpecGenSdkConfigHelper.Verify(
             x => x.GetConfigurationAsync(It.IsAny<string>(), It.IsAny<SpecGenSdkConfigType>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
+
+    #endregion
+
+    #region GetPackageInfo Tests
+
+    [Test]
+    public async Task GetPackageInfo_ValidCargoToml_ReturnsCorrectInfo()
+    {
+        // Arrange - create sdk/core/azure_core/Cargo.toml
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "core", "azure_core");
+        Directory.CreateDirectory(packageDir);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), """
+            [package]
+            name = "azure_core"
+            version = "0.34.0"
+            description = "Azure Core crate"
+            edition = "2021"
+
+            [dependencies]
+            serde = "1.0"
+            """);
+
+        _mockGitHelper
+            .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_tempDirectory.DirectoryPath);
+
+        // Act
+        var info = await _service.GetPackageInfo(packageDir);
+
+        // Assert
+        Assert.That(info.PackageName, Is.EqualTo("azure_core"));
+        Assert.That(info.PackageVersion, Is.EqualTo("0.34.0"));
+        Assert.That(info.Language, Is.EqualTo(SdkLanguage.Rust));
+        Assert.That(info.SdkTypeString, Is.EqualTo("client"));
+        Assert.That(info.IsNewSdk, Is.True);
+        Assert.That(info.ArtifactName, Is.EqualTo("azure_core"));
+        Assert.That(info.ServiceName, Is.EqualTo("core"));
+        Assert.That((string)info.ServiceDirectory!, Does.Contain("core"));
+    }
+
+    [Test]
+    public async Task GetPackageInfo_MgmtPackage_ReturnsMgmtSdkType()
+    {
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "resourcemanager", "azure_mgmt_compute");
+        Directory.CreateDirectory(packageDir);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), """
+            [package]
+            name = "azure_mgmt_compute"
+            version = "0.1.0"
+            """);
+
+        _mockGitHelper
+            .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_tempDirectory.DirectoryPath);
+
+        var info = await _service.GetPackageInfo(packageDir);
+
+        Assert.That(info.PackageName, Is.EqualTo("azure_mgmt_compute"));
+        Assert.That(info.SdkTypeString, Is.EqualTo("mgmt"));
+    }
+
+    [Test]
+    public async Task GetPackageInfo_NoCargoToml_ReturnsEmptyPackageInfo()
+    {
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "core", "missing_crate");
+        Directory.CreateDirectory(packageDir);
+
+        _mockGitHelper
+            .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_tempDirectory.DirectoryPath);
+
+        var info = await _service.GetPackageInfo(packageDir);
+
+        Assert.That(info.PackageName, Is.Null);
+        Assert.That(info.PackageVersion, Is.Null);
+        Assert.That(info.Language, Is.EqualTo(SdkLanguage.Rust));
+    }
+
+    [Test]
+    public async Task GetPackageInfo_WithReadmeAndChangelog_SetsPathsCorrectly()
+    {
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "storage", "azure_storage_blobs");
+        Directory.CreateDirectory(packageDir);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), """
+            [package]
+            name = "azure_storage_blobs"
+            version = "0.2.0"
+            """);
+        File.WriteAllText(Path.Combine(packageDir, "README.md"), "# Azure Storage Blobs");
+        File.WriteAllText(Path.Combine(packageDir, "CHANGELOG.md"), "## 0.2.0\n- Initial release");
+
+        _mockGitHelper
+            .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_tempDirectory.DirectoryPath);
+
+        var info = await _service.GetPackageInfo(packageDir);
+
+        Assert.That((string)info.ReadMePath, Does.Contain("README.md"));
+        Assert.That((string)info.ChangeLogPath, Does.Contain("CHANGELOG.md"));
+    }
+
+    [Test]
+    public async Task GetPackageInfo_WorkspaceInheritedVersion_ReturnsNullVersion()
+    {
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "core", "azure_core_macros");
+        Directory.CreateDirectory(packageDir);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), """
+            [package]
+            name = "azure_core_macros"
+            version.workspace = true
+            edition.workspace = true
+            """);
+
+        _mockGitHelper
+            .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_tempDirectory.DirectoryPath);
+
+        var info = await _service.GetPackageInfo(packageDir);
+
+        Assert.That(info.PackageName, Is.EqualTo("azure_core_macros"));
+        Assert.That(info.PackageVersion, Is.Null);
+    }
+
+    #endregion
+
+    #region ExtractCargoField (tested via GetPackageInfo)
+
+    [Test]
+    public async Task GetPackageInfo_PreReleaseVersion_ExtractsCorrectly()
+    {
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "core", "azure_core");
+        Directory.CreateDirectory(packageDir);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), """
+            [package]
+            name = "azure_core"
+            version = "1.2.3-beta.1"
+            """);
+
+        _mockGitHelper
+            .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_tempDirectory.DirectoryPath);
+
+        var info = await _service.GetPackageInfo(packageDir);
+
+        Assert.That(info.PackageVersion, Is.EqualTo("1.2.3-beta.1"));
+    }
+
+    [Test]
+    public async Task GetPackageInfo_NoDependenciesSection_DoesNotConfuse()
+    {
+        // Ensure field extraction only looks in [package], not [dependencies]
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "test", "my_crate");
+        Directory.CreateDirectory(packageDir);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), """
+            [package]
+            name = "my_crate"
+            version = "0.1.0"
+
+            [dependencies]
+            name = "should_not_match"
+            """);
+
+        _mockGitHelper
+            .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_tempDirectory.DirectoryPath);
+
+        var info = await _service.GetPackageInfo(packageDir);
+
+        Assert.That(info.PackageName, Is.EqualTo("my_crate"));
+    }
+
+    #endregion
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/RustLanguageServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/RustLanguageServiceTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics;
+using System.Text.Json;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Services;
@@ -50,6 +51,17 @@ public class RustLanguageServiceTests
     public void TearDown()
     {
         _tempDirectory.Dispose();
+    }
+
+    /// <summary>
+    /// Sets up the mock process helper to return a successful cargo read-manifest response.
+    /// </summary>
+    private void SetupCargoReadManifest(string name, string version)
+    {
+        var json = JsonSerializer.Serialize(new { name, version });
+        _mockProcessHelper
+            .Setup(x => x.Run(It.Is<ProcessOptions>(o => o.Args.Contains("read-manifest")), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, json)] });
     }
 
     #region Language Identity
@@ -200,20 +212,13 @@ public class RustLanguageServiceTests
         // Arrange - create sdk/core/azure_core/Cargo.toml
         var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "core", "azure_core");
         Directory.CreateDirectory(packageDir);
-        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), """
-            [package]
-            name = "azure_core"
-            version = "0.34.0"
-            description = "Azure Core crate"
-            edition = "2021"
-
-            [dependencies]
-            serde = "1.0"
-            """);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), "[package]\nname = \"azure_core\"\n");
 
         _mockGitHelper
             .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_tempDirectory.DirectoryPath);
+
+        SetupCargoReadManifest("azure_core", "0.34.0");
 
         // Act
         var info = await _service.GetPackageInfo(packageDir);
@@ -234,15 +239,13 @@ public class RustLanguageServiceTests
     {
         var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "resourcemanager", "azure_mgmt_compute");
         Directory.CreateDirectory(packageDir);
-        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), """
-            [package]
-            name = "azure_mgmt_compute"
-            version = "0.1.0"
-            """);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), "[package]\nname = \"azure_mgmt_compute\"\n");
 
         _mockGitHelper
             .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_tempDirectory.DirectoryPath);
+
+        SetupCargoReadManifest("azure_mgmt_compute", "0.1.0");
 
         var info = await _service.GetPackageInfo(packageDir);
 
@@ -265,6 +268,10 @@ public class RustLanguageServiceTests
         Assert.That(info.PackageName, Is.Null);
         Assert.That(info.PackageVersion, Is.Null);
         Assert.That(info.Language, Is.EqualTo(SdkLanguage.Rust));
+        // cargo read-manifest should NOT be called when Cargo.toml is missing
+        _mockProcessHelper.Verify(
+            x => x.Run(It.IsAny<ProcessOptions>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Test]
@@ -272,17 +279,15 @@ public class RustLanguageServiceTests
     {
         var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "storage", "azure_storage_blobs");
         Directory.CreateDirectory(packageDir);
-        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), """
-            [package]
-            name = "azure_storage_blobs"
-            version = "0.2.0"
-            """);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), "[package]\nname = \"azure_storage_blobs\"\n");
         File.WriteAllText(Path.Combine(packageDir, "README.md"), "# Azure Storage Blobs");
         File.WriteAllText(Path.Combine(packageDir, "CHANGELOG.md"), "## 0.2.0\n- Initial release");
 
         _mockGitHelper
             .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_tempDirectory.DirectoryPath);
+
+        SetupCargoReadManifest("azure_storage_blobs", "0.2.0");
 
         var info = await _service.GetPackageInfo(packageDir);
 
@@ -291,45 +296,43 @@ public class RustLanguageServiceTests
     }
 
     [Test]
-    public async Task GetPackageInfo_WorkspaceInheritedVersion_ReturnsNullVersion()
+    public async Task GetPackageInfo_CargoReadManifestFails_ReturnsEmptyPackageInfo()
     {
         var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "core", "azure_core_macros");
         Directory.CreateDirectory(packageDir);
-        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), """
-            [package]
-            name = "azure_core_macros"
-            version.workspace = true
-            edition.workspace = true
-            """);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), "[package]\nname = \"azure_core_macros\"\nversion.workspace = true\n");
 
         _mockGitHelper
             .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_tempDirectory.DirectoryPath);
 
+        // Simulate cargo failing (e.g., workspace root not found)
+        _mockProcessHelper
+            .Setup(x => x.Run(It.Is<ProcessOptions>(o => o.Args.Contains("read-manifest")), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessResult { ExitCode = 101, OutputDetails = [(StdioLevel.StandardError, "error: failed to read manifest")] });
+
         var info = await _service.GetPackageInfo(packageDir);
 
-        Assert.That(info.PackageName, Is.EqualTo("azure_core_macros"));
+        Assert.That(info.PackageName, Is.Null);
         Assert.That(info.PackageVersion, Is.Null);
     }
 
     #endregion
 
-    #region ExtractCargoField (tested via GetPackageInfo)
+    #region GetPackageInfo - cargo read-manifest edge cases
 
     [Test]
     public async Task GetPackageInfo_PreReleaseVersion_ExtractsCorrectly()
     {
         var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "core", "azure_core");
         Directory.CreateDirectory(packageDir);
-        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), """
-            [package]
-            name = "azure_core"
-            version = "1.2.3-beta.1"
-            """);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), "[package]\nname = \"azure_core\"\n");
 
         _mockGitHelper
             .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_tempDirectory.DirectoryPath);
+
+        SetupCargoReadManifest("azure_core", "1.2.3-beta.1");
 
         var info = await _service.GetPackageInfo(packageDir);
 
@@ -337,27 +340,36 @@ public class RustLanguageServiceTests
     }
 
     [Test]
-    public async Task GetPackageInfo_NoDependenciesSection_DoesNotConfuse()
+    public async Task GetPackageInfo_CargoOutputWithExtraFields_ParsesCorrectly()
     {
-        // Ensure field extraction only looks in [package], not [dependencies]
+        // cargo read-manifest returns many fields; ensure we extract just name and version
         var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "test", "my_crate");
         Directory.CreateDirectory(packageDir);
-        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), """
-            [package]
-            name = "my_crate"
-            version = "0.1.0"
-
-            [dependencies]
-            name = "should_not_match"
-            """);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), "[package]\nname = \"my_crate\"\n");
 
         _mockGitHelper
             .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_tempDirectory.DirectoryPath);
 
+        var fullJson = JsonSerializer.Serialize(new
+        {
+            name = "my_crate",
+            version = "0.1.0",
+            id = "my_crate 0.1.0 (path+file:///tmp/sdk/test/my_crate)",
+            license = "MIT",
+            description = "A test crate",
+            edition = "2021",
+            dependencies = new[] { new { name = "serde", version = "1.0" } }
+        });
+
+        _mockProcessHelper
+            .Setup(x => x.Run(It.Is<ProcessOptions>(o => o.Args.Contains("read-manifest")), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, fullJson)] });
+
         var info = await _service.GetPackageInfo(packageDir);
 
         Assert.That(info.PackageName, Is.EqualTo("my_crate"));
+        Assert.That(info.PackageVersion, Is.EqualTo("0.1.0"));
     }
 
     #endregion

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/RustLanguageServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/RustLanguageServiceTests.cs
@@ -1,0 +1,201 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Services.Languages;
+using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
+using Moq;
+
+namespace Azure.Sdk.Tools.Cli.Tests.Services.Languages;
+
+[TestFixture]
+public class RustLanguageServiceTests
+{
+    private RustLanguageService _service;
+    private Mock<IGitHelper> _mockGitHelper;
+    private Mock<IProcessHelper> _mockProcessHelper;
+    private Mock<IPowershellHelper> _mockPowershellHelper;
+    private Mock<ISpecGenSdkConfigHelper> _mockSpecGenSdkConfigHelper;
+    private TempDirectory _tempDirectory;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockGitHelper = new Mock<IGitHelper>();
+        _mockProcessHelper = new Mock<IProcessHelper>();
+        _mockPowershellHelper = new Mock<IPowershellHelper>();
+        _mockSpecGenSdkConfigHelper = new Mock<ISpecGenSdkConfigHelper>();
+
+        var languageLogger = new TestLogger<LanguageService>();
+        var packageInfoHelper = new PackageInfoHelper(new TestLogger<PackageInfoHelper>(), _mockGitHelper.Object);
+
+        _tempDirectory = TempDirectory.Create("RustLanguageServiceTests");
+
+        _service = new RustLanguageService(
+            _mockProcessHelper.Object,
+            _mockPowershellHelper.Object,
+            _mockGitHelper.Object,
+            languageLogger,
+            Mock.Of<ICommonValidationHelpers>(),
+            packageInfoHelper,
+            Mock.Of<IFileHelper>(),
+            _mockSpecGenSdkConfigHelper.Object,
+            Mock.Of<IChangelogHelper>());
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _tempDirectory.Dispose();
+    }
+
+    [Test]
+    public void Language_ReturnsRust()
+    {
+        Assert.That(_service.Language, Is.EqualTo(SdkLanguage.Rust));
+    }
+
+    [Test]
+    public async Task BuildAsync_EmptyPath_ReturnsFailure()
+    {
+        var (success, errorMessage, _) = await _service.BuildAsync(string.Empty);
+
+        Assert.That(success, Is.False);
+        Assert.That(errorMessage, Does.Contain("required and cannot be empty"));
+    }
+
+    [Test]
+    public async Task BuildAsync_NonexistentPath_ReturnsFailure()
+    {
+        var (success, errorMessage, _) = await _service.BuildAsync("/nonexistent/path");
+
+        Assert.That(success, Is.False);
+        Assert.That(errorMessage, Does.Contain("does not exist"));
+    }
+
+    [Test]
+    public async Task BuildAsync_MissingBuildScript_ReturnsFailure()
+    {
+        // Arrange - repo root exists but no build script
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "mypackage");
+        Directory.CreateDirectory(packageDir);
+
+        _mockGitHelper
+            .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_tempDirectory.DirectoryPath);
+
+        // Act
+        var (success, errorMessage, _) = await _service.BuildAsync(packageDir);
+
+        // Assert
+        Assert.That(success, Is.False);
+        Assert.That(errorMessage, Does.Contain("Build script not found"));
+    }
+
+    [Test]
+    public async Task BuildAsync_ScriptExists_ExecutesPowershell()
+    {
+        // Arrange - create the package dir and the build script
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "mypackage");
+        Directory.CreateDirectory(packageDir);
+        var scriptDir = Path.Combine(_tempDirectory.DirectoryPath, "eng", "scripts");
+        Directory.CreateDirectory(scriptDir);
+        File.WriteAllText(Path.Combine(scriptDir, "build-sdk.ps1"), "# build script");
+
+        _mockGitHelper
+            .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_tempDirectory.DirectoryPath);
+
+        _mockPowershellHelper
+            .Setup(x => x.Run(It.IsAny<PowershellOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Build succeeded")] });
+
+        // Act
+        var (success, errorMessage, _) = await _service.BuildAsync(packageDir);
+
+        // Assert
+        Assert.That(success, Is.True);
+        Assert.That(errorMessage, Is.Null);
+        _mockPowershellHelper.Verify(x => x.Run(
+            It.Is<PowershellOptions>(o =>
+                o.Args.Contains("-PackagePath") &&
+                o.Args.Contains(packageDir)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task BuildAsync_ScriptFails_ReturnsFailure()
+    {
+        // Arrange
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "mypackage");
+        Directory.CreateDirectory(packageDir);
+        var scriptDir = Path.Combine(_tempDirectory.DirectoryPath, "eng", "scripts");
+        Directory.CreateDirectory(scriptDir);
+        File.WriteAllText(Path.Combine(scriptDir, "build-sdk.ps1"), "# build script");
+
+        _mockGitHelper
+            .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_tempDirectory.DirectoryPath);
+
+        _mockPowershellHelper
+            .Setup(x => x.Run(It.IsAny<PowershellOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardOutput, "compilation error")] });
+
+        // Act
+        var (success, errorMessage, _) = await _service.BuildAsync(packageDir);
+
+        // Assert
+        Assert.That(success, Is.False);
+        Assert.That(errorMessage, Does.Contain("Build failed with exit code 1"));
+        Assert.That(errorMessage, Does.Contain("compilation error"));
+    }
+
+    [Test]
+    public async Task BuildAsync_DiscoverRepoRootFails_ReturnsFailure()
+    {
+        // Arrange
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "mypackage");
+        Directory.CreateDirectory(packageDir);
+
+        _mockGitHelper
+            .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(string.Empty);
+
+        // Act
+        var (success, errorMessage, _) = await _service.BuildAsync(packageDir);
+
+        // Assert
+        Assert.That(success, Is.False);
+        Assert.That(errorMessage, Does.Contain("Failed to discover local sdk repo"));
+    }
+
+    [Test]
+    public async Task BuildAsync_DoesNotUseSpecGenSdkConfig()
+    {
+        // Arrange - verify Rust doesn't call specGenSdkConfigHelper
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "mypackage");
+        Directory.CreateDirectory(packageDir);
+        var scriptDir = Path.Combine(_tempDirectory.DirectoryPath, "eng", "scripts");
+        Directory.CreateDirectory(scriptDir);
+        File.WriteAllText(Path.Combine(scriptDir, "build-sdk.ps1"), "# build script");
+
+        _mockGitHelper
+            .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_tempDirectory.DirectoryPath);
+
+        _mockPowershellHelper
+            .Setup(x => x.Run(It.IsAny<PowershellOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "ok")] });
+
+        // Act
+        await _service.BuildAsync(packageDir);
+
+        // Assert - specGenSdkConfigHelper should never be called for Rust builds
+        _mockSpecGenSdkConfigHelper.Verify(
+            x => x.GetConfigurationAsync(It.IsAny<string>(), It.IsAny<SpecGenSdkConfigType>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/SdkBuildToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/SdkBuildToolTests.cs
@@ -66,7 +66,8 @@ public class SdkBuildToolTests
             new JavaLanguageService(_mockProcessHelper.Object, _mockGitHelper.Object, new Mock<IMavenHelper>().Object, _mockPythonHelper.Object, copilotAgentRunnerMock.Object, languageLogger, _commonValidationHelpers.Object, packageInfoHelper, Mock.Of<IFileHelper>(), _mockSpecGenSdkConfigHelper.Object, Mock.Of<IChangelogHelper>()),
             new JavaScriptLanguageService(_mockProcessHelper.Object, _mockNpxHelper.Object, _mockGitHelper.Object, languageLogger, _commonValidationHelpers.Object, packageInfoHelper, Mock.Of<IFileHelper>(), _mockSpecGenSdkConfigHelper.Object, Mock.Of<IChangelogHelper>()),
             new GoLanguageService(_mockProcessHelper.Object, _mockPowerShellHelper.Object, _mockGitHelper.Object, languageLogger, _commonValidationHelpers.Object, packageInfoHelper, Mock.Of<IFileHelper>(), _mockSpecGenSdkConfigHelper.Object, Mock.Of<IChangelogHelper>()),
-            new DotnetLanguageService(_mockProcessHelper.Object, _mockPowerShellHelper.Object, Mock.Of<ICopilotAgentRunner>(), _mockGitHelper.Object, languageLogger, _commonValidationHelpers.Object, packageInfoHelper, Mock.Of<IFileHelper>(), _mockSpecGenSdkConfigHelper.Object, Mock.Of<IChangelogHelper>())
+            new DotnetLanguageService(_mockProcessHelper.Object, _mockPowerShellHelper.Object, Mock.Of<ICopilotAgentRunner>(), _mockGitHelper.Object, languageLogger, _commonValidationHelpers.Object, packageInfoHelper, Mock.Of<IFileHelper>(), _mockSpecGenSdkConfigHelper.Object, Mock.Of<IChangelogHelper>()),
+            new RustLanguageService(_mockProcessHelper.Object, _mockPowerShellHelper.Object, _mockGitHelper.Object, languageLogger, _commonValidationHelpers.Object, packageInfoHelper, Mock.Of<IFileHelper>(), _mockSpecGenSdkConfigHelper.Object, Mock.Of<IChangelogHelper>())
         ];
 
         // Create the tool instance

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/LanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/LanguageService.cs
@@ -651,6 +651,22 @@ namespace Azure.Sdk.Tools.Cli.Services.Languages
 
                 logger.LogInformation("Building SDK for project path: {PackagePath}", packagePath);
 
+                // Validate package path
+                if (string.IsNullOrWhiteSpace(packagePath))
+                {
+                    return (false, "Package path is required and cannot be empty.", null);
+                }
+
+                // Resolves relative paths to absolute
+                string fullPath = Path.GetFullPath(packagePath);
+
+                if (!Directory.Exists(fullPath))
+                {
+                    return (false, $"Package full path does not exist: {fullPath}, input package path: {packagePath}.", null);
+                }
+
+                packagePath = fullPath;
+
                 // Get repository root path from project path
                 string sdkRepoRoot = await gitHelper.DiscoverRepoRootAsync(packagePath, ct);
                 if (string.IsNullOrEmpty(sdkRepoRoot))

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/LanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/LanguageService.cs
@@ -651,22 +651,6 @@ namespace Azure.Sdk.Tools.Cli.Services.Languages
 
                 logger.LogInformation("Building SDK for project path: {PackagePath}", packagePath);
 
-                // Validate package path
-                if (string.IsNullOrWhiteSpace(packagePath))
-                {
-                    return (false, "Package path is required and cannot be empty.", null);
-                }
-
-                // Resolves relative paths to absolute
-                string fullPath = Path.GetFullPath(packagePath);
-
-                if (!Directory.Exists(fullPath))
-                {
-                    return (false, $"Package full path does not exist: {fullPath}, input package path: {packagePath}.", null);
-                }
-
-                packagePath = fullPath;
-
                 // Get repository root path from project path
                 string sdkRepoRoot = await gitHelper.DiscoverRepoRootAsync(packagePath, ct);
                 if (string.IsNullOrEmpty(sdkRepoRoot))

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/RustLanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/RustLanguageService.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.Responses.Package;
+
+namespace Azure.Sdk.Tools.Cli.Services.Languages;
+
+/// <summary>
+/// Language-specific service for Rust packages. Since the Rust SDK repo does not have a
+/// swagger_to_sdk_config.json, the build script path is hardcoded to eng/scripts/build-sdk.ps1.
+/// </summary>
+public sealed class RustLanguageService : LanguageService
+{
+    private const string BuildScriptRelativePath = "eng/scripts/build-sdk.ps1";
+
+    public RustLanguageService(
+        IProcessHelper processHelper,
+        IPowershellHelper powershellHelper,
+        IGitHelper gitHelper,
+        ILogger<LanguageService> logger,
+        ICommonValidationHelpers commonValidationHelpers,
+        IPackageInfoHelper packageInfoHelper,
+        IFileHelper fileHelper,
+        ISpecGenSdkConfigHelper specGenSdkConfigHelper,
+        IChangelogHelper changelogHelper)
+        : base(processHelper, gitHelper, logger, commonValidationHelpers, packageInfoHelper, fileHelper, specGenSdkConfigHelper, changelogHelper)
+    {
+        this.powershellHelper = powershellHelper;
+    }
+
+    private readonly IPowershellHelper powershellHelper;
+
+    public override SdkLanguage Language { get; } = SdkLanguage.Rust;
+
+    /// <summary>
+    /// Rust packages are identified by Cargo.toml files.
+    /// </summary>
+    protected override string[] PackageManifestPatterns => ["Cargo.toml"];
+
+    /// <summary>
+    /// Builds Rust SDK code by executing the hardcoded build script at eng/scripts/build-sdk.ps1.
+    /// Unlike other languages, Rust does not use swagger_to_sdk_config.json for build configuration.
+    /// </summary>
+    public override async Task<(bool Success, string? ErrorMessage, PackageInfo? PackageInfo)> BuildAsync(
+        string packagePath, int timeoutMinutes = 30, CancellationToken ct = default)
+    {
+        try
+        {
+            logger.LogInformation("Building Rust SDK for project path: {PackagePath}", packagePath);
+
+            if (string.IsNullOrWhiteSpace(packagePath))
+            {
+                return (false, "Package path is required and cannot be empty.", null);
+            }
+
+            string fullPath = Path.GetFullPath(packagePath);
+
+            if (!Directory.Exists(fullPath))
+            {
+                return (false, $"Package full path does not exist: {fullPath}, input package path: {packagePath}.", null);
+            }
+
+            packagePath = fullPath;
+
+            string sdkRepoRoot = await gitHelper.DiscoverRepoRootAsync(packagePath, ct);
+            if (string.IsNullOrEmpty(sdkRepoRoot))
+            {
+                return (false, $"Failed to discover local sdk repo with project-path: {packagePath}.", null);
+            }
+
+            PackageInfo? packageInfo = null;
+            try
+            {
+                packageInfo = await GetPackageInfo(packagePath, ct);
+            }
+            catch (NotImplementedException)
+            {
+                logger.LogDebug("GetPackageInfo not yet implemented for Rust, proceeding without package info.");
+            }
+
+            var scriptPath = Path.Combine(sdkRepoRoot, BuildScriptRelativePath);
+            if (!File.Exists(scriptPath))
+            {
+                return (false, $"Build script not found at: {scriptPath}.", packageInfo);
+            }
+
+            logger.LogDebug("Executing Rust build script: {ScriptPath}", scriptPath);
+
+            var options = new PowershellOptions(
+                scriptPath,
+                ["-PackagePath", packagePath],
+                logOutputStream: true,
+                workingDirectory: sdkRepoRoot,
+                timeout: TimeSpan.FromMinutes(timeoutMinutes)
+            );
+
+            var result = await powershellHelper.Run(options, ct);
+            var trimmedOutput = (result.Output ?? string.Empty).Trim();
+
+            if (result.ExitCode != 0)
+            {
+                var errorMessage = $"Build failed with exit code {result.ExitCode}. Output:\n{trimmedOutput}";
+                logger.LogDebug("Build failed: {ErrorMessage}", errorMessage);
+                return (false, errorMessage, packageInfo);
+            }
+
+            logger.LogDebug("Build completed successfully.");
+            return (true, null, packageInfo);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error occurred while building Rust SDK code");
+            return (false, $"An error occurred: {ex.Message}", null);
+        }
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/RustLanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/RustLanguageService.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System.Text.RegularExpressions;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Models.Responses.Package;
@@ -10,7 +11,7 @@ namespace Azure.Sdk.Tools.Cli.Services.Languages;
 /// Language-specific service for Rust packages. Since the Rust SDK repo does not have a
 /// swagger_to_sdk_config.json, the build script path is hardcoded to eng/scripts/build-sdk.ps1.
 /// </summary>
-public sealed class RustLanguageService : LanguageService
+public sealed partial class RustLanguageService : LanguageService
 {
     private const string BuildScriptRelativePath = "eng/scripts/build-sdk.ps1";
 
@@ -37,6 +38,136 @@ public sealed class RustLanguageService : LanguageService
     /// Rust packages are identified by Cargo.toml files.
     /// </summary>
     protected override string[] PackageManifestPatterns => ["Cargo.toml"];
+
+    /// <summary>
+    /// Resolves package information for a Rust crate by parsing its Cargo.toml manifest.
+    /// Extracts name, version, service directory, and SDK type following the same conventions
+    /// as the PowerShell Language-Settings.ps1 script.
+    /// </summary>
+    public override async Task<PackageInfo> GetPackageInfo(string packagePath, CancellationToken ct = default)
+    {
+        var fullPath = RealPath.GetRealPath(packagePath);
+        var repoRoot = await gitHelper.DiscoverRepoRootAsync(packagePath, ct);
+        var sdkRoot = Path.Combine(repoRoot, "sdk");
+        var relativePath = Path.GetRelativePath(sdkRoot, fullPath).TrimStart(Path.DirectorySeparatorChar);
+        var directoryPath = $"sdk/{relativePath}";
+
+        try
+        {
+            logger.LogDebug("Resolving Rust package info for path: {packagePath}", packagePath);
+
+            var cargoTomlPath = Path.Combine(fullPath, "Cargo.toml");
+            if (!File.Exists(cargoTomlPath))
+            {
+                logger.LogDebug("No Cargo.toml found at {CargoTomlPath}", cargoTomlPath);
+                return CreateEmptyPackageInfo(fullPath, repoRoot, relativePath);
+            }
+
+            var cargoContent = await File.ReadAllTextAsync(cargoTomlPath, ct);
+            var packageName = ExtractCargoField(cargoContent, "name");
+            var packageVersion = ExtractCargoField(cargoContent, "version");
+
+            if (string.IsNullOrEmpty(packageName))
+            {
+                logger.LogDebug("Unable to extract package name from Cargo.toml at {Path}", cargoTomlPath);
+                return CreateEmptyPackageInfo(fullPath, repoRoot, relativePath);
+            }
+
+            // Extract service directory from path: sdk/<serviceDir>/<package>
+            var normalizedRelative = relativePath.Replace(Path.DirectorySeparatorChar, '/');
+            var serviceDirectory = GetServiceDirectory(normalizedRelative);
+
+            // Determine SDK type: "mgmt" if name contains "mgmt", otherwise "client"
+            var sdkType = packageName.Contains("mgmt", StringComparison.OrdinalIgnoreCase) ? "mgmt" : "client";
+
+            var readmePath = Path.Combine(fullPath, "README.md");
+            var changelogPath = Path.Combine(fullPath, "CHANGELOG.md");
+            var readmeRelative = File.Exists(readmePath) ? $"sdk/{normalizedRelative}/README.md" : string.Empty;
+            var changelogRelative = File.Exists(changelogPath) ? $"sdk/{normalizedRelative}/CHANGELOG.md" : string.Empty;
+            var releaseStatus = File.Exists(changelogPath)
+                ? await changelogHelper.GetReleaseStatus(changelogPath, ct)
+                : string.Empty;
+
+            var model = new PackageInfo
+            {
+                PackagePath = fullPath,
+                RepoRoot = repoRoot,
+                RelativePath = relativePath,
+                PackageName = packageName,
+                PackageVersion = packageVersion,
+                ServiceName = serviceDirectory ?? string.Empty,
+                SdkTypeString = sdkType,
+                Language = SdkLanguage.Rust,
+                SamplesDirectory = fullPath,
+                DirectoryPath = directoryPath,
+                ServiceDirectory = serviceDirectory,
+                ReadMePath = readmeRelative,
+                ChangeLogPath = changelogRelative,
+                IsNewSdk = true,
+                ArtifactName = packageName,
+                ReleaseStatus = releaseStatus,
+                SpecProjectPath = GetSpecProjectPath(fullPath)
+            };
+
+            logger.LogDebug("Resolved Rust package: {packageName} v{packageVersion}", model.PackageName ?? "(unknown)", model.PackageVersion ?? "(unknown)");
+            return model;
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Exception thrown when trying to get package properties for {Path}", packagePath);
+            return CreateEmptyPackageInfo(fullPath, repoRoot, relativePath);
+        }
+    }
+
+    /// <summary>
+    /// Extracts a field value from the [package] section of a Cargo.toml file.
+    /// Handles workspace-inherited values (e.g., "version.workspace = true") by returning null.
+    /// </summary>
+    internal static string? ExtractCargoField(string cargoContent, string fieldName)
+    {
+        // Match: fieldName = "value" (in [package] section, before next section)
+        var packageSectionMatch = CargoPackageSectionRegex().Match(cargoContent);
+        if (!packageSectionMatch.Success)
+        {
+            return null;
+        }
+
+        var packageSection = packageSectionMatch.Groups["content"].Value;
+        var fieldPattern = new Regex($@"^{Regex.Escape(fieldName)}\s*=\s*""(?<value>[^""]+)""", RegexOptions.Multiline);
+        var fieldMatch = fieldPattern.Match(packageSection);
+        return fieldMatch.Success ? fieldMatch.Groups["value"].Value : null;
+    }
+
+    /// <summary>
+    /// Extracts the service directory from a relative path under sdk/.
+    /// For path "core/azure_core" returns "core".
+    /// </summary>
+    private static string? GetServiceDirectory(string normalizedRelativePath)
+    {
+        var parts = normalizedRelativePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length >= 1 ? parts[0] : null;
+    }
+
+    private static PackageInfo CreateEmptyPackageInfo(string fullPath, string repoRoot, string relativePath)
+    {
+        return new PackageInfo
+        {
+            PackagePath = fullPath,
+            RepoRoot = repoRoot,
+            RelativePath = relativePath,
+            PackageName = null,
+            PackageVersion = null,
+            ServiceName = string.Empty,
+            SdkType = SdkType.Unknown,
+            Language = SdkLanguage.Rust,
+            SamplesDirectory = fullPath,
+            DirectoryPath = $"sdk/{relativePath}",
+            ReadMePath = string.Empty,
+            ChangeLogPath = string.Empty,
+            ReleaseStatus = string.Empty,
+            SpecProjectPath = GetSpecProjectPath(fullPath)
+        };
+    }
 
     /// <summary>
     /// Builds Rust SDK code by executing the hardcoded build script at eng/scripts/build-sdk.ps1.
@@ -69,15 +200,7 @@ public sealed class RustLanguageService : LanguageService
                 return (false, $"Failed to discover local sdk repo with project-path: {packagePath}.", null);
             }
 
-            PackageInfo? packageInfo = null;
-            try
-            {
-                packageInfo = await GetPackageInfo(packagePath, ct);
-            }
-            catch (NotImplementedException)
-            {
-                logger.LogDebug("GetPackageInfo not yet implemented for Rust, proceeding without package info.");
-            }
+            PackageInfo? packageInfo = await GetPackageInfo(packagePath, ct);
 
             var scriptPath = Path.Combine(sdkRepoRoot, BuildScriptRelativePath);
             if (!File.Exists(scriptPath))
@@ -114,4 +237,8 @@ public sealed class RustLanguageService : LanguageService
             return (false, $"An error occurred: {ex.Message}", null);
         }
     }
+
+    // Matches the [package] section content up to the next section header or end of file
+    [GeneratedRegex(@"\[package\]\s*\n(?<content>(?:(?!\n\[).)*)", RegexOptions.Singleline | RegexOptions.CultureInvariant)]
+    private static partial Regex CargoPackageSectionRegex();
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/RustLanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/RustLanguageService.cs
@@ -180,20 +180,6 @@ public sealed partial class RustLanguageService : LanguageService
         {
             logger.LogInformation("Building Rust SDK for project path: {PackagePath}", packagePath);
 
-            if (string.IsNullOrWhiteSpace(packagePath))
-            {
-                return (false, "Package path is required and cannot be empty.", null);
-            }
-
-            string fullPath = Path.GetFullPath(packagePath);
-
-            if (!Directory.Exists(fullPath))
-            {
-                return (false, $"Package full path does not exist: {fullPath}, input package path: {packagePath}.", null);
-            }
-
-            packagePath = fullPath;
-
             string sdkRepoRoot = await gitHelper.DiscoverRepoRootAsync(packagePath, ct);
             if (string.IsNullOrEmpty(sdkRepoRoot))
             {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/RustLanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/RustLanguageService.cs
@@ -3,7 +3,6 @@
 using System.Text.Json;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
-using Azure.Sdk.Tools.Cli.Models.Responses.Package;
 
 namespace Azure.Sdk.Tools.Cli.Services.Languages;
 
@@ -46,14 +45,19 @@ public sealed class RustLanguageService : LanguageService
     /// </summary>
     public override async Task<PackageInfo> GetPackageInfo(string packagePath, CancellationToken ct = default)
     {
-        var fullPath = RealPath.GetRealPath(packagePath);
-        var repoRoot = await gitHelper.DiscoverRepoRootAsync(packagePath, ct);
-        var sdkRoot = Path.Combine(repoRoot, "sdk");
-        var relativePath = Path.GetRelativePath(sdkRoot, fullPath).TrimStart(Path.DirectorySeparatorChar);
-        var directoryPath = $"sdk/{relativePath}";
+        var fullPath = string.Empty;
+        var repoRoot = string.Empty;
+        var relativePath = string.Empty;
+        var directoryPath = string.Empty;
 
         try
         {
+            fullPath = RealPath.GetRealPath(packagePath);
+            repoRoot = await gitHelper.DiscoverRepoRootAsync(packagePath, ct);
+            var sdkRoot = Path.Combine(repoRoot, "sdk");
+            relativePath = Path.GetRelativePath(sdkRoot, fullPath).TrimStart(Path.DirectorySeparatorChar);
+            directoryPath = $"sdk/{relativePath}";
+
             logger.LogDebug("Resolving Rust package info for path: {packagePath}", packagePath);
 
             var cargoTomlPath = Path.Combine(fullPath, "Cargo.toml");
@@ -181,7 +185,6 @@ public sealed class RustLanguageService : LanguageService
 
     /// <summary>
     /// Builds Rust SDK code by executing the hardcoded build script at eng/scripts/build-sdk.ps1.
-    /// Unlike other languages, Rust does not use swagger_to_sdk_config.json for build configuration.
     /// </summary>
     public override async Task<(bool Success, string? ErrorMessage, PackageInfo? PackageInfo)> BuildAsync(
         string packagePath, int timeoutMinutes = 30, CancellationToken ct = default)
@@ -189,7 +192,18 @@ public sealed class RustLanguageService : LanguageService
         try
         {
             logger.LogInformation("Building Rust SDK for project path: {PackagePath}", packagePath);
+            if (string.IsNullOrWhiteSpace(packagePath))
+            {
+                return (false, "Package path is required and cannot be empty.", null);
+            }
 
+            string fullPath = Path.GetFullPath(packagePath);
+            if (!Directory.Exists(fullPath))
+            {
+                return (false, $"Package full path does not exist: {fullPath}, input package path: {packagePath}.", null);
+            }
+
+            packagePath = fullPath;
             string sdkRepoRoot = await gitHelper.DiscoverRepoRootAsync(packagePath, ct);
             if (string.IsNullOrEmpty(sdkRepoRoot))
             {
@@ -197,7 +211,6 @@ public sealed class RustLanguageService : LanguageService
             }
 
             PackageInfo? packageInfo = await GetPackageInfo(packagePath, ct);
-
             var scriptPath = Path.Combine(sdkRepoRoot, BuildScriptRelativePath);
             if (!File.Exists(scriptPath))
             {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/RustLanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/RustLanguageService.cs
@@ -67,11 +67,13 @@ public sealed class RustLanguageService : LanguageService
                 return CreateEmptyPackageInfo(fullPath, repoRoot, relativePath);
             }
 
-            // Use 'cargo read-manifest' to extract package metadata, matching the
-            // Language-Settings.ps1 approach: $package = cargo read-manifest ... | ConvertFrom-Json
+            // Use 'cargo metadata' to extract package metadata.
+            // cargo metadata --no-deps returns a packages array
+            // that we filter by matching the directory name.
+            var expectedCrateName = Path.GetFileName(fullPath);
             var cargoResult = await processHelper.Run(new ProcessOptions(
                 command: "cargo",
-                args: ["read-manifest", "--manifest-path", cargoTomlPath],
+                args: ["metadata", "--format-version", "1", "--no-deps", "--manifest-path", cargoTomlPath],
                 logOutputStream: false,
                 workingDirectory: fullPath,
                 timeout: TimeSpan.FromSeconds(30)
@@ -79,7 +81,7 @@ public sealed class RustLanguageService : LanguageService
 
             if (cargoResult.ExitCode != 0)
             {
-                logger.LogDebug("cargo read-manifest failed with exit code {ExitCode} for {Path}: {Output}",
+                logger.LogDebug("cargo metadata failed with exit code {ExitCode} for {Path}: {Output}",
                     cargoResult.ExitCode, cargoTomlPath, cargoResult.Output);
                 return CreateEmptyPackageInfo(fullPath, repoRoot, relativePath);
             }
@@ -90,19 +92,25 @@ public sealed class RustLanguageService : LanguageService
             using (var jsonDoc = JsonDocument.Parse(cargoResult.Stdout))
             {
                 var root = jsonDoc.RootElement;
-                if (root.TryGetProperty("name", out var nameElement))
+                if (root.TryGetProperty("packages", out var packagesElement) && packagesElement.ValueKind == JsonValueKind.Array)
                 {
-                    packageName = nameElement.GetString();
-                }
-                if (root.TryGetProperty("version", out var versionElement))
-                {
-                    packageVersion = versionElement.GetString();
+                    foreach (var pkg in packagesElement.EnumerateArray())
+                    {
+                        var name = pkg.TryGetProperty("name", out var n) ? n.GetString() : null;
+                        if (string.Equals(name, expectedCrateName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            packageName = name;
+                            packageVersion = pkg.TryGetProperty("version", out var v) ? v.GetString() : null;
+                            break;
+                        }
+                    }
                 }
             }
 
             if (string.IsNullOrEmpty(packageName))
             {
-                logger.LogDebug("Unable to extract package name from cargo read-manifest at {Path}", cargoTomlPath);
+                logger.LogDebug("Unable to find package matching '{ExpectedName}' in cargo metadata output for {Path}",
+                    expectedCrateName, cargoTomlPath);
                 return CreateEmptyPackageInfo(fullPath, repoRoot, relativePath);
             }
 
@@ -110,8 +118,8 @@ public sealed class RustLanguageService : LanguageService
             var normalizedRelative = relativePath.Replace(Path.DirectorySeparatorChar, '/');
             var serviceDirectory = GetServiceDirectory(normalizedRelative);
 
-            // Determine SDK type: "mgmt" if name contains "mgmt", otherwise "client"
-            var sdkType = packageName.Contains("mgmt", StringComparison.OrdinalIgnoreCase) ? "mgmt" : "client";
+            // Determine SDK type: "mgmt" if name contains "azure_resourcemanager_", otherwise "client"
+            var sdkType = packageName.Contains("azure_resourcemanager_", StringComparison.OrdinalIgnoreCase) ? "mgmt" : "client";
 
             var readmePath = Path.Combine(fullPath, "README.md");
             var changelogPath = Path.Combine(fullPath, "CHANGELOG.md");
@@ -142,7 +150,7 @@ public sealed class RustLanguageService : LanguageService
                 SpecProjectPath = GetSpecProjectPath(fullPath)
             };
 
-            logger.LogDebug("Resolved Rust package: {packageName} v{packageVersion}", model.PackageName ?? "(unknown)", model.PackageVersion ?? "(unknown)");
+            logger.LogDebug("Resolved Rust package: {Package}", $"{model.PackageName ?? "(unknown)"}@{model.PackageVersion ?? "(unknown)"}");
             return model;
         }
         catch (Exception ex)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/RustLanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/RustLanguageService.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using System.Text.RegularExpressions;
+using System.Text.Json;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Models.Responses.Package;
@@ -11,7 +11,7 @@ namespace Azure.Sdk.Tools.Cli.Services.Languages;
 /// Language-specific service for Rust packages. Since the Rust SDK repo does not have a
 /// swagger_to_sdk_config.json, the build script path is hardcoded to eng/scripts/build-sdk.ps1.
 /// </summary>
-public sealed partial class RustLanguageService : LanguageService
+public sealed class RustLanguageService : LanguageService
 {
     private const string BuildScriptRelativePath = "eng/scripts/build-sdk.ps1";
 
@@ -40,9 +40,9 @@ public sealed partial class RustLanguageService : LanguageService
     protected override string[] PackageManifestPatterns => ["Cargo.toml"];
 
     /// <summary>
-    /// Resolves package information for a Rust crate by parsing its Cargo.toml manifest.
-    /// Extracts name, version, service directory, and SDK type following the same conventions
-    /// as the PowerShell Language-Settings.ps1 script.
+    /// Resolves package information for a Rust crate using <c>cargo read-manifest</c>,
+    /// matching the approach used by Language-Settings.ps1 in the azure-sdk-for-rust repo.
+    /// Extracts name, version, service directory, and SDK type.
     /// </summary>
     public override async Task<PackageInfo> GetPackageInfo(string packagePath, CancellationToken ct = default)
     {
@@ -63,13 +63,42 @@ public sealed partial class RustLanguageService : LanguageService
                 return CreateEmptyPackageInfo(fullPath, repoRoot, relativePath);
             }
 
-            var cargoContent = await File.ReadAllTextAsync(cargoTomlPath, ct);
-            var packageName = ExtractCargoField(cargoContent, "name");
-            var packageVersion = ExtractCargoField(cargoContent, "version");
+            // Use 'cargo read-manifest' to extract package metadata, matching the
+            // Language-Settings.ps1 approach: $package = cargo read-manifest ... | ConvertFrom-Json
+            var cargoResult = await processHelper.Run(new ProcessOptions(
+                command: "cargo",
+                args: ["read-manifest", "--manifest-path", cargoTomlPath],
+                logOutputStream: false,
+                workingDirectory: fullPath,
+                timeout: TimeSpan.FromSeconds(30)
+            ), ct);
+
+            if (cargoResult.ExitCode != 0)
+            {
+                logger.LogDebug("cargo read-manifest failed with exit code {ExitCode} for {Path}: {Output}",
+                    cargoResult.ExitCode, cargoTomlPath, cargoResult.Output);
+                return CreateEmptyPackageInfo(fullPath, repoRoot, relativePath);
+            }
+
+            string? packageName = null;
+            string? packageVersion = null;
+
+            using (var jsonDoc = JsonDocument.Parse(cargoResult.Stdout))
+            {
+                var root = jsonDoc.RootElement;
+                if (root.TryGetProperty("name", out var nameElement))
+                {
+                    packageName = nameElement.GetString();
+                }
+                if (root.TryGetProperty("version", out var versionElement))
+                {
+                    packageVersion = versionElement.GetString();
+                }
+            }
 
             if (string.IsNullOrEmpty(packageName))
             {
-                logger.LogDebug("Unable to extract package name from Cargo.toml at {Path}", cargoTomlPath);
+                logger.LogDebug("Unable to extract package name from cargo read-manifest at {Path}", cargoTomlPath);
                 return CreateEmptyPackageInfo(fullPath, repoRoot, relativePath);
             }
 
@@ -117,25 +146,6 @@ public sealed partial class RustLanguageService : LanguageService
             logger.LogDebug(ex, "Exception thrown when trying to get package properties for {Path}", packagePath);
             return CreateEmptyPackageInfo(fullPath, repoRoot, relativePath);
         }
-    }
-
-    /// <summary>
-    /// Extracts a field value from the [package] section of a Cargo.toml file.
-    /// Handles workspace-inherited values (e.g., "version.workspace = true") by returning null.
-    /// </summary>
-    internal static string? ExtractCargoField(string cargoContent, string fieldName)
-    {
-        // Match: fieldName = "value" (in [package] section, before next section)
-        var packageSectionMatch = CargoPackageSectionRegex().Match(cargoContent);
-        if (!packageSectionMatch.Success)
-        {
-            return null;
-        }
-
-        var packageSection = packageSectionMatch.Groups["content"].Value;
-        var fieldPattern = new Regex($@"^{Regex.Escape(fieldName)}\s*=\s*""(?<value>[^""]+)""", RegexOptions.Multiline);
-        var fieldMatch = fieldPattern.Match(packageSection);
-        return fieldMatch.Success ? fieldMatch.Groups["value"].Value : null;
     }
 
     /// <summary>
@@ -223,8 +233,4 @@ public sealed partial class RustLanguageService : LanguageService
             return (false, $"An error occurred: {ex.Message}", null);
         }
     }
-
-    // Matches the [package] section content up to the next section header or end of file
-    [GeneratedRegex(@"\[package\]\s*\n(?<content>(?:(?!\n\[).)*)", RegexOptions.Singleline | RegexOptions.CultureInvariant)]
-    private static partial Regex CargoPackageSectionRegex();
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
@@ -49,6 +49,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             services.AddScoped<LanguageService, JavaScriptLanguageService>();
             services.AddScoped<LanguageService, PythonLanguageService>();
             services.AddScoped<LanguageService, GoLanguageService>();
+            services.AddScoped<LanguageService, RustLanguageService>();
 
             // Helper classes
             services.AddSingleton<IFileHelper, FileHelper>();

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkBuildTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkBuildTool.cs
@@ -101,7 +101,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
                     errorMessage ?? "Build failed with an unknown error.",
                     packageInfo,
                     nextSteps: [
-                        "Ensure the SDK repository has a valid 'buildScript' configuration in eng/swagger_to_sdk_config.json",
+                        "Ensure the SDK repository has a valid build script defined for the language",
                         "Check the build logs for details about the error",
                         "Resolve any issues reported in the build log",
                         "Re-run the tool",


### PR DESCRIPTION
## Key Changes
- Added new Rust language service that overrides `BuildAsync` to hardcode the build script path at "eng/scripts/build-sdk.ps1" and execute it via PowerShell
- Implemented `GetPackageInfo`