### PR TITLE
call azsdk_typespec_generate_authoring_plan in azsdk_customized_code_update

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/TypeSpec/TypeSpecCustomizationServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/TypeSpec/TypeSpecCustomizationServiceTests.cs
@@ -73,6 +73,7 @@ internal class TypeSpecCustomizationServiceTests
             new TestLogger<NpxHelper>(),
             rawOutputHelper);
         var tokenUsageHelper = new TokenUsageHelper(rawOutputHelper);
+        var azureSdkKnowledgeBaseService = Mock.Of<IAzureSdkKnowledgeBaseService>();
         var gitHelper = CreateRealGitHelper();
         var typeSpecHelper = new TypeSpecHelper(gitHelper);
 
@@ -94,6 +95,7 @@ internal class TypeSpecCustomizationServiceTests
             npxHelper,
             tokenUsageHelper,
             typeSpecHelper,
+            azureSdkKnowledgeBaseService,
             gitHelper);
 
         // A simple customization request
@@ -134,6 +136,7 @@ internal class TypeSpecCustomizationServiceTests
         var tokenUsageHelper = new TokenUsageHelper(Mock.Of<IRawOutputHelper>());
         var typeSpecHelper = new TypeSpecHelper(Mock.Of<IGitHelper>());
         var gitHelper = Mock.Of<IGitHelper>();
+        var azureSdkKnowledgeBaseService = Mock.Of<IAzureSdkKnowledgeBaseService>();
 
         var service = new TypeSpecCustomizationService(
             logger,
@@ -141,6 +144,7 @@ internal class TypeSpecCustomizationServiceTests
             npxHelper,
             tokenUsageHelper,
             typeSpecHelper,
+            azureSdkKnowledgeBaseService,
             gitHelper);
 
         var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
@@ -160,6 +164,7 @@ internal class TypeSpecCustomizationServiceTests
         var tokenUsageHelper = new TokenUsageHelper(Mock.Of<IRawOutputHelper>());
         var gitHelper = CreateRealGitHelper();
         var typeSpecHelper = new TypeSpecHelper(gitHelper);
+        var azureSdkKnowledgeBaseService = Mock.Of<IAzureSdkKnowledgeBaseService>();    
 
         var service = new TypeSpecCustomizationService(
             logger,
@@ -167,6 +172,7 @@ internal class TypeSpecCustomizationServiceTests
             npxHelper,
             tokenUsageHelper,
             typeSpecHelper,
+            azureSdkKnowledgeBaseService,
             gitHelper);
 
         var ex = Assert.ThrowsAsync<FileNotFoundException>(async () =>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/TypeSpec/TypeSpecCustomizationServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/TypeSpec/TypeSpecCustomizationServiceTests.cs
@@ -7,6 +7,7 @@ using Azure.Sdk.Tools.Cli.Services;
 using Azure.Sdk.Tools.Cli.Services.TypeSpec;
 using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 using GitHub.Copilot.SDK;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 using static Azure.Sdk.Tools.Cli.Tests.TestHelpers.TestCategories;
@@ -60,6 +61,18 @@ internal class TypeSpecCustomizationServiceTests
     }
 
     /// <summary>
+    /// Creates a mock ILoggerFactory that returns TestLogger instances.
+    /// </summary>
+    private static ILoggerFactory CreateMockLoggerFactory()
+    {
+        var mockFactory = new Mock<ILoggerFactory>();
+        mockFactory
+            .Setup(x => x.CreateLogger(It.IsAny<string>()))
+            .Returns((string categoryName) => new TestLogger<object>() as ILogger);
+        return mockFactory.Object;
+    }
+
+    /// <summary>
     /// Live integration test that makes actual LLM calls through the GitHub Copilot SDK.
     /// Requires GitHub Copilot CLI to be installed and authenticated.
     /// </summary>
@@ -76,6 +89,7 @@ internal class TypeSpecCustomizationServiceTests
         var azureSdkKnowledgeBaseService = Mock.Of<IAzureSdkKnowledgeBaseService>();
         var gitHelper = CreateRealGitHelper();
         var typeSpecHelper = new TypeSpecHelper(gitHelper);
+        var loggerFactory = CreateMockLoggerFactory();
 
         // Create real CopilotClient - this will use GitHub credentials
         var copilotClient = new CopilotClient(new CopilotClientOptions
@@ -96,7 +110,8 @@ internal class TypeSpecCustomizationServiceTests
             tokenUsageHelper,
             typeSpecHelper,
             azureSdkKnowledgeBaseService,
-            gitHelper);
+            gitHelper,
+            loggerFactory);
 
         // A simple customization request
         var customizationRequest = "Add a friendly name 'Contoso Employee' to the Employee model";
