### PR TITLE
Set PackageVersion in Go APIView

### DIFF
--- a/src/go/cmd/api_view_test.go
+++ b/src/go/cmd/api_view_test.go
@@ -97,6 +97,7 @@ func TestSubpackage(t *testing.T) {
 	review, err := createReview(filepath.Clean("testdata/test_subpackage"))
 	require.NoError(t, err)
 	require.Equal(t, "Go", review.Language)
+	require.Equal(t, "1.8.9", review.PackageVersion)
 	require.Equal(t, "test_subpackage", review.Name)
 	seen := map[string]bool{}
 	searchLines(review.ReviewLines, func(rl ReviewLine) bool {
@@ -126,6 +127,7 @@ func TestDiagnostics(t *testing.T) {
 	review, err := createReview(filepath.Clean("testdata/test_diagnostics"))
 	require.NoError(t, err)
 	require.Equal(t, "Go", review.Language)
+	require.Equal(t, "1.1.0", review.PackageVersion)
 	require.Equal(t, "test_diagnostics", review.Name)
 	require.Equal(t, 4, len(review.Diagnostics))
 	for _, diagnostic := range review.Diagnostics {
@@ -231,6 +233,7 @@ func TestRecursiveAliasDefinitions(t *testing.T) {
 			review, err := createReview(filepath.Clean(test.path))
 			require.NoError(t, err)
 			require.Equal(t, "Go", review.Language)
+			require.Equal(t, "1.2.3", review.PackageVersion)
 			require.Equal(t, 2, len(review.Diagnostics))
 			require.Equal(t, test.diagLevel, review.Diagnostics[0].Level)
 			require.Equal(t, aliasFor+test.sourceName, review.Diagnostics[0].Text)
@@ -277,9 +280,11 @@ func TestMajorVersion(t *testing.T) {
 	review, err := createReview(filepath.Clean("testdata/test_major_version"))
 	require.NoError(t, err)
 	require.Equal(t, "Go", review.Language)
+	require.Equal(t, "2.0.1", review.PackageVersion)
 	require.Equal(t, "test_major_version", review.Name)
-	require.Equal(t, 1, len(review.Navigation))
-	require.Equal(t, "test_major_version/subpackage", review.Navigation[0].Text)
+	require.Equal(t, 2, len(review.Navigation))
+	require.Equal(t, "test_major_version", review.Navigation[0].Text)
+	require.Equal(t, "test_major_version/subpackage", review.Navigation[1].Text)
 }
 
 func TestVars(t *testing.T) {

--- a/src/go/cmd/api_view_test.go
+++ b/src/go/cmd/api_view_test.go
@@ -153,6 +153,7 @@ func TestDiagnostics(t *testing.T) {
 func TestExternalModule(t *testing.T) {
 	review, err := createReview(filepath.Clean("testdata/test_external_module"))
 	require.NoError(t, err)
+	require.Equal(t, "1.0.0-beta.1", review.PackageVersion)
 	require.Equal(t, 1, len(review.Diagnostics))
 	require.Equal(t, aliasFor+"github.com/Azure/azure-sdk-for-go/sdk/azcore.Policy", review.Diagnostics[0].Text)
 	require.Equal(t, 1, len(review.Navigation))
@@ -290,6 +291,7 @@ func TestMajorVersion(t *testing.T) {
 func TestVars(t *testing.T) {
 	review, err := createReview(filepath.Clean("testdata/test_vars"))
 	require.NoError(t, err)
+	require.Empty(t, review.PackageVersion)
 	require.NotZero(t, review)
 	countSomeChoice := 0
 	hasHTTPClient := false

--- a/src/go/cmd/module.go
+++ b/src/go/cmd/module.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"go/ast"
@@ -25,6 +26,11 @@ var indexTestdata bool
 // versionReg is the regex for version part in import
 var versionReg = regexp.MustCompile(`/v\d+$|/v\d+/`)
 
+// used to find the semver const definition. the definition
+// is pretty standard so this is easier than using the ast,
+// plus the constant isn't exported
+var moduleVerReg = regexp.MustCompile(`.+\s*=\s*".*v(?<version>\d+\.\d+\.\d+(?:-[0-9A-Za-z]+(?:\.[0-9A-Za-z]+)*)?)"`)
+
 // Module collects the data required to describe an Azure SDK module's public API.
 type Module struct {
 	// ExternalAliases are type aliases referring to other modules
@@ -35,6 +41,8 @@ type Module struct {
 	Name string
 	// Packages maps import paths to the module's Packages
 	Packages map[string]*Pkg
+	// Version is the semantic version of the module, e.g. v1.2.3
+	Version string
 }
 
 // getPackageNameFromModPath gets the API review name for the module at modPath
@@ -95,6 +103,23 @@ func NewModule(dir string) (*Module, error) {
 			} else if !errors.Is(err, ErrNoPackages) {
 				return err
 			}
+		} else if fileName := d.Name(); strings.Contains(fileName, "constant") || strings.Contains(fileName, "version") {
+			// find the constant that contains the semver
+			// e.g.
+			// moduleVersion = "v1.2.0"
+			// Version = "v1.21.1-beta.1"
+			f, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			scanner := bufio.NewScanner(f)
+			for scanner.Scan() {
+				if match := moduleVerReg.FindStringSubmatch(scanner.Text()); match != nil {
+					m.Version = match[moduleVerReg.SubexpIndex("version")]
+					break
+				}
+			}
+			_ = f.Close()
 		}
 		return nil
 	})

--- a/src/go/cmd/module.go
+++ b/src/go/cmd/module.go
@@ -29,7 +29,7 @@ var versionReg = regexp.MustCompile(`/v\d+$|/v\d+/`)
 // used to find the semver const definition. the definition
 // is pretty standard so this is easier than using the ast,
 // plus the constant isn't exported
-var moduleVerReg = regexp.MustCompile(`.+\s*=\s*".*v(?<version>\d+\.\d+\.\d+(?:-[0-9A-Za-z]+(?:\.[0-9A-Za-z]+)*)?)"`)
+var moduleVerReg = regexp.MustCompile(`^\s*(?:const\s+)?[A-Za-z_][A-Za-z0-9_]*\s*=\s*"v(?P<version>\d+\.\d+\.\d+(?:-[0-9A-Za-z]+(?:\.[0-9A-Za-z]+)*)?)"\s*$`)
 
 // Module collects the data required to describe an Azure SDK module's public API.
 type Module struct {
@@ -41,7 +41,7 @@ type Module struct {
 	Name string
 	// Packages maps import paths to the module's Packages
 	Packages map[string]*Pkg
-	// Version is the semantic version of the module, e.g. v1.2.3
+	// Version is the semantic version of the module without the leading "v", e.g. 1.2.3
 	Version string
 }
 
@@ -84,7 +84,7 @@ func NewModule(dir string) (*Module, error) {
 		// if not, then the package name added below won't match the imported packages.
 		baseImportPath = ""
 	}
-	err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+	err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, _ error) error {
 		if d.IsDir() {
 			if !indexTestdata && strings.Contains(path, "testdata") {
 				return filepath.SkipDir
@@ -115,11 +115,20 @@ func NewModule(dir string) (*Module, error) {
 			scanner := bufio.NewScanner(f)
 			for scanner.Scan() {
 				if match := moduleVerReg.FindStringSubmatch(scanner.Text()); match != nil {
-					m.Version = match[moduleVerReg.SubexpIndex("version")]
+					matched := match[moduleVerReg.SubexpIndex("version")]
+					if m.Version != "" {
+						return fmt.Errorf("multiple semver matches, found %s when version is already %s", matched, m.Version)
+					}
+					m.Version = matched
 					break
 				}
 			}
-			_ = f.Close()
+			if err := scanner.Err(); err != nil {
+				return err
+			}
+			if err := f.Close(); err != nil {
+				return err
+			}
 		}
 		return nil
 	})

--- a/src/go/cmd/review.go
+++ b/src/go/cmd/review.go
@@ -164,9 +164,10 @@ func (r *Review) Review() (CodeFile, error) {
 		Name:        r.reviewed.Name,
 		Navigation:  nav,
 		// this must match the value in src/dotnet/APIView/APIViewWeb/Languages/GoLanguageService.cs
-		ParserVersion: "0.1",
-		ReviewLines:   lines,
-		PackageName:   r.name,
+		ParserVersion:  "0.1",
+		ReviewLines:    lines,
+		PackageName:    r.name,
+		PackageVersion: r.reviewed.Version,
 	}, nil
 }
 

--- a/src/go/cmd/testdata/test_diagnostics/internal/version.go
+++ b/src/go/cmd/testdata/test_diagnostics/internal/version.go
@@ -1,0 +1,3 @@
+package internal
+
+const Version = "v1.1.0"

--- a/src/go/cmd/testdata/test_external_module/version.go
+++ b/src/go/cmd/testdata/test_external_module/version.go
@@ -1,0 +1,3 @@
+package test_external_module
+
+const moduleVersion = "v1.0.0-beta.1"

--- a/src/go/cmd/testdata/test_major_version/version.go
+++ b/src/go/cmd/testdata/test_major_version/version.go
@@ -1,0 +1,3 @@
+package test_major_version
+
+const moduleVersion = "v2.0.1"

--- a/src/go/cmd/testdata/test_output/output.json
+++ b/src/go/cmd/testdata/test_output/output.json
@@ -251,7 +251,7 @@
     }
   ],
   "PackageName": "github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_output",
-  "PackageVersion": "",
+  "PackageVersion": "1.3.3",
   "ParserVersion": "0.1",
   "ReviewLines": [
     {

--- a/src/go/cmd/testdata/test_output/version.go
+++ b/src/go/cmd/testdata/test_output/version.go
@@ -1,0 +1,3 @@
+package test_output
+
+const moduleVersion = "v1.3.3"

--- a/src/go/cmd/testdata/test_recursive_alias/internal/exported/constants.go
+++ b/src/go/cmd/testdata/test_recursive_alias/internal/exported/constants.go
@@ -1,0 +1,3 @@
+package exported
+
+const Version = "v1.2.3"

--- a/src/go/cmd/testdata/test_subpackage/version.go
+++ b/src/go/cmd/testdata/test_subpackage/version.go
@@ -1,0 +1,3 @@
+package testsubpackage
+
+const moduleVersion = "v1.8.9"

--- a/src/go/cmd/testdata/test_vars/constants.go
+++ b/src/go/cmd/testdata/test_vars/constants.go
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package testvars
+
+// const Version = "v1.2.3"


### PR DESCRIPTION
Parse constant/version.go file looking for the const that contains the module's semver.  The algorithm is the same used as CI scripts for Go.