### PR TITLE
Add YAML lint to skill CI and fix eval.yaml indentation

### DIFF
--- a/.github/skills/.yamllint.yml
+++ b/.github/skills/.yamllint.yml
@@ -1,7 +1,0 @@
-extends: relaxed
-
-rules:
-  line-length: disable
-  new-lines: disable
-  indentation:
-    level: error

--- a/.github/skills/.yamllint.yml
+++ b/.github/skills/.yamllint.yml
@@ -1,0 +1,7 @@
+extends: relaxed
+
+rules:
+  line-length: disable
+  new-lines: disable
+  indentation:
+    level: error

--- a/.github/skills/apiview-feedback-resolution/evals/eval.yaml
+++ b/.github/skills/apiview-feedback-resolution/evals/eval.yaml
@@ -18,12 +18,12 @@ metrics:
     threshold: 0.7
     description: Did the skill stay within behavior limits?
 graders:
-- type: text
-  name: no_fatal_errors
-  config:
-    regex_not_match:
-    - (?i)fatal error
-    - (?i)unhandled exception
-    - '(?i)panic:'
+  - type: text
+    name: no_fatal_errors
+    config:
+      regex_not_match:
+        - (?i)fatal error
+        - (?i)unhandled exception
+        - '(?i)panic:'
 tasks:
   - "tasks/*.yaml"

--- a/.github/skills/markdown-token-optimizer/evals/eval.yaml
+++ b/.github/skills/markdown-token-optimizer/evals/eval.yaml
@@ -18,12 +18,12 @@ metrics:
     threshold: 0.7
     description: Did the skill stay within behavior limits?
 graders:
-- type: text
-  name: no_fatal_errors
-  config:
-    regex_not_match:
-    - (?i)fatal error
-    - (?i)unhandled exception
-    - '(?i)panic:'
+  - type: text
+    name: no_fatal_errors
+    config:
+      regex_not_match:
+        - (?i)fatal error
+        - (?i)unhandled exception
+        - '(?i)panic:'
 tasks:
   - "tasks/*.yaml"

--- a/.github/skills/pipeline-troubleshooting/evals/eval.yaml
+++ b/.github/skills/pipeline-troubleshooting/evals/eval.yaml
@@ -18,12 +18,12 @@ metrics:
     threshold: 0.7
     description: Did the skill stay within behavior limits?
 graders:
-- type: text
-  name: no_fatal_errors
-  config:
-    regex_not_match:
-    - (?i)fatal error
-    - (?i)unhandled exception
-    - '(?i)panic:'
+  - type: text
+    name: no_fatal_errors
+    config:
+      regex_not_match:
+        - (?i)fatal error
+        - (?i)unhandled exception
+        - '(?i)panic:'
 tasks:
   - "tasks/*.yaml"

--- a/.github/skills/prepare-release-plan/evals/eval.yaml
+++ b/.github/skills/prepare-release-plan/evals/eval.yaml
@@ -18,12 +18,12 @@ metrics:
     threshold: 0.7
     description: Did the skill stay within behavior limits?
 graders:
-- type: text
-  name: no_fatal_errors
-  config:
-    regex_not_match:
-    - (?i)fatal error
-    - (?i)unhandled exception
-    - '(?i)panic:'
+  - type: text
+    name: no_fatal_errors
+    config:
+      regex_not_match:
+        - (?i)fatal error
+        - (?i)unhandled exception
+        - '(?i)panic:'
 tasks:
   - "tasks/*.yaml"

--- a/.github/skills/sdk-release/evals/eval.yaml
+++ b/.github/skills/sdk-release/evals/eval.yaml
@@ -18,12 +18,12 @@ metrics:
     threshold: 0.7
     description: Did the skill stay within behavior limits?
 graders:
-- type: text
-  name: no_fatal_errors
-  config:
-    regex_not_match:
-    - (?i)fatal error
-    - (?i)unhandled exception
-    - '(?i)panic:'
+  - type: text
+    name: no_fatal_errors
+    config:
+      regex_not_match:
+        - (?i)fatal error
+        - (?i)unhandled exception
+        - '(?i)panic:'
 tasks:
   - "tasks/*.yaml"

--- a/.github/skills/sensei/evals/eval.yaml
+++ b/.github/skills/sensei/evals/eval.yaml
@@ -18,12 +18,12 @@ metrics:
     threshold: 0.7
     description: Did the skill stay within behavior limits?
 graders:
-- type: text
-  name: no_fatal_errors
-  config:
-    regex_not_match:
-    - (?i)fatal error
-    - (?i)unhandled exception
-    - '(?i)panic:'
+  - type: text
+    name: no_fatal_errors
+    config:
+      regex_not_match:
+        - (?i)fatal error
+        - (?i)unhandled exception
+        - '(?i)panic:'
 tasks:
   - "tasks/*.yaml"

--- a/.github/skills/skill-authoring/evals/eval.yaml
+++ b/.github/skills/skill-authoring/evals/eval.yaml
@@ -18,12 +18,12 @@ metrics:
     threshold: 0.7
     description: Did the skill stay within behavior limits?
 graders:
-- type: text
-  name: no_fatal_errors
-  config:
-    regex_not_match:
-    - (?i)fatal error
-    - (?i)unhandled exception
-    - '(?i)panic:'
+  - type: text
+    name: no_fatal_errors
+    config:
+      regex_not_match:
+        - (?i)fatal error
+        - (?i)unhandled exception
+        - '(?i)panic:'
 tasks:
   - "tasks/*.yaml"

--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -20,6 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Validate YAML syntax
+        run: |
+          pip install yamllint --quiet
+          yamllint -c .github/skills/.yamllint.yml .github/skills/
+
       - name: Install Azure Developer CLI
         uses: Azure/setup-azd@v2
 

--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   check-skills:
@@ -20,10 +21,24 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Validate YAML syntax
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@microsoft'
+
+      - name: Validate skills and eval specs
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pip install yamllint --quiet
-          yamllint -c .github/skills/.yamllint.yml .github/skills/
+          npm install -g @microsoft/vally-cli
+          echo "=== Linting skills ==="
+          vally lint .github/skills --strict
+          echo "=== Validating eval specs ==="
+          for eval_file in $(find .github/skills -name "eval.yaml" -type f); do
+            echo "--- $eval_file ---"
+            vally lint --eval "$eval_file" --strict
+          done
 
       - name: Install Azure Developer CLI
         uses: Azure/setup-azd@v2

--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -12,7 +12,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
 
 jobs:
   check-skills:
@@ -21,24 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@microsoft'
-
-      - name: Validate skills and eval specs
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Validate YAML syntax
         run: |
-          npm install -g @microsoft/vally-cli
-          echo "=== Linting skills ==="
-          vally lint .github/skills --strict
-          echo "=== Validating eval specs ==="
-          for eval_file in $(find .github/skills -name "eval.yaml" -type f); do
-            echo "--- $eval_file ---"
-            vally lint --eval "$eval_file" --strict
-          done
+          pip install yamllint --quiet
+          yamllint -c .github/skills/.yamllint.yml .github/skills/
 
       - name: Install Azure Developer CLI
         uses: Azure/setup-azd@v2

--- a/.yamllint.tmp.yml
+++ b/.yamllint.tmp.yml
@@ -1,0 +1,1 @@
+extends: relaxed`nrules:`n  line-length: disable`n  new-lines: disable`n  indentation:`n    level: error

--- a/.yamllint.tmp.yml
+++ b/.yamllint.tmp.yml
@@ -1,1 +1,0 @@
-extends: relaxed`nrules:`n  line-length: disable`n  new-lines: disable`n  indentation:`n    level: error


### PR DESCRIPTION
## What Changed

- **Added yamllint validation step** to \skill-eval.yml\ workflow — runs before \waza check\, catches YAML syntax errors (indentation, structure) before they sync to language repos
- **Added \.github/skills/.yamllint.yml\** — config extending \elaxed\ preset with line-length and new-lines disabled, indentation elevated to error
- **Fixed 7 \vals/eval.yaml\ files** — corrected \graders:\ section indentation where list items were not properly nested

### Why

The Copilot PR reviewer flagged invalid YAML indentation in eval files synced to language repos (e.g. [azure-sdk-for-java#48773](https://github.com/Azure/azure-sdk-for-java/pull/48773#discussion_r3066220195)). The existing \waza check\ only validates SKILL.md frontmatter — it does not lint YAML syntax. This adds a fast \yamllint\ step to catch these issues at the source.

### Files affected
- \.github/workflows/skill-eval.yml\ — new validation step
- \.github/skills/.yamllint.yml\ — new lint config
- 7x \.github/skills/*/evals/eval.yaml\ — indentation fixes