### PR TITLE
Sync sensei skill + GEPA integration from upstream

### DIFF
--- a/.github/skills/sensei/README.md
+++ b/.github/skills/sensei/README.md
@@ -123,7 +123,7 @@ npm test -- --testPathPatterns=azure-validation
 └─────────────────────┬───────────────────────────────────┘
                       ▼
 ┌─────────────────────────────────────────────────────────┐
-│  1. READ: Load plugin/skills/{skill-name}/SKILL.md      │
+│  1. READ: Load .github/skills/{skill-name}/SKILL.md      │
 │           Load tests/{skill-name}/ (if exists)          │
 │           Count tokens (baseline for comparison)        │
 └─────────────────────┬───────────────────────────────────┘
@@ -178,7 +178,7 @@ npm test -- --testPathPatterns=azure-validation
                       ▼
 ┌─────────────────────────────────────────────────────────┐
 │  8. CHECK TOKENS:                                       │
-│     npm run tokens -- check plugin/skills/{skill-name}  │
+│     npm run tokens -- check .github/skills/{skill-name}  │
 │     npm run tokens -- suggest (gather optimizations)    │
 └─────────────────────┬───────────────────────────────────┘
                       ▼
@@ -286,7 +286,7 @@ To reach Medium-High, a skill must have:
 From [skill-authoring](/.github/skills/skill-authoring):
 - **SKILL.md:** < 500 tokens (soft), < 5000 (hard)
 - **references/*.md:** < 1000 tokens each
-- Check with: `cd scripts && npm run tokens -- check plugin/skills/{skill}/SKILL.md`
+- Check with: `cd scripts && npm run tokens -- check .github/skills/{skill}/SKILL.md`
 
 ---
 
@@ -398,7 +398,7 @@ git reset --hard {commit-before-sensei}
 git log --oneline --grep="sensei:"
 
 # See changes to a specific skill
-git log --oneline -p plugin/skills/{skill-name}/SKILL.md
+git log --oneline -p .github/skills/{skill-name}/SKILL.md
 ```
 
 ---

--- a/.github/skills/sensei/README.md
+++ b/.github/skills/sensei/README.md
@@ -22,7 +22,7 @@ Sensei automates the improvement of [Agent Skills](https://agentskills.io) front
 
 ### The Problem
 
-The [frontmatter audit](https://gist.github.com/spboyer/28c31bf0cafb87489406832633aa31a7) revealed that all SDK skills have:
+The [frontmatter audit](https://gist.github.com/spboyer/28c31bf0cafb87489406832633aa31a7) revealed that all Azure skills have:
 - **0% High adherence** - No skills have triggers + anti-triggers + compatibility
 - **46% Low adherence** - 12 skills have minimal descriptions without clear triggers
 - **0/26 anti-triggers** - No skills tell agents when NOT to use them
@@ -108,7 +108,7 @@ cd tests
 npm install
 
 # Verify tests run
-npm test -- --testPathPattern=azure-validation
+npm test -- --testPathPatterns=azure-validation
 ```
 
 ---
@@ -164,7 +164,7 @@ npm test -- --testPathPattern=azure-validation
 └─────────────────────┬───────────────────────────────────┘
                       ▼
 ┌─────────────────────────────────────────────────────────┐
-│  6. VERIFY: npm test -- --testPathPattern={skill-name}  │
+│  6. VERIFY: npm test -- --testPathPatterns={skill-name}  │
 │     • If tests fail → fix and retry                     │
 │     • If tests pass → continue                          │
 └─────────────────────┬───────────────────────────────────┘
@@ -283,7 +283,7 @@ To reach Medium-High, a skill must have:
 
 ### Token Budget
 
-From **skill-authoring**:
+From [skill-authoring](/.github/skills/skill-authoring):
 - **SKILL.md:** < 500 tokens (soft), < 5000 (hard)
 - **references/*.md:** < 1000 tokens each
 - Check with: `cd scripts && npm run tokens -- check plugin/skills/{skill}/SKILL.md`
@@ -297,7 +297,7 @@ From **skill-authoring**:
 ```yaml
 ---
 name: appinsights-instrumentation
-description: 'Implement retry logic for HTTP client requests with exponential backoff'
+description: 'Instrument a webapp to send useful telemetry data to Azure App Insights'
 ---
 ```
 
@@ -313,7 +313,7 @@ description: 'Implement retry logic for HTTP client requests with exponential ba
 ---
 name: appinsights-instrumentation
 description: >-
-  Implement retry logic with exponential backoff for HTTP requests.
+  Instrument web apps to send telemetry to Azure Application Insights.
   USE FOR: "add App Insights", "instrument my app", "set up monitoring",
   "add telemetry", "track requests", "ASP.NET Core telemetry", "Node.js monitoring".
   DO NOT USE FOR: querying logs (use azure-observability), creating alerts,
@@ -368,7 +368,7 @@ const shouldNotTriggerPrompts = [
 3. Run tests manually to see specific failures:
    ```bash
    cd tests
-   npm test -- --testPathPattern={skill-name} --verbose
+   npm test -- --testPathPatterns={skill-name} --verbose
    ```
 
 ### Skill Not Reaching Target Score
@@ -441,5 +441,5 @@ If Sensei produces unexpected results:
 
 ### Related Skills
 
-- **markdown-token-optimizer** - Token analysis and optimization suggestions
-- **skill-authoring** - Guidelines for writing compliant Agent Skills
+- [markdown-token-optimizer](/.github/skills/markdown-token-optimizer) - Token analysis and optimization suggestions
+- [skill-authoring](/.github/skills/skill-authoring) - Guidelines for writing compliant Agent Skills

--- a/.github/skills/sensei/SKILL.md
+++ b/.github/skills/sensei/SKILL.md
@@ -1,64 +1,230 @@
 ---
 name: sensei
-description: "Improve skill frontmatter compliance iteratively using the Ralph loop pattern. **WORKFLOW SKILL**. WHEN: \"run sensei\", \"sensei help\", \"improve skill\", \"fix frontmatter\", \"skill compliance\", \"frontmatter audit\", \"score skill\", \"check skill tokens\". DO NOT USE FOR: writing new skills from scratch (use skill-authoring), general code review. INVOKES: waza CLI, git."
+description: "**WORKFLOW SKILL** — Iteratively improve skill frontmatter compliance using the Ralph loop pattern. WHEN: \"run sensei\", \"sensei help\", \"improve skill\", \"fix frontmatter\", \"skill compliance\", \"frontmatter audit\", \"score skill\", \"check skill tokens\". INVOKES: token counting tools, test runners, git commands. FOR SINGLE OPERATIONS: use token CLI directly for counts/checks."
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.0.0"
-compatibility:
-  platforms: "copilot-chat"
+  version: "1.0.5"
 ---
 
 # Sensei
 
-Iteratively improve skills until they pass waza check compliance.
+> "A true master teaches not by telling, but by refining." - The Skill Sensei
 
-## Usage
+Automates skill frontmatter improvement using the [Ralph loop pattern](https://github.com/soderlind/ralph) - iteratively improving skills until they reach Medium-High compliance with passing tests, then checking token usage and prompting for action.
+
+## Help
+
+When user says "sensei help" or asks how to use sensei, show this:
 
 ```
-Run sensei on <skill-name>
-Run sensei on <skill1>, <skill2>
+╔══════════════════════════════════════════════════════════════════╗
+║  SENSEI - Skill Frontmatter Compliance Improver                  ║
+╠══════════════════════════════════════════════════════════════════╣
+║                                                                  ║
+║  USAGE:                                                          ║
+║    Run sensei on <skill-name>              # Single skill        ║
+║    Run sensei on <skill-name> --skip-integration  # Fast mode    ║
+║    Run sensei on <skill1>, <skill2>, ...   # Multiple skills     ║
+║    Run sensei on all Low-adherence skills  # Batch by score      ║
+║    Run sensei on all skills                # All skills       ║
+║                                                                  ║
+║  EXAMPLES:                                                       ║
+║    Run sensei on appinsights-instrumentation                     ║
+║    Run sensei on azure-security --skip-integration               ║
+║    Run sensei on azure-security, azure-observability             ║
+║    Run sensei on all Low-adherence skills                        ║
+║                                                                  ║
+║  WHAT IT DOES:                                                   ║
+║    1. READ      - Load skill's SKILL.md, tests, and token count  ║
+║    2. SCORE     - Check compliance (Low/Medium/Medium-High/High) ║
+║    3. SCAFFOLD  - Create tests from template if missing          ║
+║    4. IMPROVE   - Add WHEN: triggers (cross-model optimized)     ║
+║    5. TEST      - Run tests, fix if needed                       ║
+║    6. REFERENCES- Validate markdown links                        ║
+║    7. TOKENS    - Check token budget, gather suggestions         ║
+║    8. SUMMARY   - Show before/after with suggestions             ║
+║    9. PROMPT    - Ask: Commit, Create Issue, or Skip?            ║
+║   10. REPEAT    - Until Medium-High score + tests pass           ║
+║                                                                  ║
+║  TARGET SCORE: Medium-High                                       ║
+║    ✓ Description > 150 chars, ≤ 60 words                         ║
+║    ✓ Has "WHEN:" trigger phrases (preferred)                     ║
+║    ✓ No "DO NOT USE FOR:" (unless disambiguation-critical)         ║
+║    ✓ SKILL.md < 500 tokens (soft limit)                          ║
+║                                                                  ║
+║  MORE INFO:                                                      ║
+║    See .github/skills/sensei/README.md for full documentation    ║
+║                                                                  ║
+╚══════════════════════════════════════════════════════════════════╝
+```
+
+## When to Use
+
+- Improving a skill's frontmatter compliance score
+- Adding trigger phrases and anti-triggers to skill descriptions
+- Batch-improving multiple skills at once
+- Auditing and fixing Low-adherence skills
+
+## Invocation Modes
+
+### Single Skill
+```
+Run sensei on azure-deploy
+```
+
+### Multiple Skills
+```
+Run sensei on azure-security, azure-observability
+```
+
+### By Adherence Level
+```
+Run sensei on all Low-adherence skills
+```
+
+### All Skills
+```
 Run sensei on all skills
+```
+
+### GEPA Mode (Deep Optimization)
+```
+Run sensei on my-skill --gepa
+Run sensei on my-skill --gepa --skip-integration
+Run sensei on all skills --gepa
+```
+
+When `--gepa` is used, Step 5 (IMPROVE) is replaced with GEPA evolutionary optimization.
+Instead of template-based improvements, GEPA parses trigger prompt arrays from the existing
+test harness and combines them with content quality heuristics to build a fitness function.
+An LLM proposes and evaluates many candidate improvements automatically. Note: GEPA does not
+execute Jest tests directly — it uses the test data (prompts) as evaluation inputs.
+
+**GEPA score-only mode** (no LLM calls, just evaluate current quality):
+```
+Run sensei score my-skill
+Run sensei score all skills
 ```
 
 ## The Ralph Loop
 
-For each skill, repeat until compliant (max 5 iterations):
+For each skill, execute this loop until score >= Medium-High AND tests pass:
 
-1. **READ** — Load SKILL.md and current token count
-2. **SCORE** — Run `waza check {skill-name}` for compliance
-3. **FIX** — Address issues: tokens, broken links, frontmatter
-4. **VERIFY** — Re-run `waza check`; loop if issues remain
-5. **COMMIT** — `sensei: improve {skill-name} frontmatter`
+1. **READ** - Load `plugin/skills/{skill-name}/SKILL.md`, tests, and token count
+2. **SCORE** - Run spec-based compliance check (see [SCORING.md](references/SCORING.md)):
+   - Validate `name` per [agentskills.io spec](https://agentskills.io/specification) (no `--`, no start/end `-`, lowercase alphanumeric)
+   - Check description length and word count (≤60 words)
+   - Check triggers (WHEN: preferred, USE FOR: accepted)
+   - Warn on "DO NOT USE FOR:" (risky in multi-skill environments — **exception**: REQUIRED for skills that share trigger overlap with broader skills like `azure-prepare`)
+   - Preserve optional spec fields (`license`, `metadata`, `allowed-tools`) if present
+3. **CHECK** - If score >= Medium-High AND tests pass → go to TOKENS step
+4. **SCAFFOLD** - If `tests/{skill-name}/` doesn't exist, create from `tests/_template/`
+5. **IMPROVE FRONTMATTER** - Add WHEN: triggers (stay under 60 words and 1024 chars)
+5b. **IMPROVE WITH GEPA** (when `--gepa` flag is set) — Replaces step 5 (IMPROVE FRONTMATTER) with automated optimization; step 6 (IMPROVE TESTS) still runs normally:
+   - Auto-discovers `tests/{skill-name}/triggers.test.ts` and extracts prompt arrays
+   - Builds a GEPA evaluator scoring content quality + trigger accuracy based on those trigger prompt arrays (not Jest test pass/fail results)
+   - Runs `python .github/skills/sensei/scripts/gepa/auto_evaluator.py optimize --skill {skill-name} --skills-dir plugin/skills --tests-dir tests`
+   - Shows diff of optimized SKILL.md for user approval
+   - GEPA uses existing test trigger definitions as configuration — it does not execute, replace, or modify Jest tests
+6. **IMPROVE TESTS** - Update `shouldTriggerPrompts` and `shouldNotTriggerPrompts` to match the finalized frontmatter (including any GEPA changes)
+7. **VERIFY** - Run `cd tests && npm test -- --testPathPatterns={skill-name}`
+8. **VALIDATE REFERENCES** - Run `cd scripts && npm run references {skill-name}` to check markdown links
+9. **TOKENS** - Check token budget and line count (< 500 lines per spec), gather optimization suggestions
+10. **SUMMARY** - Display before/after comparison with unimplemented suggestions
+11. **PROMPT** - Ask user: Commit, Create Issue, or Skip?
+12. **REPEAT** - Go to step 2 (max 5 iterations per skill)
 
-Target: High compliance, ≤500 tokens, all links valid.
+## Scoring Criteria (Quick Reference)
 
-## Frontmatter Rules
+Sensei validates skills against the [agentskills.io specification](https://agentskills.io/specification). See [SCORING.md](references/SCORING.md) for full details.
 
-- Use inline double-quoted `description` (not `>-` folded scalars)
-- Lead with action verb + domain; add `WHEN:` trigger phrases
-- Keep ≤60 words, ≤1024 chars
+| Score | Requirements |
+|-------|--------------|
+| **Invalid** | Name fails spec validation (consecutive hyphens, start/end hyphen, uppercase, etc.) |
+| **Low** | Basic description, no explicit triggers |
+| **Medium** | Has trigger keywords/phrases, description > 150 chars, >60 words |
+| **Medium-High** | Has "WHEN:" (preferred) or "USE FOR:" triggers, ≤60 words |
+| **High** | Medium-High + compatibility field |
 
-## Tools
+**Target: Medium-High** (distinctive triggers, concise description)
 
-No MCP servers required — uses waza CLI directly.
+> ⚠️ "DO NOT USE FOR:" is **risky in multi-skill environments** (15+ overlapping skills) — causes keyword contamination on fast-pattern-matching models. Safe for small, isolated skill sets. Use positive routing with `WHEN:` for cross-model safety.
+>
+> **Exception — disambiguation-critical skills:** When a skill's `USE FOR` triggers directly overlap with a broader skill (e.g., `azure-prepare` owns "deploy to Azure"), `DO NOT USE FOR:` is **REQUIRED** to prevent the broader skill from capturing prompts that belong to the specialized skill. Removing it causes routing regressions. Integration tests validate this routing -- run them before removing any `DO NOT USE FOR:` clause.
 
-| Tool | Fallback |
-|------|----------|
-| waza | `waza check` / `waza run` CLI |
-| git | Standard git CLI |
+**Strongly recommended** (reported as suggestions if missing):
+- `license` — identifies the license applied to the skill
+- `metadata.version` — tracks the skill version for consumers
 
-## Examples
+## Frontmatter Template
 
-- "Run sensei on pipeline-troubleshooting"
-- "Run sensei on all skills"
+Per the [agentskills.io spec](https://agentskills.io/specification), required and optional fields:
 
-## Troubleshooting
+```yaml
+---
+name: skill-name
+description: "[ACTION VERB] [UNIQUE_DOMAIN]. [One clarifying sentence]. WHEN: \"trigger 1\", \"trigger 2\", \"trigger 3\"."
+license: MIT
+metadata:
+  version: "1.0"
+# Other optional spec fields — preserve if already present:
+# metadata.author: example-org
+# allowed-tools: Bash(git:*) Read
+---
+```
 
-If waza fails, verify it is installed and you are in the skills directory.
+> **IMPORTANT:** Use inline double-quoted strings for descriptions. Do NOT use `>-` folded scalars (incompatible with skills.sh). Do NOT use `|` literal blocks (preserves newlines). Keep total description under 1024 characters and ≤60 words.
 
-## References
+> ⚠️ **"DO NOT USE FOR:" carries context-dependent risk.** In multi-skill environments (10+ skills with overlapping domains), anti-trigger clauses introduce the very keywords that cause wrong-skill activation on Claude Sonnet and fast-pattern-matching models ([evidence](https://gist.github.com/kvenkatrajan/52e6e77f5560ca30640490b4cc65d109)). For small, isolated skill sets (1-5 skills), the risk is low. When in doubt, use positive routing with `WHEN:` and distinctive quoted phrases.
+>
+> **Exception:** `DO NOT USE FOR:` is **REQUIRED** when a specialized skill's triggers overlap with a broader skill (e.g., `azure-hosted-copilot-sdk` vs. `azure-prepare` on "deploy to Azure"). Without the negative discriminator, the broader skill captures prompts that should route to the specialized one. Always run integration tests before removing a `DO NOT USE FOR:` clause.
 
-- [SCORING.md](references/SCORING.md) — Scoring criteria and token budgets
-- [LOOP.md](references/LOOP.md) — Detailed workflow
-- [EXAMPLES.md](references/EXAMPLES.md) — Before/after examples
+## Test Scaffolding
+
+When tests don't exist, scaffold from `tests/_template/`:
+
+```bash
+cp -r tests/_template tests/{skill-name}
+```
+
+Then update:
+1. `SKILL_NAME` constant in all test files
+2. `shouldTriggerPrompts` - 5+ prompts matching new frontmatter triggers
+3. `shouldNotTriggerPrompts` - 5+ prompts matching anti-triggers
+
+**Commit Messages:**
+```
+sensei: improve {skill-name} frontmatter
+```
+
+## Constraints
+
+- Only modify `plugin/skills/` - these are the Azure skills used by Copilot
+- `.github/skills/` contains meta-skills like sensei for developer tooling
+- Max 5 iterations per skill before moving on
+- Description must stay under 1024 characters
+- SKILL.md should stay under 500 tokens (soft limit)
+- Tests must pass before prompting for action
+- User chooses: Commit, Create Issue, or Skip after each skill
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--skip-integration` | Skip integration tests for faster iteration. Only runs unit and trigger tests. |
+| `--gepa` | Use GEPA evolutionary optimization instead of template-based improvement. Auto-discovers tests and builds evaluator at runtime. |
+
+> ⚠️ Skipping integration tests speeds up the loop but may miss runtime issues. Consider running full tests before final commit.
+
+## Reference Documentation
+
+- [SCORING.md](references/SCORING.md) - Detailed scoring criteria
+- [LOOP.md](references/LOOP.md) - Ralph loop workflow details
+- [EXAMPLES.md](references/EXAMPLES.md) - Before/after examples
+- [TOKEN-INTEGRATION.md](references/TOKEN-INTEGRATION.md) - Token budget integration
+
+## Related Skills
+
+- [markdown-token-optimizer](/.github/skills/markdown-token-optimizer) - Token analysis and optimization
+- [skill-authoring](/.github/skills/skill-authoring) - Skill writing guidelines

--- a/.github/skills/sensei/SKILL.md
+++ b/.github/skills/sensei/SKILL.md
@@ -111,7 +111,7 @@ Run sensei score all skills
 
 For each skill, execute this loop until score >= Medium-High AND tests pass:
 
-1. **READ** - Load `plugin/skills/{skill-name}/SKILL.md`, tests, and token count
+1. **READ** - Load `.github/skills/{skill-name}/SKILL.md`, tests, and token count
 2. **SCORE** - Run spec-based compliance check (see [SCORING.md](references/SCORING.md)):
    - Validate `name` per [agentskills.io spec](https://agentskills.io/specification) (no `--`, no start/end `-`, lowercase alphanumeric)
    - Check description length and word count (≤60 words)
@@ -124,7 +124,7 @@ For each skill, execute this loop until score >= Medium-High AND tests pass:
 5b. **IMPROVE WITH GEPA** (when `--gepa` flag is set) — Replaces step 5 (IMPROVE FRONTMATTER) with automated optimization; step 6 (IMPROVE TESTS) still runs normally:
    - Auto-discovers `tests/{skill-name}/triggers.test.ts` and extracts prompt arrays
    - Builds a GEPA evaluator scoring content quality + trigger accuracy based on those trigger prompt arrays (not Jest test pass/fail results)
-   - Runs `python .github/skills/sensei/scripts/gepa/auto_evaluator.py optimize --skill {skill-name} --skills-dir plugin/skills --tests-dir tests`
+   - Runs `python .github/skills/sensei/scripts/gepa/auto_evaluator.py optimize --skill {skill-name} --skills-dir .github/skills --tests-dir tests`
    - Shows diff of optimized SKILL.md for user approval
    - GEPA uses existing test trigger definitions as configuration — it does not execute, replace, or modify Jest tests
 6. **IMPROVE TESTS** - Update `shouldTriggerPrompts` and `shouldNotTriggerPrompts` to match the finalized frontmatter (including any GEPA changes)
@@ -200,7 +200,7 @@ sensei: improve {skill-name} frontmatter
 
 ## Constraints
 
-- Only modify `plugin/skills/` - these are the Azure skills used by Copilot
+- Only modify `.github/skills/` - these are the Azure skills used by Copilot
 - `.github/skills/` contains meta-skills like sensei for developer tooling
 - Max 5 iterations per skill before moving on
 - Description must stay under 1024 characters

--- a/.github/skills/sensei/references/EXAMPLES.md
+++ b/.github/skills/sensei/references/EXAMPLES.md
@@ -10,7 +10,7 @@ Before and after examples of frontmatter improvements, including token counts.
 ```yaml
 ---
 name: appinsights-instrumentation
-description: 'Implement retry logic for HTTP client requests with exponential backoff'
+description: 'Instrument a webapp to send useful telemetry data to Azure App Insights'
 ---
 ```
 
@@ -44,7 +44,7 @@ const shouldNotTriggerPrompts = [
 ```yaml
 ---
 name: appinsights-instrumentation
-description: "Implement retry logic with exponential backoff for HTTP requests. WHEN: \"add retry logic\", \"implement exponential backoff\", \"handle transient failures\", \"add resilience\", \"HTTP retry pattern\"."
+description: "Instrument web applications to send telemetry to Azure Application Insights for monitoring and diagnostics. WHEN: \"add App Insights\", \"instrument my app\", \"set up application monitoring\", \"add telemetry\", \"track requests and dependencies\", \"ASP.NET Core telemetry\", \"Node.js Application Insights\"."
 ---
 ```
 
@@ -67,16 +67,16 @@ const shouldTriggerPrompts = [
   'Set up telemetry for my Node.js app',
   'How do I track requests in App Insights?',
   'Add Application Insights monitoring to my project',
-  'Add retry logic to my HTTP client',
+  'Configure App Insights for my Azure web app',
 ];
 
 const shouldNotTriggerPrompts = [
   'What is the weather today?',
   'Help me write a poem',
   'Query my Application Insights logs',  // → azure-observability
-  'Create a health check endpoint',     // → service-health
+  'Create an alert in Azure Monitor',     // → azure-observability
   'Show me my App Insights dashboard',    // → azure-observability
-  'How much does App Insights cost?',     // → azure-cost-optimization
+  'How much does App Insights cost?',     // → azure-cost
   'Help me with AWS CloudWatch',          // Wrong cloud provider
 ];
 ```
@@ -91,7 +91,7 @@ const shouldNotTriggerPrompts = [
 ```yaml
 ---
 name: azure-security
-description: 'Security best practices including secrets management, authentication patterns, role-based access control, and threat detection.'
+description: 'Azure Security Services including Key Vault, Managed Identity, RBAC, Entra ID, and Defender. Provides secrets management, credential-free authentication, role-based access control, and threat protection.'
 ---
 ```
 
@@ -191,7 +191,7 @@ description: "Deploy applications to Azure App Service, Azure Functions, and Sta
 'Validate my Bicep template',        // → azure-deployment-preflight
 'Create an azure.yaml file',         // → azure-create-app
 'Why did my deployment fail?',       // → azure-diagnostics
-'How much will this deployment cost?', // → azure-cost-optimization
+'How much will this deployment cost?', // → azure-cost
 ```
 
 ---

--- a/.github/skills/sensei/references/LOOP.md
+++ b/.github/skills/sensei/references/LOOP.md
@@ -208,10 +208,10 @@ description: "[ACTION VERB] [UNIQUE_DOMAIN]. [One clarifying sentence]. WHEN: \"
 **Command:**
 ```bash
 # Standard (unit + trigger tests only - fast)
-cd tests && npm test -- --testPathPattern={skill-name} --testPathIgnorePatterns=integration
+cd tests && npm test -- --testPathPatterns={skill-name} --testPathIgnorePatterns=integration
 
 # With integration tests (slower, requires Copilot SDK)
-cd tests && npm test -- --testPathPattern={skill-name}
+cd tests && npm test -- --testPathPatterns={skill-name}
 ```
 
 **Skip Integration Tests Flag:**
@@ -277,7 +277,7 @@ wc -l plugin/skills/{skill-name}/SKILL.md
 ```
 Report a warning if SKILL.md exceeds 500 lines (spec recommendation).
 
-**Token Budgets** (from skill-authoring):
+**Token Budgets** (from [skill-authoring](/.github/skills/skill-authoring)):
 - SKILL.md: < 500 tokens (soft limit), < 5000 (hard limit)
 - references/*.md: < 1000 tokens each
 
@@ -288,7 +288,7 @@ Report a warning if SKILL.md exceeds 500 lines (spec recommendation).
 
 **Note:** Token optimizations are captured but NOT automatically applied. The user decides whether to implement them or create an issue for follow-up.
 
-See [SCORING.md § Token Integration](SCORING.md) for details on token optimization patterns.
+See [TOKEN-INTEGRATION.md](TOKEN-INTEGRATION.md) for details on token optimization patterns.
 
 ### Step 7: SUMMARY
 

--- a/.github/skills/sensei/references/LOOP.md
+++ b/.github/skills/sensei/references/LOOP.md
@@ -107,7 +107,7 @@ The Ralph loop is an iterative improvement cycle inspired by the ["Ralph Wiggum"
 
 **Files to read:**
 ```
-plugin/skills/{skill-name}/SKILL.md    # Required
+.github/skills/{skill-name}/SKILL.md    # Required
 tests/{skill-name}/unit.test.ts        # If exists
 tests/{skill-name}/triggers.test.ts    # If exists
 tests/{skill-name}/integration.test.ts # If exists
@@ -267,13 +267,13 @@ cd scripts && npm run references {skill-name}
 
 **Commands:**
 ```bash
-cd scripts && npm run tokens -- check plugin/skills/{skill-name}/SKILL.md
-cd scripts && npm run tokens -- suggest plugin/skills/{skill-name}/SKILL.md
+cd scripts && npm run tokens -- check .github/skills/{skill-name}/SKILL.md
+cd scripts && npm run tokens -- suggest .github/skills/{skill-name}/SKILL.md
 ```
 
 **Line count check (per spec):**
 ```bash
-wc -l plugin/skills/{skill-name}/SKILL.md
+wc -l .github/skills/{skill-name}/SKILL.md
 ```
 Report a warning if SKILL.md exceeds 500 lines (spec recommendation).
 
@@ -339,7 +339,7 @@ Choose an action:
 
 **Commit flow:**
 ```bash
-git add plugin/skills/{skill-name}/SKILL.md
+git add .github/skills/{skill-name}/SKILL.md
 git add tests/{skill-name}/
 git commit -m "sensei: improve {skill-name} frontmatter
 
@@ -417,7 +417,7 @@ Skills: [skill-a, skill-b, skill-c]
 
 ### Skill Not Found
 
-1. Verify skill exists: `ls plugin/skills/{skill-name}`
+1. Verify skill exists: `ls .github/skills/{skill-name}`
 2. Check spelling (case-sensitive)
 3. Report error and skip to next skill
 
@@ -432,7 +432,7 @@ Sensei tracks progress via git commits. To review:
 git log --oneline --grep="sensei:"
 
 # See specific skill history
-git log --oneline -- plugin/skills/{skill-name}/SKILL.md
+git log --oneline -- .github/skills/{skill-name}/SKILL.md
 
 # See diff for a commit
 git show {commit-hash}

--- a/.github/skills/sensei/references/SCORING.md
+++ b/.github/skills/sensei/references/SCORING.md
@@ -18,7 +18,7 @@ From [skill-authoring](/.github/skills/skill-authoring):
 | references/*.md | 1000 | - | Each reference file |
 | Description | - | 1024 chars | Frontmatter description field |
 
-**Check with:** `cd scripts && npm run tokens -- check plugin/skills/{skill}/SKILL.md`
+**Check with:** `cd scripts && npm run tokens -- check .github/skills/{skill}/SKILL.md`
 
 > **Units note:** Sensei measures in **tokens** (cl100k_base tokenizer), not words. Anthropic's [Complete Guide](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf) recommends "under 5,000 words" for SKILL.md, while the [Agent Skills spec](https://agentskills.io/specification) recommends "< 5000 tokens" and "under 500 lines." Sensei uses the spec's token-based limits. As a rough conversion: 5000 tokens ≈ 3,750 words.
 

--- a/.github/skills/sensei/references/SCORING.md
+++ b/.github/skills/sensei/references/SCORING.md
@@ -10,7 +10,7 @@ Sensei evaluates skills on two dimensions:
 
 ## Token Budgets
 
-From skill-authoring:
+From [skill-authoring](/.github/skills/skill-authoring):
 
 | File | Soft Limit | Hard Limit | Notes |
 |------|------------|------------|-------|
@@ -30,7 +30,7 @@ References load **only when explicitly linked** in SKILL.md, not on activation:
 - No caching between requests
 - Structure with recipes/services patterns for multi-option skills
 
-See skill-authoring REFERENCE-LOADING.md for details.
+See [skill-authoring REFERENCE-LOADING.md](/.github/skills/skill-authoring/references/REFERENCE-LOADING.md) for details.
 
 ## Adherence Levels
 
@@ -121,7 +121,7 @@ Per the [agentskills.io spec](https://agentskills.io/specification), the `name` 
 | Check | Pass | Fail |
 |-------|------|------|
 | Lowercase only | `azure-deploy` | `Azure-Deploy` |
-| Alphanumeric + hyphens | `azure-cost-optimization` | `azure_cost_optimization` |
+| Alphanumeric + hyphens | `azure-cost` | `azure_cost` |
 | No start/end hyphen | `azure-deploy` | `-azure-deploy`, `azure-deploy-` |
 | No consecutive hyphens | `azure-deploy` | `azure--deploy` |
 | Matches directory | `skill-name` = folder name | Mismatch |
@@ -166,6 +166,7 @@ Per the [agentskills.io spec](https://agentskills.io/specification), the `name` 
 | Single skill or small set (1-5 skills) with clear domain boundaries | Low | Anti-triggers are low-risk — domain boundaries are obvious |
 | Medium skill set (5-15 skills) with some overlap | Moderate | Anti-trigger keywords start competing with other skills' triggers |
 | Large skill set (15+ skills) with overlapping domains | **High** | Keyword contamination is measurable — negative keywords become activation keywords on fast-pattern-matching models |
+| **Specialized skill with trigger overlap against a broader skill** | **REQUIRED** | Anti-triggers are the **only** disambiguation mechanism when a specialized skill (e.g., `azure-hosted-copilot-sdk`) competes with a broader skill (e.g., `azure-prepare`) on shared trigger phrases like "deploy to Azure". Removing them causes routing regressions. |
 
 **Why large skill sets are risky:** On Claude Sonnet and similar models that use fast pattern matching (first ~20 words), `DO NOT USE FOR: Function apps` causes Sonnet to key on "Function apps" and **activate** the skill for Functions queries. This was empirically demonstrated across 24 Azure skills ([analysis](https://gist.github.com/kvenkatrajan/52e6e77f5560ca30640490b4cc65d109)). Anthropic's own published skills confirm this pattern — 4 of 5 skills in `anthropics/skills` use positive-only routing.
 
@@ -179,9 +180,15 @@ Per the [agentskills.io spec](https://agentskills.io/specification), the `name` 
 - `Defer to`
 
 **Scoring:**
-- Present in large skill sets → emits cross-model compatibility warning
+- Present in large skill sets without trigger overlap → emits cross-model compatibility warning
 - Present in small skill sets → informational note only
-- Absent → no penalty (preferred for cross-model compatibility)
+- **Present in skills with trigger overlap against broader skills → NO WARNING (required for disambiguation)**
+- Absent → no penalty (preferred for cross-model compatibility, **except** when disambiguation is required)
+
+**Automated routing-regression guard (Sensei rule):**
+- Detect trigger overlap between specialized skills and broad skills (for example `azure-prepare`)
+- Require disambiguation when overlap exists: either `DO NOT USE FOR:` or `PREFER OVER <competing-skill>`
+- Report an error when a PR removes an existing `DO NOT USE FOR:` or `PREFER OVER` clause from a skill (potential routing regression)
 
 ### 5. Compatibility Field
 
@@ -319,8 +326,14 @@ function scoreSkill(skill):
             score = "Medium-High"
     
     # Warn on anti-triggers (keyword contamination risk)
+    # Exception: DO NOT warn if skill has trigger overlap with a broader skill
+    # (e.g., azure-hosted-copilot-sdk overlaps with azure-prepare on "deploy")
+    # In that case, DO NOT USE FOR is REQUIRED for disambiguation
     if containsAntiTriggers(skill.description):
-        warn "DO NOT USE FOR: causes keyword contamination on Sonnet — remove"
+        if hasOverlappingTriggersWithBroaderSkill(skill):
+            pass  # anti-triggers required for disambiguation — no warning
+        else:
+            warn "DO NOT USE FOR: causes keyword contamination on Sonnet — consider removing"
     
     # Check for compatibility
     hasCompatibility = skill.compatibility != null
@@ -349,7 +362,10 @@ function collectSuggestions(skill):
     if usesBlockScalar(skill.rawDescription):
         suggestions.add("Use inline double-quoted string for description (>- incompatible with skills.sh)")
     if containsAntiTriggers(skill.description):
-        suggestions.add("Remove DO NOT USE FOR: — causes keyword contamination on Claude Sonnet")
+        if hasOverlappingTriggersWithBroaderSkill(skill):
+            pass  # anti-triggers required — do not suggest removal
+        else:
+            suggestions.add("Consider removing DO NOT USE FOR: — causes keyword contamination on Claude Sonnet. Run integration tests first to verify routing is unaffected.")
     if wordCount(skill.description) > 60:
         suggestions.add("Trim description to ≤60 words for cross-model reliability")
     return suggestions
@@ -390,7 +406,7 @@ From the [frontmatter audit](https://gist.github.com/spboyer/28c31bf0cafb8748940
 4. `azure-postgres`
 5. `azure-functions`
 6. `azure-quick-review`
-7. `azure-cost-optimization`
+7. `azure-cost`
 8. `azure-kusto`
 9. `azure-keyvault-expiration-audit`
 10. `azure-aigateway`
@@ -398,127 +414,3 @@ From the [frontmatter audit](https://gist.github.com/spboyer/28c31bf0cafb8748940
 12. `microsoft-foundry`
 13. `skill-authoring`
 14. `markdown-token-optimizer`
-# Token Integration
-
-Sensei integrates with the token management system to ensure skills stay within budget while improving frontmatter compliance.
-
-## Token Budgets
-
-From the skill-authoring skill:
-
-| File Type | Soft Limit | Hard Limit |
-|-----------|------------|------------|
-| SKILL.md | 500 tokens | 5000 tokens |
-| references/*.md | 1000 tokens | - |
-| Total skill | 2000 tokens | - |
-
-## Token Commands
-
-Sensei uses the token CLI from `scripts/`:
-
-```bash
-# Count tokens in a file
-cd scripts && npm run tokens -- count plugin/skills/{skill-name}/SKILL.md
-
-# Check against limits
-cd scripts && npm run tokens -- check plugin/skills/{skill-name}/SKILL.md
-
-# Get optimization suggestions
-cd scripts && npm run tokens -- suggest plugin/skills/{skill-name}/SKILL.md
-```
-
-## Integration Points
-
-### 1. READ Phase (Capture Baseline)
-
-At loop start, capture initial token count:
-```bash
-cd scripts && npm run tokens -- count plugin/skills/{skill-name}/SKILL.md --json
-```
-
-Store: `beforeTokens = result.tokens`
-
-### 2. CHECK TOKENS Phase (After Improvements)
-
-After frontmatter improvements pass tests:
-```bash
-# Get current count
-cd scripts && npm run tokens -- count plugin/skills/{skill-name}/SKILL.md --json
-
-# Get suggestions
-cd scripts && npm run tokens -- suggest plugin/skills/{skill-name}/SKILL.md --json
-```
-
-Store:
-- `afterTokens = result.tokens`
-- `tokenDelta = afterTokens - beforeTokens`
-- `suggestions = suggestResult.suggestions`
-
-### 3. SUMMARY Phase (Report)
-
-Include in summary:
-- Token count before/after
-- Delta (+/- tokens)
-- Suggestions not implemented (for user review)
-
-## Optimization Patterns
-
-For detailed optimization guidance, reference the markdown-token-optimizer skill:
-
-- ANTI-PATTERNS.md (in markdown-token-optimizer) - Token-wasting patterns to avoid
-- OPTIMIZATION-PATTERNS.md (in markdown-token-optimizer) - Techniques to reduce tokens
-
-### Quick Reference: Common Optimizations
-
-| Pattern | Savings | Example |
-|---------|---------|---------|
-| Remove emojis | 1-3 tokens each | `✅` → (remove) |
-| Shorten headings | 2-5 tokens | `## Step 1: Configuration` → `## Configuration` |
-| Remove filler words | 1-2 tokens each | "In order to" → "To" |
-| Consolidate lists | 5-10 tokens | Multiple bullets → single sentence |
-| Use abbreviations | 1-2 tokens | "Application Insights" → "App Insights" |
-
-## When to Apply Token Suggestions
-
-Sensei captures token optimization suggestions but does **not** auto-apply them. The user decides:
-
-**Apply immediately if:**
-- Skill exceeds soft limit (500 tokens)
-- Suggestions don't reduce clarity
-- Changes are straightforward
-
-**Create issue if:**
-- Suggestions require careful review
-- Multiple skills need same optimization
-- Changes might affect functionality
-
-**Skip if:**
-- Skill is well under budget
-- Suggestions trade clarity for brevity
-- Time constraints
-
-## Example Summary with Tokens
-
-```
-╔══════════════════════════════════════════════════════════════════╗
-║  SENSEI SUMMARY: appinsights-instrumentation                     ║
-╠══════════════════════════════════════════════════════════════════╣
-║  BEFORE                          AFTER                           ║
-║  ──────                          ─────                           ║
-║  Score: Low                      Score: Medium-High              ║
-║  Tokens: 142                     Tokens: 385                     ║
-║  Triggers: 0                     Triggers: 7                     ║
-║  Anti-triggers: 0                Anti-triggers: 4                ║
-║                                                                  ║
-║  TOKEN STATUS: ✅ Under budget (385 < 500)                       ║
-║                                                                  ║
-║  SUGGESTIONS NOT IMPLEMENTED:                                    ║
-║  • (none - skill is under budget)                                ║
-║                                                                  ║
-╚══════════════════════════════════════════════════════════════════╝
-```
-
-## Related Skills
-
-- markdown-token-optimizer - Token analysis and suggestions
-- skill-authoring - Skill writing guidelines and constraints

--- a/.github/skills/sensei/references/TOKEN-INTEGRATION.md
+++ b/.github/skills/sensei/references/TOKEN-INTEGRATION.md
@@ -1,0 +1,124 @@
+# Token Integration
+
+Sensei integrates with the token management system to ensure skills stay within budget while improving frontmatter compliance.
+
+## Token Budgets
+
+From the [skill-authoring](/.github/skills/skill-authoring) skill:
+
+| File Type | Soft Limit | Hard Limit |
+|-----------|------------|------------|
+| SKILL.md | 500 tokens | 5000 tokens |
+| references/*.md | 1000 tokens | - |
+| Total skill | 2000 tokens | - |
+
+## Token Commands
+
+Sensei uses the token CLI from `scripts/`:
+
+```bash
+# Count tokens in a file
+cd scripts && npm run tokens -- count plugin/skills/{skill-name}/SKILL.md
+
+# Check against limits
+cd scripts && npm run tokens -- check plugin/skills/{skill-name}/SKILL.md
+
+# Get optimization suggestions
+cd scripts && npm run tokens -- suggest plugin/skills/{skill-name}/SKILL.md
+```
+
+## Integration Points
+
+### 1. READ Phase (Capture Baseline)
+
+At loop start, capture initial token count:
+```bash
+cd scripts && npm run tokens -- count plugin/skills/{skill-name}/SKILL.md --json
+```
+
+Store: `beforeTokens = result.tokens`
+
+### 2. CHECK TOKENS Phase (After Improvements)
+
+After frontmatter improvements pass tests:
+```bash
+# Get current count
+cd scripts && npm run tokens -- count plugin/skills/{skill-name}/SKILL.md --json
+
+# Get suggestions
+cd scripts && npm run tokens -- suggest plugin/skills/{skill-name}/SKILL.md --json
+```
+
+Store:
+- `afterTokens = result.tokens`
+- `tokenDelta = afterTokens - beforeTokens`
+- `suggestions = suggestResult.suggestions`
+
+### 3. SUMMARY Phase (Report)
+
+Include in summary:
+- Token count before/after
+- Delta (+/- tokens)
+- Suggestions not implemented (for user review)
+
+## Optimization Patterns
+
+For detailed optimization guidance, reference the [markdown-token-optimizer](/.github/skills/markdown-token-optimizer) skill:
+
+- [ANTI-PATTERNS.md](/.github/skills/markdown-token-optimizer/references/ANTI-PATTERNS.md) - Token-wasting patterns to avoid
+- [OPTIMIZATION-PATTERNS.md](/.github/skills/markdown-token-optimizer/references/OPTIMIZATION-PATTERNS.md) - Techniques to reduce tokens
+
+### Quick Reference: Common Optimizations
+
+| Pattern | Savings | Example |
+|---------|---------|---------|
+| Remove emojis | 1-3 tokens each | `✅` → (remove) |
+| Shorten headings | 2-5 tokens | `## Step 1: Configuration` → `## Configuration` |
+| Remove filler words | 1-2 tokens each | "In order to" → "To" |
+| Consolidate lists | 5-10 tokens | Multiple bullets → single sentence |
+| Use abbreviations | 1-2 tokens | "Application Insights" → "App Insights" |
+
+## When to Apply Token Suggestions
+
+Sensei captures token optimization suggestions but does **not** auto-apply them. The user decides:
+
+**Apply immediately if:**
+- Skill exceeds soft limit (500 tokens)
+- Suggestions don't reduce clarity
+- Changes are straightforward
+
+**Create issue if:**
+- Suggestions require careful review
+- Multiple skills need same optimization
+- Changes might affect functionality
+
+**Skip if:**
+- Skill is well under budget
+- Suggestions trade clarity for brevity
+- Time constraints
+
+## Example Summary with Tokens
+
+```
+╔══════════════════════════════════════════════════════════════════╗
+║  SENSEI SUMMARY: appinsights-instrumentation                     ║
+╠══════════════════════════════════════════════════════════════════╣
+║  BEFORE                          AFTER                           ║
+║  ──────                          ─────                           ║
+║  Score: Low                      Score: Medium-High              ║
+║  Tokens: 142                     Tokens: 385                     ║
+║  Triggers: 0                     Triggers: 7                     ║
+║  Anti-triggers: 0                Anti-triggers: 4                ║
+║                                                                  ║
+║  TOKEN STATUS: ✅ Under budget (385 < 500)                       ║
+║                                                                  ║
+║  SUGGESTIONS NOT IMPLEMENTED:                                    ║
+║  • (none - skill is under budget)                                ║
+║                                                                  ║
+╚══════════════════════════════════════════════════════════════════╝
+```
+
+## Related Skills
+
+- [markdown-token-optimizer](/.github/skills/markdown-token-optimizer) - Token analysis and suggestions
+- [skill-authoring](/.github/skills/skill-authoring) - Skill writing guidelines and constraints

--- a/.github/skills/sensei/references/TOKEN-INTEGRATION.md
+++ b/.github/skills/sensei/references/TOKEN-INTEGRATION.md
@@ -18,13 +18,13 @@ Sensei uses the token CLI from `scripts/`:
 
 ```bash
 # Count tokens in a file
-cd scripts && npm run tokens -- count plugin/skills/{skill-name}/SKILL.md
+cd scripts && npm run tokens -- count .github/skills/{skill-name}/SKILL.md
 
 # Check against limits
-cd scripts && npm run tokens -- check plugin/skills/{skill-name}/SKILL.md
+cd scripts && npm run tokens -- check .github/skills/{skill-name}/SKILL.md
 
 # Get optimization suggestions
-cd scripts && npm run tokens -- suggest plugin/skills/{skill-name}/SKILL.md
+cd scripts && npm run tokens -- suggest .github/skills/{skill-name}/SKILL.md
 ```
 
 ## Integration Points
@@ -33,7 +33,7 @@ cd scripts && npm run tokens -- suggest plugin/skills/{skill-name}/SKILL.md
 
 At loop start, capture initial token count:
 ```bash
-cd scripts && npm run tokens -- count plugin/skills/{skill-name}/SKILL.md --json
+cd scripts && npm run tokens -- count .github/skills/{skill-name}/SKILL.md --json
 ```
 
 Store: `beforeTokens = result.tokens`
@@ -43,10 +43,10 @@ Store: `beforeTokens = result.tokens`
 After frontmatter improvements pass tests:
 ```bash
 # Get current count
-cd scripts && npm run tokens -- count plugin/skills/{skill-name}/SKILL.md --json
+cd scripts && npm run tokens -- count .github/skills/{skill-name}/SKILL.md --json
 
 # Get suggestions
-cd scripts && npm run tokens -- suggest plugin/skills/{skill-name}/SKILL.md --json
+cd scripts && npm run tokens -- suggest .github/skills/{skill-name}/SKILL.md --json
 ```
 
 Store:

--- a/.github/skills/sensei/scripts/gepa/auto_evaluator.py
+++ b/.github/skills/sensei/scripts/gepa/auto_evaluator.py
@@ -1,0 +1,585 @@
+#!/usr/bin/env python3
+"""
+GEPA auto-evaluator for sensei.
+
+Discovers a skill's existing Jest-based test harness at runtime and builds a
+GEPA-compatible evaluator with zero manual configuration.
+
+Currently, the evaluator:
+  - parses triggers.test.ts files to extract trigger prompt arrays
+  - detects the presence of unit.test.ts and integration.test.ts files
+  - uses this structural information plus content/keyword heuristics to
+    construct a fitness function
+
+It does not execute Jest or incorporate unit/integration test pass/fail
+results into the score.
+
+Usage:
+    # Score a skill (no optimization, no LLM calls)
+    python auto_evaluator.py score --skill azure-deploy --skills-dir plugin/skills --tests-dir tests
+
+    # Optimize a skill (requires LLM API)
+    python auto_evaluator.py optimize --skill azure-deploy --skills-dir plugin/skills --tests-dir tests
+
+    # Score all skills
+    python auto_evaluator.py score-all --skills-dir plugin/skills --tests-dir tests
+
+    # JSON output
+    python auto_evaluator.py score --skill azure-deploy --json
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+
+# ── Keyword matching (mirrors trigger-matcher.ts) ──────────────────────────
+
+AZURE_KEYWORDS = [
+    "azure", "storage", "cosmos", "sql", "redis", "keyvault", "key vault",
+    "function", "app service", "container", "aks", "kubernetes", "bicep",
+    "terraform", "deploy", "monitor", "diagnostic", "security", "rbac",
+    "identity", "entra", "authentication", "cli", "mcp", "validation",
+    "networking", "observability", "foundry", "agent", "model",
+]
+
+STOP_WORDS = {
+    "the", "and", "for", "with", "this", "that", "from", "have", "has",
+    "are", "was", "were", "been", "being", "will", "would", "could",
+    "should", "may", "might", "can", "shall", "not", "use", "when",
+    "what", "how", "why", "who", "which", "where", "does", "don",
+    "your", "its", "our", "their", "these", "those", "some", "any",
+    "all", "each", "every", "both", "such", "than", "also", "only",
+}
+
+
+def strip_frontmatter(content: str) -> str:
+    """Strip YAML frontmatter from skill content, safely handling malformed files."""
+    lines = content.splitlines()
+    if lines and lines[0].strip() == "---":
+        closing_idx = None
+        for i in range(1, len(lines)):
+            if lines[i].strip() == "---":
+                closing_idx = i
+                break
+        if closing_idx is not None:
+            return "\n".join(lines[closing_idx + 1 :]).strip()
+    return content
+
+
+def stem(word: str) -> str:
+    """Minimal stemmer for keyword matching."""
+    for suffix in ("ation", "ting", "ing", "ies", "ied", "es", "ed", "ly", "s"):
+        if word.endswith(suffix) and len(word) - len(suffix) >= 3:
+            return word[: -len(suffix)]
+    return word
+
+
+def extract_keywords(skill_name: str, description: str) -> list[str]:
+    """Extract keywords from skill name + description."""
+    keywords = set()
+    for part in skill_name.split("-"):
+        if len(part) > 2:
+            keywords.add(part.lower())
+    desc_lower = description.lower()
+    for word in re.split(r"\s+", desc_lower):
+        clean = re.sub(r"[^a-z0-9-]", "", word)
+        if clean == "ai" or len(clean) > 3:
+            if clean not in STOP_WORDS:
+                keywords.add(clean)
+    for kw in AZURE_KEYWORDS:
+        if kw in desc_lower:
+            keywords.add(kw)
+    return sorted(keywords)
+
+
+def check_trigger(prompt: str, keywords: list[str]) -> tuple[bool, list[str], float]:
+    """Check if a prompt triggers based on keyword matching with stemming."""
+    prompt_lower = prompt.lower()
+    matched = []
+    for kw in keywords:
+        kw_stem = stem(kw)
+        if kw in prompt_lower or kw_stem in prompt_lower:
+            matched.append(kw)
+            continue
+        for word in re.split(r"\s+", prompt_lower):
+            clean = re.sub(r"[^a-z0-9-]", "", word)
+            if clean and stem(clean) == kw_stem:
+                matched.append(kw)
+                break
+    confidence = len(matched) / max(len(keywords), 1)
+    triggered = len(matched) >= 2 or confidence >= 0.2
+    return triggered, matched, confidence
+
+
+# ── Test harness discovery ─────────────────────────────────────────────────
+
+def parse_trigger_arrays(test_file: Path) -> dict:
+    """Parse shouldTrigger/shouldNotTrigger arrays from a triggers.test.ts file.
+
+    Uses regex to extract string arrays without needing a TS parser.
+    Resolves simple ...varName spread patterns by extracting strings from
+    the referenced arrays in the same file.
+    """
+    content = test_file.read_text()
+    result = {"should_trigger": [], "should_not_trigger": []}
+
+    def _extract_array_text(text: str, start: int) -> str:
+        """Extract text between balanced brackets starting at position after '['."""
+        depth = 1
+        i = start
+        while i < len(text) and depth > 0:
+            if text[i] == "[":
+                depth += 1
+            elif text[i] == "]":
+                depth -= 1
+            i += 1
+        return text[start : i - 1]
+
+    def _extract_strings(array_text: str) -> list[str]:
+        """Extract quoted strings from array text, stripping comments."""
+        cleaned = re.sub(r"//.*", "", array_text)
+        cleaned = re.sub(r"/\*.*?\*/", "", cleaned, flags=re.DOTALL)
+        return re.findall(r'["\']([^"\']+)["\']', cleaned)
+
+    def _resolve_spreads(array_text: str) -> list[str]:
+        """Resolve ...varName spreads by finding the referenced arrays."""
+        extra = []
+        for spread_var in re.findall(r"\.\.\.\s*(\w+)", array_text):
+            var_pattern = rf"{spread_var}\s*(?::\s*\w+(?:\[\])?)?\s*=\s*\["
+            var_match = re.search(var_pattern, content)
+            if var_match:
+                var_array = _extract_array_text(content, var_match.end())
+                extra.extend(_extract_strings(var_array))
+        return extra
+
+    # Match arrays like: shouldTrigger = ["...", "..."] or const shouldTriggerPrompts = [...]
+    for var_pattern, key in [
+        (r"shouldTrigger(?:Prompts)?(?:\s*:\s*\w+(?:\[\])?)?\s*=\s*\[", "should_trigger"),
+        (r"shouldNotTrigger(?:Prompts)?(?:\s*:\s*\w+(?:\[\])?)?\s*=\s*\[", "should_not_trigger"),
+    ]:
+        match = re.search(var_pattern, content, re.IGNORECASE)
+        if match:
+            array_text = _extract_array_text(content, match.end())
+            strings = _extract_strings(array_text)
+            strings.extend(_resolve_spreads(array_text))
+            result[key] = strings
+
+    return result
+
+
+def discover_test_harness(tests_dir: Path, skill_name: str) -> dict:
+    """Discover available test files for a skill.
+
+    Returns dict with:
+      - has_triggers: bool
+      - has_integration: bool
+      - has_unit: bool
+      - trigger_prompts: {should_trigger: [...], should_not_trigger: [...]}
+    """
+    skill_test_dir = tests_dir / skill_name
+    result = {
+        "has_triggers": False,
+        "has_integration": False,
+        "has_unit": False,
+        "trigger_prompts": {"should_trigger": [], "should_not_trigger": []},
+    }
+
+    if not skill_test_dir.exists():
+        return result
+
+    # Check for test files (search recursively for nested dirs like microsoft-foundry/foundry-agent/)
+    for trigger_file in skill_test_dir.rglob("triggers.test.ts"):
+        result["has_triggers"] = True
+        prompts = parse_trigger_arrays(trigger_file)
+        result["trigger_prompts"]["should_trigger"].extend(prompts["should_trigger"])
+        result["trigger_prompts"]["should_not_trigger"].extend(prompts["should_not_trigger"])
+
+    for _ in skill_test_dir.rglob("integration.test.ts"):
+        result["has_integration"] = True
+        break
+
+    for _ in skill_test_dir.rglob("unit.test.ts"):
+        result["has_unit"] = True
+        break
+
+    return result
+
+
+# ── Content quality scorer ─────────────────────────────────────────────────
+
+def score_content_quality(skill_md_content: str) -> tuple[float, dict]:
+    """Score SKILL.md content quality. Pure Python, no LLM calls.
+
+    Returns (score, detail_scores).
+    """
+    scores = {}
+    feedback = []
+    content_lower = skill_md_content.lower()
+
+    # Description length (first non-heading paragraph)
+    lines = skill_md_content.strip().split("\n")
+    desc_text = " ".join(l for l in lines[:5] if l.strip() and not l.startswith("#"))
+    if 150 <= len(desc_text) <= 1024:
+        scores["description_length"] = 1.0
+    elif len(desc_text) < 150:
+        scores["description_length"] = len(desc_text) / 150
+        feedback.append(f"Description too short ({len(desc_text)} chars, need 150+)")
+    else:
+        scores["description_length"] = min(1.0, 1024 / len(desc_text))
+        feedback.append(f"Description too long ({len(desc_text)} chars, max 1024)")
+
+    # Required sections
+    for section in ["trigger", "rule", "step"]:
+        if f"## {section}" in content_lower or f"# {section}" in content_lower:
+            scores[f"has_{section}s"] = 1.0
+        else:
+            scores[f"has_{section}s"] = 0.0
+            feedback.append(f"Missing '## {section.title()}s' section")
+
+    # Routing patterns (DO NOT USE FOR is optional — can cause keyword contamination)
+    for pattern, label in [
+        ("use for:", "has_use_for"),
+        ("when:", "has_when"),
+    ]:
+        if pattern in content_lower:
+            scores[label] = 1.0
+        else:
+            scores[label] = 0.0
+            feedback.append(f"Missing '{pattern.upper()}' pattern")
+
+    # Bad patterns
+    bad = [
+        (r"api(?:[\s_-]+)?key\s*[:=]", "Contains API key pattern"),
+        (r"password\s*[:=]", "Contains password pattern"),
+        (r"TODO|FIXME|HACK", "Contains TODO/FIXME markers"),
+    ]
+    for pat, msg in bad:
+        if re.search(pat, skill_md_content, re.IGNORECASE):
+            scores["no_bad_patterns"] = 0.0
+            feedback.append(msg)
+            break
+    else:
+        scores["no_bad_patterns"] = 1.0
+
+    score = sum(scores.values()) / len(scores) if scores else 0.0
+    return score, {"scores": scores, "feedback": feedback}
+
+
+# ── Composite evaluator builder ────────────────────────────────────────────
+
+def build_evaluator(skill_name: str, tests_dir: Path):
+    """Auto-build a GEPA evaluator for a skill from its test harness.
+
+    Returns a callable(candidate, example) -> (score, asi_dict).
+    """
+    harness = discover_test_harness(tests_dir, skill_name)
+
+    def evaluator(candidate: str, example: dict) -> tuple[float, dict]:
+        import gepa.optimize_anything as oa
+
+        scores = {}
+        asi = {}
+
+        # 1. Content quality (always, fast)
+        quality_score, quality_detail = score_content_quality(candidate)
+        scores["quality"] = quality_score
+        if quality_detail["feedback"]:
+            asi["QualityIssues"] = "\n".join(quality_detail["feedback"])
+
+        # 2. Trigger accuracy (if tests discovered)
+        if harness["has_triggers"] and harness["trigger_prompts"]["should_trigger"]:
+            # Extract description from candidate for keyword matching
+            desc_lines = []
+            for line in candidate.split("\n"):
+                if line.strip() and not line.startswith("#"):
+                    desc_lines.append(line)
+                if len(desc_lines) >= 5:
+                    break
+            desc_text = " ".join(desc_lines)
+            keywords = extract_keywords(skill_name, desc_text + " " + candidate[:500])
+
+            correct = 0
+            total = 0
+            trigger_failures = []
+
+            for prompt in harness["trigger_prompts"]["should_trigger"]:
+                triggered, matched, conf = check_trigger(prompt, keywords)
+                total += 1
+                if triggered:
+                    correct += 1
+                else:
+                    trigger_failures.append(
+                        f"FN: '{prompt[:60]}...' (matched: {matched}, conf: {conf:.1%})"
+                    )
+
+            for prompt in harness["trigger_prompts"]["should_not_trigger"]:
+                triggered, matched, conf = check_trigger(prompt, keywords)
+                total += 1
+                if not triggered:
+                    correct += 1
+                else:
+                    trigger_failures.append(
+                        f"FP: '{prompt[:60]}...' (matched: {matched}, conf: {conf:.1%})"
+                    )
+
+            scores["triggers"] = correct / total if total else 1.0
+            if trigger_failures:
+                asi["TriggerFailures"] = "\n".join(trigger_failures[:5])
+
+        # Aggregate
+        final_score = sum(scores.values()) / len(scores) if scores else 0.0
+
+        oa.log(
+            f"[{skill_name}] quality={scores.get('quality', 0):.2f} "
+            f"triggers={scores.get('triggers', 'N/A')}"
+        )
+
+        return final_score, asi
+
+    return evaluator, harness
+
+
+# ── Score command ──────────────────────────────────────────────────────────
+
+def score_skill(
+    skill_name: str,
+    skills_dir: Path,
+    tests_dir: Path,
+) -> dict:
+    """Score a single skill's SKILL.md content quality + trigger accuracy."""
+    skill_md = skills_dir / skill_name / "SKILL.md"
+    if not skill_md.exists():
+        return {"skill": skill_name, "error": f"SKILL.md not found at {skill_md}"}
+
+    content = skill_md.read_text()
+    body = strip_frontmatter(content)
+
+    # Build evaluator and score
+    harness = discover_test_harness(tests_dir, skill_name)
+    quality_score, quality_detail = score_content_quality(body)
+
+    result = {
+        "skill": skill_name,
+        "quality_score": round(quality_score, 2),
+        "quality_score_raw": quality_score,
+        "quality_detail": quality_detail["scores"],
+        "quality_feedback": quality_detail["feedback"],
+        "has_triggers_test": harness["has_triggers"],
+        "has_integration_test": harness["has_integration"],
+        "has_unit_test": harness["has_unit"],
+        "trigger_prompt_count": len(harness["trigger_prompts"]["should_trigger"]),
+    }
+
+    # Trigger accuracy if test data available
+    if harness["has_triggers"] and harness["trigger_prompts"]["should_trigger"]:
+        # Use full content for keyword extraction
+        keywords = extract_keywords(skill_name, body[:1000])
+        correct = total = 0
+        for p in harness["trigger_prompts"]["should_trigger"]:
+            t, _, _ = check_trigger(p, keywords)
+            total += 1
+            correct += int(t)
+        for p in harness["trigger_prompts"]["should_not_trigger"]:
+            t, _, _ = check_trigger(p, keywords)
+            total += 1
+            correct += int(not t)
+        result["trigger_accuracy"] = round(correct / total, 2) if total else None
+    else:
+        result["trigger_accuracy"] = None
+
+    return result
+
+
+# ── Optimize command ───────────────────────────────────────────────────────
+
+def optimize_skill(
+    skill_name: str,
+    skills_dir: Path,
+    tests_dir: Path,
+    max_iterations: int = 80,
+    model: str = "openai/gpt-4o",
+) -> dict:
+    """Run GEPA optimize_anything on a skill's SKILL.md body content."""
+    import gepa.optimize_anything as oa
+
+    skill_md = skills_dir / skill_name / "SKILL.md"
+    if not skill_md.exists():
+        return {"skill": skill_name, "error": f"SKILL.md not found at {skill_md}"}
+
+    content = skill_md.read_text()
+    body = strip_frontmatter(content)
+
+    # Auto-build evaluator from test harness
+    evaluator, harness = build_evaluator(skill_name, tests_dir)
+
+    # Build dataset from discovered trigger prompts
+    dataset = []
+    if harness["has_triggers"]:
+        for prompt in harness["trigger_prompts"]["should_trigger"]:
+            dataset.append({"skill_name": skill_name, "prompt": prompt, "expected": True})
+        for prompt in harness["trigger_prompts"]["should_not_trigger"]:
+            dataset.append({"skill_name": skill_name, "prompt": prompt, "expected": False})
+
+    if not dataset:
+        dataset = [{"skill_name": skill_name, "aspect": "overall"}]
+
+    # Configure LLM via GitHub Models
+    try:
+        token = subprocess.check_output(["gh", "auth", "token"]).decode().strip()
+        os.environ.setdefault("OPENAI_API_KEY", token)
+        os.environ.setdefault("OPENAI_API_BASE", "https://models.github.ai/inference")
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass  # Let litellm find credentials from env
+
+    proposer_lm = oa.make_litellm_lm(model)
+
+    result = oa.optimize_anything(
+        seed_candidate=body,
+        evaluator=evaluator,
+        dataset=dataset,
+        objective=(
+            f"Optimize the SKILL.md content for the '{skill_name}' skill. "
+            f"The goal is to make an LLM correctly invoke this skill for relevant prompts. "
+            f"Include sections: ## Triggers, ## Rules, ## Steps, ## MCP Tools, ## References. "
+            f"Include 'USE FOR:', 'WHEN:', and 'DO NOT USE FOR:' patterns for routing."
+        ),
+        background=(
+            f"This is a SKILL.md for GitHub Copilot. The LLM reads it to decide which "
+            f"skill to invoke. It competes with ~24 other skills for selection. "
+            f"The content must clearly differentiate what this skill does vs others."
+        ),
+        config=oa.GEPAConfig(
+            engine=oa.EngineConfig(max_metric_calls=max_iterations),
+            reflection=oa.ReflectionConfig(reflection_lm=proposer_lm),
+        ),
+    )
+
+    return {
+        "skill": skill_name,
+        "original": body,
+        "optimized": result.best_candidate,
+        "best_score": getattr(result, "best_score", None),
+    }
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="GEPA auto-evaluator for sensei skill optimization"
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # score command
+    score_p = subparsers.add_parser("score", help="Score a skill's quality")
+    score_p.add_argument("--skill", required=True)
+    score_p.add_argument("--skills-dir", default="plugin/skills")
+    score_p.add_argument("--tests-dir", default="tests")
+    score_p.add_argument("--json", action="store_true")
+
+    # score-all command
+    all_p = subparsers.add_parser("score-all", help="Score all skills")
+    all_p.add_argument("--skills-dir", default="plugin/skills")
+    all_p.add_argument("--tests-dir", default="tests")
+    all_p.add_argument("--json", action="store_true")
+    all_p.add_argument("--sort", choices=["score", "name"], default="score")
+
+    # optimize command
+    opt_p = subparsers.add_parser("optimize", help="Optimize a skill with GEPA")
+    opt_p.add_argument("--skill", required=True)
+    opt_p.add_argument("--skills-dir", default="plugin/skills")
+    opt_p.add_argument("--tests-dir", default="tests")
+    opt_p.add_argument("--iterations", type=int, default=80)
+    opt_p.add_argument("--model", default="openai/gpt-4o")
+    opt_p.add_argument("--json", action="store_true")
+
+    args = parser.parse_args()
+    skills_dir = Path(args.skills_dir)
+    tests_dir = Path(args.tests_dir)
+
+    if args.command == "score":
+        result = score_skill(args.skill, skills_dir, tests_dir)
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            _print_score(result)
+
+    elif args.command == "score-all":
+        skills = sorted(
+            d.name for d in skills_dir.iterdir() if d.is_dir() and not d.name.startswith(".")
+        )
+        results = [score_skill(s, skills_dir, tests_dir) for s in skills]
+        if args.sort == "score":
+            results.sort(key=lambda r: r.get("quality_score", 0))
+        if args.json:
+            print(json.dumps(results, indent=2))
+        else:
+            _print_score_table(results)
+
+    elif args.command == "optimize":
+        result = optimize_skill(
+            args.skill, skills_dir, tests_dir, args.iterations, args.model
+        )
+        if args.json:
+            print(json.dumps(result, indent=2, default=str))
+        else:
+            if "error" in result:
+                print(f"Error: {result['error']}")
+            else:
+                print(f"✓ Optimized {args.skill}")
+                print(f"  Score: {result.get('best_score', 'N/A')}")
+                print(f"  Original length: {len(result['original'])} chars")
+                print(f"  Optimized length: {len(result['optimized'])} chars")
+                print(f"\n--- Optimized content (first 500 chars) ---")
+                print(result["optimized"][:500])
+
+
+def _print_score(result: dict):
+    """Pretty-print a single skill score."""
+    if "error" in result:
+        print(f"⚠ {result['skill']}: {result['error']}")
+        return
+    q = result["quality_score"]
+    t = result.get("trigger_accuracy")
+    icon = "✓" if q >= 0.8 else "✗"
+    print(f"\n  {icon} {result['skill']}")
+    print(f"    Quality:  {q:.2f}")
+    if t is not None:
+        print(f"    Triggers: {t:.2f}")
+    print(f"    Tests:    {'T' if result['has_triggers_test'] else '-'}"
+          f"{'I' if result['has_integration_test'] else '-'}"
+          f"{'U' if result['has_unit_test'] else '-'}")
+    if result["quality_feedback"]:
+        for fb in result["quality_feedback"]:
+            print(f"    ⚠ {fb}")
+
+
+def _print_score_table(results: list[dict]):
+    """Pretty-print score table for all skills."""
+    print(f"\n{'Skill':<30} {'Quality':>8} {'Triggers':>9} {'Tests':>6}")
+    print("─" * 56)
+    for r in results:
+        if "error" in r:
+            print(f"{r['skill']:<30} {'ERROR':>8}")
+            continue
+        q = r["quality_score"]
+        t = r.get("trigger_accuracy")
+        tests = (
+            f"{'T' if r['has_triggers_test'] else '-'}"
+            f"{'I' if r['has_integration_test'] else '-'}"
+            f"{'U' if r['has_unit_test'] else '-'}"
+        )
+        icon = "✓" if q >= 0.8 else "✗"
+        t_str = f"{t:.2f}" if t is not None else "N/A"
+        print(f"{icon} {r['skill']:<28} {q:>8.2f} {t_str:>9} {tests:>6}")
+
+    passing = sum(1 for r in results if r.get("quality_score", 0) >= 0.8)
+    print(f"\n  {passing}/{len(results)} skills at quality >= 0.80")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/sensei/scripts/gepa/auto_evaluator.py
+++ b/.github/skills/sensei/scripts/gepa/auto_evaluator.py
@@ -16,13 +16,13 @@ results into the score.
 
 Usage:
     # Score a skill (no optimization, no LLM calls)
