### PR TITLE
Add CODEOWNERS verification pipeline step and script

### DIFF
--- a/eng/common/pipelines/templates/steps/verify-codeowners.yml
+++ b/eng/common/pipelines/templates/steps/verify-codeowners.yml
@@ -24,7 +24,7 @@ steps:
     condition: and(succeeded(), ne(variables['Skip.VerifyCodeowners'], 'true'))
     inputs:
       pwsh: true
-      filePath: eng/common/scripts/Test-CodeownersForArtifacts.ps1
+      filePath: $(Build.SourcesDirectory)/eng/common/scripts/Test-CodeownersForArtifacts.ps1
       arguments: >-
         -AzsdkPath '$(AZSDK)'
         -PackageInfoDirectory '${{ parameters.ArtifactPath }}'

--- a/eng/common/pipelines/templates/steps/verify-codeowners.yml
+++ b/eng/common/pipelines/templates/steps/verify-codeowners.yml
@@ -1,0 +1,32 @@
+parameters:
+  - name: ArtifactPath
+    type: string
+    default: $(Build.ArtifactStagingDirectory)/PackageInfo
+  - name: Repo
+    type: string
+    default: $(Build.Repository.Name)
+  - name: SdkTypes
+    type: object
+    default:
+      - client
+      - compat
+      - data
+      - functions
+      - datamovement
+
+steps:
+  - template: /eng/common/pipelines/templates/steps/install-azsdk-cli.yml
+    parameters:
+      Condition: and(succeeded(), ne(variables['Skip.VerifyCodeowners'], 'true'))
+
+  - task: PowerShell@2
+    displayName: Verify Codeowners
+    condition: and(succeeded(), ne(variables['Skip.VerifyCodeowners'], 'true'))
+    inputs:
+      pwsh: true
+      filePath: eng/common/scripts/Test-CodeownersForArtifacts.ps1
+      arguments: >-
+        -AzsdkPath '$(AZSDK)'
+        -PackageInfoDirectory '${{ parameters.ArtifactPath }}'
+        -SdkTypes ${{ join(',', parameters.SdkTypes) }}
+        -Repo '${{ parameters.Repo }}'

