### PR TITLE
Updates cspell

### DIFF
--- a/eng/common/spelling/package-lock.json
+++ b/eng/common/spelling/package-lock.json
@@ -12,63 +12,63 @@
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-9.7.0.tgz",
-      "integrity": "sha512-s7h1vo++Q3AsfQa3cs0u/KGwm3SYInuIlC4kjlCBWjQmb4KddiZB5O1u0+3TlA7GycHb5M4CR7MDfHUICgJf+w==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-9.8.0.tgz",
+      "integrity": "sha512-MpXFpVyBPfJQ1YuVotljqUaGf6lWuf+fuWBBgs0PHFYTSjRPWuIxviAaCDnup/CJLLH60xQL4IlcQe4TOjzljw==",
       "license": "MIT",
       "dependencies": {
         "@cspell/dict-ada": "^4.1.1",
         "@cspell/dict-al": "^1.1.1",
         "@cspell/dict-aws": "^4.0.17",
         "@cspell/dict-bash": "^4.2.2",
-        "@cspell/dict-companies": "^3.2.10",
+        "@cspell/dict-companies": "^3.2.11",
         "@cspell/dict-cpp": "^7.0.2",
         "@cspell/dict-cryptocurrencies": "^5.0.5",
         "@cspell/dict-csharp": "^4.0.8",
-        "@cspell/dict-css": "^4.0.19",
+        "@cspell/dict-css": "^4.1.1",
         "@cspell/dict-dart": "^2.3.2",
         "@cspell/dict-data-science": "^2.0.13",
         "@cspell/dict-django": "^4.1.6",
         "@cspell/dict-docker": "^1.1.17",
-        "@cspell/dict-dotnet": "^5.0.12",
+        "@cspell/dict-dotnet": "^5.0.13",
         "@cspell/dict-elixir": "^4.0.8",
-        "@cspell/dict-en_us": "^4.4.29",
+        "@cspell/dict-en_us": "^4.4.33",
         "@cspell/dict-en-common-misspellings": "^2.1.12",
-        "@cspell/dict-en-gb-mit": "^3.1.18",
-        "@cspell/dict-filetypes": "^3.0.15",
+        "@cspell/dict-en-gb-mit": "^3.1.22",
+        "@cspell/dict-filetypes": "^3.0.18",
         "@cspell/dict-flutter": "^1.1.1",
-        "@cspell/dict-fonts": "^4.0.5",
+        "@cspell/dict-fonts": "^4.0.6",
         "@cspell/dict-fsharp": "^1.1.1",
-        "@cspell/dict-fullstack": "^3.2.8",
+        "@cspell/dict-fullstack": "^3.2.9",
         "@cspell/dict-gaming-terms": "^1.1.2",
         "@cspell/dict-git": "^3.1.0",
         "@cspell/dict-golang": "^6.0.26",
         "@cspell/dict-google": "^1.0.9",
         "@cspell/dict-haskell": "^4.0.6",
-        "@cspell/dict-html": "^4.0.14",
+        "@cspell/dict-html": "^4.0.15",
         "@cspell/dict-html-symbol-entities": "^4.0.5",
         "@cspell/dict-java": "^5.0.12",
         "@cspell/dict-julia": "^1.1.1",
         "@cspell/dict-k8s": "^1.0.12",
         "@cspell/dict-kotlin": "^1.1.1",
-        "@cspell/dict-latex": "^5.0.0",
+        "@cspell/dict-latex": "^5.1.0",
         "@cspell/dict-lorem-ipsum": "^4.0.5",
         "@cspell/dict-lua": "^4.0.8",
         "@cspell/dict-makefile": "^1.0.5",
-        "@cspell/dict-markdown": "^2.0.14",
+        "@cspell/dict-markdown": "^2.0.16",
         "@cspell/dict-monkeyc": "^1.0.12",
         "@cspell/dict-node": "^5.0.9",
-        "@cspell/dict-npm": "^5.2.34",
+        "@cspell/dict-npm": "^5.2.38",
         "@cspell/dict-php": "^4.1.1",
         "@cspell/dict-powershell": "^5.0.15",
-        "@cspell/dict-public-licenses": "^2.0.15",
-        "@cspell/dict-python": "^4.2.25",
+        "@cspell/dict-public-licenses": "^2.0.16",
+        "@cspell/dict-python": "^4.2.26",
         "@cspell/dict-r": "^2.1.1",
-        "@cspell/dict-ruby": "^5.1.0",
+        "@cspell/dict-ruby": "^5.1.1",
         "@cspell/dict-rust": "^4.1.2",
         "@cspell/dict-scala": "^5.0.9",
         "@cspell/dict-shell": "^1.1.2",
-        "@cspell/dict-software-terms": "^5.1.21",
+        "@cspell/dict-software-terms": "^5.2.2",
         "@cspell/dict-sql": "^2.2.1",
         "@cspell/dict-svelte": "^1.0.7",
         "@cspell/dict-swift": "^2.0.6",
@@ -82,39 +82,39 @@
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-9.7.0.tgz",
-      "integrity": "sha512-6xpGXlMtQA3hV2BCAQcPkpx9eI12I0o01i9eRqSSEDKtxuAnnrejbcCpL+5OboAjTp3/BSeNYSnhuWYLkSITWQ==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-9.8.0.tgz",
+      "integrity": "sha512-nqUaSo9T7l8KrE22gc7ZIs+zvP7ak1i7JqGdRs8sGvh2Ijqj43qYQLePgb1b/vm8a1bavnc51m+vf05hpd3g3Q==",
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "9.7.0"
+        "@cspell/cspell-types": "9.8.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@cspell/cspell-performance-monitor": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-performance-monitor/-/cspell-performance-monitor-9.7.0.tgz",
-      "integrity": "sha512-w1PZIFXuvjnC6mQHyYAFnrsn5MzKnEcEkcK1bj4OG00bAt7WX2VUA/eNNt9c1iHozCQ+FcRYlfbGxuBmNyzSgw==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-performance-monitor/-/cspell-performance-monitor-9.8.0.tgz",
+      "integrity": "sha512-IsrXYzn23yJICIQ915ACdf+2lNEcFNTu5BIQt3khHOsGVvZ9/AZYpu9Dk825vUyZG7RHg2Oi6dYNiJtULG4ouQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18"
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-9.7.0.tgz",
-      "integrity": "sha512-iiisyRpJciU9SOHNSi0ZEK0pqbEMFRatI/R4O+trVKb+W44p4MNGClLVRWPGUmsFbZKPJL3jDtz0wPlG0/JCZA==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-9.8.0.tgz",
+      "integrity": "sha512-ISEUD8PHYkd2Ktafc6hFfIXdGKYUvthA09NbwwZsWmOqYyk4wWKHZKqyyxD+BcrFwOyMOJcD8OEvIjkRQp2SJw==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-9.7.0.tgz",
-      "integrity": "sha512-uiEgS238mdabDnwavo6HXt8K98jlh/jpm7NONroM9NTr9rzck2VZKD2kXEj85wDNMtRsRXNoywTjwQ8WTB6/+w==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-9.8.0.tgz",
+      "integrity": "sha512-PZJj56BZpKfMxOzWkyt7b+aIXObe+8Ku/zLI4xDXPSuQPENbHBFHfPIZx68CyGEkanKxZ1ewKVx/FT1FUy+wDA==",
       "license": "MIT",
       "dependencies": {
         "global-directory": "^5.0.0"
@@ -124,30 +124,30 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-9.7.0.tgz",
-      "integrity": "sha512-fkqtaCkg4jY/FotmzjhIavbXuH0AgUJxZk78Ktf4XlhqOZ4wDeUWrCf220bva4mh3TWiLx/ae9lIlpl59Vx6hA==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-9.8.0.tgz",
+      "integrity": "sha512-P45sd2nqwcqhulBBbQnZB/JNcobecTrP4Ky3vmEq0cprsvavc+ZoHF9U2Ql5ghMSUzjrF2n1aNzZ8cH4IlsnKg==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-9.7.0.tgz",
-      "integrity": "sha512-Tdfx4eH2uS+gv9V9NCr3Rz+c7RSS6ntXp3Blliud18ibRUlRxO9dTaOjG4iv4x0nAmMeedP1ORkEpeXSkh2QiQ==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-9.8.0.tgz",
+      "integrity": "sha512-7Ge4UD6SCA49Tcc3+GTlz3Xn4cqVUAXtDO0u9IeHvJgkN3Me2Rw2GB/CtGmhKST3YeEeZMX7ww09TdHMUJlehw==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@cspell/cspell-worker": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-worker/-/cspell-worker-9.7.0.tgz",
-      "integrity": "sha512-cjEApFF0aOAa1vTUk+e7xP8ofK7iC7hsRzj1FmvvVQz8PoLWPRaq+1bT89ypPsZQvavqm5sIgb97S60/aW4TVg==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-worker/-/cspell-worker-9.8.0.tgz",
+      "integrity": "sha512-W8FLdE3MXPLbWtAXciILQhk9CHd6Mt+HRjZHM8m+dwE1Bc2TAjUai8kIxsdhHUq58p7gYY2ekr5sg1uYOUgTAA==",
       "license": "MIT",
       "dependencies": {
-        "cspell-lib": "9.7.0"
+        "cspell-lib": "9.8.0"
       },
       "engines": {
         "node": ">=20.18"
@@ -235,9 +235,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-dotnet": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.12.tgz",
-      "integrity": "sha512-FiV934kNieIjGTkiApu/WKvLYi/KBpvfWB2TSqpDQtmXZlt3uSa5blwblO1ZC8OvjH8RCq/31H5IdEYmTaZS7A==",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.13.tgz",
+      "integrity": "sha512-xPp7jMnFpOri7tzmqmm/dXMolXz1t2bhNqxYkOyMqXhvs08oc7BFs+EsbDY0X7hqiISgeFZGNqn0dOCr+ncPYw==",
       "license": "MIT"
     },
     "node_modules/@cspell/dict-elixir": {
@@ -247,9 +247,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-en_us": {
-      "version": "4.4.32",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.32.tgz",
-      "integrity": "sha512-37NZrwnI9FyZLtUolgOtA2Xy2u1dYIiwQMqwVFKKd8tcyaM8SgONFqbs6c/rzr2JcL0n6ziCy/ptBQSREgfBMw==",
+      "version": "4.4.33",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.33.tgz",
+      "integrity": "sha512-zWftVqfUStDA37wO1ZNDN1qMJOfcxELa8ucHW8W8wBAZY3TK5Nb6deLogCK/IJi/Qljf30dwwuqqv84Qqle9Tw==",
       "license": "MIT"
     },
     "node_modules/@cspell/dict-en-common-misspellings": {
@@ -259,9 +259,9 @@
       "license": "CC BY-SA 4.0"
     },
     "node_modules/@cspell/dict-en-gb-mit": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.21.tgz",
-      "integrity": "sha512-7Q4SDABCIk3ZAngrfSlSZEE+8Uiiu3wssBjC6t7iN++SM2wMjqSnHaHh1GJoLONI3+5m3XsYakZ5KnYuAXqncQ==",
+      "version": "3.1.22",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.22.tgz",
+      "integrity": "sha512-xE5Vg6gGdMkZ1Ep6z9SJMMioGkkT1GbxS5Mm0U3Ey1/H68P0G7cJcyiVr1CARxFbLqKE4QUpoV1o6jz1Z5Yl9Q==",
       "license": "MIT"
     },
     "node_modules/@cspell/dict-filetypes": {
@@ -472,9 +472,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.2.1.tgz",
-      "integrity": "sha512-a25D44ZcccvimNbUgpY94UnqRT46e2PjFf4dgxKXHoMCEcH0NqI4682k4PYsT1AmWMGn7EAA8tS2tN5yxhkm5g==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.2.2.tgz",
+      "integrity": "sha512-0CaYd6TAsKtEoA7tNswm1iptEblTzEe3UG8beG2cpSTHk7afWIVMtJLgXDv0f/Li67Lf3Z1Jf3JeXR7GsJ2TRw==",
       "license": "MIT"
     },
     "node_modules/@cspell/dict-sql": {
@@ -520,12 +520,12 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-9.7.0.tgz",
-      "integrity": "sha512-Ws36IYvtS/8IN3x6K9dPLvTmaArodRJmzTn2Rkf2NaTnIYWhRuFzsP3SVVO59NN3fXswAEbmz5DSbVUe8bPZHg==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-9.8.0.tgz",
+      "integrity": "sha512-wMgb32lqG9g6lCipUQsY9Bk5idXPDz7wvzOqEsU1M2HmNYmdE1wfPoRpfQfsVL965iG3+6h8QLr2+8FKpweFEQ==",
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "9.7.0",
+        "@cspell/url": "9.8.0",
         "import-meta-resolve": "^4.2.0"
       },
       "engines": {
@@ -533,36 +533,36 @@
       }
     },
     "node_modules/@cspell/filetypes": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-9.7.0.tgz",