-    python auto_evaluator.py score --skill azure-deploy --skills-dir plugin/skills --tests-dir tests
+    python auto_evaluator.py score --skill azure-deploy --skills-dir .github/skills --tests-dir tests
 
     # Optimize a skill (requires LLM API)
-    python auto_evaluator.py optimize --skill azure-deploy --skills-dir plugin/skills --tests-dir tests
+    python auto_evaluator.py optimize --skill azure-deploy --skills-dir .github/skills --tests-dir tests
 
     # Score all skills
-    python auto_evaluator.py score-all --skills-dir plugin/skills --tests-dir tests
+    python auto_evaluator.py score-all --skills-dir .github/skills --tests-dir tests
 
     # JSON output
     python auto_evaluator.py score --skill azure-deploy --json
@@ -477,13 +477,13 @@ def main():
     # score command
     score_p = subparsers.add_parser("score", help="Score a skill's quality")
     score_p.add_argument("--skill", required=True)
-    score_p.add_argument("--skills-dir", default="plugin/skills")
+    score_p.add_argument("--skills-dir", default=".github/skills")
     score_p.add_argument("--tests-dir", default="tests")
     score_p.add_argument("--json", action="store_true")
 
     # score-all command
     all_p = subparsers.add_parser("score-all", help="Score all skills")