@@ -137,6 +152,7 @@ internal class TypeSpecCustomizationServiceTests
         var typeSpecHelper = new TypeSpecHelper(Mock.Of<IGitHelper>());
         var gitHelper = Mock.Of<IGitHelper>();
         var azureSdkKnowledgeBaseService = Mock.Of<IAzureSdkKnowledgeBaseService>();
+        var loggerFactory = CreateMockLoggerFactory();
 
         var service = new TypeSpecCustomizationService(
             logger,
@@ -145,7 +161,8 @@ internal class TypeSpecCustomizationServiceTests
             tokenUsageHelper,
             typeSpecHelper,
             azureSdkKnowledgeBaseService,
-            gitHelper);
+            gitHelper,
+            loggerFactory);
 
         var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
             await service.ApplyCustomizationAsync(
@@ -164,7 +181,8 @@ internal class TypeSpecCustomizationServiceTests
         var tokenUsageHelper = new TokenUsageHelper(Mock.Of<IRawOutputHelper>());
         var gitHelper = CreateRealGitHelper();
         var typeSpecHelper = new TypeSpecHelper(gitHelper);
-        var azureSdkKnowledgeBaseService = Mock.Of<IAzureSdkKnowledgeBaseService>();    
+        var azureSdkKnowledgeBaseService = Mock.Of<IAzureSdkKnowledgeBaseService>();
+        var loggerFactory = CreateMockLoggerFactory();
 
         var service = new TypeSpecCustomizationService(
             logger,
@@ -173,7 +191,8 @@ internal class TypeSpecCustomizationServiceTests
             tokenUsageHelper,
             typeSpecHelper,
             azureSdkKnowledgeBaseService,
-            gitHelper);
+            gitHelper,
+            loggerFactory);
 
         var ex = Assert.ThrowsAsync<FileNotFoundException>(async () =>
             await service.ApplyCustomizationAsync(

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/TypeSpec/TypeSpecCustomizationServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/TypeSpec/TypeSpecCustomizationServiceTests.cs
@@ -171,37 +171,37 @@ internal class TypeSpecCustomizationServiceTests
 
         Assert.That(ex!.Message, Does.Contain("Invalid TypeSpec project path"));
     }
+    //comment out this test.ApplyCustomizationAsync does not check reference doc 
+    //[Test]
+    //public void ApplyCustomization_WithInvalidReferenceDocPath_ThrowsFileNotFoundException()
+    //{
+    //    var logger = new TestLogger<TypeSpecCustomizationService>();
+    //    var copilotAgentRunner = Mock.Of<ICopilotAgentRunner>();
+    //    var npxHelper = Mock.Of<INpxHelper>();
+    //    var tokenUsageHelper = new TokenUsageHelper(Mock.Of<IRawOutputHelper>());
+    //    var gitHelper = CreateRealGitHelper();
+    //    var typeSpecHelper = new TypeSpecHelper(gitHelper);
+    //    var azureSdkKnowledgeBaseService = Mock.Of<IAzureSdkKnowledgeBaseService>();
+    //    var loggerFactory = CreateMockLoggerFactory();
 
-    [Test]
-    public void ApplyCustomization_WithInvalidReferenceDocPath_ThrowsFileNotFoundException()
-    {
-        var logger = new TestLogger<TypeSpecCustomizationService>();
-        var copilotAgentRunner = Mock.Of<ICopilotAgentRunner>();
-        var npxHelper = Mock.Of<INpxHelper>();
-        var tokenUsageHelper = new TokenUsageHelper(Mock.Of<IRawOutputHelper>());
-        var gitHelper = CreateRealGitHelper();
-        var typeSpecHelper = new TypeSpecHelper(gitHelper);
-        var azureSdkKnowledgeBaseService = Mock.Of<IAzureSdkKnowledgeBaseService>();
-        var loggerFactory = CreateMockLoggerFactory();
+    //    var service = new TypeSpecCustomizationService(
+    //        logger,
+    //        copilotAgentRunner,
+    //        npxHelper,
+    //        tokenUsageHelper,
+    //        typeSpecHelper,
+    //        azureSdkKnowledgeBaseService,
+    //        gitHelper,
+    //        loggerFactory);
 
-        var service = new TypeSpecCustomizationService(
-            logger,
-            copilotAgentRunner,
-            npxHelper,
-            tokenUsageHelper,
-            typeSpecHelper,
-            azureSdkKnowledgeBaseService,
-            gitHelper,
-            loggerFactory);
+    //    var ex = Assert.ThrowsAsync<FileNotFoundException>(async () =>
+    //        await service.ApplyCustomizationAsync(
+    //            typeSpecProjectPath,
+    //            "Some customization request",
+    //            referenceDocPath: "/nonexistent/customizing-client-tsp.md"));
 
-        var ex = Assert.ThrowsAsync<FileNotFoundException>(async () =>
-            await service.ApplyCustomizationAsync(
-                typeSpecProjectPath,
-                "Some customization request",
-                referenceDocPath: "/nonexistent/customizing-client-tsp.md"));
-
-        Assert.That(ex!.Message, Does.Contain("Reference document not found"));
-    }
+    //    Assert.That(ex!.Message, Does.Contain("Reference document not found"));
+    //}
 
     [Test]
     public async Task ReferenceDocDiscovery_FindsDocumentInEngCommonKnowledge()

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CopilotAgents/Tools/TypeSpecTools.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CopilotAgents/Tools/TypeSpecTools.cs
@@ -2,15 +2,10 @@
 // Licensed under the MIT License.
 
 using System.ComponentModel;
-using System.IO.Enumeration;
 using System.Reflection;
-using System.Text.Json;
 using Azure.Sdk.Tools.Cli.Helpers;
-using Azure.Sdk.Tools.Cli.Telemetry;
-using Azure.Sdk.Tools.Cli.Tools.Core;
 using Azure.Sdk.Tools.Cli.Tools.TypeSpec;
 using Microsoft.Extensions.AI;
-using Microsoft.TeamFoundation.TestManagement.WebApi;
 using ModelContextProtocol.Server;
 
 namespace Azure.Sdk.Tools.Cli.CopilotAgents.Tools;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CopilotAgents/Tools/TypeSpecTools.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CopilotAgents/Tools/TypeSpecTools.cs
@@ -1,8 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.IO.Enumeration;
+using System.Reflection;
+using System.Text.Json;
 using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Telemetry;
+using Azure.Sdk.Tools.Cli.Tools.Core;
+using Azure.Sdk.Tools.Cli.Tools.TypeSpec;
 using Microsoft.Extensions.AI;
+using Microsoft.TeamFoundation.TestManagement.WebApi;
+using ModelContextProtocol.Server;
 
 namespace Azure.Sdk.Tools.Cli.CopilotAgents.Tools;
 
@@ -76,6 +84,22 @@ public static class TypeSpecTools
             },
             "CompileTypeSpec",
             "Compile the TypeSpec project to validate there are no errors in the TypeSpec definitions");
