### PR TITLE
Added checkpoint and more detail steps to generate sdk skill

### DIFF
--- a/.github/skills/generate-sdk-locally/SKILL.md
+++ b/.github/skills/generate-sdk-locally/SKILL.md
@@ -4,7 +4,7 @@ license: MIT
 metadata:
   version: "1.1.0"
   distribution: shared
-description: "Generate, build, and test Azure SDKs locally from TypeSpec, with automatic customization to resolve build errors and apply SDK changes. **UTILITY SKILL**. USE FOR: \"generate SDK locally\", \"build SDK\", \"run SDK tests\", \"update changelog\", \"fix SDK build errors\", \"fix breaking changes\", \"resolve SDK generation errors\", \"customize TypeSpec\", \"apply TypeSpec customization\", \"rename SDK client\", \"rename SDK model\", \"hide operation from SDK\", \"fix analyzer errors\", \"fix compilation errors\", \"resolve customization drift\", \"create subclient\", \"apply client.tsp changes\". DO NOT USE FOR: publishing to package registries, CI pipeline configuration, API design review. INVOKES: azure-sdk-mcp:azsdk_package_generate_code, azure-sdk-mcp:azsdk_package_build_code, azure-sdk-mcp:azsdk_package_run_tests, azure-sdk-mcp:azsdk_customized_code_update."
+description: "Generate, build, and test Azure SDKs locally from TypeSpec with automatic customization. WHEN: \"generate SDK locally\", \"build SDK\", \"run SDK tests\", \"update changelog\", \"fix SDK build errors\", \"fix breaking changes\", \"resolve SDK generation errors\", \"customize TypeSpec\", \"rename SDK client\", \"rename SDK model\", \"hide operation from SDK\", \"fix analyzer errors\", \"resolve customization drift\", \"create subclient\", \"update metadata\", \"update version\". DO NOT USE FOR: publishing to package registries, CI pipeline configuration, API design review. INVOKES: azsdk_verify_setup, azsdk_package_generate_code, azsdk_package_build_code, azsdk_package_run_check, azsdk_package_run_tests, azsdk_customized_code_update, azsdk_package_update_changelog_content, azsdk_package_update_metadata, azsdk_package_update_version."
 compatibility:
   requires: "azure-sdk-mcp server, local azure-sdk-for-{language} clone, language build tools"
 ---
@@ -15,25 +15,35 @@ compatibility:
 
 | Tool | Purpose |
 |------|---------|
-| `azure-sdk-mcp:azsdk_package_generate_code` | Generate SDK from TypeSpec |
-| `azure-sdk-mcp:azsdk_package_build_code` | Build package |
-| `azure-sdk-mcp:azsdk_package_run_check` | Validate package |
-| `azure-sdk-mcp:azsdk_package_run_tests` | Run tests |
-| `azure-sdk-mcp:azsdk_customized_code_update` | Apply TypeSpec and code customizations to resolve build errors, breaking changes, or SDK modification requests (includes regeneration and build internally) |
+| `azsdk_verify_setup` | Verify environment |
+| `azsdk_package_generate_code` | Generate SDK |
+| `azsdk_package_build_code` | Build package |
+| `azsdk_package_run_check` | Validate package |
+| `azsdk_package_run_tests` | Run tests |
+| `azsdk_customized_code_update` | Apply customizations (includes regeneration and build) |
+| `azsdk_package_update_changelog_content` | Update changelog |
+| `azsdk_package_update_metadata` | Update metadata including ci.yml |
+| `azsdk_package_update_version` | Update version |
 
-**Prerequisites:** azure-sdk-mcp server must be running. Without MCP, use `npx tsp-client` CLI.
+Prerequisites: azure-sdk-mcp server must be running. Without MCP, use `npx tsp-client` CLI.
 
 ## Steps
 
