### PR TITLE
[APIView] Fix duplicate left panel navigation entries in diff view

### DIFF
--- a/src/dotnet/APIView/ClientSPA/src/app/_workers/apitree-builder.worker.spec.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_workers/apitree-builder.worker.spec.ts
@@ -1,25 +1,6 @@
 import { NavigationTreeNode, NavigationTreeNodeData } from '../_models/navigationTreeModels';
 import { DIFF_ADDED, DIFF_REMOVED } from '../_helpers/common-helpers';
-
-// Replicates the nav-node deduplication logic from buildCodePanelRows so it can be tested
-// independently of the Web Worker environment.
-function applyNavNodeToTree(
-  navTree: NavigationTreeNode[],
-  node: NavigationTreeNode,
-  codeLineDiffKinds: string[]
-): void {
-  const isAllRemovedNode = codeLineDiffKinds.length > 0 && codeLineDiffKinds.every(k => k === DIFF_REMOVED);
-  if (isAllRemovedNode) {
-    navTree.push(node);
-  } else {
-    const existingRemovedIndex = navTree.findIndex(n => n.label === node.label);
-    if (existingRemovedIndex >= 0) {
-      navTree[existingRemovedIndex] = node;
-    } else {
-      navTree.push(node);
-    }
-  }
-}
+import { applyNavNodeToTree } from './nav-node-helpers';
 
 function makeNavNode(label: string, nodeIdHashed: string): NavigationTreeNode {
   const node = new NavigationTreeNode();

--- a/src/dotnet/APIView/ClientSPA/src/app/_workers/apitree-builder.worker.spec.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_workers/apitree-builder.worker.spec.ts
@@ -1,0 +1,102 @@
+import { NavigationTreeNode, NavigationTreeNodeData } from '../_models/navigationTreeModels';
+import { DIFF_ADDED, DIFF_REMOVED } from '../_helpers/common-helpers';
+
+// Replicates the nav-node deduplication logic from buildCodePanelRows so it can be tested
+// independently of the Web Worker environment.
+function applyNavNodeToTree(
+  navTree: NavigationTreeNode[],
+  node: NavigationTreeNode,
+  codeLineDiffKinds: string[]
+): void {
+  const isAllRemovedNode = codeLineDiffKinds.length > 0 && codeLineDiffKinds.every(k => k === DIFF_REMOVED);
+  if (isAllRemovedNode) {
+    navTree.push(node);
+  } else {
+    const existingRemovedIndex = navTree.findIndex(n => n.label === node.label);
+    if (existingRemovedIndex >= 0) {
+      navTree[existingRemovedIndex] = node;
+    } else {
+      navTree.push(node);
+    }
+  }
+}
+
+function makeNavNode(label: string, nodeIdHashed: string): NavigationTreeNode {
+  const node = new NavigationTreeNode();
+  node.label = label;
+  node.data = new NavigationTreeNodeData();
+  node.data.nodeIdHashed = nodeIdHashed;
+  node.data.kind = 'class';
+  return node;
+}
+
+describe('apitree-builder nav deduplication', () => {
+  describe('modified element (removed-side + added-side with same label)', () => {
+    it('results in a single nav entry', () => {
+      const navTree: NavigationTreeNode[] = [];
+      const removedNode = makeNavNode('SearchClient', 'hash-removed');
+      const addedNode = makeNavNode('SearchClient', 'hash-added');
+
+      applyNavNodeToTree(navTree, removedNode, [DIFF_REMOVED]);
+      applyNavNodeToTree(navTree, addedNode, [DIFF_ADDED]);
+
+      expect(navTree.length).toBe(1);
+    });
+
+    it('keeps the added-side (active-revision) entry, not the removed-side', () => {
+      const navTree: NavigationTreeNode[] = [];
+      const removedNode = makeNavNode('SearchClient', 'hash-removed');
+      const addedNode = makeNavNode('SearchClient', 'hash-added');
+
+      applyNavNodeToTree(navTree, removedNode, [DIFF_REMOVED]);
+      applyNavNodeToTree(navTree, addedNode, [DIFF_ADDED]);
+
+      expect(navTree[0].data.nodeIdHashed).toBe('hash-added');
+    });
+  });
+
+  describe('purely deleted element (no active-revision counterpart)', () => {
+    it('keeps the nav entry so the deleted element remains navigable', () => {
+      const navTree: NavigationTreeNode[] = [];
+      const deletedNode = makeNavNode('DeletedClass', 'hash-deleted');
+
+      applyNavNodeToTree(navTree, deletedNode, [DIFF_REMOVED]);
+
+      expect(navTree.length).toBe(1);
+      expect(navTree[0].data.nodeIdHashed).toBe('hash-deleted');
+    });
+  });
+
+  describe('unchanged element', () => {
+    it('adds the nav entry normally', () => {
+      const navTree: NavigationTreeNode[] = [];
+      const node = makeNavNode('UnchangedClass', 'hash-unchanged');
+
+      applyNavNodeToTree(navTree, node, ['unchanged']);
+
+      expect(navTree.length).toBe(1);
+      expect(navTree[0].data.nodeIdHashed).toBe('hash-unchanged');
+    });
+  });
+
+  describe('mixed siblings', () => {
+    it('produces one entry per unique element (modified + deleted + unchanged)', () => {
+      const navTree: NavigationTreeNode[] = [];
+
+      // Modified element: removed first, then added
+      applyNavNodeToTree(navTree, makeNavNode('ModifiedClass', 'modified-removed'), [DIFF_REMOVED]);
+      applyNavNodeToTree(navTree, makeNavNode('ModifiedClass', 'modified-added'), [DIFF_ADDED]);
+
+      // Purely deleted element
+      applyNavNodeToTree(navTree, makeNavNode('DeletedClass', 'deleted'), [DIFF_REMOVED]);
+
+      // Unchanged element
+      applyNavNodeToTree(navTree, makeNavNode('UnchangedClass', 'unchanged'), ['unchanged']);
+
+      expect(navTree.length).toBe(3);
+      expect(navTree.map(n => n.label)).toEqual(['ModifiedClass', 'DeletedClass', 'UnchangedClass']);
+      expect(navTree.find(n => n.label === 'ModifiedClass')!.data.nodeIdHashed).toBe('modified-added');
+      expect(navTree.find(n => n.label === 'DeletedClass')!.data.nodeIdHashed).toBe('deleted');
+    });
+  });
+});

--- a/src/dotnet/APIView/ClientSPA/src/app/_workers/apitree-builder.worker.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_workers/apitree-builder.worker.ts
@@ -5,6 +5,7 @@ import { CodePanelData, CodePanelNodeMetaData, CodePanelRowData, CodePanelRowDat
 import { InsertCodePanelRowDataMessage, ReviewPageWorkerMessageDirective } from '../_models/insertCodePanelRowDataMessage';
 import { NavigationTreeNode } from '../_models/navigationTreeModels';
 import { DIFF_ADDED, DIFF_REMOVED, FULL_DIFF_STYLE, TREE_DIFF_STYLE } from '../_helpers/common-helpers';
+import { applyNavNodeToTree } from './nav-node-helpers';
 import { CommentSource } from '../_models/commentItemModel';
 
 let codePanelData: CodePanelData | null = null;
@@ -191,17 +192,7 @@ function buildCodePanelRows(nodeIdHashed: string, navigationTree: NavigationTree
   }
 
   if (buildNode && node.navigationTreeNode && !isNavigationTreeCreated) {
-    const isAllRemovedNode = node.codeLines?.length > 0 && node.codeLines.every(l => l.diffKind === DIFF_REMOVED);
-    if (isAllRemovedNode) {
-      navigationTree.push(node.navigationTreeNode);
-    } else {
-      const existingRemovedIndex = navigationTree.findIndex(n => n.label === node.navigationTreeNode!.label);
-      if (existingRemovedIndex >= 0) {
-        navigationTree[existingRemovedIndex] = node.navigationTreeNode;
-      } else {
-        navigationTree.push(node.navigationTreeNode);
-      }
-    }
+    applyNavNodeToTree(navigationTree, node.navigationTreeNode, (node.codeLines || []).map(l => l.diffKind));
   }
 
   if (node.bottomTokenNodeIdHash) {

--- a/src/dotnet/APIView/ClientSPA/src/app/_workers/apitree-builder.worker.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_workers/apitree-builder.worker.ts
@@ -191,12 +191,23 @@ function buildCodePanelRows(nodeIdHashed: string, navigationTree: NavigationTree
   }
 
   if (buildNode && node.navigationTreeNode && !isNavigationTreeCreated) {
-    // Skip nav entries for removed nodes (diff revision side of a modification, or purely deleted items).
-    const isRemovedNode = node.codeLines?.length > 0 && node.codeLines.every(l => l.diffKind === DIFF_REMOVED);
-    if (!isRemovedNode) {
+    const isAllRemovedNode = node.codeLines?.length > 0 && node.codeLines.every(l => l.diffKind === DIFF_REMOVED);
+    if (isAllRemovedNode) {
+      // Removed-side node: add tentatively. A non-removed counterpart with the same label (modification)
+      // will replace this entry, ensuring the nav points to the active-revision line.
+      // Purely-deleted elements have no such counterpart and are kept as-is.
       navigationTree.push(node.navigationTreeNode);
+    } else {
+      // Non-removed node: replace any removed-side sibling entry with the same label
+      // (deduplicates modifications), otherwise push as a new entry.
+      const existingRemovedIndex = navigationTree.findIndex(n => n.label === node.navigationTreeNode!.label);
+      if (existingRemovedIndex >= 0) {
+        navigationTree[existingRemovedIndex] = node.navigationTreeNode;
+      } else {
+        navigationTree.push(node.navigationTreeNode);
+      }
     }
-  }  
+  }
 
   if (node.bottomTokenNodeIdHash) {
     codePanelRowData.push(...diffBuffer);

--- a/src/dotnet/APIView/ClientSPA/src/app/_workers/apitree-builder.worker.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_workers/apitree-builder.worker.ts
@@ -191,7 +191,11 @@ function buildCodePanelRows(nodeIdHashed: string, navigationTree: NavigationTree
   }
 
   if (buildNode && node.navigationTreeNode && !isNavigationTreeCreated) {
-    navigationTree.push(node.navigationTreeNode);
+    // Skip nav entries for removed nodes (diff revision side of a modification, or purely deleted items).
+    const isRemovedNode = node.codeLines?.length > 0 && node.codeLines.every(l => l.diffKind === DIFF_REMOVED);
+    if (!isRemovedNode) {
+      navigationTree.push(node.navigationTreeNode);
+    }
   }  
 
   if (node.bottomTokenNodeIdHash) {

--- a/src/dotnet/APIView/ClientSPA/src/app/_workers/apitree-builder.worker.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_workers/apitree-builder.worker.ts
@@ -193,13 +193,8 @@ function buildCodePanelRows(nodeIdHashed: string, navigationTree: NavigationTree
   if (buildNode && node.navigationTreeNode && !isNavigationTreeCreated) {
     const isAllRemovedNode = node.codeLines?.length > 0 && node.codeLines.every(l => l.diffKind === DIFF_REMOVED);
     if (isAllRemovedNode) {
-      // Removed-side node: add tentatively. A non-removed counterpart with the same label (modification)
-      // will replace this entry, ensuring the nav points to the active-revision line.
-      // Purely-deleted elements have no such counterpart and are kept as-is.
       navigationTree.push(node.navigationTreeNode);
     } else {
-      // Non-removed node: replace any removed-side sibling entry with the same label
-      // (deduplicates modifications), otherwise push as a new entry.
       const existingRemovedIndex = navigationTree.findIndex(n => n.label === node.navigationTreeNode!.label);
       if (existingRemovedIndex >= 0) {
         navigationTree[existingRemovedIndex] = node.navigationTreeNode;

--- a/src/dotnet/APIView/ClientSPA/src/app/_workers/nav-node-helpers.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_workers/nav-node-helpers.ts
@@ -1,0 +1,35 @@
+import { NavigationTreeNode } from '../_models/navigationTreeModels';
+import { DIFF_REMOVED } from '../_helpers/common-helpers';
+
+/**
+ * Adds a nav node to the tree while deduplicating modified elements.
+ *
+ * When a diff is computed, both sides of a modification appear as separate nodes:
+ * - removed-side: all codeLines have diffKind === "removed"
+ * - added-side:   codeLines have diffKind === "added" or "unchanged"
+ *
+ * Strategy:
+ * - Removed-side nodes are pushed tentatively. A non-removed counterpart with
+ *   the same label (the modification case) will replace it later, so the nav
+ *   entry points to the active-revision line. Purely-deleted elements have no
+ *   such counterpart, so their entry is kept.
+ * - Non-removed nodes replace any existing removed-side entry with the same
+ *   label, or are pushed as new entries.
+ */
+export function applyNavNodeToTree(
+  navTree: NavigationTreeNode[],
+  navNode: NavigationTreeNode,
+  codeLineDiffKinds: string[]
+): void {
+  const isAllRemovedNode = codeLineDiffKinds.length > 0 && codeLineDiffKinds.every(k => k === DIFF_REMOVED);
+  if (isAllRemovedNode) {
+    navTree.push(navNode);
+  } else {
+    const existingRemovedIndex = navTree.findIndex(n => n.label === navNode.label);
+    if (existingRemovedIndex >= 0) {
+      navTree[existingRemovedIndex] = navNode;
+    } else {
+      navTree.push(navNode);
+    }
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-tools/issues/15076

Fix duplicate left panel navigation entries when viewing a diff. Modified API elements were appearing twice in the nav panel (one link to the deleted line, one to the modified) by keeping deleted, but dedupe/replace when an active counterpart exists