### PR TITLE
Move azure-typespec-author skill from azure-rest-api-specs to azure-sdk-tools

### DIFF
--- a/.github/skills/azure-typespec-author/SKILL.md
+++ b/.github/skills/azure-typespec-author/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: azure-typespec-author
+license: MIT
+metadata:
+  version: "1.0.0"
+description: "Authors and modifies Azure TypeSpec (.tsp) API specifications. USE FOR: any TypeSpec/tsp change — api versions (add, bump, preview, stable, promote), resources, operations, models, properties, decorators, visibility, constraints, breaking changes, LRO, suppressions, operationId, spread model. Covers ARM resource-manager and data-plane services. DO NOT USE FOR: SDK generation, releasing SDK packages, or single MCP tool calls. INVOKES: azure-sdk-mcp:azsdk_typespec_generate_authoring_plan, azure-sdk-mcp:azsdk_run_typespec_validation."
+compatibility:
+  requires: "azure-sdk-mcp server with azsdk_typespec_generate_authoring_plan and azsdk_run_typespec_validation tools"
+---
+
+# Azure TypeSpec Author
+
+## MCP Tools
+
+| Tool                                                   | Purpose                                                   |
+| ------------------------------------------------------ | --------------------------------------------------------- |
+| `azure-sdk-mcp:azsdk_typespec_generate_authoring_plan` | Generate grounded authoring plan (General Authoring only) |
+| `azure-sdk-mcp:azsdk_run_typespec_validation`          | Validate TypeSpec                                         |
+
+**Prerequisite:** `azure-sdk-mcp` server must be running.
+
+## Constraints
+
+- **Always follow the full workflow** — even seemingly simple changes (e.g. adding a default value) can require complex versioning decorator changes. Never skip steps.
+- **Mandatory for ALL `.tsp` edits** — even a single `?` change can be breaking.
+- **Minimal, scoped edits** — only change what the request requires.
+- **Always validate** — run every steps in [validation](references/validation.md) after every edit.
+- **Always cite references** — provide links that justify the approach.
+- **Follow the authoring plan exactly** — code changes in Step 4 MUST follow the authoring plan generated in Step 3. Do not deviate by referring to existing code patterns in the TypeSpec project; the authoring plan is the single source of truth for what to change.
+
+---
+
+## Workflow
+
+> Classify → Intake → Plan → Apply → Validate
+
+### Progress Checklist
+
+Copy and update as you progress:
+
+- [ ] Step 1: Analyzed project & classified as: \_\_\_
+- [ ] Step 2: Collected intake inputs
+- [ ] Step 3: Retrieved authoring plan
+- [ ] Step 4: Applied changes
+- [ ] Step 5: Validated with TypeSpec validation and `tsp compile .`
+
+### Step 1: Analyze & Classify
+
+Follow [analyze project & classify task](references/analyze-project-and-classify-task.md).
+
+Classify as exactly one:
+
+| Task Type                 | When                                                                              | `azsdk_typespec_generate_authoring_plan` |
+| ------------------------- | --------------------------------------------------------------------------------- | ---------------------------------------- |
+| **API Version Evolution** | Adding a new preview or stable API version to an existing ARM service. (ARM only) | **MUST NOT** call                        |
+| **General Authoring**     | Any other `.tsp` change (resources, operations, models, properties, etc.)         | **MUST** call                            |
+
+State your classification explicitly before proceeding.
+
+---
+
+### Step 2: Intake
+
+Collect inputs needed for the change. Branch by task type:
+
+- **API Version Evolution** → Follow [API version evolution reference — Step 2](references/api-version-evolution.md#step-2-intake).
+- **General Authoring** → Follow [intake guide](references/general-authoring-intake.md).
+
+---
+
+### Step 3: Retrieve Authoring Plan
+
+Check your classification from Step 1, then branch:
+
+- **API Version Evolution** → Follow [API version evolution reference — Step 3](references/api-version-evolution.md#step-3-retrieve-authoring-plan). **MUST NOT** call `azsdk_typespec_generate_authoring_plan`.
+- **General Authoring** → **MUST** invoke `azure-sdk-mcp:azsdk_typespec_generate_authoring_plan` with:
+
+  | Parameter                 | Value                                                                                                                                                                       |
+  | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | `request`                 | User request (verbatim)                                                                                                                                                     |
+  | `additionalInformation`   | All content gathered from Steps 1–2 (intake analysis, user answers, relevant `.tsp` code read from the project), **including any case-specific Defaults noted in Step 2.2** |
+  | `typeSpecProjectRootPath` | TypeSpec project root path                                                                                                                                                  |
+
+  Do not proceed without an authoring plan from this tool.
+
+---
+
+### Step 4: Apply Changes
+
+Confirm uncertainties with the user, then make minimal `.tsp` edits.
+
+- **API Version Evolution** → Apply the plan from Step 3.
+- **General Authoring** → Apply the authoring plan from Step 3.
+
+---
+
+### Step 5: Validate
+
+See [validation guide](references/validation.md) for sub-steps. You must run TypeSpec validation (5.1), `tsp compile .` (5.2), and example verification (5.3, API Version Evolution only).
+
+---
+
+## Reference Files
+
+| File                                                                                    | Purpose                                   |
+| --------------------------------------------------------------------------------------- | ----------------------------------------- |
+| [analyze-project-and-classify-task.md](references/analyze-project-and-classify-task.md) | Step 1: project analysis + classification |
+| [api-version-evolution.md](references/api-version-evolution.md)                         | Steps 2–4 for API Version Evolution tasks |
+| [general-authoring-intake.md](references/general-authoring-intake.md)                   | Step 2 for General Authoring tasks        |
+| [agentic-search.md](references/agentic-search.md)                                       | Procedure for fetching external docs      |
+| [validation.md](references/validation.md)                                               | Step 5: validation sub-steps              |
+
+## Examples
+
+- "Add a new preview API version 2026-01-01-preview for widget resource manager"
+- "Bump to stable version 2026-01-01 for Microsoft.Widget"
+- "Add an ARM resource named Asset with CRUD operations"
+- "Add a new property to the Widget model"
+
+## Troubleshooting
+
+- **TypeSpec validation fails** — display all errors, provide fix suggestions, re-run validation.
+- **API Version Evolution** — use the versioning guide URLs in the [version evolution reference](references/api-version-evolution.md); do not call the authoring plan tool.

--- a/.github/skills/azure-typespec-author/references/agentic-search.md
+++ b/.github/skills/azure-typespec-author/references/agentic-search.md
@@ -1,0 +1,15 @@
+# Agentic Search
+
+Procedure for fetching external documentation and extracting actionable guidance.
+
+## Input
+
+A set of document URLs to fetch (provided by the caller).
+
+## Procedure
+
+1. **Fetch documents** — use `web_fetch` to download each URL. Extract the page content as markdown.
+2. **Search content** — read the downloaded content and identify instructions, code examples, and patterns relevant to the current task.
+3. **Build authoring plan** — synthesize the extracted content into a concrete authoring plan grounded in the fetched material.
+
+> Do not proceed without an authoring plan grounded in the fetched reference material.

--- a/.github/skills/azure-typespec-author/references/analyze-project-and-classify-task.md
+++ b/.github/skills/azure-typespec-author/references/analyze-project-and-classify-task.md
@@ -1,0 +1,62 @@
+# Analyze Project & Classify Task
+
+## Part 1 — Analyze Project
+
+Collect the inputs below from the TypeSpec project. Ask **up to 6 concise questions** for any that are missing.
+
+| #   | Input                       | Example                                                          |
+| --- | --------------------------- | ---------------------------------------------------------------- |
+| 1   | TypeSpec project root       | `/specification/widget/resource-manager/Microsoft.Widget/Widget` |
+| 2   | Path to `tspconfig.yaml`    | `<spec-root>/tspconfig.yaml`                                     |
+| 3   | Service type                | ARM / data-plane                                                 |
+| 4   | Existing API versions       | `2024-01-01 (stable)`, `2024-06-01-preview`                      |
+| 5   | Latest API version          | Most recent entry in the `Versions` enum                         |
+| 6   | Current working API version | The version being added or modified this session                 |
+| 7   | Intent                      | add / modify / fix                                               |
+| 8   | Target resource/interface   | Resource or operation name (if known)                            |
+| 9   | Constraints                 | Breaking-change limits, naming rules, emitter targets, etc.      |
+
+## Part 2 — Classify Task
+
+> **CRITICAL:** Classify into exactly one task type below and state your classification **before** proceeding to Step 2.
+
+### Definitions
+
+| Type                      | What it means                                                                                                                       | Tool Restriction                                                                        |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| **API Version Evolution** | Adding a new preview or stable API version to an existing ARM service. Data-plane API version evolution is not fully supported yet. | **MUST NOT** call `azsdk_typespec_generate_authoring_plan`. Uses web-fetched docs only. |
+| **General Authoring**     | Any other TypeSpec authoring task that modifies `.tsp` files (resources, operations, models, properties, etc.)                      | **MUST** call `azsdk_typespec_generate_authoring_plan` in Step 3.                       |
+
+### How to Classify
+
+**API Version Evolution** — any request whose **primary intent** is to introduce a new API version string.
+Keyword patterns:
+
+- _"add a new … API version"_, _"new preview version"_, _"new stable version"_
+- _"bump API version"_, _"introduce version"_, _"add … preview"_, _"add … stable"_
+
+**General Authoring** — everything else that modifies `.tsp` files **without** introducing a new API version.
+
+### Example Prompts
+
+| Type                      | Examples                                                                                                                                                                                                                          |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **API Version Evolution** | "Add a new preview API version 2026-01-01-preview for widget resource manager", "Add preview version 2025-06-01-preview", "Bump to stable version 2026-01-01 for Microsoft.Widget", "Introduce a new preview API version for Foo" |
+| **General Authoring**     | "Add an ARM resource named Asset with CRUD operations", "Add a new property to the Widget model"                                                                                                                                  |
+
+## Output
+
+Display the results before proceeding:
+
+```
+TypeSpec project root: /path/to/project
+tspconfig.yaml:  /path/to/project/tspconfig.yaml
+Service Type:    ARM
+API Versions:    2024-01-01 (stable), 2024-06-01-preview (preview)
+Latest Version:  2024-06-01-preview
+Working Version: [TBD]
+Intent:          [add/modify/fix]
+Target:          [resource/operation if known]
+Constraints:     [if any]
+Task Type:       [API Version Evolution | General Authoring]
+```

--- a/.github/skills/azure-typespec-author/references/api-version-evolution.md
+++ b/.github/skills/azure-typespec-author/references/api-version-evolution.md
@@ -1,0 +1,31 @@
+# API Version Evolution — Reference
+
+**MUST NOT** call `azsdk_typespec_generate_authoring_plan` for API Version Evolution tasks.
+
+---
+
+## Step 2: Intake
+
+Search using [agentic search](agentic-search.md) in below documents to determine information needed from user.
+
+- MUST collect information from user rather than making assumptions.
+- MUST use a user friendly way to collect information.
+  e.g. you MUST List features from latest version and let user select which to carry over vs exclude, rather than assume user wants to carry over all features.
+
+  | Doc                      | Guide URL                                                                                     |
+  | ------------------------ | --------------------------------------------------------------------------------------------- |
+  | Preview version overview | `https://azure.github.io/typespec-azure/docs/howtos/versioning/01-preview-version`            |
+  | preview > preview        | `https://azure.github.io/typespec-azure/docs/howtos/versioning/arm/02-preview-after-preview/` |
+  | preview > stable         | `https://azure.github.io/typespec-azure/docs/howtos/versioning/arm/03-stable-after-preview/`  |
+  | stable > preview         | `https://azure.github.io/typespec-azure/docs/howtos/versioning/arm/04-preview-after-stable/`  |
+  | stable > stable          | `https://azure.github.io/typespec-azure/docs/howtos/versioning/arm/05-stable-after-stable/`   |
+
+---
+
+## Step 3: Retrieve Authoring Plan
+
+1. Build an authoring plan from the fetched guide. Follow its rules for carried-over features and excluded features. Note there should be only one preview version and the preview version should be decorated with `@previewVersion`.
+
+2. Set up example folder: Copy all `.json` files from the latest version's `examples/` folder into new version's `examples/` folder. Create folder if necessary and update example content if necessary, e.g. api-version should be updated.
+
+3. update readme.md.

--- a/.github/skills/azure-typespec-author/references/general-authoring-intake.md
+++ b/.github/skills/azure-typespec-author/references/general-authoring-intake.md
@@ -1,0 +1,42 @@
+# Intake — General Authoring
+
+> Step 1 (Analyze Project) must be complete. Do not re-collect those inputs.
+
+### Step 2.1: Identify the Case
+
+| Case | Name                    | Description                               | Service Type |
+| ---- | ----------------------- | ----------------------------------------- | ------------ |
+| 1    | Add Resource Type       | Define a new ARM resource with operations | ARM          |
+| 2    | Add Resource Operations | Add CRUD or custom actions on a resource  | ARM          |
+
+- **Match found** → collect case-specific inputs (Step 2.2).
+- **No match** → skip to Step 3 using Step 1 analysis and the user's request.
+
+### Step 2.2: Collect Inputs
+
+**Case 1 — Add Resource Type (For ARM service only)**
+Collect: target API version, resource name (PascalCase), hierarchy (top-level or nested + parent), properties (name, type, required/optional).
+
+Defaults: top-level → `TrackedResource`, child → `ProxyResource`. Operations: `createOrReplace` (PUT/async), `get`, `update/patch`, `delete` (async), list by parent. Top-level adds list by subscription. Use `createOrReplace` (not `createOrUpdate`),
+
+> MUST use `ArmCustomPatch` for PATCH `update/patch`.
+> Top-level tracked resources MUST have `listByResourceGroup` and `listBySubscription`.
+
+**Case 2 — Add Resource Operations (For ARM service only)**  
+Collect: target resource, operation type (CRUD or custom), operation name (custom actions), request/response models (custom actions).
+
+Defaults: never async → GET, LIST, HEAD. Default async → PUT, DELETE. Default sync → PATCH. Always ask user → POST/action.
+
+> Use `createOrReplace` templates (not `createOrUpdate`). Use `ArmCustomPatch` for PATCH.
+> For POST async operation, make sure use ARM combined headers. ` LroHeaders = ArmCombinedLroHeaders<FinalResult = ExportResult>`.
+
+### Step 2.3: Confirm
+
+Display collected information and wait for user confirmation:
+
+```
+Case:              [Name]
+Target Version:    [version]
+Requested Changes: [summary]
+Defaults:          [defaults guidelines]
+```

--- a/.github/skills/azure-typespec-author/references/validation.md
+++ b/.github/skills/azure-typespec-author/references/validation.md
@@ -1,0 +1,36 @@
+# Validation
+
+After applying changes (Step 4), run through all sub-steps below in order.
+
+| Sub-step | Action                             | When                       |
+| -------- | ---------------------------------- | -------------------------- |
+| 5.1      | TypeSpec Validation (error checks) | Always                     |
+| 5.2      | `tsp compile .` (generate swagger) | Always                     |
+| 5.3      | Example Verification               | API Version Evolution only |
+
+> Steps 5.1 and 5.2 serve different purposes. Step 5.1 validates for errors/warnings. Step 5.2 compiles and generates the OpenAPI `.json` output files. Both must be executed.
+
+### Step 5.1: TypeSpec Validation
+
+Invoke `azure-sdk-mcp:azsdk_run_typespec_validation` with the TypeSpec project root path.
+
+- **Pass** → proceed to Step 5.2.
+- **Fail** → fix with minimal, scoped changes, then re-run. Repeat until resolved.
+
+> Never skip this step, even for trivial changes.
+
+### Step 5.2: Compile successfully
+
+> This step is separate from Step 5.1. Validation alone does not produce output files — you must also run `tsp compile .` to generate the OpenAPI swagger.
+
+Run `tsp compile .` from the TypeSpec project root path. After compilation succeeds, verify that the swagger `.json` file has been generated under `{TypeSpec project root}/{version-status}/{target-version}/` (e.g. `preview/2025-01-01-preview/widget.json`). Fix any compile errors if they occur.
+
+### Step 5.3: Example Verification
+
+> Applies only for API Version Evolution tasks
+
+Verify that the example folder set up in Step 3 (copied from the latest version's `examples/` into `{TypeSpec project root}/{version-status}/{target-version}/examples/`) exists and contains example files.
+
+1. **Folder exists** — confirm `{TypeSpec project root}/{version-status}/{target-version}/examples/` was created. If missing, copy all `.json` files from the latest version's `examples/` folder.
+2. **Files exist** — confirm the folder contains at least one `.json` example file. If empty, copy examples from the latest version's `examples/` folder.
+3. **api-version updated** — each example file must use the correct `api-version` value matching the target version (e.g. `2024-02-01-preview`, not the source version).


### PR DESCRIPTION
Relates to https://github.com/Azure/azure-sdk-tools/issues/15188
## Summary

This PR moves the `azure-typespec-author` Copilot skill from the [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs/tree/main/.github/skills/azure-typespec-author) repository to its permanent home in the azure-sdk-tools repository.

## Files Added

- `.github/skills/azure-typespec-author/SKILL.md` — main skill definition
- `.github/skills/azure-typespec-author/references/agentic-search.md`
- `.github/skills/azure-typespec-author/references/analyze-project-and-classify-task.md`
- `.github/skills/azure-typespec-author/references/api-version-evolution.md`
- `.github/skills/azure-typespec-author/references/general-authoring-intake.md`
- `.github/skills/azure-typespec-author/references/validation.md`

## Motivation

The azure-typespec-author skill was initially developed and iterated on in the azure-rest-api-specs repo. As discussed, we agreed to move the skill and related benchmark cases to the azure-sdk-tools repo.

## About validating the skill in sdk repo
Hi @ronniegeraghty , I replied in this issue [comment](https://github.com/Azure/azure-sdk-tools/issues/15187#issuecomment-4278348500). I'm still a bit unsure about what user scenarios are we validating here. 

## Related

- Source: https://github.com/Azure/azure-rest-api-specs/tree/main/.github/skills/azure-typespec-author
- Tracking issue: https://github.com/Azure/azure-sdk-tools/issues/14667