-    all_p.add_argument("--skills-dir", default="plugin/skills")
+    all_p.add_argument("--skills-dir", default=".github/skills")
     all_p.add_argument("--tests-dir", default="tests")
     all_p.add_argument("--json", action="store_true")
     all_p.add_argument("--sort", choices=["score", "name"], default="score")
@@ -491,7 +491,7 @@ def main():
     # optimize command
     opt_p = subparsers.add_parser("optimize", help="Optimize a skill with GEPA")
     opt_p.add_argument("--skill", required=True)
-    opt_p.add_argument("--skills-dir", default="plugin/skills")
+    opt_p.add_argument("--skills-dir", default=".github/skills")
     opt_p.add_argument("--tests-dir", default="tests")
     opt_p.add_argument("--iterations", type=int, default=80)
     opt_p.add_argument("--model", default="openai/gpt-4o")

--- a/.github/workflows/gepa-quality-score-comment.yml
+++ b/.github/workflows/gepa-quality-score-comment.yml
@@ -1,0 +1,107 @@
+name: GEPA Quality Score Comment
+
+on:
+  workflow_run:
+    workflows: ["GEPA Skill Quality Score"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  comment:
+    name: Post Quality Score Comment
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Download score artifact
+        id: download
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: gepa-quality-scores
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Resolve PR number
+        id: pr
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            if (!fs.existsSync('score-results.json')) {
+              core.info('No gepa-quality-scores artifact found — skipping comment.');
+              core.setOutput('number', '');
+              return;
+            }
+            const prs = context.payload.workflow_run.pull_requests;
+            if (!prs || prs.length === 0) {
+              core.info('No PR associated (fork or direct push) — skipping comment.');
+              core.setOutput('number', '');
+              return;
+            }
+            core.setOutput('number', prs[0].number.toString());
+
+      - name: Comment on PR
+        if: steps.pr.outputs.number != ''
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const results = JSON.parse(fs.readFileSync('score-results.json', 'utf8'));
+            const items = Array.isArray(results) ? results : [results];
+            const prNumber = parseInt('${{ steps.pr.outputs.number }}', 10);
+
+            const marker = '<!-- gepa-quality-score -->';
+            let body = marker + '\n## 📊 GEPA Skill Quality Scores\n\n';
+            body += '| Skill | Quality | Triggers | Tests |\n';
+            body += '|-------|---------|----------|-------|\n';
+
+            for (const r of items) {
+              if (r.error) {
+                body += `| ${r.skill} | ❌ ERROR | - | - |\n`;
+                continue;
+              }
+              const q = r.quality_score.toFixed(2);
+              const t = r.trigger_accuracy !== null ? r.trigger_accuracy.toFixed(2) : 'N/A';
+              const tests = `${r.has_triggers_test ? 'T' : '-'}${r.has_integration_test ? 'I' : '-'}${r.has_unit_test ? 'U' : '-'}`;
+              const icon = r.quality_score >= 0.8 ? '✅' : r.quality_score >= 0.5 ? '⚠️' : '❌';
+              body += `| ${r.skill} | ${icon} ${q} | ${t} | ${tests} |\n`;
+            }
+
+            const passing = items.filter(r => (r.quality_score || 0) >= 0.8).length;
+            body += `\n**${passing}/${items.length}** skills at quality ≥ 0.80\n`;
+            body += '\n<details><summary>How to improve</summary>\n\n';
+            body += '```bash\n';
+            body += '# Score a specific skill\n';
+            body += 'python .github/skills/sensei/scripts/gepa/auto_evaluator.py score --skill <name> --skills-dir plugin/skills --tests-dir tests\n\n';
+            body += '# Optimize a skill with GEPA\n';
+            body += 'python .github/skills/sensei/scripts/gepa/auto_evaluator.py optimize --skill <name> --skills-dir plugin/skills --tests-dir tests\n';
+            body += '```\n</details>';
+
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                comment_id: existing.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: prNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body,
+              });
+            }