--- a/eng/common/scripts/Test-CodeownersForArtifacts.ps1
+++ b/eng/common/scripts/Test-CodeownersForArtifacts.ps1
@@ -22,9 +22,10 @@ foreach ($pkgPropertiesFile in Get-ChildItem -Path $PackageInfoDirectory -Filter
 
     Write-Host "Validating codeowners for package: $($pkgProperties.Name) $($pkgProperties.DirectoryPath)"
 
-    if (!$pkgProperties.ReleaseStatus) { 
-        LogWarning "  Skipping CODEOWNERS validation for package: $($pkgProperties.Name) because it does not have a ReleaseStatus property."
-         continue
+    if (!$pkgProperties.ReleaseStatus) {
+        LogError "Package $($pkgProperties.Name) at $($pkgProperties.DirectoryPath) is missing a ReleaseStatus property."
+        $failedPackages += $pkgProperties.DirectoryPath
+        continue
     }
 
     # Validate packages with a release date (intended to release)

--- a/eng/common/scripts/Test-CodeownersForArtifacts.ps1
+++ b/eng/common/scripts/Test-CodeownersForArtifacts.ps1
@@ -9,7 +9,7 @@ param(
 
 $failedPackages = @()
 
-foreach ($pkgPropertiesFile in Get-ChildItem -Path $PackageInfoDirectory -File) {
+foreach ($pkgPropertiesFile in Get-ChildItem -Path $PackageInfoDirectory -Filter '*.json' -File) {
     $pkgProperties = Get-Content -Raw -Path $pkgPropertiesFile | ConvertFrom-Json
     if ($SdkTypes -notcontains $pkgProperties.SdkType) {
         Write-Host "Skipping package: $($pkgProperties.Name) $($pkgProperties.DirectoryPath) because its SdkType '$($pkgProperties.SdkType)' is not in the list of SdkTypes to validate."

--- a/eng/common/scripts/Test-CodeownersForArtifacts.ps1
+++ b/eng/common/scripts/Test-CodeownersForArtifacts.ps1
@@ -1,0 +1,49 @@
+param(
+    [string] $AzsdkPath,
+    [string] $PackageInfoDirectory,
+    [array] $SdkTypes,
+    [string] $Repo
+)
+
+. "$PSScriptRoot/common.ps1"
+
+$failedPackages = @()
+
+foreach ($pkgPropertiesFile in Get-ChildItem -Path $PackageInfoDirectory -File) {
+    $pkgProperties = Get-Content -Raw -Path $pkgPropertiesFile | ConvertFrom-Json
+    if ($SdkTypes -notcontains $pkgProperties.SdkType) {
+        Write-Host "Skipping package: $($pkgProperties.Name) $($pkgProperties.DirectoryPath) because its SdkType '$($pkgProperties.SdkType)' is not in the list of SdkTypes to validate."
+        continue
+    }
+
+    Write-Host "Validating codeowners for package: $($pkgProperties.Name) $($pkgProperties.DirectoryPath)"
+
+    # Validate packages with a release date (intended to release)
+    if ($pkgProperties.ReleaseStatus -ne "Unreleased") {
+        $output = & $AzsdkPath config codeowners check-package `
+            --directory-path $pkgProperties.DirectoryPath `
+            --repo $Repo `
+            --output json 2>&1
+
+        if ($LASTEXITCODE) {
+            LogError "Codeowners validation failed for package: $($pkgProperties.DirectoryPath)"
+            $output | Write-Host
+            $failedPackages += $pkgProperties.DirectoryPath
+        } else {
+            Write-Host "  Codeowners validation succeeded for package: $($pkgProperties.DirectoryPath)"
+        }
+    } else {
+        Write-Host "  Skipping CODEOWNERS validation, package is not intended to release."
+    }
+}
+
+if ($failedPackages.Count -gt 0) {
+    Write-Host ""
+    Write-Host "Failed Packages:"
+    foreach ($directoryPath in $failedPackages) {
+        LogError "  - $directoryPath does not have sufficient code owners coverage"
+    }
+    LogError "Codeowners validation failed for one or more packages. See http://aka.ms/azsdk/codeowners for instructions to fix the issue."
+    exit 1
+}
+exit 0

--- a/eng/common/scripts/Test-CodeownersForArtifacts.ps1
+++ b/eng/common/scripts/Test-CodeownersForArtifacts.ps1
@@ -1,3 +1,4 @@
+[CmdletBinding()]
 param(
     [string] $AzsdkPath,
     [string] $PackageInfoDirectory,
@@ -6,6 +7,9 @@ param(
 )
 
 . "$PSScriptRoot/common.ps1"
+
+Set-StrictMode -Version 3
+$ErrorActionPreference = 'Stop'
 
 $failedPackages = @()
 
@@ -17,6 +21,11 @@ foreach ($pkgPropertiesFile in Get-ChildItem -Path $PackageInfoDirectory -Filter
     }
 
     Write-Host "Validating codeowners for package: $($pkgProperties.Name) $($pkgProperties.DirectoryPath)"
+
+    if (!$pkgProperties.ReleaseStatus) { 
+        LogWarning "  Skipping CODEOWNERS validation for package: $($pkgProperties.Name) because it does not have a ReleaseStatus property."
+         continue
+    }
 
     # Validate packages with a release date (intended to release)
     if ($pkgProperties.ReleaseStatus -ne "Unreleased") {


### PR DESCRIPTION
Add verify-codeowners.yml pipeline template step and Test-CodeownersForArtifacts.ps1 script to validate that packages intended for release have sufficient CODEOWNERS coverage.