### PR TITLE
Support running publish artifact step in pipeline re-run scenario

### DIFF
--- a/eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+++ b/eng/common/pipelines/templates/steps/publish-1es-artifact.yml
@@ -15,35 +15,32 @@ parameters:
 
 steps:
   - pwsh: |
+      $artifactName = "${{ parameters.ArtifactName }}"
+      $skipPublish = "false"
+
       if ($env:AGENT_JOBSTATUS -eq "Failed") {
-        Write-Host "Setting artifact name to ${{ parameters.ArtifactName }}-FailedAttempt$(System.JobAttempt) because there were failures." 
-        Write-Host "##vso[task.setvariable variable=PublishArtifactName;]${{ parameters.ArtifactName }}-FailedAttempt$(System.JobAttempt)"
-        Write-Host "##vso[task.setvariable variable=SkipArtifactPublish;]false"
+        $artifactName = "${{ parameters.ArtifactName }}-FailedAttempt$(System.JobAttempt)"
+        Write-Host "Setting artifact name to $artifactName because there were failures."
       } else {
         # Check if the artifact already exists from a previous job attempt (re-run scenario).
         # This avoids the "Artifact <name> already exists for build" error when re-running failed jobs.
-        $artifactName = "${{ parameters.ArtifactName }}"
         $headers = @{ Authorization = "Bearer $(System.AccessToken)" }
         $url = "$(System.CollectionUri)$(System.TeamProject)/_apis/build/builds/$(Build.BuildId)/artifacts?artifactName=$artifactName&api-version=7.0"
         try {
           $response = Invoke-RestMethod -Uri $url -Headers $headers -Method Get -MaximumRetryCount 3 -RetryIntervalSec 5 -ErrorAction Stop
           if ($response -and $response.name) {
             Write-Host "Artifact '$artifactName' already exists from a previous attempt. Skipping publish."
-            Write-Host "##vso[task.setvariable variable=SkipArtifactPublish;]true"
-            Write-Host "##vso[task.setvariable variable=PublishArtifactName;]$artifactName"
-          } else {
-            Write-Host "Setting artifact name to $artifactName"
-            Write-Host "##vso[task.setvariable variable=PublishArtifactName;]$artifactName"
-            Write-Host "##vso[task.setvariable variable=SkipArtifactPublish;]false"
+            $skipPublish = "true"
           }
         } catch {
           Write-Host "Failed to check if artifact '$artifactName' exists. Proceeding with publish."
-          Write-Host "##vso[task.setvariable variable=PublishArtifactName;]$artifactName"
-          Write-Host "##vso[task.setvariable variable=SkipArtifactPublish;]false"
         }
       }
+
+      Write-Host "##vso[task.setvariable variable=PublishArtifactName;]$artifactName"
+      Write-Host "##vso[task.setvariable variable=SkipArtifactPublish;]$skipPublish"
     condition: and(succeededOrFailed(), ${{ parameters.CustomCondition }})
-    displayName: Set Artifact Name 
+    displayName: Set Artifact Variables
 
   - task: 1ES.PublishPipelineArtifact@1
     condition: and(succeededOrFailed(), ${{ parameters.CustomCondition }}, ne(variables['SkipArtifactPublish'], 'true'))

--- a/eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+++ b/eng/common/pipelines/templates/steps/publish-1es-artifact.yml
@@ -18,15 +18,35 @@ steps:
       if ($env:AGENT_JOBSTATUS -eq "Failed") {
         Write-Host "Setting artifact name to ${{ parameters.ArtifactName }}-FailedAttempt$(System.JobAttempt) because there were failures." 
         Write-Host "##vso[task.setvariable variable=PublishArtifactName;]${{ parameters.ArtifactName }}-FailedAttempt$(System.JobAttempt)"
+        Write-Host "##vso[task.setvariable variable=SkipArtifactPublish;]false"
       } else {
-        Write-Host "Setting artifact name to ${{ parameters.ArtifactName }}" 
-        Write-Host "##vso[task.setvariable variable=PublishArtifactName;]${{ parameters.ArtifactName }}"
+        # Check if the artifact already exists from a previous job attempt (re-run scenario).
+        # This avoids the "Artifact <name> already exists for build" error when re-running failed jobs.
+        $artifactName = "${{ parameters.ArtifactName }}"
+        $headers = @{ Authorization = "Bearer $(System.AccessToken)" }
+        $url = "$(System.CollectionUri)$(System.TeamProject)/_apis/build/builds/$(Build.BuildId)/artifacts?artifactName=$artifactName&api-version=7.0"
+        try {
+          $response = Invoke-RestMethod -Uri $url -Headers $headers -Method Get -MaximumRetryCount 3 -RetryIntervalSec 5 -ErrorAction Stop
+          if ($response -and $response.name) {
+            Write-Host "Artifact '$artifactName' already exists from a previous attempt. Skipping publish."
+            Write-Host "##vso[task.setvariable variable=SkipArtifactPublish;]true"
+            Write-Host "##vso[task.setvariable variable=PublishArtifactName;]$artifactName"
+          } else {
+            Write-Host "Setting artifact name to $artifactName"
+            Write-Host "##vso[task.setvariable variable=PublishArtifactName;]$artifactName"
+            Write-Host "##vso[task.setvariable variable=SkipArtifactPublish;]false"
+          }
+        } catch {
+          Write-Host "Failed to check if artifact '$artifactName' exists. Proceeding with publish."
+          Write-Host "##vso[task.setvariable variable=PublishArtifactName;]$artifactName"
+          Write-Host "##vso[task.setvariable variable=SkipArtifactPublish;]false"
+        }
       }
     condition: and(succeededOrFailed(), ${{ parameters.CustomCondition }})
     displayName: Set Artifact Name 
 
   - task: 1ES.PublishPipelineArtifact@1
-    condition: and(succeededOrFailed(), ${{ parameters.CustomCondition }})
+    condition: and(succeededOrFailed(), ${{ parameters.CustomCondition }}, ne(variables['SkipArtifactPublish'], 'true'))
     displayName: 'Publish ${{ parameters.ArtifactName }} Artifacts'
     inputs:
       artifactName: '$(PublishArtifactName)'

--- a/eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+++ b/eng/common/pipelines/templates/steps/publish-1es-artifact.yml
@@ -33,7 +33,7 @@ steps:
             $skipPublish = "true"
           }
         } catch {
-          Write-Host "Failed to check if artifact '$artifactName' exists. Proceeding with publish."
+          Write-Host "Failed to check if artifact '$artifactName' exists: $_. Proceeding with publish."
         }
       }
 


### PR DESCRIPTION
Resolved https://github.com/Azure/azure-sdk-tools/issues/14986

This pull request improves the artifact publishing process in the Azure DevOps pipeline template to better handle job re-runs and avoid duplicate artifact errors. The main changes include checking for existing artifacts before publishing and conditionally skipping the publish step if the artifact already exists.

## Changes:

* Added logic to check if an artifact with the same name already exists from a previous job attempt, using a REST API call; if it does, sets a variable to skip publishing to prevent errors.
* Introduced a new variable `SkipArtifactPublish` and updated the publish step condition to skip publishing when this variable is set to `true`.

## Test run
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6175811&view=logs&j=7e6a3fb7-dbfe-5169-4db8-92b72295ba6c&t=d793b578-7aef-5656-c8a1-2d090a8d668c&s=ff05ad62-bb9a-53b6-ce9f-72f329a63e7c