### PR TITLE
Implement Rust packaging support in azsdk pkg pack

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/RustLanguageServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/RustLanguageServiceTests.cs
@@ -116,7 +116,7 @@ public class RustLanguageServiceTests
         Directory.CreateDirectory(packageDir);
         var scriptDir = Path.Combine(_tempDirectory.DirectoryPath, "eng", "scripts");
         Directory.CreateDirectory(scriptDir);
-        File.WriteAllText(Path.Combine(scriptDir, "build-sdk.ps1"), "# build script");
+        File.WriteAllText(Path.Combine(scriptDir, "Build-Sdk.ps1"), "# build script");
 
         _mockGitHelper
             .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -144,7 +144,7 @@ public class RustLanguageServiceTests
         Directory.CreateDirectory(packageDir);
         var scriptDir = Path.Combine(_tempDirectory.DirectoryPath, "eng", "scripts");
         Directory.CreateDirectory(scriptDir);
-        File.WriteAllText(Path.Combine(scriptDir, "build-sdk.ps1"), "# build script");
+        File.WriteAllText(Path.Combine(scriptDir, "Build-Sdk.ps1"), "# build script");
 
         _mockGitHelper
             .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -184,7 +184,7 @@ public class RustLanguageServiceTests
         Directory.CreateDirectory(packageDir);
         var scriptDir = Path.Combine(_tempDirectory.DirectoryPath, "eng", "scripts");
         Directory.CreateDirectory(scriptDir);