-1. **Verify** — Run `azure-sdk-mcp:azsdk_verify_setup` to confirm environment.
-2. **Generate** — Run `azure-sdk-mcp:azsdk_package_generate_code` with `tspconfig.yaml` or `tsp-location.yaml` path.
-3. **Build** — Run `azure-sdk-mcp:azsdk_package_build_code`. If the build succeeds, proceed to step 5.
-4. **Customize** — If build fails, or if the user requests SDK modifications, run `azure-sdk-mcp:azsdk_customized_code_update` with the build errors or user request. The tool handles the full workflow internally: it classifies the issue, applies TypeSpec decorators and/or code patches, regenerates the SDK, and builds — all in one call. See [customization workflow](references/customization-workflow.md).
-5. **Validate** — Run `azure-sdk-mcp:azsdk_package_run_check` and `azure-sdk-mcp:azsdk_package_run_tests`.
-6. **Metadata** — Update metadata, changelog, and version. _(Note: For .NET data plane, skip this step — metadata, changelog, and version updates are per-commit tasks, not part of the generate/build/test workflow.)_
+1. **Select language** — Confirm target language: .NET, Java, JavaScript, Python, Go, or Rust.
+2. **Verify repo** — Ensure the user has a local clone of the correct [SDK repo](references/sdk-repos.md). If not cloned, instruct user to clone it.
+3. **Identify config file** — Determine the path to the TypeSpec configuration file. See [config file details](references/detailed-workflow.md).
+   - From `azure-rest-api-specs` repo: use path to `tspconfig.yaml`.
+   - From an SDK language repo: use path to `tsp-location.yaml`.
+4. **Verify setup** — Run `azure-sdk-mcp:azsdk_verify_setup` to confirm environment.
+5. **Generate** — Run `azure-sdk-mcp:azsdk_package_generate_code` with the config file path.
+6. **Build** — Run `azure-sdk-mcp:azsdk_package_build_code`. If build succeeds, proceed to step 8.
+7. **Customize** — If build fails, or if user requests SDK modifications, run `azure-sdk-mcp:azsdk_customized_code_update` with the build errors or user request. The tool handles the full workflow internally: it classifies the issue, applies TypeSpec decorators and/or code patches, regenerates the SDK, and builds — all in one call. See [customization workflow](references/customization-workflow.md).
+8. **Commit checkpoint** — Prompt the user to commit generated changes before proceeding. See [commit checkpoint details](references/detailed-workflow.md).
+9. **Validate** — Run `azure-sdk-mcp:azsdk_package_run_check` and `azure-sdk-mcp:azsdk_package_run_tests`.
+10. **Metadata** — Run `azure-sdk-mcp:azsdk_package_update_changelog_content`, `azure-sdk-mcp:azsdk_package_update_metadata`, and `azure-sdk-mcp:azsdk_package_update_version`. _(Note: For .NET data plane, skip this step — metadata, changelog, and version updates are per-commit tasks, not part of the generate/build/test workflow.)_
+11. **Final commit** — Prompt the user to commit final changes (changelog, metadata, version). See [commit checkpoint details](references/detailed-workflow.md).
 
-[SDK repos](references/sdk-repos.md)
-[Customization workflow](references/customization-workflow.md)
+[SDK repos](references/sdk-repos.md) | [Customization workflow](references/customization-workflow.md) | [Detailed workflow](references/detailed-workflow.md)
 
 ## Examples
 
@@ -47,6 +57,9 @@ compatibility:
 - "The build is failing because a customization references a renamed property"
 - "Create a subclient architecture for the Python SDK"
 - "Apply TypeSpec customizations to fix compilation errors"
+- "Update the changelog for this SDK package"
+- "Update the package version"
+- "Update the package metadata and ci.yml"
 
 ## Troubleshooting
 