-      "integrity": "sha512-Ln9e/8wGOyTeL3DCCs6kwd18TSpTw3kxsANjTrzLDASrX4cNmAdvc9J5dcIuBHPaqOAnRQxuZbzUlpRh73Y24w==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-9.8.0.tgz",
+      "integrity": "sha512-yHvtYn9qt6zykua77sNzTcf7HrG/dpo/+2pCMGSrfSrQypSNT6FUFvMS04W7kwhP86U1GkCjppNykXuoH3cqug==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@cspell/rpc": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/rpc/-/rpc-9.7.0.tgz",
-      "integrity": "sha512-VnZ4ABgQeoS4RwofcePkDP7L6tf3Kh5D7LQKoyRM4R6XtfSsYefym6XKaRl3saGtthH5YyjgNJ0Tgdjen4wAAw==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@cspell/rpc/-/rpc-9.8.0.tgz",
+      "integrity": "sha512-t4lHEa254W+PePXNQ1noW7QhQxz/mhsJ9X8LEt0ILzBbPWCJzN+JuaM7EiolIPiwxtfxpMwKx9482kt4eTja7A==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18"
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-9.7.0.tgz",
-      "integrity": "sha512-5xbvDASjklrmy88O6gmGXgYhpByCXqOj5wIgyvwZe2l83T1bE+iOfGI4pGzZJ/mN+qTn1DNKq8BPBPtDgb7Q2Q==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-9.8.0.tgz",
+      "integrity": "sha512-HocksAqZ0JcWA5oWO7TIlOCftXVGkPGzbeFlCRRrjJpZmYQH+4NdeEXyQC6T89NGocp45td/CgyBcAaFMy1N9w==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@cspell/url": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-9.7.0.tgz",
-      "integrity": "sha512-ZaaBr0pTvNxmyUbIn+nVPXPr383VqJzfUDMWicgTjJIeo2+T2hOq2kNpgpvTIrWtZrsZnSP8oXms1+sKTjcvkw==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-9.8.0.tgz",
+      "integrity": "sha512-LY1lFiZLTQF/ma1ilfKmRmFmEOw0RfYhyl0UMhY7/d93b+kiDMhxP/9Qir4+5LyiRncaE3++ZcWno9Hya+ssRg==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -661,30 +661,30 @@
       }
     },
     "node_modules/cspell": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-9.7.0.tgz",