--- a/.github/workflows/gepa-quality-score-comment.yml
+++ b/.github/workflows/gepa-quality-score-comment.yml
@@ -78,9 +78,9 @@ jobs:
             body += '\n<details><summary>How to improve</summary>\n\n';
             body += '```bash\n';
             body += '# Score a specific skill\n';
-            body += 'python .github/skills/sensei/scripts/gepa/auto_evaluator.py score --skill <name> --skills-dir plugin/skills --tests-dir tests\n\n';
+            body += 'python .github/skills/sensei/scripts/gepa/auto_evaluator.py score --skill <name> --skills-dir .github/skills --tests-dir tests\n\n';
             body += '# Optimize a skill with GEPA\n';
-            body += 'python .github/skills/sensei/scripts/gepa/auto_evaluator.py optimize --skill <name> --skills-dir plugin/skills --tests-dir tests\n';
+            body += 'python .github/skills/sensei/scripts/gepa/auto_evaluator.py optimize --skill <name> --skills-dir .github/skills --tests-dir tests\n';
             body += '```\n</details>';
 
             const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/gepa-quality-score.yml
+++ b/.github/workflows/gepa-quality-score.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install GEPA evaluator deps
-        run: pip install "gepa==0.7.0"
+        run: pip install "gepa>=0.1.1"
 
       - name: Score skills
         id: score

