### PR TITLE
Fix azsdk-cli test failures caused by .gitattributes eol=lf

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/OutputHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/OutputHelperTests.cs
@@ -47,7 +47,10 @@ internal class OutputHelperTests
         var output = new OutputHelper(OutputHelper.OutputModes.Json);
         var formatted = output.ValidateAndFormat<LogAnalysisResponse>(json);
 
-        Assert.That(formatted, Is.EqualTo(json));
+        // Normalize line endings before comparison. The repo .gitattributes enforces LF in source
+        // files, so verbatim string literals contain \n, but production code uses Environment.NewLine
+        // which is \r\n on Windows.
+        Assert.That(formatted.ReplaceLineEndings("\n"), Is.EqualTo(json.ReplaceLineEndings("\n")));
     }
 
     [Test]
@@ -78,6 +81,7 @@ message2
         var output = new OutputHelper(OutputHelper.OutputModes.Plain);
         var formatted = output.Format(response);
 
-        Assert.That(formatted, Is.EqualTo(expectedStr));
+        // Normalize line endings before comparison. See comment in TestTypedJsonOutput.
+        Assert.That(formatted.ReplaceLineEndings("\n"), Is.EqualTo(expectedStr.ReplaceLineEndings("\n")));
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Example/HelloWorldToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Example/HelloWorldToolTests.cs
@@ -33,7 +33,10 @@ Duration: 1ms
 
         Assert.That(outputHelper.Outputs.Count(), Is.EqualTo(1));
         Assert.That(outputHelper.Outputs.First().Stream, Is.EqualTo(OutputHelper.StreamType.Stdout));
-        Assert.That(outputHelper.Outputs.Last().Output, Is.EqualTo(expected));
+        // Normalize line endings before comparison. The repo .gitattributes enforces LF in source
+        // files, so verbatim string literals contain \n, but production code uses Environment.NewLine
+        // which is \r\n on Windows.
+        Assert.That(outputHelper.Outputs.Last().Output.ReplaceLineEndings("\n"), Is.EqualTo(expected.ReplaceLineEndings("\n")));
     }
 
     [Test]


### PR DESCRIPTION
The .gitattributes added in #15142 enforces LF line endings in source files. On Windows CI (fresh clone), verbatim string literals in tests contain \n, but production code uses Environment.NewLine (\r\n), causing 3 test failures. This normalizes line endings with ReplaceLineEndings before comparison to fix tests.