-      "integrity": "sha512-ftxOnkd+scAI7RZ1/ksgBZRr0ouC7QRKtPQhD/PbLTKwAM62sSvRhE1bFsuW3VKBn/GilWzTjkJ40WmnDqH5iQ==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-9.8.0.tgz",
+      "integrity": "sha512-qL0VErMSn8BDxaPxcV+9uenffgjPS+5Jfz+m4rCsvYjzLwr7AaaJBWWSV2UiAe/4cturae8n8qzxiGnbbazkRw==",
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-json-reporter": "9.7.0",
-        "@cspell/cspell-performance-monitor": "9.7.0",
-        "@cspell/cspell-pipe": "9.7.0",
-        "@cspell/cspell-types": "9.7.0",
-        "@cspell/cspell-worker": "9.7.0",
-        "@cspell/dynamic-import": "9.7.0",
-        "@cspell/url": "9.7.0",
+        "@cspell/cspell-json-reporter": "9.8.0",
+        "@cspell/cspell-performance-monitor": "9.8.0",
+        "@cspell/cspell-pipe": "9.8.0",
+        "@cspell/cspell-types": "9.8.0",
+        "@cspell/cspell-worker": "9.8.0",
+        "@cspell/dynamic-import": "9.8.0",
+        "@cspell/url": "9.8.0",
         "ansi-regex": "^6.2.2",
         "chalk": "^5.6.2",
         "chalk-template": "^1.1.2",
         "commander": "^14.0.3",