--- a/.github/workflows/gepa-quality-score.yml
+++ b/.github/workflows/gepa-quality-score.yml
@@ -1,0 +1,94 @@
+name: GEPA Skill Quality Score
+
+on:
+  pull_request:
+    paths:
+      - '.github/skills/**/SKILL.md'
+      - 'tests/**'
+  workflow_dispatch:
+    inputs:
+      skill:
+        description: 'Specific skill to score (blank = all)'
+        required: false
+      min_score:
+        description: 'Minimum quality score (0.0-1.0)'
+        required: false
+        default: '0.5'
+
+permissions:
+  contents: read
+
+jobs:
+  score:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Install GEPA evaluator deps
+        run: pip install "gepa==0.7.0"
+
+      - name: Score skills
+        id: score
+        run: |
+          if [ -n "${{ github.event.inputs.skill }}" ]; then
+            python .github/skills/sensei/scripts/gepa/auto_evaluator.py score \
+              --skill "${{ github.event.inputs.skill }}" \
+              --skills-dir .github/skills \
+              --tests-dir tests \
+              --json > score-results.json
+
+            # Display results for specific skill
+            python .github/skills/sensei/scripts/gepa/auto_evaluator.py score \
+              --skill "${{ github.event.inputs.skill }}" \
+              --skills-dir .github/skills \
+              --tests-dir tests
+          else
+            python .github/skills/sensei/scripts/gepa/auto_evaluator.py score-all \
+              --skills-dir .github/skills \
+              --tests-dir tests \
+              --json > score-results.json
+
+            # Display results for all skills
+            python .github/skills/sensei/scripts/gepa/auto_evaluator.py score-all \
+              --skills-dir .github/skills \
+              --tests-dir tests
+          fi
+
+      - name: Check quality gate (advisory)
+        if: github.event_name == 'pull_request'
+        run: |
+          MIN_SCORE="${{ github.event.inputs.min_score || '0.5' }}"
+          python -c "
+          import json, sys
+          with open('score-results.json') as f:
+              results = json.load(f)
+          if not isinstance(results, list):
+              results = [results]
+
+          failed = []
+          for r in results:
+              if 'error' in r:
+                  continue
+              if r.get('quality_score', 0) < float('${MIN_SCORE}'):
+                  failed.append(f\"{r['skill']}: {r['quality_score']:.2f} (need >= ${MIN_SCORE})\")
+
+          if failed:
+              print('⚠️ Skills below quality threshold (advisory — not blocking):')
+              for f in failed:
+                  print(f'  {f}')
+              print()
+              print('💡 Run: python .github/skills/sensei/scripts/gepa/auto_evaluator.py optimize --skill <name> --skills-dir .github/skills --tests-dir tests')
+          else:
+              print('✅ All skills meet quality threshold')
+          "
+
+      - name: Upload score results
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: gepa-quality-scores
+          path: score-results.json


### PR DESCRIPTION
## Summary

Syncs the `.github/skills/sensei` folder with the upstream source at [microsoft/GitHub-Copilot-for-Azure](https://github.com/microsoft/GitHub-Copilot-for-Azure/tree/main/.github/skills/sensei).

Fixes #15096

## Changes

### Sensei Skill Updates (v1.0.0 → v1.0.5)
- **SKILL.md**: Rich help banner, batch mode, `--skip-integration`, trigger-overlap disambiguation
- **SCORING.md**: Routing-regression guard logic, overlap exception rules, guard pseudocode
- **README.md / LOOP.md / EXAMPLES.md**: `testPathPatterns` fix, link alignment

### GEPA Integration (new)
- **`scripts/gepa/auto_evaluator.py`** — Quality scoring evaluator (score, optimize, score-all)
- **`references/TOKEN-INTEGRATION.md`** — Token budget integration docs
- **`.github/workflows/gepa-quality-score.yml`** — CI pipeline for SKILL.md quality scoring
- **`.github/workflows/gepa-quality-score-comment.yml`** — Posts score comments on PRs

### Path Adjustments
- Pipeline refs updated from `plugin/skills/` → `.github/skills/` for this repo's layout

### Preserved (not modified)
- `eval.yaml`, `evals/`, `tasks/` — local eval configs kept as-is