+    }
+
+
+    public static AIFunction CreateTypeSpecAuthoringTool(
+        string workingDirectory,
+        INpxHelper npxHelper,
+        string entryPoint = "./client.tsp",
+        TimeSpan? timeout = null)
+    {
+        JsonSerializerOptions? serializerOptions = null;
+        timeout ??= TimeSpan.FromMinutes(2);
+        var toolType = typeof(TypeSpecAuthoringTool);
+        var toolMethods = toolType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance)
+                                    .Where(m => m.GetCustomAttribute<McpServerToolAttribute>() is not null);
+        var toolMethod = toolMethods.First(m => m.Name == nameof(TypeSpecAuthoringTool.GenerateTypeSpecAuthoringPlan));
+        return AIFunctionFactory.Create(toolMethod, toolMethod.Name, toolMethod.GetCustomAttribute<DescriptionAttribute>()?.Description ?? "TypeSpec authoring tool");
     }
 
     /// <summary>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CopilotAgents/Tools/TypeSpecTools.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CopilotAgents/Tools/TypeSpecTools.cs
@@ -89,22 +89,16 @@ public static class TypeSpecTools
 
 
     public static AIFunction CreateTypeSpecAuthoringTool(
-        TypeSpecAuthoringTool toolInstance,
-        string workingDirectory,
-        INpxHelper npxHelper,
-        string entryPoint = "./client.tsp",
-        TimeSpan? timeout = null)
+        TypeSpecAuthoringTool toolInstance)
     {
         ArgumentNullException.ThrowIfNull(toolInstance);
 
-        timeout ??= TimeSpan.FromMinutes(2);
         var toolType = typeof(TypeSpecAuthoringTool);
         var toolMethods = toolType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance)
                                     .Where(m => m.GetCustomAttribute<McpServerToolAttribute>() is not null);
         var toolMethod = toolMethods.First(m => m.Name == nameof(TypeSpecAuthoringTool.GenerateTypeSpecAuthoringPlan));
         var mcpToolAttr = toolMethod.GetCustomAttribute<McpServerToolAttribute>();
         var toolName = mcpToolAttr?.Name ?? toolMethod.Name;