-        "cspell-config-lib": "9.7.0",
-        "cspell-dictionary": "9.7.0",
-        "cspell-gitignore": "9.7.0",
-        "cspell-glob": "9.7.0",
-        "cspell-io": "9.7.0",
-        "cspell-lib": "9.7.0",
+        "cspell-config-lib": "9.8.0",
+        "cspell-dictionary": "9.8.0",
+        "cspell-gitignore": "9.8.0",
+        "cspell-glob": "9.8.0",
+        "cspell-io": "9.8.0",
+        "cspell-lib": "9.8.0",
         "fast-json-stable-stringify": "^2.1.0",
-        "flatted": "^3.3.3",
+        "flatted": "^3.4.2",
         "semver": "^7.7.4",
         "tinyglobby": "^0.2.15"
       },
@@ -700,30 +700,30 @@
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-9.7.0.tgz",
-      "integrity": "sha512-pguh8A3+bSJ1OOrKCiQan8bvaaY125de76OEFz7q1Pq309lIcDrkoL/W4aYbso/NjrXaIw6OjkgPMGRBI/IgGg==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-9.8.0.tgz",
+      "integrity": "sha512-gMJBAgYPvvO+uDFLUcGWaTu6/e+r8mm4GD4rQfWa/yV4F9fj+yOYLIMZqLWRvT1moHZX1FxyVvUbJcmZ1gfebg==",
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "9.7.0",
-        "comment-json": "^4.5.1",
-        "smol-toml": "^1.6.0",
-        "yaml": "^2.8.2"
+        "@cspell/cspell-types": "9.8.0",
+        "comment-json": "^4.6.2",
+        "smol-toml": "^1.6.1",
+        "yaml": "^2.8.3"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-9.7.0.tgz",
-      "integrity": "sha512-k/Wz0so32+0QEqQe21V9m4BNXM5ZN6lz3Ix/jLCbMxFIPl6wT711ftjOWIEMFhvUOP0TWXsbzcuE9mKtS5mTig==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-9.8.0.tgz",
+      "integrity": "sha512-QW4hdkWcrxZA1QNqi26U0S/U3/V+tKCm7JaaesEJW2F6Ao+23AbHVwidyAVtXaEhGkn6PxB+epKrrAa6nE69qA==",
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-performance-monitor": "9.7.0",
-        "@cspell/cspell-pipe": "9.7.0",
-        "@cspell/cspell-types": "9.7.0",
-        "cspell-trie-lib": "9.7.0",
+        "@cspell/cspell-performance-monitor": "9.8.0",
+        "@cspell/cspell-pipe": "9.8.0",
+        "@cspell/cspell-types": "9.8.0",
+        "cspell-trie-lib": "9.8.0",
         "fast-equals": "^6.0.0"
       },
       "engines": {
@@ -731,14 +731,14 @@
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-9.7.0.tgz",
-      "integrity": "sha512-MtoYuH4ah4K6RrmaF834npMcRsTKw0658mC6yvmBacUQOmwB/olqyuxF3fxtbb55HDb7cXDQ35t1XuwwGEQeZw==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-9.8.0.tgz",
+      "integrity": "sha512-SDUa1DmSfT20+JH7XtyzcEL9KfurneoR/XbmlrtPQZP/LUHXh3yz4x/0vFIkEFXNWdSckY0QdWTz8DaxClCf4Q==",
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "9.7.0",
-        "cspell-glob": "9.7.0",
-        "cspell-io": "9.7.0"
+        "@cspell/url": "9.8.0",
+        "cspell-glob": "9.8.0",
+        "cspell-io": "9.8.0"
       },
       "bin": {
         "cspell-gitignore": "bin.mjs"
@@ -748,26 +748,26 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-9.7.0.tgz",
-      "integrity": "sha512-LUeAoEsoCJ+7E3TnUmWBscpVQOmdwBejMlFn0JkXy6LQzxrybxXBKf65RSdIv1o5QtrhQIMa358xXYQG0sv/tA==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-9.8.0.tgz",
+      "integrity": "sha512-Uvj/iHXs+jpsJyIEnhEoJTWXb1GVyZ9T05L5JFtZfsQNXrh8SRDQPscjxbg4okKr63N7WevfioQum/snHNYvmw==",
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "9.7.0",
-        "picomatch": "^4.0.3"
+        "@cspell/url": "9.8.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-9.7.0.tgz",
-      "integrity": "sha512-oEYME+7MJztfVY1C06aGcJgEYyqBS/v/ETkQGPzf/c6ObSAPRcUbVtsXZgnR72Gru9aBckc70xJcD6bELdoWCA==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-9.8.0.tgz",
+      "integrity": "sha512-01XMq2vhPS0Gvxnfed9uvOwH+3cXddHYxW0PwCE+SZdcC6TN8yM6glByuLt1qFustAmQVE5GSr7uAY9o4pZQRg==",
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "9.7.0",
-        "@cspell/cspell-types": "9.7.0"
+        "@cspell/cspell-pipe": "9.8.0",
+        "@cspell/cspell-types": "9.8.0"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -777,41 +777,41 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-9.7.0.tgz",
-      "integrity": "sha512-V7x0JHAUCcJPRCH8c0MQkkaKmZD2yotxVyrNEx2SZTpvnKrYscLEnUUTWnGJIIf9znzISqw116PLnYu2c+zd6Q==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-9.8.0.tgz",
+      "integrity": "sha512-JINaEWQEzR4f2upwdZOFcft+nBvQgizJfrOLszxG3p+BIzljnGklqE/nUtLFZpBu0oMJvuM/Fd+GsWor0yP7Xw==",
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-service-bus": "9.7.0",
-        "@cspell/url": "9.7.0"
+        "@cspell/cspell-service-bus": "9.8.0",
+        "@cspell/url": "9.8.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-9.7.0.tgz",
-      "integrity": "sha512-aTx/aLRpnuY1RJnYAu+A8PXfm1oIUdvAQ4W9E66bTgp1LWI+2G2++UtaPxRIgI0olxE9vcXqUnKpjOpO+5W9bQ==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-9.8.0.tgz",
+      "integrity": "sha512-G2TtPcye5QE5ev3YgWq42UOJLpTZ6naO/47oIm+jmeSYbgnbcOSThnEE7uMycx+TTNOz/vJVFpZmQyt0bWCftw==",
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "9.7.0",
-        "@cspell/cspell-performance-monitor": "9.7.0",
-        "@cspell/cspell-pipe": "9.7.0",
-        "@cspell/cspell-resolver": "9.7.0",
-        "@cspell/cspell-types": "9.7.0",
-        "@cspell/dynamic-import": "9.7.0",
-        "@cspell/filetypes": "9.7.0",
-        "@cspell/rpc": "9.7.0",
-        "@cspell/strong-weak-map": "9.7.0",
-        "@cspell/url": "9.7.0",
+        "@cspell/cspell-bundled-dicts": "9.8.0",
+        "@cspell/cspell-performance-monitor": "9.8.0",
+        "@cspell/cspell-pipe": "9.8.0",
+        "@cspell/cspell-resolver": "9.8.0",
+        "@cspell/cspell-types": "9.8.0",
+        "@cspell/dynamic-import": "9.8.0",
+        "@cspell/filetypes": "9.8.0",
+        "@cspell/rpc": "9.8.0",
+        "@cspell/strong-weak-map": "9.8.0",
+        "@cspell/url": "9.8.0",
         "clear-module": "^4.1.2",
-        "cspell-config-lib": "9.7.0",
-        "cspell-dictionary": "9.7.0",
-        "cspell-glob": "9.7.0",
-        "cspell-grammar": "9.7.0",
-        "cspell-io": "9.7.0",
-        "cspell-trie-lib": "9.7.0",
+        "cspell-config-lib": "9.8.0",
+        "cspell-dictionary": "9.8.0",
+        "cspell-glob": "9.8.0",
+        "cspell-grammar": "9.8.0",
+        "cspell-io": "9.8.0",
+        "cspell-trie-lib": "9.8.0",
         "env-paths": "^4.0.0",
         "gensequence": "^8.0.8",
         "import-fresh": "^3.3.1",
@@ -825,15 +825,15 @@
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-9.7.0.tgz",
-      "integrity": "sha512-a2YqmcraL3g6I/4gY7SYWEZfP73oLluUtxO7wxompk/kOG2K1FUXyQfZXaaR7HxVv10axT1+NrjhOmXpfbI6LA==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-9.8.0.tgz",
+      "integrity": "sha512-GXIyqxya8QLp6SjKsAN9w3apvt1Ww7GKcZvTBaP76OfLoyb1QC6unwmObY2cZs1manCntGwHrgU6vFNuXnTzpw==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@cspell/cspell-types": "9.7.0"
+        "@cspell/cspell-types": "9.8.0"
       }
     },
     "node_modules/env-paths": {
@@ -1052,13 +1052,13 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"


### PR DESCRIPTION
Bumps cspell dependency.  Goal is to update the following dependencies:
- yaml -> 2.8.3
- smol-toml -> 1.6.1
- picomatch -> 4.0.4