-        File.WriteAllText(Path.Combine(scriptDir, "build-sdk.ps1"), "# build script");
+        File.WriteAllText(Path.Combine(scriptDir, "Build-Sdk.ps1"), "# build script");
 
         _mockGitHelper
             .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -199,6 +199,173 @@ public class RustLanguageServiceTests
         _mockSpecGenSdkConfigHelper.Verify(
             x => x.GetConfigurationAsync(It.IsAny<string>(), It.IsAny<SpecGenSdkConfigType>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    #endregion
+
+    #region PackAsync Tests
+
+    [Test]
+    public async Task PackAsync_EmptyPath_ReturnsFailure()
+    {
+        var (success, errorMessage, _, _) = await _service.PackAsync(string.Empty);
+
+        Assert.That(success, Is.False);
+        Assert.That(errorMessage, Does.Contain("required and cannot be empty"));
+    }
+
+    [Test]
+    public async Task PackAsync_NonexistentPath_ReturnsFailure()
+    {
+        var (success, errorMessage, _, _) = await _service.PackAsync("/nonexistent/path");
+
+        Assert.That(success, Is.False);
+        Assert.That(errorMessage, Does.Contain("does not exist"));
+    }
+
+    [Test]
+    public async Task PackAsync_MissingPackScript_ReturnsFailure()
+    {
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "core", "azure_core");
+        Directory.CreateDirectory(packageDir);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), "[package]\nname = \"azure_core\"\n");
+
+        _mockGitHelper
+            .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_tempDirectory.DirectoryPath);
+
+        SetupCargoMetadata("azure_core", "0.34.0");
+
+        var (success, errorMessage, _, _) = await _service.PackAsync(packageDir);
+
+        Assert.That(success, Is.False);
+        Assert.That(errorMessage, Does.Contain("Pack script not found"));
+    }
+
+    [Test]
+    public async Task PackAsync_ScriptExists_ExecutesPowershellWithCorrectArgs()
+    {
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "core", "azure_core");
+        Directory.CreateDirectory(packageDir);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), "[package]\nname = \"azure_core\"\n");
+        CreatePackScript();
+
+        _mockGitHelper
+            .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_tempDirectory.DirectoryPath);
+
+        SetupCargoMetadata("azure_core", "0.34.0");
+
+        _mockPowershellHelper
+            .Setup(x => x.Run(It.IsAny<PowershellOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "ok")] });
+
+        var (success, _, _, _) = await _service.PackAsync(packageDir);
+
+        Assert.That(success, Is.True);
+        _mockPowershellHelper.Verify(x => x.Run(
+            It.Is<PowershellOptions>(o =>
+                o.Args.Contains("-PackageNames") &&
+                o.Args.Contains("azure_core") &&
+                o.Args.Contains("-NoVerify")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task PackAsync_WithOutputPath_PassesOutputPathArg()
+    {
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "core", "azure_core");
+        Directory.CreateDirectory(packageDir);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), "[package]\nname = \"azure_core\"\n");
+        CreatePackScript();
+        var outputDir = Path.Combine(_tempDirectory.DirectoryPath, "output");
+
+        _mockGitHelper
+            .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_tempDirectory.DirectoryPath);
+
+        SetupCargoMetadata("azure_core", "0.34.0");
+
+        _mockPowershellHelper
+            .Setup(x => x.Run(It.IsAny<PowershellOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [] });
+
+        await _service.PackAsync(packageDir, outputDir);
+
+        _mockPowershellHelper.Verify(x => x.Run(
+            It.Is<PowershellOptions>(o =>
+                o.Args.Contains("-OutputPath") &&
+                o.Args.Contains(outputDir)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task PackAsync_ScriptFails_ReturnsFailure()
+    {
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "core", "azure_core");
+        Directory.CreateDirectory(packageDir);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), "[package]\nname = \"azure_core\"\n");
+        CreatePackScript();
+
+        _mockGitHelper
+            .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_tempDirectory.DirectoryPath);
+
+        SetupCargoMetadata("azure_core", "0.34.0");
+
+        _mockPowershellHelper
+            .Setup(x => x.Run(It.IsAny<PowershellOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardOutput, "cargo publish failed")] });
+
+        var (success, errorMessage, _, _) = await _service.PackAsync(packageDir);
+
+        Assert.That(success, Is.False);
+        Assert.That(errorMessage, Does.Contain("Pack failed with exit code 1"));
+    }
+
+    [Test]
+    public async Task PackAsync_ResolvesArtifactPath_WhenCrateExists()
+    {
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "core", "azure_core");
+        Directory.CreateDirectory(packageDir);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), "[package]\nname = \"azure_core\"\n");
+        CreatePackScript();
+
+        // Create the .crate artifact
+        var targetDir = Path.Combine(_tempDirectory.DirectoryPath, "target", "package");
+        Directory.CreateDirectory(targetDir);
+        File.WriteAllText(Path.Combine(targetDir, "azure_core-0.34.0.crate"), "fake");
+
+        _mockGitHelper
+            .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_tempDirectory.DirectoryPath);
+
+        SetupCargoMetadata("azure_core", "0.34.0");
+
+        _mockPowershellHelper
+            .Setup(x => x.Run(It.IsAny<PowershellOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [] });
+
+        var (success, _, _, artifactPath) = await _service.PackAsync(packageDir);
+
+        Assert.That(success, Is.True);
+        Assert.That(artifactPath, Does.Contain("azure_core-0.34.0.crate"));
+    }
+
+    [Test]
+    public async Task PackAsync_DiscoverRepoRootFails_ReturnsFailure()
+    {
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "core", "azure_core");
+        Directory.CreateDirectory(packageDir);
+
+        _mockGitHelper
+            .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(string.Empty);
+
+        var (success, errorMessage, _, _) = await _service.PackAsync(packageDir);
+
+        Assert.That(success, Is.False);
+        Assert.That(errorMessage, Does.Contain("Failed to discover local sdk repo"));
     }
 
     #endregion
@@ -372,6 +539,17 @@ public class RustLanguageServiceTests
 
         Assert.That(info.PackageName, Is.EqualTo("my_crate"));
         Assert.That(info.PackageVersion, Is.EqualTo("0.1.0"));
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private void CreatePackScript()
+    {
+        var scriptDir = Path.Combine(_tempDirectory.DirectoryPath, "eng", "scripts");
+        Directory.CreateDirectory(scriptDir);
+        File.WriteAllText(Path.Combine(scriptDir, "Pack-Crates.ps1"), "# pack script");
     }
 
     #endregion

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/RustLanguageServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/RustLanguageServiceTests.cs
@@ -116,7 +116,7 @@ public class RustLanguageServiceTests
         Directory.CreateDirectory(packageDir);
         var scriptDir = Path.Combine(_tempDirectory.DirectoryPath, "eng", "scripts");
         Directory.CreateDirectory(scriptDir);