-        Console.WriteLine($"Creating TypeSpec Authoring Tool with method: {toolMethod.Name}, tool name: {toolName}");
         var description = toolMethod.GetCustomAttribute<DescriptionAttribute>()?.Description ?? "TypeSpec authoring tool";
 
         return AIFunctionFactory.Create(

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CopilotAgents/Tools/TypeSpecTools.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CopilotAgents/Tools/TypeSpecTools.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.ComponentModel;
 using System.IO.Enumeration;
 using System.Reflection;
 using System.Text.Json;
@@ -88,18 +89,29 @@ public static class TypeSpecTools
 
 
     public static AIFunction CreateTypeSpecAuthoringTool(
+        TypeSpecAuthoringTool toolInstance,
         string workingDirectory,
         INpxHelper npxHelper,
         string entryPoint = "./client.tsp",
         TimeSpan? timeout = null)
     {
-        JsonSerializerOptions? serializerOptions = null;
+        ArgumentNullException.ThrowIfNull(toolInstance);
+
         timeout ??= TimeSpan.FromMinutes(2);
         var toolType = typeof(TypeSpecAuthoringTool);
         var toolMethods = toolType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance)
                                     .Where(m => m.GetCustomAttribute<McpServerToolAttribute>() is not null);
         var toolMethod = toolMethods.First(m => m.Name == nameof(TypeSpecAuthoringTool.GenerateTypeSpecAuthoringPlan));
-        return AIFunctionFactory.Create(toolMethod, toolMethod.Name, toolMethod.GetCustomAttribute<DescriptionAttribute>()?.Description ?? "TypeSpec authoring tool");
+        var mcpToolAttr = toolMethod.GetCustomAttribute<McpServerToolAttribute>();
+        var toolName = mcpToolAttr?.Name ?? toolMethod.Name;
+        Console.WriteLine($"Creating TypeSpec Authoring Tool with method: {toolMethod.Name}, tool name: {toolName}");
+        var description = toolMethod.GetCustomAttribute<DescriptionAttribute>()?.Description ?? "TypeSpec authoring tool";
+
+        return AIFunctionFactory.Create(
+            toolMethod,
+            toolInstance,  // Pass the target instance
+            toolName,
+            description);
     }
 
     /// <summary>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/TypeSpec/TypeSpecCustomizationService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/TypeSpec/TypeSpecCustomizationService.cs
@@ -60,7 +60,6 @@ public class TypeSpecCustomizationService : ITypeSpecCustomizationService
         this.logger = logger;
         this.copilotAgentRunner = copilotAgentRunner;
         this.npxHelper = npxHelper;
-        this.tokenUsageHelper = tokenUsageHelper;
         this.typeSpecHelper = typeSpecHelper;
         this.azureSdkKnowledgeBaseService = azureSdkKnowledgeBaseService;
         this.gitHelper = gitHelper;
@@ -87,60 +86,30 @@ public class TypeSpecCustomizationService : ITypeSpecCustomizationService
                 $"Invalid TypeSpec project path: {typespecProjectPath}. Directory must exist and contain tspconfig.yaml.",
                 nameof(typespecProjectPath));
         }