--- a/.github/skills/generate-sdk-locally/references/detailed-workflow.md
+++ b/.github/skills/generate-sdk-locally/references/detailed-workflow.md
@@ -1,0 +1,32 @@
+# Detailed Workflow
+
+## Config File Identification
+
+Determine the correct path to the TypeSpec configuration file based on the working context.
+
+**Scenario A: Working in `azure-rest-api-specs`**
+- Identify the path to `tspconfig.yaml` (local path or HTTPS URL).
+- The local folder name can be arbitrary; MCP validates that the remote origin points to the official repo.
+- Example paths:
+  - `/home/usr/azure-rest-api-specs/specification/contosowidgetmanager/Contoso.Management/tspconfig.yaml`
+  - `https://github.com/Azure/azure-rest-api-specs/blob/main/specification/contosowidgetmanager/Contoso.Management/tspconfig.yaml`
+
+**Scenario B: Working in an Azure SDK language repo**
+- Identify the path to `tsp-location.yaml`.
+- Example: `/home/usr/azure-sdk-for-net/sdk/contoso/Azure.ResourceManager.Contoso/tsp-location.yaml`
+
+## Commit Checkpoints
+
+There are two commit checkpoints in the workflow. At each one:
+
+1. Inform the user that the preceding steps completed successfully.
+2. **Prompt the user** to decide whether to commit now. Do NOT skip this prompt.
+3. If user chooses to commit:
+   - Check if on the `main` branch. If so, prompt: *"You are currently on the main branch. Please create a new branch using `git checkout -b <branch-name>` before proceeding."* Suggest a default branch name (e.g., `sdk/<service-name>/<package-name>`).
+   - Stage changed files with `git add`.
+   - Prompt for a commit message, then run `git commit -m "<message>"`.
+4. If user skips, acknowledge and proceed.
+
+**Checkpoint 1 (after step 7/8):** Commit generated + built SDK changes before running validation and tests.
+
+**Checkpoint 2 (after step 10/11):** Commit changelog, metadata, and version updates.

--- a/.github/skills/generate-sdk-locally/references/sdk-repos.md
+++ b/.github/skills/generate-sdk-locally/references/sdk-repos.md
@@ -9,11 +9,26 @@
 | JavaScript | `azure-sdk-for-js`     |
 | Python     | `azure-sdk-for-python` |
 | Go         | `azure-sdk-for-go`     |
+| Rust       | `azure-sdk-for-rust`   |
 
 ## Configuration File Paths
 
 - **From azure-rest-api-specs repo:** Use path to `tspconfig.yaml`
 - **From SDK language repo:** Use path to `tsp-location.yaml`
+
+## MCP Tools
+
+| Tool | Purpose |
+|------|---------|
+| `azure-sdk-mcp:azsdk_verify_setup` | Verify local environment for selected language |
+| `azure-sdk-mcp:azsdk_package_generate_code` | Generate SDK from TypeSpec |
+| `azure-sdk-mcp:azsdk_package_build_code` | Build package |
+| `azure-sdk-mcp:azsdk_package_run_check` | Validate package |
+| `azure-sdk-mcp:azsdk_package_run_tests` | Run tests |
+| `azure-sdk-mcp:azsdk_customized_code_update` | Apply TypeSpec and code customizations to resolve build errors, breaking changes, or SDK modification requests (includes regeneration and build internally) |
+| `azure-sdk-mcp:azsdk_package_update_changelog_content` | Update changelog |
+| `azure-sdk-mcp:azsdk_package_update_metadata` | Update package metadata including ci.yml |
+| `azure-sdk-mcp:azsdk_package_update_version` | Update package version |
 
 ## Build Failure Resolution
 

--- a/.github/skills/generate-sdk-locally/tasks/basic-usage.yaml
+++ b/.github/skills/generate-sdk-locally/tasks/basic-usage.yaml
@@ -18,8 +18,6 @@ expected:
       tool_name: azsdk_verify_setup
     - type: tool_called
       tool_name: azsdk_package_generate_code
-    - type: tool_called
-      tool_name: azsdk_package_build_code
   behavior:
     max_tool_calls: 10
     max_response_time_ms: 60000

--- a/.github/skills/generate-sdk-locally/tasks/full-workflow.yaml
+++ b/.github/skills/generate-sdk-locally/tasks/full-workflow.yaml
@@ -25,6 +25,12 @@ expected:
       tool_name: azsdk_package_run_check
     - type: tool_called
       tool_name: azsdk_package_run_tests
