### PR TITLE
[Java] Add SYSTEM_ACCESSTOKEN to Git release template and publish blob template

### DIFF
--- a/eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+++ b/eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
@@ -25,6 +25,7 @@ steps:
   timeoutInMinutes: 5
   env:
     GH_TOKEN: $(azuresdk-github-pat)
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     ${{ if ne(parameters.NpmConfigUserConfig, '') }}:
       NPM_CONFIG_USERCONFIG: ${{ parameters.NpmConfigUserConfig }}
     ${{ if ne(parameters.NpmConfigRegistry, '') }}:

--- a/eng/common/pipelines/templates/steps/publish-blobs.yml
+++ b/eng/common/pipelines/templates/steps/publish-blobs.yml
@@ -26,3 +26,4 @@ steps:
     pwsh: true
   env:
     AZCOPY_AUTO_LOGIN_TYPE: 'PSCRED'
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)


### PR DESCRIPTION
This pull request makes minor updates to the Azure Pipelines YAML templates by adding the `SYSTEM_ACCESSTOKEN` environment variable to two pipeline steps. This change ensures that the system access token is available for authentication during the execution of these steps.

- Pipeline environment updates:
  * Added `SYSTEM_ACCESSTOKEN: $(System.AccessToken)` to the environment variables in `create-tags-and-git-release.yml` to enable access to the system token during tag and release creation.
  * Added `SYSTEM_ACCESSTOKEN: $(System.AccessToken)` to the environment variables in `publish-blobs.yml` to ensure the system token is available during blob publishing.