+        
+        var instructions = $"""
+            You are applying TypeSpec client customizations to a client.tsp file.
 
-        // Find reference doc path if not provided
-        if (string.IsNullOrEmpty(referenceDocPath))
-        {
-            referenceDocPath = await FindReferenceDocAsync(typespecProjectPath, ct) ?? throw new FileNotFoundException(
-                    "Could not find customizing-client-tsp.md reference document. Please provide the reference doc path.");
-        }
+            **TypeSpec Project Path:** {typespecProjectPath}
 
-        if (!File.Exists(referenceDocPath))
-        {
-            throw new FileNotFoundException(
-                $"Reference document not found: {referenceDocPath}", referenceDocPath);
-        }
+            **Working Directory for Tools:**
+            All file operations use RELATIVE paths from the TypeSpec project directory above.
+            - To read client.tsp, use: ReadFile("client.tsp")
+            - To read main.tsp, use: ReadFile("main.tsp")
+            - To read files in subdirectories, use: ReadFile("connections/models.tsp")
+            - Do NOT use absolute paths or paths relative to the repository root
+            - The WriteFile and CompileTypeSpec tools also use relative paths from this directory
 
-        logger.LogInformation("Using reference doc: {RefDoc}", referenceDocPath);
-
-        // Read the reference doc content
-        var referenceDocContent = await File.ReadAllTextAsync(referenceDocPath, ct);
-
-        // Build the prompt template
-        var template = new TypeSpecCustomizationTemplate(
-            customizationRequest: customizationRequest,
-            typespecProjectPath: typespecProjectPath,
-            referenceDocContent: referenceDocContent);
-
-        var instructions = template.BuildPrompt();
-        logger.LogDebug("Generated prompt with {Length} characters", instructions.Length);
-
-        // Build request
-        var completionRequest = new CompletionRequest
-        {
-            AzureSdkKnowledgeServiceTenant = AzureSdkKnowledgeServiceTenant.AzureTypespecAuthoring,
-            Message = new Message
-            {
-                Role = Role.User,
-                Content = "how to" + customizationRequest,
-            },
-            WithAgenticSearch = false, // For authoring, disable agentic search
-        };
-
-        //var response = await azureSdkKnowledgeBaseService.SendCompletionRequestAsync(completionRequest, ct);
-
-        //instructions = "apply the solution:" + response.Answer;
-        //logger.LogInformation("Received response from Azure SDK Knowledge Base service. Answer: {Answer}",
-        //   response.Answer);
-        instructions = $"""
-            Please follow the steps:
-            step 1: invoke `azure-sdk-mcp:azsdk_typespec_generate_authoring_plan` with:
+            **Your Tasks:**
+            step 1: Understand the customization request: {customizationRequest}, and read the relavant '.tsp' code from the project to understand the context.
+            step 2: invoke `azure-sdk-mcp:azsdk_typespec_generate_authoring_plan` with:
 
             | Parameter                 | Value                                                                                                                                                                       |
             | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
             | `request`                 |  {customizationRequest} (verbatim)|
+            | `additionalInformation`   | All content gathered from Steps 1 (analysis, relevant `.tsp` code read from the project) |
             | `typeSpecProjectRootPath` | {typespecProjectPath}|