-        File.WriteAllText(Path.Combine(scriptDir, "Build-Sdk.ps1"), "# build script");
+        File.WriteAllText(Path.Combine(scriptDir, "Build-Crates.ps1"), "# build script");
 
         _mockGitHelper
             .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -144,7 +144,7 @@ public class RustLanguageServiceTests
         Directory.CreateDirectory(packageDir);
         var scriptDir = Path.Combine(_tempDirectory.DirectoryPath, "eng", "scripts");
         Directory.CreateDirectory(scriptDir);
-        File.WriteAllText(Path.Combine(scriptDir, "Build-Sdk.ps1"), "# build script");
+        File.WriteAllText(Path.Combine(scriptDir, "Build-Crates.ps1"), "# build script");
 
         _mockGitHelper
             .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/RustLanguageServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/Languages/RustLanguageServiceTests.cs
@@ -132,7 +132,7 @@ public class RustLanguageServiceTests
         Assert.That(errorMessage, Is.Null);
         _mockPowershellHelper.Verify(x => x.Run(
             It.Is<PowershellOptions>(o =>
-                o.Args.Contains("-PackagePath") &&
+                o.Args.Contains("-ManifestDir") &&
                 o.Args.Contains(packageDir)),
             It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -265,8 +265,8 @@ public class RustLanguageServiceTests
         Assert.That(success, Is.True);
         _mockPowershellHelper.Verify(x => x.Run(
             It.Is<PowershellOptions>(o =>
-                o.Args.Contains("-PackageNames") &&
-                o.Args.Contains("azure_core") &&
+                o.Args.Contains("-ManifestDir") &&
+                o.Args.Contains(packageDir) &&
                 o.Args.Contains("-NoVerify")),
             It.IsAny<CancellationToken>()), Times.Once);
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackToolTests.cs
@@ -80,7 +80,7 @@ public class PackToolTests
             new JavaScriptLanguageService(_mockProcessHelper.Object, _mockNpxHelper.Object, Mock.Of<ICopilotAgentRunner>(), _mockGitHelper.Object, languageLogger, _commonValidationHelpers.Object, _mockPackageInfoHelper.Object, Mock.Of<IFileHelper>(), _mockSpecGenSdkConfigHelper.Object, Mock.Of<IChangelogHelper>()),
             new GoLanguageService(_mockProcessHelper.Object, _mockPowerShellHelper.Object, _mockGitHelper.Object, languageLogger, _commonValidationHelpers.Object, _mockPackageInfoHelper.Object, Mock.Of<IFileHelper>(), _mockSpecGenSdkConfigHelper.Object, Mock.Of<IChangelogHelper>()),
             new DotnetLanguageService(_mockProcessHelper.Object, _mockPowerShellHelper.Object, Mock.Of<ICopilotAgentRunner>(), _mockGitHelper.Object, languageLogger, _commonValidationHelpers.Object, _mockPackageInfoHelper.Object, Mock.Of<IFileHelper>(), _mockSpecGenSdkConfigHelper.Object, Mock.Of<IChangelogHelper>()),
-            new RustLanguageService(_mockProcessHelper.Object, _mockPowerShellHelper.Object, _mockGitHelper.Object, languageLogger, _commonValidationHelpers.Object, _mockPackageInfoHelper.Object, Mock.Of<IFileHelper>(), _mockSpecGenSdkConfigHelper.Object, Mock.Of<IChangelogHelper>())
+            new RustLanguageService(_mockProcessHelper.Object, _mockPowerShellHelper.Object, _mockGitHelper.Object, languageLogger, _commonValidationHelpers.Object, _mockPackageInfoHelper.Object, Mock.Of<IFileHelper>(), _mockSpecGenSdkConfigHelper.Object, Mock.Of<IChangelogHelper>()),
         ];
 
         _tool = new PackTool(

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackToolTests.cs
@@ -79,7 +79,8 @@ public class PackToolTests
             new JavaLanguageService(_mockProcessHelper.Object, _mockGitHelper.Object, _mockMavenHelper.Object, Mock.Of<IPythonHelper>(), mockCopilotAgentRunner.Object, languageLogger, _commonValidationHelpers.Object, _mockPackageInfoHelper.Object, Mock.Of<IFileHelper>(), _mockSpecGenSdkConfigHelper.Object, Mock.Of<IChangelogHelper>()),
             new JavaScriptLanguageService(_mockProcessHelper.Object, _mockNpxHelper.Object, Mock.Of<ICopilotAgentRunner>(), _mockGitHelper.Object, languageLogger, _commonValidationHelpers.Object, _mockPackageInfoHelper.Object, Mock.Of<IFileHelper>(), _mockSpecGenSdkConfigHelper.Object, Mock.Of<IChangelogHelper>()),
             new GoLanguageService(_mockProcessHelper.Object, _mockPowerShellHelper.Object, _mockGitHelper.Object, languageLogger, _commonValidationHelpers.Object, _mockPackageInfoHelper.Object, Mock.Of<IFileHelper>(), _mockSpecGenSdkConfigHelper.Object, Mock.Of<IChangelogHelper>()),
-            new DotnetLanguageService(_mockProcessHelper.Object, _mockPowerShellHelper.Object, Mock.Of<ICopilotAgentRunner>(), _mockGitHelper.Object, languageLogger, _commonValidationHelpers.Object, _mockPackageInfoHelper.Object, Mock.Of<IFileHelper>(), _mockSpecGenSdkConfigHelper.Object, Mock.Of<IChangelogHelper>())
+            new DotnetLanguageService(_mockProcessHelper.Object, _mockPowerShellHelper.Object, Mock.Of<ICopilotAgentRunner>(), _mockGitHelper.Object, languageLogger, _commonValidationHelpers.Object, _mockPackageInfoHelper.Object, Mock.Of<IFileHelper>(), _mockSpecGenSdkConfigHelper.Object, Mock.Of<IChangelogHelper>()),
+            new RustLanguageService(_mockProcessHelper.Object, _mockPowerShellHelper.Object, _mockGitHelper.Object, languageLogger, _commonValidationHelpers.Object, _mockPackageInfoHelper.Object, Mock.Of<IFileHelper>(), _mockSpecGenSdkConfigHelper.Object, Mock.Of<IChangelogHelper>())
         ];
 
         _tool = new PackTool(
@@ -501,6 +502,141 @@ public class PackToolTests
 
     #endregion
 
+    #region Rust Pack Tests
+
+    [Test]
+    public async Task PackAsync_Rust_Success_ReturnsSuccessWithArtifact()
+    {
+        // Arrange
+        SetupRustRepo();
+        SetupRustPackScript();
+
+        // Create package in a properly named subdirectory
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "core", "azure_core");
+        Directory.CreateDirectory(packageDir);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), "[package]\nname = \"azure_core\"\n");
+        SetupCargoMetadata("azure_core", "0.34.0");
+
+        _mockPowerShellHelper
+            .Setup(x => x.Run(It.IsAny<PowershellOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, "Finished packing crates")] });
+
+        // Create the .crate artifact at the expected location
+        var targetPackageDir = Path.Combine(_tempDirectory.DirectoryPath, "target", "package");
+        Directory.CreateDirectory(targetPackageDir);
+        File.WriteAllText(Path.Combine(targetPackageDir, "azure_core-0.34.0.crate"), "fake crate");
+
+        // Act
+        var result = await _tool.PackAsync(null, packageDir);
+
+        // Assert
+        Assert.That(result.ResponseErrors, Is.Null.Or.Empty);
+        Assert.That(result.Message, Does.Contain("Pack completed successfully"));
+    }
+
+    [Test]
+    public async Task PackAsync_Rust_WithOutputPath_PassesOutputArg()
+    {
+        // Arrange
+        SetupRustRepo();
+        SetupRustPackScript();
+
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "core", "azure_core");
+        Directory.CreateDirectory(packageDir);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), "[package]\nname = \"azure_core\"\n");
+        SetupCargoMetadata("azure_core", "0.34.0");
+
+        var outputDir = Path.Combine(_tempDirectory.DirectoryPath, "output");
+        Directory.CreateDirectory(outputDir);
+
+        _mockPowerShellHelper
+            .Setup(x => x.Run(It.IsAny<PowershellOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [] });
+
+        // Act
+        var result = await _tool.PackAsync(null, packageDir, outputDir);
+
+        // Assert
+        Assert.That(result.ResponseErrors, Is.Null.Or.Empty);
+        _mockPowerShellHelper.Verify(x => x.Run(
+            It.Is<PowershellOptions>(o =>
+                o.Args.Contains("-OutputPath") &&
+                o.Args.Contains(outputDir)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task PackAsync_Rust_ScriptFails_ReturnsFailure()
+    {
+        // Arrange
+        SetupRustRepo();
+        SetupRustPackScript();
+
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "core", "azure_core");
+        Directory.CreateDirectory(packageDir);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), "[package]\nname = \"azure_core\"\n");
+        SetupCargoMetadata("azure_core", "0.34.0");
+
+        _mockPowerShellHelper
+            .Setup(x => x.Run(It.IsAny<PowershellOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessResult { ExitCode = 1, OutputDetails = [(StdioLevel.StandardError, "cargo publish failed")] });
+
+        // Act
+        var result = await _tool.PackAsync(null, packageDir);
+
+        // Assert
+        Assert.That(result.ResponseErrors?.First(), Does.Contain("Pack failed with exit code 1"));
+    }
+
+    [Test]
+    public async Task PackAsync_Rust_MissingPackScript_ReturnsFailure()
+    {
+        // Arrange
+        SetupRustRepo();
+        // Do NOT create the pack script
+
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "core", "azure_core");
+        Directory.CreateDirectory(packageDir);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), "[package]\nname = \"azure_core\"\n");
+        SetupCargoMetadata("azure_core", "0.34.0");
+
+        // Act
+        var result = await _tool.PackAsync(null, packageDir);
+
+        // Assert
+        Assert.That(result.ResponseErrors?.First(), Does.Contain("Pack script not found"));
+    }
+
+    [Test]
+    public async Task PackAsync_Rust_PassesNoVerifyAndPackageNames()
+    {
+        // Arrange
+        SetupRustRepo();
+        SetupRustPackScript();
+
+        var packageDir = Path.Combine(_tempDirectory.DirectoryPath, "sdk", "core", "azure_core");
+        Directory.CreateDirectory(packageDir);
+        File.WriteAllText(Path.Combine(packageDir, "Cargo.toml"), "[package]\nname = \"azure_core\"\n");
+        SetupCargoMetadata("azure_core", "0.34.0");
+
+        _mockPowerShellHelper
+            .Setup(x => x.Run(It.IsAny<PowershellOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [] });
+
+        // Act
+        await _tool.PackAsync(null, packageDir);
+
+        // Assert
+        _mockPowerShellHelper.Verify(x => x.Run(
+            It.Is<PowershellOptions>(o =>
+                o.Args.Contains("-PackageNames") &&
+                o.Args.Contains("azure_core") &&
+                o.Args.Contains("-NoVerify")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    #endregion
+
     #region Exception Handling Tests
 
     [Test]
@@ -596,6 +732,31 @@ public class PackToolTests
         _mockGitHelper
             .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_tempDirectory.DirectoryPath);
+    }
+
+    private void SetupRustRepo()
+    {
+        _mockGitHelper
+            .Setup(x => x.GetRepoNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("azure-sdk-for-rust");
+        _mockGitHelper
+            .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_tempDirectory.DirectoryPath);
+    }
+
+    private void SetupRustPackScript()
+    {
+        var scriptDir = Path.Combine(_tempDirectory.DirectoryPath, "eng", "scripts");
+        Directory.CreateDirectory(scriptDir);
+        File.WriteAllText(Path.Combine(scriptDir, "Pack-Crates.ps1"), "# pack script");
+    }
+
+    private void SetupCargoMetadata(string name, string version)
+    {
+        var json = System.Text.Json.JsonSerializer.Serialize(new { packages = new[] { new { name, version } } });
+        _mockProcessHelper
+            .Setup(x => x.Run(It.Is<ProcessOptions>(o => o.Args.Contains("metadata")), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessResult { ExitCode = 0, OutputDetails = [(StdioLevel.StandardOutput, json)] });
     }
 
     #endregion

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackToolTests.cs
@@ -629,8 +629,8 @@ public class PackToolTests
         // Assert
         _mockPowerShellHelper.Verify(x => x.Run(
             It.Is<PowershellOptions>(o =>
-                o.Args.Contains("-PackageNames") &&
-                o.Args.Contains("azure_core") &&
+                o.Args.Contains("-ManifestDir") &&
+                o.Args.Contains(packageDir) &&
                 o.Args.Contains("-NoVerify")),
             It.IsAny<CancellationToken>()), Times.Once);
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/RustLanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/RustLanguageService.cs
@@ -230,7 +230,7 @@ public sealed class RustLanguageService : LanguageService
 
             var options = new PowershellOptions(
                 scriptPath,
-                ["-PackagePath", packagePath],
+                ["-ManifestDir", packagePath],
                 logOutputStream: true,
                 workingDirectory: sdkRepoRoot,
                 timeout: TimeSpan.FromMinutes(timeoutMinutes)
@@ -291,15 +291,9 @@ public sealed class RustLanguageService : LanguageService
                 return (false, $"Pack script not found at: {scriptPath}.", packageInfo, null);
             }
 
-            var packageName = packageInfo?.PackageName;
-            if (string.IsNullOrEmpty(packageName))
-            {
-                return (false, $"Could not determine package name from path: {packagePath}.", packageInfo, null);
-            }
+            logger.LogDebug("Executing Rust pack script: {ScriptPath} for package: {PackageName}", scriptPath, packageInfo?.PackageName ?? "(unknown)");
 
-            logger.LogDebug("Executing Rust pack script: {ScriptPath} for package: {PackageName}", scriptPath, packageName);
-
-            var args = new List<string> { "-PackageNames", packageName, "-NoVerify" };
+            var args = new List<string> { "-ManifestDir", packagePath, "-NoVerify" };
             if (!string.IsNullOrWhiteSpace(outputPath))
             {
                 args.AddRange(["-OutputPath", outputPath]);
@@ -324,6 +318,11 @@ public sealed class RustLanguageService : LanguageService
             }
 
             var artifactPath = ResolveArtifactPath(sdkRepoRoot, packageInfo, outputPath);
+            if (artifactPath == null)
+            {
+                logger.LogDebug("Could not resolve artifact path. Package name: {Name}, version: {Version}",
+                    packageInfo?.PackageName ?? "(null)", packageInfo?.PackageVersion ?? "(null)");
+            }
             logger.LogDebug("Pack completed successfully. Artifact: {ArtifactPath}", artifactPath ?? "(unknown)");
             return (true, null, packageInfo, artifactPath);
         }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/RustLanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/RustLanguageService.cs
@@ -8,11 +8,11 @@ namespace Azure.Sdk.Tools.Cli.Services.Languages;
 
 /// <summary>
 /// Language-specific service for Rust packages. Since the Rust SDK repo does not have a
-/// swagger_to_sdk_config.json, the build script path is hardcoded to eng/scripts/Build-Sdk.ps1.
+/// swagger_to_sdk_config.json, the build script path is hardcoded to eng/scripts/Build-Crates.ps1.
 /// </summary>
 public sealed class RustLanguageService : LanguageService
 {
-    private const string BuildScriptRelativePath = "eng/scripts/Build-Sdk.ps1";
+    private const string BuildScriptRelativePath = "eng/scripts/Build-Crates.ps1";
     private const string PackScriptRelativePath = "eng/scripts/Pack-Crates.ps1";
 
     public RustLanguageService(

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/RustLanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/RustLanguageService.cs
@@ -8,11 +8,12 @@ namespace Azure.Sdk.Tools.Cli.Services.Languages;
 
 /// <summary>
 /// Language-specific service for Rust packages. Since the Rust SDK repo does not have a
-/// swagger_to_sdk_config.json, the build script path is hardcoded to eng/scripts/build-sdk.ps1.
+/// swagger_to_sdk_config.json, the build script path is hardcoded to eng/scripts/Build-Sdk.ps1.
 /// </summary>
 public sealed class RustLanguageService : LanguageService
 {
-    private const string BuildScriptRelativePath = "eng/scripts/build-sdk.ps1";
+    private const string BuildScriptRelativePath = "eng/scripts/Build-Sdk.ps1";
+    private const string PackScriptRelativePath = "eng/scripts/Pack-Crates.ps1";
 
     public RustLanguageService(
         IProcessHelper processHelper,
@@ -253,5 +254,105 @@ public sealed class RustLanguageService : LanguageService
             logger.LogError(ex, "Error occurred while building Rust SDK code");
             return (false, $"An error occurred: {ex.Message}", null);
         }
+    }
+
+    /// <summary>
+    /// Packs Rust crates by executing the Pack-Crates.ps1 script from the SDK repo.
+    /// </summary>
+    public override async Task<(bool Success, string? ErrorMessage, PackageInfo? PackageInfo, string? ArtifactPath)> PackAsync(
+        string packagePath, string? outputPath = null, int timeoutMinutes = 30, CancellationToken ct = default)
+    {
+        try
+        {
+            logger.LogInformation("Packing Rust crate at: {PackagePath}", packagePath);
+
+            if (string.IsNullOrWhiteSpace(packagePath))
+            {
+                return (false, "Package path is required and cannot be empty.", null, null);
+            }
+
+            string fullPath = Path.GetFullPath(packagePath);
+            if (!Directory.Exists(fullPath))
+            {
+                return (false, $"Package path does not exist: {fullPath}, input package path: {packagePath}.", null, null);
+            }
+
+            packagePath = fullPath;
+            string sdkRepoRoot = await gitHelper.DiscoverRepoRootAsync(packagePath, ct);
+            if (string.IsNullOrEmpty(sdkRepoRoot))
+            {
+                return (false, $"Failed to discover local sdk repo with project-path: {packagePath}.", null, null);
+            }
+
+            PackageInfo? packageInfo = await GetPackageInfo(packagePath, ct);
+            var scriptPath = Path.Combine(sdkRepoRoot, PackScriptRelativePath);
+            if (!File.Exists(scriptPath))
+            {
+                return (false, $"Pack script not found at: {scriptPath}.", packageInfo, null);
+            }
+
+            var packageName = packageInfo?.PackageName;
+            if (string.IsNullOrEmpty(packageName))
+            {
+                return (false, $"Could not determine package name from path: {packagePath}.", packageInfo, null);
+            }
+
+            logger.LogDebug("Executing Rust pack script: {ScriptPath} for package: {PackageName}", scriptPath, packageName);
+
+            var args = new List<string> { "-PackageNames", packageName, "-NoVerify" };
+            if (!string.IsNullOrWhiteSpace(outputPath))
+            {
+                args.AddRange(["-OutputPath", outputPath]);
+            }
+
+            var options = new PowershellOptions(
+                scriptPath,
+                args.ToArray(),
+                logOutputStream: true,
+                workingDirectory: sdkRepoRoot,
+                timeout: TimeSpan.FromMinutes(timeoutMinutes)
+            );
+
+            var result = await powershellHelper.Run(options, ct);
+            var trimmedOutput = (result.Output ?? string.Empty).Trim();
+
+            if (result.ExitCode != 0)
+            {
+                var errorMessage = $"Pack failed with exit code {result.ExitCode}. Output:\n{trimmedOutput}";
+                logger.LogDebug("Pack failed: {ErrorMessage}", errorMessage);
+                return (false, errorMessage, packageInfo, null);
+            }
+
+            var artifactPath = ResolveArtifactPath(sdkRepoRoot, packageInfo, outputPath);
+            logger.LogDebug("Pack completed successfully. Artifact: {ArtifactPath}", artifactPath ?? "(unknown)");
+            return (true, null, packageInfo, artifactPath);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error occurred while packing Rust crate");
+            return (false, $"An error occurred: {ex.Message}", null, null);
+        }
+    }
+
+    /// <summary>
+    /// Resolves the path to the generated .crate artifact after a successful pack.
+    /// When an output path is specified, the script copies artifacts to &lt;outputPath&gt;/&lt;name&gt;/&lt;name&gt;-&lt;version&gt;.crate.
+    /// Otherwise, cargo places them at target/package/&lt;name&gt;-&lt;version&gt;.crate.
+    /// </summary>
+    private static string? ResolveArtifactPath(string repoRoot, PackageInfo? packageInfo, string? outputPath)
+    {
+        var name = packageInfo?.PackageName;
+        var version = packageInfo?.PackageVersion;
+        if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(version))
+        {
+            return null;
+        }
+
+        var dir = !string.IsNullOrWhiteSpace(outputPath)
+            ? Path.Combine(outputPath, name)
+            : Path.Combine(repoRoot, "target", "package");
+
+        var artifactPath = Path.Combine(dir, $"{name}-{version}.crate");
+        return File.Exists(artifactPath) ? artifactPath : null;
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/PackTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/PackTool.cs
@@ -36,7 +36,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
 
         private static readonly Option<string?> OutputPath = new("--output-path")
         {
-            Description = "Output directory for generated artifacts. If not specified, uses the default location for the language.",
+            Description = "Output directory for generated artifacts. Relative paths are resolved to absolute. If not specified, uses the default location for the language.",
             Required = false,
         };
 
@@ -59,7 +59,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
             IProgress<ProgressNotificationValue>? progress,
             [Description("Absolute path to the SDK package directory.")]
             string packagePath,
-            [Description("Optional output directory for the generated artifact.")]
+            [Description("Optional output directory for the generated artifact. Relative paths are resolved to absolute.")]
             string? outputPath = null,
             CancellationToken ct = default)
         {
@@ -88,13 +88,16 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
                 reporter.NextStep($"Packing {languageService.Language} SDK project");
                 logger.LogInformation("Packing SDK project at: {PackagePath} for language: {Language}", fullPath, languageService.Language);
 
+                // Normalize outputPath to absolute so language services receive a consistent path
+                string? fullOutputPath = !string.IsNullOrWhiteSpace(outputPath) ? Path.GetFullPath(outputPath) : null;
+
                 bool success;
                 string? errorMessage;
                 PackageInfo? packageInfo;
                 string? artifactPath;
                 await using (reporter.StartHeartbeat($"Packing {languageService.Language} SDK project", ct))
                 {
-                    (success, errorMessage, packageInfo, artifactPath) = await languageService.PackAsync(fullPath, outputPath, CommandTimeoutInMinutes, ct);
+                    (success, errorMessage, packageInfo, artifactPath) = await languageService.PackAsync(fullPath, fullOutputPath, CommandTimeoutInMinutes, ct);
                 }
 
                 reporter.NextStep(success ? "Pack completed successfully" : "Pack failed");


### PR DESCRIPTION
Resolved https://github.com/Azure/azure-sdk-tools/issues/14927

## What
Add Rust crate packaging to `azsdk pkg pack` by shelling out to `eng/scripts/Pack-Crates.ps1` in the azure-sdk-for-rust repo.

## Changes
- **RustLanguageService.cs**: Add `PackAsync` override that invokes `Pack-Crates.ps1` with \-PackageNames\, \-NoVerify\, and optional \-OutputPath\.
- Extended test coverage.