+    - type: tool_called
+      tool_name: azsdk_package_update_changelog_content
+    - type: tool_called
+      tool_name: azsdk_package_update_metadata
+    - type: tool_called
+      tool_name: azsdk_package_update_version
   behavior:
     max_tool_calls: 15
     max_response_time_ms: 120000

--- a/.github/skills/generate-sdk-locally/tasks/update-changelog.yaml
+++ b/.github/skills/generate-sdk-locally/tasks/update-changelog.yaml
@@ -1,0 +1,20 @@
+id: sdk-local-update-changelog-001
+name: Update SDK Package Changelog
+description: |
+  Test that the skill triggers changelog update for a generated SDK package.
+tags:
+  - metadata
+  - changelog
+inputs:
+  prompt: "Update the changelog for the Python SDK package at sdk/compute/azure-mgmt-compute."
+expected:
+  output_contains:
+    - "changelog"
+  output_excludes:
+    - "cannot help"
+  outcomes:
+    - type: tool_called
+      tool_name: azsdk_package_update_changelog_content
+  behavior:
+    max_tool_calls: 5
+    max_response_time_ms: 30000

--- a/.github/skills/generate-sdk-locally/tasks/update-metadata.yaml
+++ b/.github/skills/generate-sdk-locally/tasks/update-metadata.yaml
@@ -1,0 +1,21 @@
+id: sdk-local-update-metadata-001
+name: Update SDK Package Metadata and ci.yml
+description: |
+  Test that the skill triggers metadata update (including ci.yml)
+  for a generated SDK package.
+tags:
+  - metadata
+  - ci
+inputs:
+  prompt: "Update the package metadata and ci.yml for the .NET SDK at sdk/contoso/Azure.ResourceManager.Contoso."
+expected:
+  output_contains:
+    - "metadata"
+  output_excludes:
+    - "cannot help"
+  outcomes:
+    - type: tool_called
+      tool_name: azsdk_package_update_metadata
+  behavior:
+    max_tool_calls: 5
+    max_response_time_ms: 30000

--- a/.github/skills/generate-sdk-locally/tasks/update-version.yaml
+++ b/.github/skills/generate-sdk-locally/tasks/update-version.yaml
@@ -1,0 +1,20 @@
+id: sdk-local-update-version-001
+name: Update SDK Package Version
+description: |
+  Test that the skill triggers version update for a generated SDK package.
+tags:
+  - metadata
+  - version
+inputs:
+  prompt: "Update the package version for the Java SDK at sdk/contoso/azure-resourcemanager-contoso."
+expected:
+  output_contains:
+    - "version"
+  output_excludes:
+    - "cannot help"
+  outcomes:
+    - type: tool_called
+      tool_name: azsdk_package_update_version
+  behavior:
+    max_tool_calls: 5
+    max_response_time_ms: 30000


### PR DESCRIPTION
This pull request enhances the "Generate SDK Locally" skill by expanding its supported operations, and adding new test cases for changelog, metadata, and version updates. The changes add support for Rust, clarify tool usage, and introduce detailed commit checkpoint instructions.

* Expanded the skill description and workflow in `.github/skills/generate-sdk-locally/SKILL.md` to include changelog, metadata, and version updates, added Rust support, and provided more granular workflow steps and commit checkpoints. 
* Added a new reference file `.github/skills/generate-sdk-locally/references/detailed-workflow.md` detailing configuration file identification and explicit commit checkpoint instructions.
* Updated `.github/skills/generate-sdk-locally/references/sdk-repos.md` to include Rust, and documented all MCP tools and their purposes.

* Added new task files and test cases to ensure the skill correctly triggers changelog (`azsdk_package_update_changelog_content`), metadata (`azsdk_package_update_metadata`), and version (`azsdk_package_update_version`) updates for SDK packages. 
* Updated existing test workflows to reflect the new steps and tool invocations, ensuring the skill's expanded capabilities are verified. 