-            step 2: apply the solution return from step 1
+            step 3: apply the solution return from step 2
             """;
         // Create the tools using shared tool factories
         var tools = CreateTools(typespecProjectPath);
@@ -181,7 +150,7 @@ public class TypeSpecCustomizationService : ITypeSpecCustomizationService
             FileTools.CreateReadFileTool(typespecProjectPath, description: "Read the contents of a file from the TypeSpec project directory"),
             FileTools.CreateWriteFileTool(typespecProjectPath, "Write content to a file in the TypeSpec project directory"),
             TypeSpecTools.CreateCompileTypeSpecTool(typespecProjectPath, npxHelper),
-            TypeSpecTools.CreateTypeSpecAuthoringTool(typeSpecAuthoringToolInstance, typespecProjectPath, npxHelper)
+            TypeSpecTools.CreateTypeSpecAuthoringTool(typeSpecAuthoringToolInstance)
         ];
     }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/TypeSpec/TypeSpecCustomizationService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/TypeSpec/TypeSpecCustomizationService.cs
@@ -99,7 +99,7 @@ public class TypeSpecCustomizationService : ITypeSpecCustomizationService
 
             **Your Tasks:**
             step 1: Understand the customization request: {customizationRequest}, and read the relevant '.tsp' code from the project to understand the context.
-            step 2: invoke `azsdk_typespec_generate_authoring_plan` with:
+            step 2: invoke `azure-sdk-mcp:azsdk_typespec_generate_authoring_plan` with:
 
             | Parameter                 | Value                                                                                                                                                                       |
             | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/TypeSpec/TypeSpecCustomizationService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/TypeSpec/TypeSpecCustomizationService.cs
@@ -7,6 +7,7 @@ using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Models.AzureSdkKnowledgeAICompletion;
 using Azure.Sdk.Tools.Cli.Prompts.Templates;
+using Azure.Sdk.Tools.Cli.Tools.TypeSpec;
 using Microsoft.Extensions.AI;
 
 namespace Azure.Sdk.Tools.Cli.Services.TypeSpec;
@@ -41,10 +42,10 @@ public class TypeSpecCustomizationService : ITypeSpecCustomizationService
     private readonly ILogger<TypeSpecCustomizationService> logger;
     private readonly ICopilotAgentRunner copilotAgentRunner;
     private readonly INpxHelper npxHelper;
-    private readonly TokenUsageHelper tokenUsageHelper;
     private readonly ITypeSpecHelper typeSpecHelper;
     private readonly IAzureSdkKnowledgeBaseService azureSdkKnowledgeBaseService;
     private readonly IGitHelper gitHelper;
+    private readonly ILoggerFactory loggerFactory;
 
     public TypeSpecCustomizationService(
         ILogger<TypeSpecCustomizationService> logger,
@@ -53,7 +54,8 @@ public class TypeSpecCustomizationService : ITypeSpecCustomizationService
         TokenUsageHelper tokenUsageHelper,
         ITypeSpecHelper typeSpecHelper,
         IAzureSdkKnowledgeBaseService azureSdkKnowledgeBaseService,
-        IGitHelper gitHelper)
+        IGitHelper gitHelper,
+        ILoggerFactory loggerFactory)
     {
         this.logger = logger;
         this.copilotAgentRunner = copilotAgentRunner;
@@ -62,6 +64,7 @@ public class TypeSpecCustomizationService : ITypeSpecCustomizationService
         this.typeSpecHelper = typeSpecHelper;
         this.azureSdkKnowledgeBaseService = azureSdkKnowledgeBaseService;
         this.gitHelper = gitHelper;
+        this.loggerFactory = loggerFactory;
     }
 
     /// <inheritdoc />
@@ -124,12 +127,21 @@ public class TypeSpecCustomizationService : ITypeSpecCustomizationService
             WithAgenticSearch = false, // For authoring, disable agentic search
         };
 
-        var response = await azureSdkKnowledgeBaseService.SendCompletionRequestAsync(completionRequest, ct);
+        //var response = await azureSdkKnowledgeBaseService.SendCompletionRequestAsync(completionRequest, ct);
 
-        instructions = "apply the solution:" + response.Answer;
-        logger.LogInformation("Received response from Azure SDK Knowledge Base service. Answer: {Answer}",
-           response.Answer);
+        //instructions = "apply the solution:" + response.Answer;
+        //logger.LogInformation("Received response from Azure SDK Knowledge Base service. Answer: {Answer}",
+        //   response.Answer);
+        instructions = $"""
+            Please follow the steps:
+            step 1: invoke `azure-sdk-mcp:azsdk_typespec_generate_authoring_plan` with:
 
