### PR TITLE
[Python APIView] add code-model.yaml input support

### DIFF
--- a/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
@@ -32,6 +32,12 @@ from apistub._generated.treestyle.parser._model_base import (
     SdkJSONEncoder as APIViewEncoder,
 )
 
+try:
+    import yaml as _yaml
+    _YAML_AVAILABLE = True
+except ImportError:
+    _YAML_AVAILABLE = False
+
 INIT_PY_FILE = "__init__.py"
 INIT_EXTENSION_SUBSTRING = ".extend_path(__path__, __name__)"
 
@@ -49,8 +55,19 @@ class StubGenerator:
             )
             parser.add_argument(
                 "--pkg-path",
-                required=True,
+                required=False,
+                default=None,
                 help=("Path to the package source root, WHL, ZIP, or TAR file."),
+            )
+            parser.add_argument(
+                "--code-model-path",
+                required=False,
+                default=None,
+                help=(
+                    "Path to a preprocessed code-model.yaml file produced by the TypeSpec emitter. "
+                    "When provided, generates the token file directly from the CodeModel, "
+                    "skipping package install and inspection."
+                ),
             )
             parser.add_argument(
                 "--temp-path",
@@ -98,6 +115,7 @@ class StubGenerator:
             self._args = parser.parse_args()
 
         pkg_path = self._parse_arg("pkg_path")
+        code_model_path = self._parse_arg("code_model_path")
         temp_path = self._parse_arg("temp_path") or tempfile.gettempdir()
         out_path = self._parse_arg("out_path")
         mapping_path = self._parse_arg("mapping_path")
@@ -106,16 +124,43 @@ class StubGenerator:
         source_url = self._parse_arg("source_url")
         skip_pylint = self._parse_arg("skip_pylint")
 
-        if not os.path.exists(pkg_path):
-            logging.error("Package path [{}] is invalid".format(pkg_path))
-            exit(1)
-        elif not os.path.exists(temp_path):
-            logging.error("Temp path [{0}] is invalid".format(temp_path))
-            exit(1)
+        self.code_model_path = code_model_path
 
-        if os.path.isdir(pkg_path):
-            pkg_path = os.path.abspath(pkg_path)
-        self.pkg_path = pkg_path
+        if code_model_path:
+            # Code-model path: skip package validation entirely
+            if not os.path.exists(code_model_path):
+                logging.error("Code model path [{}] is invalid".format(code_model_path))
+                exit(1)
+            if not os.path.exists(temp_path):
+                logging.error("Temp path [{0}] is invalid".format(temp_path))
+                exit(1)
+            self.pkg_path = None
+            self.wheel_path = None
+        else:
+            if not pkg_path:
+                logging.error("Either --pkg-path or --code-model-path must be provided")
+                exit(1)
+            if not os.path.exists(pkg_path):
+                logging.error("Package path [{}] is invalid".format(pkg_path))
+                exit(1)
+            elif not os.path.exists(temp_path):
+                logging.error("Temp path [{0}] is invalid".format(temp_path))
+                exit(1)
+
+            if os.path.isdir(pkg_path):
+                pkg_path = os.path.abspath(pkg_path)
+            self.pkg_path = pkg_path
+            self.temp_path = temp_path
+
+            # Extract package to temp directory if it is wheel or sdist
+            if self.pkg_path.endswith((".whl", ".zip", ".tar.gz")):
+                self.wheel_path = self._extract_wheel()
+            else:
+                self.wheel_path = None
+
+            if not skip_pylint:
+                PylintParser.parse(self.wheel_path or self.pkg_path)
+
         self.temp_path = temp_path
         self.out_path = out_path
         self.source_url = source_url
@@ -124,15 +169,6 @@ class StubGenerator:
         self.namespace = ""
         if verbose:
             logging.getLogger().setLevel(logging.DEBUG)
-
-        # Extract package to temp directory if it is wheel or sdist
-        if self.pkg_path.endswith((".whl", ".zip", ".tar.gz")):
-            self.wheel_path = self._extract_wheel()
-        else:
-            self.wheel_path = None
-
-        if not skip_pylint:
-            PylintParser.parse(self.wheel_path or self.pkg_path)
 
     def _parse_arg(self, name):
         value = self._kwargs.get(name, None)
@@ -191,6 +227,9 @@ class StubGenerator:
         return pkg_root_path, pkg_name, version
 
     def generate_tokens(self):
+        if self.code_model_path:
+            return self._generate_tokens_from_code_model()
+
         # TODO: We should install to a virtualenv
         logging.debug("Installing package from {}".format(self.pkg_path))
         self._install_package()
@@ -231,6 +270,26 @@ class StubGenerator:
             logging.info(
                 "*************** Completed parsing package and generating tokens ***************"
             )
+        return apiview
+
+    def _generate_tokens_from_code_model(self):
+        """Generate tokens directly from a preprocessed code-model.yaml file, skipping package install/inspection."""
+        from apistub.nodes._code_model_parser import CodeModelParser
+
+        if not _YAML_AVAILABLE:
+            raise RuntimeError(
+                "PyYAML is required to use --code-model-path. Install it with: pip install pyyaml"
+            )
+
+        logging.info("Generating tokens from code model: {}".format(self.code_model_path))
+        with open(self.code_model_path, "r", encoding="utf-8") as f:
+            yaml_data = _yaml.safe_load(f)
+
+        parser = CodeModelParser(yaml_data, mapping_path=self.mapping_path, source_url=self.source_url)
+        apiview = parser.generate_tokens()
+
+        self.check_unique_line_ids(apiview)
+        logging.info("*************** Completed generating tokens from code model ***************")
         return apiview
 
     def check_unique_line_ids(self, apiview: ApiView):

--- a/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
@@ -32,11 +32,7 @@ from apistub._generated.treestyle.parser._model_base import (
     SdkJSONEncoder as APIViewEncoder,
 )
 
-try:
-    import yaml as _yaml
-    _YAML_AVAILABLE = True
-except ImportError:
-    _YAML_AVAILABLE = False
+import yaml as _yaml
 
 INIT_PY_FILE = "__init__.py"
 INIT_EXTENSION_SUBSTRING = ".extend_path(__path__, __name__)"
@@ -275,11 +271,6 @@ class StubGenerator:
     def _generate_tokens_from_code_model(self):
         """Generate tokens directly from a preprocessed code-model.yaml file, skipping package install/inspection."""
         from apistub.nodes._code_model_parser import CodeModelParser
-
-        if not _YAML_AVAILABLE:
-            raise RuntimeError(
-                "PyYAML is required to use --code-model-path. Install it with: pip install pyyaml"
-            )
 
         logging.info("Generating tokens from code model: {}".format(self.code_model_path))
         with open(self.code_model_path, "r", encoding="utf-8") as f:

--- a/packages/python-packages/apiview-stub-generator/apistub/nodes/__init__.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/nodes/__init__.py
@@ -12,6 +12,7 @@ from ._key_node import KeyNode
 from ._module_node import ModuleNode
 from ._property_node import PropertyNode
 from ._variable_node import VariableNode
+from ._code_model_parser import CodeModelParser
 
 
 __all__ = [

--- a/packages/python-packages/apiview-stub-generator/apistub/nodes/_code_model_parser.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/nodes/_code_model_parser.py
@@ -1,0 +1,668 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+"""CodeModelParser: generates APIView token files from a preprocessed code-model.yaml.
+
+The code-model.yaml is written by the TypeSpec http-client-python emitter (pygen)
+*after* TCGC preprocessing, so all Python names (clientName, snakeCaseName,
+className, propertyName) are already set and all client.tsp customisations
+(@client, @operationGroup, @override, @access, @usage) have been applied.
+
+The emitter invokes apistub with --code-model-path (and --skip-pylint) to generate
+api.md directly, without installing or inspecting the generated Python SDK.
+Users who need the full package-inspection path (e.g. to pick up handwritten
+customisations from _patch.py) opt out at the emitter level; this parser is not
+involved in that decision.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from apistub._generated.treestyle.parser.models import ApiView, ReviewLines
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Type annotation rendering
+# ---------------------------------------------------------------------------
+
+# YAML "type" discriminator → Python annotation string (no Optional wrapper).
+_PRIMITIVE_MAP: Dict[str, str] = {
+    "string": "str",
+    "integer": "int",
+    "float": "float",
+    "decimal": "decimal.Decimal",
+    "boolean": "bool",
+    "binary": "IO[bytes]",
+    "bytes": "bytes",
+    "any": "Any",
+    "any-object": "JSON",
+    "utcDateTime": "datetime",
+    "offsetDateTime": "datetime",
+    "plainDate": "date",
+    "plainTime": "time",
+    "duration": "timedelta",
+    "unixtime": "datetime",
+    "credential": "str",
+}
+
+# Credential / policy types that appear in parameters but are not user-visible types.
+_CREDENTIAL_TYPES = {"OAuth2", "Key", "ARMChallengeAuthenticationPolicy",
+                     "BearerTokenCredentialPolicy", "KeyCredentialPolicy"}
+
+
+def _type_annotation(type_dict: Dict[str, Any], *, is_optional: bool = False) -> str:
+    """Recursively convert a YAML type descriptor to a Python annotation string."""
+    if not type_dict:
+        return "Any"
+
+    t = type_dict.get("type", "")
+
+    # Credential types
+    if t in _CREDENTIAL_TYPES:
+        ann = "TokenCredential"
+        return f"Optional[{ann}]" if is_optional else ann
+
+    # Primitive
+    if t in _PRIMITIVE_MAP:
+        ann = _PRIMITIVE_MAP[t]
+        return f"Optional[{ann}]" if is_optional else ann
+
+    # model → "_models.ClassName"
+    if t == "model":
+        name = type_dict.get("name", "Unknown")
+        ann = f"_models.{name}"
+        return f"Optional[{ann}]" if is_optional else ann
+
+    # enum → "Union[str, _models.EnumName]"
+    if t == "enum":
+        name = type_dict.get("name", "Unknown")
+        # Capitalise first letter as pygen does
+        name = name[0].upper() + name[1:] if name else name
+        ann = f"Union[str, _models.{name}]"
+        return f"Optional[{ann}]" if is_optional else ann
+
+    # constant → use valueType
+    if t == "constant":
+        val = type_dict.get("value")
+        value_type = type_dict.get("valueType", {})
+        if val is not None:
+            base = _PRIMITIVE_MAP.get(value_type.get("type", ""), "str")
+            if isinstance(val, str):
+                ann = f'Literal["{val}"]'
+            else:
+                ann = f"Literal[{val}]"
+        else:
+            ann = _type_annotation(value_type)
+        return f"Optional[{ann}]" if is_optional else ann
+
+    # list → "List[ElementType]"
+    if t == "list":
+        elem = type_dict.get("elementType", {})
+        inner = _type_annotation(elem)
+        ann = f"List[{inner}]"
+        return f"Optional[{ann}]" if is_optional else ann
+
+    # dict → "Dict[str, ValueType]"
+    if t == "dict":
+        val = type_dict.get("valueType", {})
+        inner = _type_annotation(val)
+        ann = f"Dict[str, {inner}]"
+        return f"Optional[{ann}]" if is_optional else ann
+
+    # combined / union → "Union[A, B]"
+    if t == "combined":
+        types = type_dict.get("types", [])
+        parts = [_type_annotation(sub) for sub in types]
+        if len(parts) == 1:
+            ann = parts[0]
+        else:
+            ann = f"Union[{', '.join(parts)}]"
+        return f"Optional[{ann}]" if is_optional else ann
+
+    # sdkcore / multipartfile / external — render as their name or generic
+    if t in ("sdkcore", "multipartfile", "external"):
+        name = type_dict.get("name") or type_dict.get("xmlName") or t
+        ann = name
+        return f"Optional[{ann}]" if is_optional else ann
+
+    # enumvalue → Literal
+    if t == "enumvalue":
+        parent = type_dict.get("enumType", {}).get("name", "")
+        name = type_dict.get("name", "")
+        if parent:
+            ann = f"Literal[_models.{parent}.{name}]"
+        else:
+            ann = f'Literal["{name}"]'
+        return f"Optional[{ann}]" if is_optional else ann
+
+    # Fallback
+    logger.debug("Unknown YAML type %r, falling back to Any", t)
+    return "Optional[Any]" if is_optional else "Any"
+
+
+# ---------------------------------------------------------------------------
+# Helper: build method signature string from a list of parameter dicts
+# ---------------------------------------------------------------------------
+
+def _build_method_signature(params: List[Dict[str, Any]], *, is_async: bool = False) -> str:
+    """Render a comma-separated parameter string for a method, grouped as
+    positional → ``*`` → keyword-only → ``**kwargs``.
+
+    Returns the inner signature (no ``self``, no ``def name(``).
+    """
+    # Separate by location
+    POSITIONAL_LOCATIONS = {"path", "query", "header", "body", "positional"}
+    KWARG_LOCATION = "kwarg"
+    KW_ONLY_LOCATION = "keywordOnly"
+
+    positional: List[str] = []
+    kw_only: List[str] = []
+    has_kwargs = False
+
+    for p in params:
+        if p.get("inOverload") or p.get("hideInMethod"):
+            continue
+        client_name = p.get("clientName", p.get("name", ""))
+        location = p.get("location", "")
+        optional = p.get("optional", False)
+        type_dict = p.get("type", {})
+        annotation = _type_annotation(type_dict, is_optional=optional)
+
+        default_val = p.get("clientDefaultValue")
+        # **kwargs placeholder
+        if client_name == "kwargs" or location == KWARG_LOCATION:
+            has_kwargs = True
+            continue
+
+        if default_val is not None:
+            if isinstance(default_val, str):
+                default_str = f' = "{default_val}"'
+            elif isinstance(default_val, bool):
+                default_str = f" = {default_val}"
+            elif default_val is None:
+                default_str = " = None"
+            else:
+                default_str = f" = {default_val}"
+        elif optional:
+            default_str = " = None"
+        else:
+            default_str = ""
+
+        rendered = f"{client_name}: {annotation}{default_str}"
+
+        if location in POSITIONAL_LOCATIONS:
+            positional.append(rendered)
+        else:
+            kw_only.append(rendered)
+
+    parts: List[str] = ["self"]
+    parts.extend(positional)
+    if kw_only:
+        parts.append("*")
+        parts.extend(kw_only)
+    if has_kwargs:
+        parts.append("**kwargs: Any")
+
+    return ", ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Main parser class
+# ---------------------------------------------------------------------------
+
+class CodeModelParser:
+    """Generates an ApiView token file from a preprocessed code-model.yaml dict."""
+
+    def __init__(
+        self,
+        yaml_data: Dict[str, Any],
+        *,
+        mapping_path: Optional[str] = None,
+        source_url: Optional[str] = None,
+    ):
+        self._yaml = yaml_data
+        self._mapping_path = mapping_path
+        self._source_url = source_url
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    def generate_tokens(self) -> ApiView:
+        """Walk the YAML and produce a fully populated ApiView."""
+        namespace = self._yaml.get("namespace", "")
+        pkg_name = self._yaml.get("packageName") or namespace
+        pkg_version = self._yaml.get("packageVersion") or ""
+        cross_language_package_id = self._yaml.get("crossLanguagePackageId")
+
+        # Build cross-language map from all types and operations
+        cross_language_map = self._build_cross_language_map()
+        cross_language_version = None  # not stored in YAML directly
+
+        # Create MetadataMap-like wrapper
+        metadata_map = _YamlMetadataMap(
+            cross_language_package_id=cross_language_package_id,
+            cross_language_map=cross_language_map,
+            cross_language_version=cross_language_version,
+        )
+
+        apiview = ApiView(
+            pkg_name=pkg_name,
+            namespace=namespace,
+            metadata_map=metadata_map,
+            source_url=self._source_url,
+            pkg_version=pkg_version,
+        )
+        apiview.generate_tokens()  # writes header line
+
+        review_lines: ReviewLines = apiview.review_lines
+
+        # Render enums, models, clients, operation groups
+        self._render_enums(review_lines, apiview)
+        self._render_models(review_lines, apiview)
+        self._render_clients(review_lines, apiview, namespace, is_async=False)
+        self._render_clients(review_lines, apiview, namespace, is_async=True)
+
+        return apiview
+
+    # ------------------------------------------------------------------
+    # Cross-language map builder
+    # ------------------------------------------------------------------
+
+    def _build_cross_language_map(self) -> Dict[str, str]:
+        """Build {python_qualified_name: crossLanguageDefinitionId} map."""
+        result: Dict[str, str] = {}
+        namespace = self._yaml.get("namespace", "")
+
+        for t in self._yaml.get("types", []):
+            cid = t.get("crossLanguageDefinitionId")
+            if not cid:
+                continue
+            if t["type"] == "model":
+                key = f"{namespace}.{t['name']}"
+            elif t["type"] == "enum":
+                name = t["name"][0].upper() + t["name"][1:]
+                key = f"{namespace}.{name}"
+            else:
+                continue
+            result[key] = cid
+
+        for client in self._yaml.get("clients", []):
+            for og in _all_operation_groups(client.get("operationGroups", [])):
+                class_name = og.get("className", "")
+                for op in og.get("operations", []):
+                    cid = op.get("crossLanguageDefinitionId")
+                    if cid:
+                        op_name = op.get("name", "")
+                        key = f"{namespace}.{class_name}.{op_name}"
+                        result[key] = cid
+                        # async variant
+                        key_async = f"{namespace}.aio.{class_name}.{op_name}"
+                        result[key_async] = cid
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Enums
+    # ------------------------------------------------------------------
+
+    def _render_enums(self, review_lines: ReviewLines, apiview: ApiView):
+        namespace = self._yaml.get("namespace", "")
+        for type_dict in self._yaml.get("types", []):
+            if type_dict.get("type") != "enum":
+                continue
+            self._render_enum(review_lines, apiview, type_dict, namespace)
+
+    def _render_enum(
+        self,
+        review_lines: ReviewLines,
+        apiview: ApiView,
+        type_dict: Dict[str, Any],
+        namespace: str,
+    ):
+        raw_name = type_dict.get("name", "Unknown")
+        name = raw_name[0].upper() + raw_name[1:] if raw_name else raw_name
+        line_id = f"{namespace}.{name}"
+        cid = type_dict.get("crossLanguageDefinitionId")
+
+        line = review_lines.create_review_line(line_id=line_id)
+        if cid:
+            line.cross_language_id = cid
+        line.add_keyword("class")
+        line.add_text(name, navigation_display_name=name)
+        line.add_punctuation("(", has_suffix_space=False)
+        line.add_type("str", apiview)
+        line.add_punctuation(",", has_suffix_space=True)
+        line.add_type("Enum", apiview)
+        line.add_punctuation(")", has_suffix_space=False)
+        line.add_punctuation(":")
+
+        children = ReviewLines()
+        for val in type_dict.get("values", []):
+            val_name = val.get("name", "")
+            value = val.get("value", "")
+            val_line_id = f"{line_id}.{val_name}"
+            val_line = children.create_review_line(line_id=val_line_id)
+            val_line.add_text(val_name)
+            val_line.add_punctuation("=")
+            if isinstance(value, str):
+                val_line.add_string_literal(value, has_suffix_space=False)
+            else:
+                val_line.add_literal(str(value), has_suffix_space=False)
+            children.append(val_line)
+
+        children.set_blank_lines(last_is_context_end_line=True)
+        line.add_children(children)
+        review_lines.append(line)
+        review_lines.set_blank_lines(2)
+
+    # ------------------------------------------------------------------
+    # Models
+    # ------------------------------------------------------------------
+
+    def _render_models(self, review_lines: ReviewLines, apiview: ApiView):
+        namespace = self._yaml.get("namespace", "")
+        for type_dict in self._yaml.get("types", []):
+            if type_dict.get("type") not in ("model",):
+                continue
+            # Skip internal / error-only models
+            usage = type_dict.get("usage", 0)
+            if usage == 0:
+                continue
+            self._render_model(review_lines, apiview, type_dict, namespace)
+
+    def _render_model(
+        self,
+        review_lines: ReviewLines,
+        apiview: ApiView,
+        type_dict: Dict[str, Any],
+        namespace: str,
+    ):
+        name = type_dict.get("name", "Unknown")
+        line_id = f"{namespace}.{name}"
+        cid = type_dict.get("crossLanguageDefinitionId")
+
+        parents = type_dict.get("parents", [])
+        parent_names = [p.get("name", "") for p in parents if p.get("name")]
+
+        line = review_lines.create_review_line(line_id=line_id)
+        if cid:
+            line.cross_language_id = cid
+        line.add_keyword("class")
+        line.add_text(name, navigation_display_name=name)
+        if parent_names:
+            line.add_punctuation("(", has_suffix_space=False)
+            for i, pname in enumerate(parent_names):
+                line.add_type(pname, apiview, has_suffix_space=False)
+                if i < len(parent_names) - 1:
+                    line.add_punctuation(",", has_suffix_space=True)
+            line.add_punctuation(")", has_suffix_space=False)
+        line.add_punctuation(":")
+
+        children = ReviewLines()
+        props = type_dict.get("properties", [])
+        if not props:
+            # Empty class body
+            pass_line = children.create_review_line()
+            pass_line.add_punctuation("...", has_suffix_space=False)
+            children.append(pass_line)
+        else:
+            for prop in props:
+                self._render_property(children, apiview, prop, line_id)
+
+        children.set_blank_lines(last_is_context_end_line=True)
+        line.add_children(children)
+        review_lines.append(line)
+        review_lines.set_blank_lines(2)
+
+    def _render_property(
+        self,
+        review_lines: ReviewLines,
+        apiview: ApiView,
+        prop: Dict[str, Any],
+        parent_line_id: str,
+    ):
+        client_name = prop.get("clientName", prop.get("name", ""))
+        line_id = f"{parent_line_id}.{client_name}"
+        optional = prop.get("optional", False)
+        readonly = prop.get("readOnly", False)
+        type_dict = prop.get("type", {})
+        annotation = _type_annotation(type_dict, is_optional=optional)
+
+        line = review_lines.create_review_line(line_id=line_id)
+        line.add_text(client_name)
+        line.add_punctuation(":", has_suffix_space=True)
+        line.add_type(annotation, apiview, has_suffix_space=False)
+        if optional:
+            line.add_text(" = None", has_prefix_space=False, has_suffix_space=False)
+        review_lines.append(line)
+
+    # ------------------------------------------------------------------
+    # Clients
+    # ------------------------------------------------------------------
+
+    def _render_clients(
+        self,
+        review_lines: ReviewLines,
+        apiview: ApiView,
+        namespace: str,
+        is_async: bool,
+    ):
+        ns = f"{namespace}.aio" if is_async else namespace
+        for client in self._yaml.get("clients", []):
+            self._render_client(review_lines, apiview, client, ns, is_async)
+
+    def _render_client(
+        self,
+        review_lines: ReviewLines,
+        apiview: ApiView,
+        client: Dict[str, Any],
+        namespace: str,
+        is_async: bool,
+    ):
+        name = client.get("name", "UnknownClient")
+        line_id = f"{namespace}.{name}"
+
+        line = review_lines.create_review_line(line_id=line_id)
+        line.add_keyword("class")
+        line.add_text(name, navigation_display_name=name)
+        line.add_punctuation(":")
+
+        children = ReviewLines()
+
+        # __init__
+        self._render_init(children, apiview, client, line_id, is_async)
+
+        # Operation group properties
+        for og in client.get("operationGroups", []):
+            og_prop = og.get("propertyName", "")
+            og_class = og.get("className", "")
+            if og_prop and og_class:
+                og_line_id = f"{line_id}.{og_prop}"
+                og_line = children.create_review_line(line_id=og_line_id)
+                og_line.add_text(og_prop)
+                og_line.add_punctuation(":", has_suffix_space=True)
+                og_line.add_type(og_class, apiview, has_suffix_space=False)
+                children.append(og_line)
+
+        children.set_blank_lines(last_is_context_end_line=True)
+        line.add_children(children)
+        review_lines.append(line)
+        review_lines.set_blank_lines(2)
+
+        # Render each operation group class
+        for og in _all_operation_groups(client.get("operationGroups", [])):
+            self._render_operation_group(review_lines, apiview, og, namespace, is_async)
+
+    def _render_init(
+        self,
+        review_lines: ReviewLines,
+        apiview: ApiView,
+        client: Dict[str, Any],
+        parent_line_id: str,
+        is_async: bool,
+    ):
+        line_id = f"{parent_line_id}.__init__"
+        params = client.get("parameters", [])
+        sig = _build_method_signature(params, is_async=is_async)
+
+        line = review_lines.create_review_line(line_id=line_id)
+        line.add_keyword("def")
+        line.add_text("__init__")
+        line.add_punctuation("(", has_suffix_space=False)
+        line.add_text(sig, has_prefix_space=False, has_suffix_space=False)
+        line.add_punctuation(")", has_suffix_space=False)
+        line.add_punctuation(":")
+
+        body = ReviewLines()
+        dots = body.create_review_line()
+        dots.add_punctuation("...", has_suffix_space=False)
+        body.append(dots)
+        line.add_children(body)
+        review_lines.append(line)
+        review_lines.set_blank_lines(1)
+
+    # ------------------------------------------------------------------
+    # Operation groups
+    # ------------------------------------------------------------------
+
+    def _render_operation_group(
+        self,
+        review_lines: ReviewLines,
+        apiview: ApiView,
+        og: Dict[str, Any],
+        namespace: str,
+        is_async: bool,
+    ):
+        class_name = og.get("className", "UnknownOperations")
+        # mixin groups have an empty identify_name and a leading underscore
+        is_mixin = not og.get("identifyName", "")
+        if is_mixin:
+            class_name = f"_{class_name}" if not class_name.startswith("_") else class_name
+        line_id = f"{namespace}.{class_name}"
+
+        line = review_lines.create_review_line(line_id=line_id)
+        line.add_keyword("class")
+        line.add_text(class_name, navigation_display_name=class_name)
+        line.add_punctuation(":")
+
+        children = ReviewLines()
+
+        for op in og.get("operations", []):
+            # Render @overload stubs first
+            for overload in op.get("overloads", []):
+                self._render_operation(children, apiview, overload, line_id, is_async, is_overload=True)
+            # Render main method
+            self._render_operation(children, apiview, op, line_id, is_async, is_overload=False)
+
+        children.set_blank_lines(last_is_context_end_line=True)
+        line.add_children(children)
+        review_lines.append(line)
+        review_lines.set_blank_lines(2)
+
+    def _render_operation(
+        self,
+        review_lines: ReviewLines,
+        apiview: ApiView,
+        op: Dict[str, Any],
+        parent_line_id: str,
+        is_async: bool,
+        is_overload: bool,
+    ):
+        op_name = op.get("name", "unknown")
+        line_id = f"{parent_line_id}.{op_name}"
+        cid = op.get("crossLanguageDefinitionId")
+        params = op.get("parameters", [])
+        sig = _build_method_signature(params, is_async=is_async)
+        return_type = self._build_return_type(op)
+
+        if is_overload:
+            dec_line = review_lines.create_review_line()
+            dec_line.add_punctuation("@", has_suffix_space=False)
+            dec_line.add_text("overload", has_prefix_space=False)
+            review_lines.append(dec_line)
+
+        line = review_lines.create_review_line(line_id=line_id if not is_overload else None)
+        if not is_overload and cid:
+            line.cross_language_id = cid
+        if is_async:
+            line.add_keyword("async")
+        line.add_keyword("def")
+        line.add_text(op_name, navigation_display_name=op_name if not is_overload else None)
+        line.add_punctuation("(", has_suffix_space=False)
+        line.add_text(sig, has_prefix_space=False, has_suffix_space=False)
+        line.add_punctuation(")", has_suffix_space=False)
+        if return_type:
+            line.add_text("->", has_prefix_space=True, has_suffix_space=True)
+            line.add_type(return_type, apiview, has_suffix_space=False)
+        line.add_punctuation(":")
+
+        body = ReviewLines()
+        dots = body.create_review_line()
+        dots.add_punctuation("...", has_suffix_space=False)
+        body.append(dots)
+        line.add_children(body)
+        review_lines.append(line)
+        review_lines.set_blank_lines(1)
+
+    def _build_return_type(self, op: Dict[str, Any]) -> Optional[str]:
+        """Derive the Python return type annotation from an operation dict."""
+        discriminator = op.get("discriminator", "")
+        responses = op.get("responses", [])
+
+        # Collect all non-None body types from responses
+        return_types = []
+        for resp in responses:
+            body_type = resp.get("type")
+            if body_type:
+                ann = _type_annotation(body_type)
+                if ann and ann not in return_types:
+                    return_types.append(ann)
+
+        if discriminator == "paging":
+            inner = return_types[0] if return_types else "Any"
+            return f"ItemPaged[{inner}]"
+        if discriminator in ("lro", "lropaging"):
+            inner = return_types[0] if return_types else "Any"
+            return f"LROPoller[{inner}]"
+
+        if not return_types:
+            return "None"
+        if len(return_types) == 1:
+            return return_types[0]
+        return f"Union[{', '.join(return_types)}]"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _all_operation_groups(groups: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Flatten nested operation groups (BFS)."""
+    result = []
+    queue = list(groups)
+    while queue:
+        og = queue.pop(0)
+        result.append(og)
+        queue.extend(og.get("operationGroups", []))
+    return result
+
+
+class _YamlMetadataMap:
+    """Minimal MetadataMap-like object populated from YAML data."""
+
+    def __init__(
+        self,
+        *,
+        cross_language_package_id: Optional[str],
+        cross_language_map: Dict[str, str],
+        cross_language_version: Optional[str],
+    ):
+        self.cross_language_package_id = cross_language_package_id or ""
+        self.cross_language_map = cross_language_map
+        self.cross_language_version = cross_language_version

--- a/packages/python-packages/apiview-stub-generator/apiview_reqs.txt
+++ b/packages/python-packages/apiview-stub-generator/apiview_reqs.txt
@@ -1,5 +1,6 @@
 astroid==3.3.8
 charset-normalizer==3.4.1
+PyYAML==6.0.1
 dill==0.3.9
 isodate==0.6.1
 isort==5.13.2

--- a/packages/python-packages/apiview-stub-generator/pyproject.toml
+++ b/packages/python-packages/apiview-stub-generator/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "isodate>=0.6.1",
     "typing-extensions>=4.6.0",
     "pkginfo",
+    "pyyaml",
 ]
 dynamic = ["version", "readme"]
 

--- a/packages/python-packages/apiview-stub-generator/tests/_test_util.py
+++ b/packages/python-packages/apiview-stub-generator/tests/_test_util.py
@@ -4,8 +4,25 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from apistub import ApiView
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
 from typing import List
+
+from apistub import ApiView
+
+# Path to Export-APIViewMarkdown.ps1, resolved relative to this file so it
+# works both locally and in CI without any configuration.
+#   tests/_test_util.py
+#     → tests/
+#       → apiview-stub-generator/
+#         → python-packages/
+#           → packages/
+#             → <repo root>/eng/common/scripts/
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_EXPORT_SCRIPT = _REPO_ROOT / "eng" / "common" / "scripts" / "Export-APIViewMarkdown.ps1"
 
 
 def _tokenize(node):
@@ -64,3 +81,54 @@ def _count_review_line_metadata(tokens, metadata):
             _count_review_line_metadata(token["Children"], metadata)
 
     return metadata
+
+
+def render_api_view_markdown(apiview) -> str:
+    """Serialize *apiview* to a temp JSON file, run Export-APIViewMarkdown.ps1 via
+    ``pwsh``, and return the resulting markdown string.
+
+    Skips (via ``pytest.skip``) when:
+    * ``pwsh`` is not on PATH (CI agents that lack PowerShell Core)
+    * the Export-APIViewMarkdown.ps1 script cannot be found
+
+    This intentionally delegates all rendering logic to the PS1 script so that
+    the tests stay in sync automatically when the script changes.
+    """
+    import pytest  # local import – only needed for tests
+
+    if not shutil.which("pwsh"):
+        pytest.skip("pwsh not available – skipping api.md comparison")
+
+    if not _EXPORT_SCRIPT.exists():
+        pytest.skip(f"Export-APIViewMarkdown.ps1 not found at {_EXPORT_SCRIPT}")
+
+    from apistub._stub_generator import APIViewEncoder  # noqa: PLC0415
+
+    with tempfile.TemporaryDirectory() as tmp:
+        json_path = Path(tmp) / "tokens.json"
+        md_path = Path(tmp) / "api.md"
+
+        json_path.write_text(APIViewEncoder().encode(apiview), encoding="utf-8")
+
+        result = subprocess.run(
+            [
+                "pwsh",
+                "-NoProfile",
+                "-NonInteractive",
+                "-File",
+                str(_EXPORT_SCRIPT),
+                "-TokenJsonPath",
+                str(json_path),
+                "-OutputPath",
+                str(md_path),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Export-APIViewMarkdown.ps1 failed (exit {result.returncode}):\n"
+                f"{result.stderr or result.stdout}"
+            )
+
+        return md_path.read_text(encoding="utf-8")

--- a/packages/python-packages/apiview-stub-generator/tests/azure_tests/azure_test.py
+++ b/packages/python-packages/apiview-stub-generator/tests/azure_tests/azure_test.py
@@ -49,6 +49,10 @@ SDK_PARAMS = [
     ("azure-mgmt-compute", "37.2.0", "compute", "azure.mgmt.compute", "whl"),
     ("azure-mgmt-compute", "37.2.0", "compute", "azure.mgmt.compute", "sdist"),
     ("azure-mgmt-compute", "37.2.0", "compute", "azure.mgmt.compute", "src"),
+    # Management plane packages: pylint is skipped automatically (see test_sdks).
+    ("azure-mgmt-network", "27.0.0", "network", "azure.mgmt.network", "whl"),
+    ("azure-mgmt-network", "27.0.0", "network", "azure.mgmt.network", "sdist"),
+    ("azure-mgmt-network", "27.0.0", "network", "azure.mgmt.network", "src"),
 ]
 SDK_IDS = [f"{pkg_name}_{version}[{pkg_type}]" for pkg_name, version, _, _, pkg_type in SDK_PARAMS]
 
@@ -338,9 +342,11 @@ class TestApiViewAzure:
     def test_sdks(self, pkg_name, version, directory, pkg_namespace, pkg_type):
         pkg_path, mapping_file = self._download_packages(directory, pkg_name, version, pkg_type)
         temp_path = tempfile.gettempdir()
-        # Explicitly pass through mapping file path
+        # Management-plane packages: skip pylint (diagnostics not meaningful for mgmt, and it's slow).
+        is_mgmt = pkg_name.startswith("azure-mgmt-")
         stub_gen = StubGenerator(
-            pkg_path=pkg_path, temp_path=temp_path, out_path=temp_path, mapping_path=mapping_file
+            pkg_path=pkg_path, temp_path=temp_path, out_path=temp_path,
+            mapping_path=mapping_file, skip_pylint=is_mgmt,
         )
         apiview = self._write_tokens(stub_gen)
         self._validate_line_ids(apiview)

--- a/packages/python-packages/apiview-stub-generator/tests/azure_tests/code_model_test.py
+++ b/packages/python-packages/apiview-stub-generator/tests/azure_tests/code_model_test.py
@@ -1,0 +1,272 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+"""Integration tests: StubGenerator --code-model-path end-to-end."""
+
+import json
+import os
+import sys
+
+import pytest
+import yaml
+
+from apistub import StubGenerator
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from _test_util import render_api_view_markdown
+
+
+# ---------------------------------------------------------------------------
+# A self-contained code-model that exercises the main constructs.
+# ---------------------------------------------------------------------------
+
+CODE_MODEL = {
+    "namespace": "azure.widgets",
+    "packageName": "azure-widgets",
+    "packageVersion": "1.0.0b1",
+    "crossLanguagePackageId": "Azure.Widgets",
+    "types": [
+        {
+            "type": "enum",
+            "name": "widgetStatus",
+            "crossLanguageDefinitionId": "Azure.Widgets.WidgetStatus",
+            "values": [
+                {"name": "ACTIVE", "value": "active"},
+                {"name": "INACTIVE", "value": "inactive"},
+            ],
+        },
+        {
+            "type": "model",
+            "name": "Widget",
+            "usage": 3,
+            "crossLanguageDefinitionId": "Azure.Widgets.Widget",
+            "parents": [],
+            "properties": [
+                {"clientName": "widget_id", "type": {"type": "string"}, "optional": False},
+                {"clientName": "status", "type": {"type": "enum", "name": "widgetStatus"}, "optional": True},
+                {"clientName": "tags", "type": {"type": "dict", "valueType": {"type": "string"}}, "optional": True},
+            ],
+        },
+        {
+            "type": "model",
+            "name": "WidgetList",
+            "usage": 2,  # output only – should still render
+            "crossLanguageDefinitionId": "Azure.Widgets.WidgetList",
+            "parents": [],
+            "properties": [
+                {"clientName": "items", "type": {"type": "list", "elementType": {"type": "model", "name": "Widget"}}, "optional": False},
+            ],
+        },
+    ],
+    "clients": [
+        {
+            "name": "WidgetsClient",
+            "parameters": [
+                {
+                    "clientName": "endpoint",
+                    "type": {"type": "string"},
+                    "optional": False,
+                    "location": "path",
+                },
+                {
+                    "clientName": "credential",
+                    "type": {"type": "credential"},
+                    "optional": False,
+                    "location": "other",
+                },
+            ],
+            "operationGroups": [
+                {
+                    "identifyName": "widgets",
+                    "propertyName": "widgets",
+                    "className": "WidgetsOperations",
+                    "operations": [
+                        {
+                            "name": "get",
+                            "crossLanguageDefinitionId": "Azure.Widgets.Widgets.get",
+                            "parameters": [
+                                {
+                                    "clientName": "widget_id",
+                                    "type": {"type": "string"},
+                                    "optional": False,
+                                    "location": "path",
+                                }
+                            ],
+                            "responses": [{"type": {"type": "model", "name": "Widget"}}],
+                            "overloads": [],
+                        },
+                        {
+                            "name": "list",
+                            "discriminator": "paging",
+                            "crossLanguageDefinitionId": "Azure.Widgets.Widgets.list",
+                            "parameters": [],
+                            "responses": [{"type": {"type": "model", "name": "Widget"}}],
+                            "overloads": [],
+                        },
+                        {
+                            "name": "create",
+                            "crossLanguageDefinitionId": "Azure.Widgets.Widgets.create",
+                            "parameters": [
+                                {
+                                    "clientName": "body",
+                                    "type": {"type": "model", "name": "Widget"},
+                                    "optional": False,
+                                    "location": "body",
+                                }
+                            ],
+                            "responses": [{"type": {"type": "model", "name": "Widget"}}],
+                            "overloads": [
+                                {
+                                    "name": "create",
+                                    "parameters": [
+                                        {"clientName": "body", "type": {"type": "model", "name": "Widget"}, "optional": False, "location": "body"}
+                                    ],
+                                    "responses": [],
+                                    "overloads": [],
+                                },
+                                {
+                                    "name": "create",
+                                    "parameters": [
+                                        {"clientName": "body", "type": {"type": "dict", "valueType": {"type": "any"}}, "optional": False, "location": "body"}
+                                    ],
+                                    "responses": [],
+                                    "overloads": [],
+                                },
+                            ],
+                        },
+                    ],
+                    "operationGroups": [],
+                }
+            ],
+        }
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_yaml(path, data):
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.dump(data, f)
+
+
+def _run_stub_generator(code_model_path):
+    """Run StubGenerator with --code-model-path and return (apiview, token_json_dict)."""
+    gen = StubGenerator(
+        code_model_path=code_model_path,
+        source_url=None,
+        filter_namespace=None,
+        mapping_path=None,
+        pkg_path=None,
+        verbose=False,
+    )
+    apiview = gen.generate_tokens()
+    json_str = gen.serialize(apiview)
+    token_json = json.loads(json_str)
+    return apiview, token_json
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestStubGeneratorCodeModelPath:
+    @pytest.fixture(autouse=True)
+    def _setup(self, tmp_path):
+        self.yaml_path = str(tmp_path / "code-model.yaml")
+        _write_yaml(self.yaml_path, CODE_MODEL)
+
+    def test_apiview_object_returned(self):
+        apiview, _ = _run_stub_generator(self.yaml_path)
+        assert apiview is not None
+
+    def test_package_name_in_token_file(self):
+        _, token_json = _run_stub_generator(self.yaml_path)
+        assert token_json.get("PackageName") == "azure-widgets"
+
+    def test_package_version_in_token_file(self):
+        _, token_json = _run_stub_generator(self.yaml_path)
+        assert token_json.get("PackageVersion") == "1.0.0b1"
+
+    def test_review_lines_not_empty(self):
+        _, token_json = _run_stub_generator(self.yaml_path)
+        assert len(token_json.get("ReviewLines", [])) > 0
+
+    def test_enum_in_output(self):
+        _, token_json = _run_stub_generator(self.yaml_path)
+        text = json.dumps(token_json)
+        assert "WidgetStatus" in text
+
+    def test_model_in_output(self):
+        _, token_json = _run_stub_generator(self.yaml_path)
+        text = json.dumps(token_json)
+        assert "Widget" in text
+
+    def test_client_in_output(self):
+        _, token_json = _run_stub_generator(self.yaml_path)
+        text = json.dumps(token_json)
+        assert "WidgetsClient" in text
+
+    def test_operation_group_in_output(self):
+        _, token_json = _run_stub_generator(self.yaml_path)
+        text = json.dumps(token_json)
+        assert "WidgetsOperations" in text
+
+    def test_operations_in_output(self):
+        _, token_json = _run_stub_generator(self.yaml_path)
+        text = json.dumps(token_json)
+        assert '"get"' in text
+        assert '"list"' in text
+        assert '"create"' in text
+
+    def test_overload_in_output(self):
+        _, token_json = _run_stub_generator(self.yaml_path)
+        text = json.dumps(token_json)
+        assert "overload" in text
+
+    def test_paging_return_type_in_output(self):
+        _, token_json = _run_stub_generator(self.yaml_path)
+        text = json.dumps(token_json)
+        assert "ItemPaged" in text
+
+    def test_cross_language_metadata_in_output(self):
+        _, token_json = _run_stub_generator(self.yaml_path)
+        meta = token_json.get("CrossLanguageMetadata")
+        assert meta is not None
+        assert meta.get("CrossLanguagePackageId") == "Azure.Widgets"
+
+    def test_apiview_package_name(self):
+        apiview, _ = _run_stub_generator(self.yaml_path)
+        assert apiview.package_name == "azure-widgets"
+
+    def test_apiview_package_version(self):
+        apiview, _ = _run_stub_generator(self.yaml_path)
+        assert apiview.package_version == "1.0.0b1"
+
+    def test_markdown_contains_key_symbols(self):
+        """Render api.md via Export-APIViewMarkdown.ps1 and spot-check key symbols."""
+        apiview, _ = _run_stub_generator(self.yaml_path)
+        md = render_api_view_markdown(apiview)
+        assert "WidgetStatus" in md
+        assert "Widget" in md
+        assert "WidgetsClient" in md
+        assert "WidgetsOperations" in md
+        assert "def get" in md
+        assert "def list" in md
+        assert "ItemPaged" in md
+
+    def test_file_not_found_raises(self):
+        with pytest.raises(SystemExit):
+            StubGenerator(
+                code_model_path="/nonexistent/code-model.yaml",
+                source_url=None,
+                filter_namespace=None,
+                mapping_path=None,
+                pkg_path=None,
+                verbose=False,
+            )

--- a/packages/python-packages/apiview-stub-generator/tests/code_model_parsing_test.py
+++ b/packages/python-packages/apiview-stub-generator/tests/code_model_parsing_test.py
@@ -1,0 +1,384 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+"""Unit tests for CodeModelParser and _type_annotation."""
+
+import pytest
+from apistub.nodes._code_model_parser import CodeModelParser, _type_annotation
+
+
+# ---------------------------------------------------------------------------
+# _type_annotation tests
+# ---------------------------------------------------------------------------
+
+
+def _ann(type_dict, optional=False):
+    return _type_annotation(type_dict, is_optional=optional)
+
+
+class TestTypeAnnotation:
+    def test_string(self):
+        assert _ann({"type": "string"}) == "str"
+
+    def test_integer(self):
+        assert _ann({"type": "integer"}) == "int"
+
+    def test_float(self):
+        assert _ann({"type": "float"}) == "float"
+
+    def test_boolean(self):
+        assert _ann({"type": "boolean"}) == "bool"
+
+    def test_binary(self):
+        assert _ann({"type": "binary"}) == "IO[bytes]"
+
+    def test_any(self):
+        assert _ann({"type": "any"}) == "Any"
+
+    def test_any_object(self):
+        assert _ann({"type": "any-object"}) == "JSON"
+
+    def test_datetime(self):
+        assert _ann({"type": "utcDateTime"}) == "datetime"
+        assert _ann({"type": "offsetDateTime"}) == "datetime"
+
+    def test_bytes(self):
+        assert _ann({"type": "bytes"}) == "bytes"
+
+    def test_duration(self):
+        assert _ann({"type": "duration"}) == "timedelta"
+
+    def test_optional_wraps(self):
+        assert _ann({"type": "string"}, optional=True) == "Optional[str]"
+
+    def test_model(self):
+        assert _ann({"type": "model", "name": "Widget"}) == "_models.Widget"
+
+    def test_model_optional(self):
+        assert _ann({"type": "model", "name": "Widget"}, optional=True) == "Optional[_models.Widget]"
+
+    def test_enum(self):
+        # enum name should be capitalised
+        assert _ann({"type": "enum", "name": "myStatus"}) == "Union[str, _models.MyStatus]"
+
+    def test_enum_already_capitalised(self):
+        assert _ann({"type": "enum", "name": "Status"}) == "Union[str, _models.Status]"
+
+    def test_list_of_string(self):
+        assert _ann({"type": "list", "elementType": {"type": "string"}}) == "List[str]"
+
+    def test_list_of_model(self):
+        assert _ann({"type": "list", "elementType": {"type": "model", "name": "Widget"}}) == "List[_models.Widget]"
+
+    def test_dict_of_int(self):
+        assert _ann({"type": "dict", "valueType": {"type": "integer"}}) == "Dict[str, int]"
+
+    def test_constant_string(self):
+        assert _ann({"type": "constant", "value": "xml", "valueType": {"type": "string"}}) == 'Literal["xml"]'
+
+    def test_constant_int(self):
+        assert _ann({"type": "constant", "value": 5, "valueType": {"type": "integer"}}) == "Literal[5]"
+
+    def test_combined(self):
+        ann = _ann({"type": "combined", "types": [{"type": "string"}, {"type": "integer"}]})
+        assert ann == "Union[str, int]"
+
+    def test_combined_single(self):
+        assert _ann({"type": "combined", "types": [{"type": "boolean"}]}) == "bool"
+
+    def test_unknown_falls_back_to_any(self):
+        assert _ann({"type": "unknownFuture"}) == "Any"
+
+    def test_empty_dict(self):
+        assert _ann({}) == "Any"
+
+
+# ---------------------------------------------------------------------------
+# Minimal YAML fixtures
+# ---------------------------------------------------------------------------
+
+MINIMAL_YAML = {
+    "namespace": "azure.foo",
+    "packageName": "azure-foo",
+    "packageVersion": "1.0.0b1",
+    "crossLanguagePackageId": "Azure.Foo",
+    "types": [],
+    "clients": [],
+}
+
+
+def _make_enum(**kwargs):
+    base = {
+        "type": "enum",
+        "name": "MyStatus",
+        "crossLanguageDefinitionId": "Azure.Foo.MyStatus",
+        "values": [
+            {"name": "ACTIVE", "value": "active"},
+            {"name": "INACTIVE", "value": "inactive"},
+        ],
+    }
+    base.update(kwargs)
+    return base
+
+
+def _make_model(**kwargs):
+    base = {
+        "type": "model",
+        "name": "Widget",
+        "usage": 3,
+        "crossLanguageDefinitionId": "Azure.Foo.Widget",
+        "properties": [
+            {"clientName": "name", "type": {"type": "string"}, "optional": False},
+        ],
+        "parents": [],
+    }
+    base.update(kwargs)
+    return base
+
+
+def _make_client(operations=None):
+    ops = operations or [
+        {
+            "name": "get_widget",
+            "crossLanguageDefinitionId": "Azure.Foo.Widgets.getWidget",
+            "parameters": [
+                {"clientName": "widget_id", "type": {"type": "string"}, "optional": False, "location": "path"},
+            ],
+            "responses": [{"type": {"type": "model", "name": "Widget"}}],
+            "overloads": [],
+        }
+    ]
+    return {
+        "name": "FooClient",
+        "parameters": [
+            {"clientName": "endpoint", "type": {"type": "string"}, "optional": False, "location": "path"},
+            {"clientName": "credential", "type": {"type": "credential"}, "optional": False, "location": "other"},
+        ],
+        "operationGroups": [
+            {
+                "identifyName": "widgets",
+                "propertyName": "widgets",
+                "className": "WidgetsOperations",
+                "operations": ops,
+                "operationGroups": [],
+            }
+        ],
+    }
+
+
+def _parse(yaml_data):
+    parser = CodeModelParser(yaml_data)
+    return parser.generate_tokens()
+
+
+def _rendered(apiview):
+    return "".join(apiview.review_lines.render())
+
+
+# ---------------------------------------------------------------------------
+# CodeModelParser tests
+# ---------------------------------------------------------------------------
+
+
+class TestCodeModelParserEnum:
+    def test_enum_class_header_present(self):
+        yaml_data = {**MINIMAL_YAML, "types": [_make_enum()]}
+        text = _rendered(_parse(yaml_data))
+        assert "class MyStatus" in text
+        assert "str" in text
+        assert "Enum" in text
+
+    def test_enum_values_present(self):
+        yaml_data = {**MINIMAL_YAML, "types": [_make_enum()]}
+        text = _rendered(_parse(yaml_data))
+        assert "ACTIVE" in text
+        assert "INACTIVE" in text
+
+    def test_enum_cross_language_id_set(self):
+        yaml_data = {**MINIMAL_YAML, "types": [_make_enum()]}
+        apiview = _parse(yaml_data)
+        line = _find_line(apiview, "azure.foo.MyStatus")
+        assert line is not None
+        assert line.cross_language_id == "Azure.Foo.MyStatus"
+
+    def test_integer_enum_values(self):
+        enum = _make_enum(name="Priority", values=[{"name": "HIGH", "value": 1}, {"name": "LOW", "value": 0}])
+        yaml_data = {**MINIMAL_YAML, "types": [enum]}
+        text = _rendered(_parse(yaml_data))
+        assert "HIGH" in text
+        assert "1" in text
+
+
+class TestCodeModelParserModel:
+    def test_model_class_header_present(self):
+        yaml_data = {**MINIMAL_YAML, "types": [_make_model()]}
+        text = _rendered(_parse(yaml_data))
+        assert "class Widget" in text
+
+    def test_model_property_present(self):
+        yaml_data = {**MINIMAL_YAML, "types": [_make_model()]}
+        text = _rendered(_parse(yaml_data))
+        assert "name" in text
+        assert "str" in text
+
+    def test_model_usage_zero_excluded(self):
+        yaml_data = {**MINIMAL_YAML, "types": [_make_model(usage=0)]}
+        text = _rendered(_parse(yaml_data))
+        assert "class Widget" not in text
+
+    def test_model_with_parent(self):
+        parent = {"type": "model", "name": "WidgetBase", "usage": 3, "properties": [], "parents": []}
+        child = _make_model(parents=[{"name": "WidgetBase"}])
+        yaml_data = {**MINIMAL_YAML, "types": [child, parent]}
+        text = _rendered(_parse(yaml_data))
+        assert "WidgetBase" in text
+
+    def test_optional_property_has_default_none(self):
+        model = _make_model(properties=[
+            {"clientName": "tag", "type": {"type": "string"}, "optional": True}
+        ])
+        yaml_data = {**MINIMAL_YAML, "types": [model]}
+        text = _rendered(_parse(yaml_data))
+        assert "= None" in text
+
+
+class TestCodeModelParserClient:
+    def test_client_class_present(self):
+        yaml_data = {**MINIMAL_YAML, "clients": [_make_client()]}
+        text = _rendered(_parse(yaml_data))
+        assert "class FooClient" in text
+
+    def test_client_init_present(self):
+        yaml_data = {**MINIMAL_YAML, "clients": [_make_client()]}
+        text = _rendered(_parse(yaml_data))
+        assert "__init__" in text
+
+    def test_operation_group_property_present(self):
+        yaml_data = {**MINIMAL_YAML, "clients": [_make_client()]}
+        text = _rendered(_parse(yaml_data))
+        assert "widgets" in text
+        assert "WidgetsOperations" in text
+
+    def test_operation_group_class_present(self):
+        yaml_data = {**MINIMAL_YAML, "clients": [_make_client()]}
+        text = _rendered(_parse(yaml_data))
+        assert "class WidgetsOperations" in text
+
+    def test_operation_present(self):
+        yaml_data = {**MINIMAL_YAML, "clients": [_make_client()]}
+        text = _rendered(_parse(yaml_data))
+        assert "def get_widget" in text
+
+    def test_async_operation_present(self):
+        yaml_data = {**MINIMAL_YAML, "clients": [_make_client()]}
+        text = _rendered(_parse(yaml_data))
+        assert "async def get_widget" in text
+
+    def test_operation_return_type(self):
+        yaml_data = {**MINIMAL_YAML, "clients": [_make_client()]}
+        text = _rendered(_parse(yaml_data))
+        assert "Widget" in text
+
+    def test_void_return_type(self):
+        ops = [{"name": "delete_widget", "parameters": [], "responses": [], "overloads": []}]
+        yaml_data = {**MINIMAL_YAML, "clients": [_make_client(operations=ops)]}
+        text = _rendered(_parse(yaml_data))
+        assert "None" in text
+
+    def test_paging_return_type(self):
+        ops = [
+            {
+                "name": "list_widgets",
+                "discriminator": "paging",
+                "parameters": [],
+                "responses": [{"type": {"type": "model", "name": "Widget"}}],
+                "overloads": [],
+            }
+        ]
+        yaml_data = {**MINIMAL_YAML, "clients": [_make_client(operations=ops)]}
+        text = _rendered(_parse(yaml_data))
+        assert "ItemPaged" in text
+
+    def test_lro_return_type(self):
+        ops = [
+            {
+                "name": "create_widget",
+                "discriminator": "lro",
+                "parameters": [],
+                "responses": [{"type": {"type": "model", "name": "Widget"}}],
+                "overloads": [],
+            }
+        ]
+        yaml_data = {**MINIMAL_YAML, "clients": [_make_client(operations=ops)]}
+        text = _rendered(_parse(yaml_data))
+        assert "LROPoller" in text
+
+    def test_overload_decorators_present(self):
+        ops = [
+            {
+                "name": "create_widget",
+                "parameters": [],
+                "responses": [],
+                "overloads": [
+                    {"name": "create_widget", "parameters": [{"clientName": "body", "type": {"type": "model", "name": "Widget"}, "optional": False, "location": "body"}], "responses": [], "overloads": []},
+                    {"name": "create_widget", "parameters": [{"clientName": "body", "type": {"type": "dict", "valueType": {"type": "any"}}, "optional": False, "location": "body"}], "responses": [], "overloads": []},
+                ],
+            }
+        ]
+        yaml_data = {**MINIMAL_YAML, "clients": [_make_client(operations=ops)]}
+        text = _rendered(_parse(yaml_data))
+        assert "@overload" in text
+
+
+class TestCodeModelParserMetadata:
+    def test_package_name(self):
+        apiview = _parse(MINIMAL_YAML)
+        assert apiview.package_name == "azure-foo"
+
+    def test_package_version(self):
+        apiview = _parse(MINIMAL_YAML)
+        assert apiview.package_version == "1.0.0b1"
+
+    def test_cross_language_package_id(self):
+        apiview = _parse({**MINIMAL_YAML, "types": [_make_model()]})
+        # cross_language_metadata is populated from the YAML
+        assert apiview.cross_language_metadata is not None
+        assert apiview.cross_language_metadata.cross_language_package_id == "Azure.Foo"
+
+    def test_aio_namespace_in_async_section(self):
+        yaml_data = {**MINIMAL_YAML, "clients": [_make_client()]}
+        text = _rendered(_parse(yaml_data))
+        # Async client classes are rendered under namespace.aio
+        # The class is the same name but appears twice (sync + async)
+        assert text.count("class FooClient") == 2
+
+    def test_operation_cross_language_id(self):
+        yaml_data = {**MINIMAL_YAML, "clients": [_make_client()]}
+        apiview = _parse(yaml_data)
+        line = _find_line(apiview, "azure.foo.WidgetsOperations.get_widget")
+        assert line is not None
+        assert line.cross_language_id == "Azure.Foo.Widgets.getWidget"
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _find_line(apiview, line_id):
+    """Recursively search for a ReviewLine with the given line_id."""
+
+    def _search(lines):
+        for line in lines:
+            if getattr(line, "line_id", None) == line_id:
+                return line
+            children = getattr(line, "children", None)
+            if children:
+                result = _search(children)
+                if result:
+                    return result
+        return None
+
+    return _search(apiview.review_lines)


### PR DESCRIPTION
Adding code-model.yaml as an input option for generating api.md, to be used by the tsp-python emitter.

Unblocking: https://github.com/microsoft/typespec/issues/10089