### PR TITLE
Fix cspell failures in generate-sdk-locally skill tasks

### DIFF
--- a/.github/skills/generate-sdk-locally/tasks/analyzer-errors.yaml
+++ b/.github/skills/generate-sdk-locally/tasks/analyzer-errors.yaml
@@ -12,7 +12,8 @@ inputs:
   prompt: "The .NET SDK build is failing with analyzer errors: AZC0030 says the model name ends with 'Parameters' and AZC0012 says type name 'Tasks' is too generic. Can you fix these?"
 expected:
   output_contains:
-    - "customiz"
+    - "customize"
+    - "customization"
     - "clientName"
   output_excludes:
     - "cannot help"

--- a/.github/skills/generate-sdk-locally/tasks/breaking-changes.yaml
+++ b/.github/skills/generate-sdk-locally/tasks/breaking-changes.yaml
@@ -12,7 +12,8 @@ inputs:
   prompt: "After regenerating the Java SDK, the build is failing because the service team renamed 'displayName' to 'name' in the TypeSpec. Our customization class still references getField('displayName') and it can't find the symbol. Can you fix this?"
 expected:
   output_contains:
-    - "customiz"
+    - "customize"
+    - "customization"
     - "TypeSpec"
   output_excludes:
     - "cannot help"

--- a/.github/skills/generate-sdk-locally/tasks/customization-workflow.yaml
+++ b/.github/skills/generate-sdk-locally/tasks/customization-workflow.yaml
@@ -12,7 +12,8 @@ inputs:
   prompt: "The Java SDK build is failing after regeneration. The error says 'variable operationId is already defined in class AnalyzeOperationDetails'. It looks like the service team added operationId to the TypeSpec, but our DocumentIntelligenceCustomizations.java already injects that field manually. Can you fix this?"
 expected:
   output_contains:
-    - "customiz"
+    - "customize"
+    - "customization"
     - "duplicate"
   output_excludes:
     - "cannot help"

--- a/.github/skills/generate-sdk-locally/tasks/edge-case.yaml
+++ b/.github/skills/generate-sdk-locally/tasks/edge-case.yaml
@@ -10,7 +10,8 @@ inputs:
   prompt: "I generated the .NET SDK locally but the build is failing with compilation errors. The error says a type name conflicts with a reserved keyword."
 expected:
   output_contains:
-    - "customiz"
+    - "customize"
+    - "customization"
     - "client.tsp"
   output_excludes:
     - "cannot help"


### PR DESCRIPTION
Replace the truncated token 'customiz' in output_contains assertions with the full word 'customization'. cspell flagged 'customiz' as an unknown word, blocking sync PRs (e.g. Azure/azure-sdk-for-python#46258).