+            | Parameter                 | Value                                                                                                                                                                       |
+            | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+            | `request`                 |  {customizationRequest} (verbatim)|
+            | `typeSpecProjectRootPath` | {typespecProjectPath}|
+            step 2: apply the solution return from step 1
+            """;
         // Create the tools using shared tool factories
         var tools = CreateTools(typespecProjectPath);
 
@@ -157,11 +169,19 @@ public class TypeSpecCustomizationService : ITypeSpecCustomizationService
     /// </summary>
     private List<AIFunction> CreateTools(string typespecProjectPath)
     {
+        // Create an instance of TypeSpecAuthoringTool with required dependencies
+        var authoringToolLogger = loggerFactory.CreateLogger<Tools.TypeSpec.TypeSpecAuthoringTool>();
+        var typeSpecAuthoringToolInstance = new Tools.TypeSpec.TypeSpecAuthoringTool(
+            azureSdkKnowledgeBaseService,
+            authoringToolLogger,
+            typeSpecHelper);
+
         return
         [
             FileTools.CreateReadFileTool(typespecProjectPath, description: "Read the contents of a file from the TypeSpec project directory"),
             FileTools.CreateWriteFileTool(typespecProjectPath, "Write content to a file in the TypeSpec project directory"),
-            TypeSpecTools.CreateCompileTypeSpecTool(typespecProjectPath, npxHelper)
+            TypeSpecTools.CreateCompileTypeSpecTool(typespecProjectPath, npxHelper),
+            TypeSpecTools.CreateTypeSpecAuthoringTool(typeSpecAuthoringToolInstance, typespecProjectPath, npxHelper)
         ];
     }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/TypeSpec/TypeSpecCustomizationService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/TypeSpec/TypeSpecCustomizationService.cs
@@ -101,7 +101,7 @@ public class TypeSpecCustomizationService : ITypeSpecCustomizationService
             - The WriteFile and CompileTypeSpec tools also use relative paths from this directory
 
             **Your Tasks:**
-            step 1: Understand the customization request: {customizationRequest}, and read the relavant '.tsp' code from the project to understand the context.
+            step 1: Understand the customization request: {customizationRequest}, and read the relevant '.tsp' code from the project to understand the context.
             step 2: invoke `azsdk_typespec_generate_authoring_plan` with:
 
             | Parameter                 | Value                                                                                                                                                                       |

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/TypeSpec/TypeSpecCustomizationService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/TypeSpec/TypeSpecCustomizationService.cs
@@ -102,7 +102,7 @@ public class TypeSpecCustomizationService : ITypeSpecCustomizationService
 
             **Your Tasks:**
             step 1: Understand the customization request: {customizationRequest}, and read the relavant '.tsp' code from the project to understand the context.
-            step 2: invoke `azure-sdk-mcp:azsdk_typespec_generate_authoring_plan` with:
+            step 2: invoke `azsdk_typespec_generate_authoring_plan` with:
 
             | Parameter                 | Value                                                                                                                                                                       |
             | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/TypeSpec/TypeSpecCustomizationService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/TypeSpec/TypeSpecCustomizationService.cs
@@ -5,9 +5,6 @@ using Azure.Sdk.Tools.Cli.CopilotAgents;
 using Azure.Sdk.Tools.Cli.CopilotAgents.Tools;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
-using Azure.Sdk.Tools.Cli.Models.AzureSdkKnowledgeAICompletion;
-using Azure.Sdk.Tools.Cli.Prompts.Templates;
-using Azure.Sdk.Tools.Cli.Tools.TypeSpec;
 using Microsoft.Extensions.AI;
 
 namespace Azure.Sdk.Tools.Cli.Services.TypeSpec;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/TypeSpec/TypeSpecCustomizationService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/TypeSpec/TypeSpecCustomizationService.cs
@@ -99,7 +99,7 @@ public class TypeSpecCustomizationService : ITypeSpecCustomizationService
 
             **Your Tasks:**
             step 1: Understand the customization request: {customizationRequest}, and read the relevant '.tsp' code from the project to understand the context.
-            step 2: invoke `azure-sdk-mcp:azsdk_typespec_generate_authoring_plan` with:
+            step 2: invoke `azsdk_typespec_generate_authoring_plan` with:
 
             | Parameter                 | Value                                                                                                                                                                       |
             | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -110,6 +110,12 @@ public class TypeSpecCustomizationService : ITypeSpecCustomizationService
             """;
         // Create the tools using shared tool factories
         var tools = CreateTools(typespecProjectPath);
+
+        logger.LogDebug("Created {ToolCount} tools for CopilotAgent", tools.Count);
+        foreach (var tool in tools)
+        {
+            logger.LogDebug("  - Tool registered with name: '{ToolName}'", tool.Name);
+        }
 
         // Create and run the copilot agent
         var agent = new CopilotAgent<TypeSpecCustomizationServiceResult>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/TypeSpec/TypeSpecCustomizationService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/TypeSpec/TypeSpecCustomizationService.cs
@@ -5,6 +5,7 @@ using Azure.Sdk.Tools.Cli.CopilotAgents;
 using Azure.Sdk.Tools.Cli.CopilotAgents.Tools;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.AzureSdkKnowledgeAICompletion;
 using Azure.Sdk.Tools.Cli.Prompts.Templates;
 using Microsoft.Extensions.AI;
 
@@ -42,6 +43,7 @@ public class TypeSpecCustomizationService : ITypeSpecCustomizationService
     private readonly INpxHelper npxHelper;
     private readonly TokenUsageHelper tokenUsageHelper;
     private readonly ITypeSpecHelper typeSpecHelper;
+    private readonly IAzureSdkKnowledgeBaseService azureSdkKnowledgeBaseService;
     private readonly IGitHelper gitHelper;
 
     public TypeSpecCustomizationService(
@@ -50,6 +52,7 @@ public class TypeSpecCustomizationService : ITypeSpecCustomizationService
         INpxHelper npxHelper,
         TokenUsageHelper tokenUsageHelper,
         ITypeSpecHelper typeSpecHelper,
+        IAzureSdkKnowledgeBaseService azureSdkKnowledgeBaseService,
         IGitHelper gitHelper)
     {
         this.logger = logger;
@@ -57,6 +60,7 @@ public class TypeSpecCustomizationService : ITypeSpecCustomizationService
         this.npxHelper = npxHelper;
         this.tokenUsageHelper = tokenUsageHelper;
         this.typeSpecHelper = typeSpecHelper;
+        this.azureSdkKnowledgeBaseService = azureSdkKnowledgeBaseService;
         this.gitHelper = gitHelper;
     }
 
@@ -107,6 +111,24 @@ public class TypeSpecCustomizationService : ITypeSpecCustomizationService
 
         var instructions = template.BuildPrompt();
         logger.LogDebug("Generated prompt with {Length} characters", instructions.Length);
+
+        // Build request
+        var completionRequest = new CompletionRequest
+        {
+            AzureSdkKnowledgeServiceTenant = AzureSdkKnowledgeServiceTenant.AzureTypespecAuthoring,
+            Message = new Message
+            {
+                Role = Role.User,
+                Content = "how to" + customizationRequest,
+            },
+            WithAgenticSearch = false, // For authoring, disable agentic search
+        };
+
+        var response = await azureSdkKnowledgeBaseService.SendCompletionRequestAsync(completionRequest, ct);
+
+        instructions = "apply the solution:" + response.Answer;
+        logger.LogInformation("Received response from Azure SDK Knowledge Base service. Answer: {Answer}",
+           response.Answer);
 
         // Create the tools using shared tool factories
         var tools = CreateTools(typespecProjectPath);

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-backend/service/prompt/azure_typespec_authoring/agentic_search.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-backend/service/prompt/azure_typespec_authoring/agentic_search.md
@@ -15,7 +15,7 @@ Analyze the question and identify its category, then generate focused sub-querie
 - **Versioning**: Questions about API versioning, adding properties, avoiding breaking changes
 - **ARM Template**: Questions about ARM resource templates and patterns
 - **TypeSpec Migration**: Questions about converting OpenAPI/Swagger to TypeSpec
-- **SDK Generation**: Questions about generating SDKs from TypeSpec
+- **Typespec Customization**:  Questions about how to customize typespec for client SDKs
 - **SDK/Spec Onboarding**: Questions about codebase permission, onboarding services, API design, SDK development, or release processes
 - **TypeSpec Validation**: Questions about TypeSpec validation(CI) errors. **For search performance, you need to rewrite TypeSpec CI failures into TypeSpec Validation failures**
 

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-backend/service/prompt/azure_typespec_authoring/intention.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-backend/service/prompt/azure_typespec_authoring/intention.md
@@ -41,8 +41,11 @@ The question must be classified into one of these categories:
   - how to implement x-ms-pageable in typespec?
   - how to implement allOf in typespec?
 
-- **SDK Generation**: Question about how to generate SDK based on TypeSpec, such as:
-  - How to generate dotnet SDK?
+- **Typespec Customization**:  Questions about how to customize typespec for client SDKs
+  - how to rename model AuthorizeCopyRequest to AuthorizeCopyRequestOptions for SDKs
+  - how to rename model AuthorizeCopyRequest to AuthorizeCopyRequestOptions for java SDK
+  - how to change operation parameter order from (context.Context, string, string, string, *ClientListReplicaSKUsOptions) to (string, string, string, *ClientListReplicaSKUsOptions, context.Context) for SDKs
+  - how to change property age type from int to string for SDKs
 
 - **TypeSpec Validation**: Questions about TypeSpec validation(CI) errors, such as: 
   - Why is my TypeSpec CI failing? -> Why is my TypeSpec validation failing?


### PR DESCRIPTION
Currently, `azsdk_customized_code_update` instructs CopilotAgent to refer to customizing-client-tsp.md to generate and apply TypeSpec-based customization solutions.
At the same time, `azsdk_typespec_generate_authoring_plan` independently generates a TypeSpec customization solution for the same purpose.
This results in duplicated logic and overlapping responsibilities for TypeSpec customization plan generation.
Proposal
To eliminate duplication and establish a single source of truth, this change consolidates TypeSpec customization solution generation by:

This PR proposal a combination approach:
- Making `azsdk_typespec_generate_authoring_plan`  the sole component responsible for generating the TypeSpec customization plan.
- Updating `azsdk_customized_code_update` to invoke `azsdk_typespec_generate_authoring_plan` and consume its output, instead of generating its own solution.