### PR TITLE
[APIView] Bug: Automatic revision cleanup leaves stale pending revisions behind

### DIFF
--- a/src/dotnet/APIView/APIViewUnitTests/AutoReviewServiceTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/AutoReviewServiceTests.cs
@@ -520,69 +520,9 @@ namespace APIViewUnitTests
         #region Deleted Revision Bug Tests
 
         [Fact]
-        public async Task CreateAutomaticRevisionAsync_WhenCandidateMatchesAPISurface_ReusesIt()
-        {
-            // The candidate reuse check compares only API surface (considerPackageVersion=false).
-            // The pre-filter already scopes candidates to the same APIVersionId, so version is irrelevant here.
-            var codeFile = CreateCodeFile("TestPackage", "1.0.0", "C#");
-            using var memoryStream = new MemoryStream();
-
-            var existingReview = new ReviewListItemModel
-            {
-                Id = "review-id",
-                PackageName = "TestPackage",
-                Language = "C#"
-            };
-
-            var pendingRevision = new APIRevisionListItemModel
-            {
-                Id = "pending-revision",
-                ReviewId = "review-id",
-                APIRevisionType = APIRevisionType.Automatic,
-                IsApproved = false,
-                IsReleased = false,
-                CreatedOn = DateTime.UtcNow.AddDays(-1),
-                Files = new List<APICodeFileModel> { new APICodeFileModel { PackageVersion = "1.0.0" } }
-            };
-
-            _mockReviewManager.Setup(m => m.GetReviewAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
-                .ReturnsAsync(existingReview);
-
-            _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
-                .ReturnsAsync(new List<APIRevisionListItemModel> { pendingRevision });
-
-            // Candidate reuse check uses considerPackageVersion=false — API surface matches
-            _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
-                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<RenderedCodeFile>(), false, It.IsAny<string>()))
-                .ReturnsAsync(true);
-
-            _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
-                .ReturnsAsync(new List<CommentItemModel>());
-
-            var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
-                _testUser, codeFile, "test-label", "test.json", memoryStream, null);
-
-            // Candidate matches → reused, not deleted
-            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-
-            _mockApiRevisionsManager.Verify(m => m.CreateAPIRevisionAsync(
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
-                It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
-                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never);
-
-            apiRevision.Should().NotBeNull();
-            apiRevision.Id.Should().Be("pending-revision");
-        }
-
-        [Fact]
         public async Task CreateAutomaticRevisionAsync_WhenOnlyRevisionHasComment_CreatesNewRevision()
         {
             // A revision with comments is protected and skipped when selecting the candidate.
-            // Since there is no unprotected candidate, a new revision is created.
-            // The commented revision is never deleted.
             var codeFile = CreateCodeFile("TestPackage", "1.0.0", "C#");
             using var memoryStream = new MemoryStream();
 
@@ -647,29 +587,79 @@ namespace APIViewUnitTests
             apiRevision.Id.Should().Be("new-revision-id");
         }
 
+        [Fact]
+        public async Task CreateAutomaticRevisionAsync_WhenCandidateHasSameContent_StillDeletesAndCreatesNew()
+        {
+            // Even when the incoming upload is byte-for-byte identical to the existing revision,
+            // we always delete the candidate and create a fresh revision. No reuse.
+            var codeFile = CreateCodeFile("TestPackage", "1.0.0", "C#");
+            using var memoryStream = new MemoryStream();
+
+            var review = new ReviewListItemModel { Id = "review-id", PackageName = "TestPackage", Language = "C#" };
+
+            var existingRevision = new APIRevisionListItemModel
+            {
+                Id = "existing-revision", ReviewId = "review-id",
+                APIRevisionType = APIRevisionType.Automatic,
+                IsApproved = false, IsReleased = false,
+                CreatedOn = DateTime.UtcNow.AddDays(-1),
+                Files = [new APICodeFileModel { PackageVersion = "1.0.0" }]
+            };
+
+            var newRevision = new APIRevisionListItemModel { Id = "new-revision", ReviewId = "review-id" };
+
+            _mockReviewManager.Setup(m => m.GetReviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
+                .ReturnsAsync(review);
+            _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
+                .ReturnsAsync(new List<APIRevisionListItemModel> { existingRevision });
+            _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
+                .ReturnsAsync(new List<CommentItemModel>());
+            _mockApiRevisionsManager.Setup(m => m.SoftDeleteAPIRevisionAsync(
+                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+            _mockApiRevisionsManager.Setup(m => m.CreateAPIRevisionAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
+                    It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
+                    It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
+                .ReturnsAsync(newRevision);
+
+            var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
+                _testUser, codeFile, "test-label", "test.json", memoryStream, null);
+
+            // Candidate must be deleted even though content is identical
+            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "existing-revision"),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+
+            // A new revision must always be created
+            _mockApiRevisionsManager.Verify(m => m.CreateAPIRevisionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
+                It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
+                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Once);
+
+            apiRevision.Should().NotBeNull();
+            apiRevision.Id.Should().Be("new-revision");
+        }
+
         #endregion
 
         #region Rolling Build / Package Version Tests
 
         /// <summary>
-        /// Rolling (alpha/nightly) builds produce a new package version every day even when the API surface
-        /// is identical, e.g. 1.4.0-alpha.20201211.0 → 1.4.0-alpha.20201212.0.
-        ///
-        /// The candidate reuse check uses <c>considerPackageVersion=false</c> because the pre-filter already
-        /// scopes candidates to the same <c>APIVersionId</c>. This means rolling builds with identical API
-        /// surface correctly reuse the previous day's revision instead of creating a new one each time.
+        /// Rolling (alpha/nightly) builds produce a new package version every day,
+        /// e.g. 1.4.0-alpha.20201211.0 → 1.4.0-alpha.20201212.0.
+        /// The previous pending revision is always deleted and a fresh one created.
+        /// Both belong to the same <c>APIVersionId</c> so the v1-stable bucket is never touched.
         /// </summary>
         [Fact]
-        public async Task CreateAutomaticRevisionAsync_RollingAlphaBuild_WithSameAPISurface_ReusesExistingRevision()
+        public async Task CreateAutomaticRevisionAsync_RollingAlphaBuild_DeletesPreviousAndCreatesNew()
         {
-            // Incoming: daily alpha build with a new date in the version
             var codeFile = CreateCodeFile("TestPackage", "1.4.0-alpha.20201212.0", "C#");
             using var memoryStream = new MemoryStream();
 
             var review = new ReviewListItemModel { Id = "review-id", PackageName = "TestPackage", Language = "C#" };
             var versionModel = new APIVersionModel { Id = "ver-alpha" };
 
-            // Previous day's build — same API surface, only version date differs
             var previousBuild = new APIRevisionListItemModel
             {
                 Id = "alpha-20201211",
@@ -681,6 +671,8 @@ namespace APIViewUnitTests
                 Files = [new APICodeFileModel { PackageVersion = "1.4.0-alpha.20201211.0" }]
             };
 
+            var newBuild = new APIRevisionListItemModel { Id = "alpha-20201212", ReviewId = "review-id" };
+
             _mockReviewManager.Setup(m => m.GetReviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
                 .ReturnsAsync(review);
             _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
@@ -689,26 +681,87 @@ namespace APIViewUnitTests
                 .ReturnsAsync(versionModel);
             _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
                 .ReturnsAsync(new List<CommentItemModel>());
-
-            // Candidate reuse check uses considerPackageVersion=false — API surface is identical
-            _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
-                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<RenderedCodeFile>(), false, It.IsAny<string>()))
-                .ReturnsAsync(true);
+            _mockApiRevisionsManager.Setup(m => m.SoftDeleteAPIRevisionAsync(
+                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+            _mockApiRevisionsManager.Setup(m => m.CreateAPIRevisionAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
+                    It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
+                    It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
+                .ReturnsAsync(newBuild);
 
             var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
                 _testUser, codeFile, "build-label", "test.json", memoryStream, null);
 
-            // Previous build reused — no delete, no new revision
+            // Previous build deleted, fresh revision created
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-
+                It.Is<APIRevisionListItemModel>(r => r.Id == "alpha-20201211"),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Once);
             _mockApiRevisionsManager.Verify(m => m.CreateAPIRevisionAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
                 It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
-                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never);
+                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Once);
 
             apiRevision.Should().NotBeNull();
-            apiRevision.Id.Should().Be("alpha-20201211");
+            apiRevision.Id.Should().Be("alpha-20201212");
+        }
+
+        /// <summary>
+        /// Even when a rolling build uploads identical API surface to the previous day,
+        /// the previous revision is deleted and a new one created — no reuse.
+        /// </summary>
+        [Fact]
+        public async Task CreateAutomaticRevisionAsync_RollingAlphaBuild_WithSameAPISurface_StillDeletesAndCreatesNew()
+        {
+            // Same API surface as yesterday's build — only the date in the version string differs
+            var codeFile = CreateCodeFile("TestPackage", "1.4.0-alpha.20201212.0", "C#");
+            using var memoryStream = new MemoryStream();
+
+            var review = new ReviewListItemModel { Id = "review-id", PackageName = "TestPackage", Language = "C#" };
+            var versionModel = new APIVersionModel { Id = "ver-alpha" };
+
+            var previousBuild = new APIRevisionListItemModel
+            {
+                Id = "alpha-20201211", ReviewId = "review-id",
+                APIRevisionType = APIRevisionType.Automatic,
+                IsApproved = false, APIVersionId = "ver-alpha",
+                CreatedOn = DateTime.UtcNow.AddDays(-1),
+                Files = [new APICodeFileModel { PackageVersion = "1.4.0-alpha.20201211.0" }]
+            };
+
+            var newBuild = new APIRevisionListItemModel { Id = "alpha-20201212", ReviewId = "review-id" };
+
+            _mockReviewManager.Setup(m => m.GetReviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
+                .ReturnsAsync(review);
+            _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
+                .ReturnsAsync(new List<APIRevisionListItemModel> { previousBuild });
+            _mockApiVersionsManager.Setup(m => m.GetOrCreateVersionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
+                .ReturnsAsync(versionModel);
+            _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
+                .ReturnsAsync(new List<CommentItemModel>());
+            _mockApiRevisionsManager.Setup(m => m.SoftDeleteAPIRevisionAsync(
+                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+            _mockApiRevisionsManager.Setup(m => m.CreateAPIRevisionAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
+                    It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
+                    It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
+                .ReturnsAsync(newBuild);
+
+            var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
+                _testUser, codeFile, "build-label", "test.json", memoryStream, null);
+
+            // Identical API surface is not a reason to reuse — must delete old and create new
+            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "alpha-20201211"),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            _mockApiRevisionsManager.Verify(m => m.CreateAPIRevisionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
+                It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
+                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Once);
+
+            apiRevision.Should().NotBeNull();
+            apiRevision.Id.Should().Be("alpha-20201212");
         }
 
         #endregion
@@ -780,7 +833,7 @@ namespace APIViewUnitTests
         /// Revisions for a different version are excluded from cleanup entirely.
         ///
         /// History (newest first):
-        ///   B3 — pending, v2-beta  (same version as incoming, matches content → reused)
+        ///   B3 — pending, v2-beta  (same version as incoming — candidate, deleted)
         ///   B2 — pending, v1-stable  (different version — must never be touched)
         ///   B1 — pending, v1-stable  (different version — must never be touched)
         /// </summary>
@@ -829,18 +882,27 @@ namespace APIViewUnitTests
             _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
                 .ReturnsAsync(new List<CommentItemModel>());
 
-            // B3 matches incoming → reused, no new revision created
-            _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
-                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<RenderedCodeFile>(), It.IsAny<bool>(), It.IsAny<string>()))
-                .ReturnsAsync(true);
+            _mockApiRevisionsManager.Setup(m => m.SoftDeleteAPIRevisionAsync(
+                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+            _mockApiRevisionsManager.Setup(m => m.CreateAPIRevisionAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
+                    It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
+                    It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
+                .ReturnsAsync(new APIRevisionListItemModel { Id = "new-v2beta", ReviewId = "review-id" });
 
             (_, APIRevisionListItemModel apiRevision) = await _service.CreateAutomaticRevisionAsync(
                 _testUser, codeFile, "build-label", "test.json", memoryStream, null);
 
             apiRevision.Should().NotBeNull();
-            apiRevision.Id.Should().Be("b3-v2beta");
+            apiRevision.Id.Should().Be("new-v2beta");
 
-            // v1-stable revisions are never even visited — must never be touched
+            // B3 (v2-beta candidate) is deleted and replaced
+            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b3-v2beta"),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+
+            // v1-stable revisions are never touched
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
                 It.Is<APIRevisionListItemModel>(r => r.Id == "b1-v1stable"),
                 It.IsAny<string>(), It.IsAny<string>()), Times.Never);

--- a/src/dotnet/APIView/APIViewUnitTests/AutoReviewServiceTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/AutoReviewServiceTests.cs
@@ -222,123 +222,6 @@ namespace APIViewUnitTests
 
         #endregion
 
-        #region Version Comparison and Revision Reuse Tests
-
-        [Fact]
-        public async Task CreateAutomaticRevisionAsync_WithSameVersionAndContent_ReusesExistingRevision()
-        {
-            var codeFile = CreateCodeFile("TestPackage", "1.0.0", "C#");
-            using var memoryStream = new MemoryStream();
-
-            var existingReview = new ReviewListItemModel
-            {
-                Id = "review-id",
-                PackageName = "TestPackage",
-                Language = "C#"
-            };
-
-            var existingRevision = new APIRevisionListItemModel
-            {
-                Id = "existing-revision-id",
-                ReviewId = "review-id",
-                APIRevisionType = APIRevisionType.Automatic,
-                IsApproved = false,
-                IsReleased = false,
-                CreatedOn = DateTime.UtcNow.AddDays(-1),
-                Files = new List<APICodeFileModel> { new APICodeFileModel { PackageVersion = "1.0.0" } }
-            };
-
-            _mockReviewManager.Setup(m => m.GetReviewAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
-                .ReturnsAsync(existingReview);
-
-            _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
-                .ReturnsAsync(new List<APIRevisionListItemModel> { existingRevision });
-
-            _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
-                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<RenderedCodeFile>(), It.IsAny<bool>(), It.IsAny<string>()))
-                .ReturnsAsync(true); // Same content
-
-            _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
-                .ReturnsAsync(new List<CommentItemModel>());
-
-            var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
-                _testUser, codeFile, "test-label", "test.json", memoryStream, null);
-
-            _mockApiRevisionsManager.Verify(m => m.CreateAPIRevisionAsync(
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
-                It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
-                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never);
-
-            apiRevision.Should().NotBeNull();
-            apiRevision.Id.Should().Be("existing-revision-id");
-        }
-
-        [Fact]
-        public async Task CreateAutomaticRevisionAsync_WithDifferentContent_CreatesNewRevision()
-        {
-            var codeFile = CreateCodeFile("TestPackage", "1.1.0", "C#");
-            using var memoryStream = new MemoryStream();
-
-            var existingReview = new ReviewListItemModel
-            {
-                Id = "review-id",
-                PackageName = "TestPackage",
-                Language = "C#"
-            };
-
-            var existingRevision = new APIRevisionListItemModel
-            {
-                Id = "existing-revision-id",
-                ReviewId = "review-id",
-                APIRevisionType = APIRevisionType.Automatic,
-                IsApproved = false,
-                IsReleased = false,
-                CreatedOn = DateTime.UtcNow.AddDays(-1),
-                Files = new List<APICodeFileModel> { new APICodeFileModel { PackageVersion = "1.0.0" } }
-            };
-
-            var newRevision = new APIRevisionListItemModel
-            {
-                Id = "new-revision-id",
-                ReviewId = "review-id"
-            };
-
-            _mockReviewManager.Setup(m => m.GetReviewAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
-                .ReturnsAsync(existingReview);
-
-            _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
-                .ReturnsAsync(new List<APIRevisionListItemModel> { existingRevision });
-
-            _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
-                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<RenderedCodeFile>(), It.IsAny<bool>(), It.IsAny<string>()))
-                .ReturnsAsync(false); // Different content
-
-            _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
-                .ReturnsAsync(new List<CommentItemModel>());
-
-            _mockApiRevisionsManager.Setup(m => m.CreateAPIRevisionAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
-                    It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
-                    It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
-                .ReturnsAsync(newRevision);
-
-            var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
-                _testUser, codeFile, "test-label", "test.json", memoryStream, null);
-
-            _mockApiRevisionsManager.Verify(m => m.CreateAPIRevisionAsync(
-                "testuser", "review-id", APIRevisionType.Automatic,
-                "test-label", memoryStream, codeFile, "test.json", null, null), Times.Once);
-
-            apiRevision.Should().NotBeNull();
-            apiRevision.Id.Should().Be("new-revision-id");
-        }
-
-        #endregion
-
         #region Compare All Revisions Tests
 
         [Fact]
@@ -454,13 +337,8 @@ namespace APIViewUnitTests
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
                 .ReturnsAsync(new List<APIRevisionListItemModel> { approvedRevision });
 
-            // New content doesn't match existing revision for version comparison (so we create a new one)
-            _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
-                    It.Is<APIRevisionListItemModel>(r => r.Id == "approved-revision-id"),
-                    It.IsAny<RenderedCodeFile>(), true, It.IsAny<string>()))
-                .ReturnsAsync(false);
-
-            // But for approval copying (no version consideration), the content DOES match
+            // The approved revision is excluded as a candidate (!r.IsApproved filter), so a new revision is created.
+            // In the post-creation approval-copying loop, the API surface matches → approval is carried forward.
             _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
                     It.Is<APIRevisionListItemModel>(r => r.Id == "approved-revision-id"),
                     It.IsAny<RenderedCodeFile>(), false, It.IsAny<string>()))
@@ -642,9 +520,10 @@ namespace APIViewUnitTests
         #region Deleted Revision Bug Tests
 
         [Fact]
-        public async Task CreateAutomaticRevisionAsync_WhenAllPendingRevisionsDeleted_CreatesNewRevision()
+        public async Task CreateAutomaticRevisionAsync_WhenCandidateDoesntMatch_DeletesCandidateAndCreatesNew()
         {
-            // This test covers Edge Case 1: Multiple pending revisions that don't match get deleted
+            // Only the newest unprotected revision (the candidate) is deleted when it doesn't match.
+            // Older pending revisions are left alone — handled by the separate cleanup script.
             var codeFile = CreateCodeFile("TestPackage", "1.0.0", "C#");
             using var memoryStream = new MemoryStream();
 
@@ -723,18 +602,20 @@ namespace APIViewUnitTests
             var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
                 _testUser, codeFile, "test-label", "test.json", memoryStream, null);
 
-            // Verify all three revisions were deleted since none match the new content
+            // Only the candidate (newest = pending-revision-3) is deleted
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
                 It.Is<APIRevisionListItemModel>(r => r.Id == "pending-revision-3"),
                 It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+
+            // Older revisions are left alone
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
                 It.Is<APIRevisionListItemModel>(r => r.Id == "pending-revision-2"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never);
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
                 It.Is<APIRevisionListItemModel>(r => r.Id == "pending-revision-1"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never);
 
-            // Should create new revision because pending-revision-1 doesn't match
+            // New revision created because candidate didn't match
             _mockApiRevisionsManager.Verify(m => m.CreateAPIRevisionAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
                 It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
@@ -745,10 +626,10 @@ namespace APIViewUnitTests
         }
 
         [Fact]
-        public async Task CreateAutomaticRevisionAsync_WhenRevisionMatchesWithVersionConsideration_ReusesIt()
+        public async Task CreateAutomaticRevisionAsync_WhenCandidateMatchesAPISurface_ReusesIt()
         {
-            // The reuse check uses considerPackageVersion=true when the incoming code file has a version.
-            // A revision that matches with version should be reused, not deleted and recreated.
+            // The candidate reuse check compares only API surface (considerPackageVersion=false).
+            // The pre-filter already scopes candidates to the same APIVersionId, so version is irrelevant here.
             var codeFile = CreateCodeFile("TestPackage", "1.0.0", "C#");
             using var memoryStream = new MemoryStream();
 
@@ -778,9 +659,9 @@ namespace APIViewUnitTests
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
                 .ReturnsAsync(new List<APIRevisionListItemModel> { pendingRevision });
 
-            // Matches when version is considered (considerPackageVersion=true)
+            // Candidate reuse check uses considerPackageVersion=false — API surface matches
             _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
-                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<RenderedCodeFile>(), true, It.IsAny<string>()))
+                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<RenderedCodeFile>(), false, It.IsAny<string>()))
                 .ReturnsAsync(true);
 
             _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
@@ -789,7 +670,7 @@ namespace APIViewUnitTests
             var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
                 _testUser, codeFile, "test-label", "test.json", memoryStream, null);
 
-            // Revision matches → reused, not deleted
+            // Candidate matches → reused, not deleted
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
                 It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
 
@@ -803,9 +684,11 @@ namespace APIViewUnitTests
         }
 
         [Fact]
-        public async Task CreateAutomaticRevisionAsync_WhenRevisionWithCommentsNotDeleted_CanReuseIt()
+        public async Task CreateAutomaticRevisionAsync_WhenOnlyRevisionHasComment_CreatesNewRevision()
         {
-            // Verify that revisions with comments are not deleted and can be reused
+            // A revision with comments is protected and skipped when selecting the candidate.
+            // Since there is no unprotected candidate, a new revision is created.
+            // The commented revision is never deleted.
             var codeFile = CreateCodeFile("TestPackage", "1.0.0", "C#");
             using var memoryStream = new MemoryStream();
 
@@ -827,6 +710,8 @@ namespace APIViewUnitTests
                 Files = new List<APICodeFileModel> { new APICodeFileModel { PackageVersion = "1.0.0" } }
             };
 
+            var newRevision = new APIRevisionListItemModel { Id = "new-revision-id", ReviewId = "review-id" };
+
             var comment = new CommentItemModel
             {
                 Id = "comment-1",
@@ -842,28 +727,94 @@ namespace APIViewUnitTests
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
                 .ReturnsAsync(new List<APIRevisionListItemModel> { revisionWithComments });
 
-            _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
-                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<RenderedCodeFile>(), It.IsAny<bool>(), It.IsAny<string>()))
-                .ReturnsAsync(true); // Same content
-
             _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
                 .ReturnsAsync(new List<CommentItemModel> { comment });
+
+            _mockApiRevisionsManager.Setup(m => m.CreateAPIRevisionAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
+                    It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
+                    It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
+                .ReturnsAsync(newRevision);
 
             var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
                 _testUser, codeFile, "test-label", "test.json", memoryStream, null);
 
-            // Should NOT delete revision with comments
+            // Commented revision is never touched
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
                 It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
 
-            // Should reuse existing revision
+            // New revision created since there was no usable candidate
+            _mockApiRevisionsManager.Verify(m => m.CreateAPIRevisionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
+                It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
+                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Once);
+
+            apiRevision.Should().NotBeNull();
+            apiRevision.Id.Should().Be("new-revision-id");
+        }
+
+        #endregion
+
+        #region Rolling Build / Package Version Tests
+
+        /// <summary>
+        /// Rolling (alpha/nightly) builds produce a new package version every day even when the API surface
+        /// is identical, e.g. 1.4.0-alpha.20201211.0 → 1.4.0-alpha.20201212.0.
+        ///
+        /// The candidate reuse check uses <c>considerPackageVersion=false</c> because the pre-filter already
+        /// scopes candidates to the same <c>APIVersionId</c>. This means rolling builds with identical API
+        /// surface correctly reuse the previous day's revision instead of creating a new one each time.
+        /// </summary>
+        [Fact]
+        public async Task CreateAutomaticRevisionAsync_RollingAlphaBuild_WithSameAPISurface_ReusesExistingRevision()
+        {
+            // Incoming: daily alpha build with a new date in the version
+            var codeFile = CreateCodeFile("TestPackage", "1.4.0-alpha.20201212.0", "C#");
+            using var memoryStream = new MemoryStream();
+
+            var review = new ReviewListItemModel { Id = "review-id", PackageName = "TestPackage", Language = "C#" };
+            var versionModel = new APIVersionModel { Id = "ver-alpha" };
+
+            // Previous day's build — same API surface, only version date differs
+            var previousBuild = new APIRevisionListItemModel
+            {
+                Id = "alpha-20201211",
+                ReviewId = "review-id",
+                APIRevisionType = APIRevisionType.Automatic,
+                IsApproved = false,
+                APIVersionId = "ver-alpha",
+                CreatedOn = DateTime.UtcNow.AddDays(-1),
+                Files = [new APICodeFileModel { PackageVersion = "1.4.0-alpha.20201211.0" }]
+            };
+
+            _mockReviewManager.Setup(m => m.GetReviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
+                .ReturnsAsync(review);
+            _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
+                .ReturnsAsync(new List<APIRevisionListItemModel> { previousBuild });
+            _mockApiVersionsManager.Setup(m => m.GetOrCreateVersionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
+                .ReturnsAsync(versionModel);
+            _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
+                .ReturnsAsync(new List<CommentItemModel>());
+
+            // Candidate reuse check uses considerPackageVersion=false — API surface is identical
+            _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
+                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<RenderedCodeFile>(), false, It.IsAny<string>()))
+                .ReturnsAsync(true);
+
+            var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
+                _testUser, codeFile, "build-label", "test.json", memoryStream, null);
+
+            // Previous build reused — no delete, no new revision
+            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
+                It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+
             _mockApiRevisionsManager.Verify(m => m.CreateAPIRevisionAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
                 It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
                 It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never);
 
             apiRevision.Should().NotBeNull();
-            apiRevision.Id.Should().Be("revision-with-comments");
+            apiRevision.Id.Should().Be("alpha-20201211");
         }
 
         #endregion
@@ -1009,21 +960,16 @@ namespace APIViewUnitTests
         #region Multi-Build Progression Tests
 
         /// <summary>
-        /// Simulates a realistic sequence of CI builds arriving for the same package:
+        /// When incoming content matches the candidate (newest unprotected), it is reused.
+        /// Older pending revisions are not touched — only the candidate is evaluated.
         ///
-        /// History (newest first, all same version / version filter disabled):
-        ///   B4 — pending, different content  (most recent build, e.g. new API change)
-        ///   B3 — pending, same content as B4 (duplicate CI run)
-        ///   B2 — pending, same content as B4 (another duplicate)
-        ///   B1 — approved                    (anchor — must never be touched)
+        /// History (newest first):
+        ///   B4 — pending (candidate — matches incoming)
+        ///   B3 — pending (not the candidate, not touched)
+        ///   B2 — pending (not the candidate, not touched)
+        ///   B1 — approved anchor (not touched)
         ///
-        /// Expected outcome when B5 (also same content as B4) arrives:
-        ///   - B4 is kept as the candidate (newest unprotected)
-        ///   - B3 is deleted  (older unprotected)
-        ///   - B2 is deleted  (older unprotected)
-        ///   - B1 is NOT deleted (approved anchor — hard stop)
-        ///   - B5 is NOT created (B4 content matches incoming)
-        ///   - Returned revision is B4
+        /// Expected outcome: B4 reused, nothing deleted, no new revision created.
         /// </summary>
         [Fact]
         public async Task CreateAutomaticRevisionAsync_MultiBuildProgression_OnlyNewestPendingKept()
@@ -1113,40 +1059,24 @@ namespace APIViewUnitTests
             apiRevision.Should().NotBeNull();
             apiRevision.Id.Should().Be("b4-pending");
 
-            // B3 and B2 (older unprotected) are deleted
+            // Nothing deleted — candidate matched and was reused
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "b3-pending"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Once, "B3 should be deleted as an older unprotected revision");
-
-            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "b2-pending"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Once, "B2 should be deleted as an older unprotected revision");
-
-            // B4 (kept as candidate) must NOT be deleted
-            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "b4-pending"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B4 is the candidate and must be kept");
-
-            // B1 (approved anchor) must NOT be deleted
-            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "b1-approved"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B1 is approved and must never be touched");
+                It.IsAny<APIRevisionListItemModel>(),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
 
         /// <summary>
-        /// Same multi-build history but the incoming build (B5) has a NEW API change (different content).
+        /// When incoming content does NOT match the candidate (newest unprotected),
+        /// only the candidate is deleted and a new revision is created.
+        /// Older pending revisions are not touched.
         ///
         /// History (newest first):
-        ///   B4 — pending, old content
-        ///   B3 — pending, old content
-        ///   B2 — pending, old content
-        ///   B1 — approved anchor
+        ///   B4 — pending (candidate — doesn't match)
+        ///   B3 — pending (not the candidate, not touched)
+        ///   B2 — pending (not the candidate, not touched)
+        ///   B1 — approved anchor (not touched)
         ///
-        /// Expected outcome when B5 (new content) arrives:
-        ///   - B4 is kept as candidate (newest unprotected — never deleted by cleanup)
-        ///   - B3 and B2 are deleted (older unprotected)
-        ///   - B1 is NOT deleted (approved anchor)
-        ///   - B5 is created as a new revision 
+        /// Expected outcome: B4 deleted, B5 created, B3/B2/B1 untouched.
         /// </summary>
         [Fact]
         public async Task CreateAutomaticRevisionAsync_MultiBuildProgression_NewAPIChange_CreatesNewRevision()
@@ -1228,18 +1158,18 @@ namespace APIViewUnitTests
             apiRevision.Should().NotBeNull();
             apiRevision.Id.Should().Be("b5-new");
 
-            // B4 is the candidate but doesn't match — deleted before new revision is created
+            // Only B4 (candidate) is deleted — B3, B2, B1 are not touched
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
                 It.Is<APIRevisionListItemModel>(r => r.Id == "b4-pending"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Once, "B4 is stale and must be deleted before B5 is created");
+                It.IsAny<string>(), It.IsAny<string>()), Times.Once, "B4 is the candidate and must be deleted");
 
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
                 It.Is<APIRevisionListItemModel>(r => r.Id == "b3-pending"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Once, "B3 should be deleted");
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B3 is not the candidate and must not be touched");
 
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
                 It.Is<APIRevisionListItemModel>(r => r.Id == "b2-pending"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Once, "B2 should be deleted");
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B2 is not the candidate and must not be touched");
 
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
                 It.Is<APIRevisionListItemModel>(r => r.Id == "b1-approved"),
@@ -1252,19 +1182,16 @@ namespace APIViewUnitTests
         }
 
         /// <summary>
-        /// Pending revisions exist both above and below an approval anchor, and the
-        /// second-newest pending revision has a comment attached (protected).
+        /// Protected revisions (commented, approved, released) are skipped when selecting the candidate.
+        /// The first unprotected revision is selected, regardless of what comes after it.
         ///
         /// History (newest first):
-        ///   B4 — pending, no comments
-        ///   B3 — pending, HAS a comment  ← protected
-        ///   B2 — pending, no comments
-        ///   B1 — approved anchor
+        ///   B4 — pending, no comments  ← candidate
+        ///   B3 — HAS a comment (protected — skipped by FirstOrDefault)
+        ///   B2 — pending, no comments  (skipped — not the candidate)
+        ///   B1 — approved anchor       (protected — skipped)
         ///
-        /// Expected outcome when B5 (any content) arrives:
-        ///   - B4 is kept as candidate
-        ///   - B3 is hit: protected by comment → hard stop, B2 is never visited
-        ///   - B2 and B1 are NOT deleted
+        /// Expected outcome: B4 deleted (candidate, doesn't match), B5 created, B3/B2/B1 untouched.
         /// </summary>
         [Fact]
         public async Task CreateAutomaticRevisionAsync_MultiBuildProgression_StopsAtCommentedRevision()
@@ -1339,20 +1266,20 @@ namespace APIViewUnitTests
             apiRevision.Should().NotBeNull();
             apiRevision.Id.Should().Be("b5-new");
 
-            // B4 is the candidate but doesn't match — deleted before new revision is created
+            // B4 (candidate) is deleted before B5 is created
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
                 It.Is<APIRevisionListItemModel>(r => r.Id == "b4-pending"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Once, "B4 is stale and must be deleted before B5 is created");
+                It.IsAny<string>(), It.IsAny<string>()), Times.Once, "B4 is the candidate and must be deleted");
 
-            // B3 has a comment → hard stop, must NOT be deleted
+            // B3 has a comment — skipped as candidate, must NOT be deleted
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
                 It.Is<APIRevisionListItemModel>(r => r.Id == "b3-with-comment"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B3 has a comment and must be kept");
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B3 has a comment and must not be touched");
 
-            // B2 is never reached because B3 caused a hard stop
+            // B2 is not the candidate and must not be touched
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
                 It.Is<APIRevisionListItemModel>(r => r.Id == "b2-pending"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B2 is behind the comment anchor and must not be touched");
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B2 is not the candidate and must not be touched");
 
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
                 It.Is<APIRevisionListItemModel>(r => r.Id == "b1-approved"),

--- a/src/dotnet/APIView/APIViewUnitTests/AutoReviewServiceTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/AutoReviewServiceTests.cs
@@ -745,10 +745,10 @@ namespace APIViewUnitTests
         }
 
         [Fact]
-        public async Task CreateAutomaticRevisionAsync_WhenLastRevisionDeletedButMatchesWithVersion_CreatesNewRevision()
+        public async Task CreateAutomaticRevisionAsync_WhenRevisionMatchesWithVersionConsideration_ReusesIt()
         {
-            // This test covers Edge Case 2: Comparison parameter inconsistency
-            // Without version: different (deleted), with version: same (would match after deletion)
+            // The reuse check uses considerPackageVersion=true when the incoming code file has a version.
+            // A revision that matches with version should be reused, not deleted and recreated.
             var codeFile = CreateCodeFile("TestPackage", "1.0.0", "C#");
             using var memoryStream = new MemoryStream();
 
@@ -761,19 +761,13 @@ namespace APIViewUnitTests
 
             var pendingRevision = new APIRevisionListItemModel
             {
-                Id = "pending-revision-to-delete",
+                Id = "pending-revision",
                 ReviewId = "review-id",
                 APIRevisionType = APIRevisionType.Automatic,
                 IsApproved = false,
                 IsReleased = false,
                 CreatedOn = DateTime.UtcNow.AddDays(-1),
                 Files = new List<APICodeFileModel> { new APICodeFileModel { PackageVersion = "1.0.0" } }
-            };
-
-            var newRevision = new APIRevisionListItemModel
-            {
-                Id = "new-revision-id",
-                ReviewId = "review-id"
             };
 
             _mockReviewManager.Setup(m => m.GetReviewAsync(
@@ -784,44 +778,28 @@ namespace APIViewUnitTests
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
                 .ReturnsAsync(new List<APIRevisionListItemModel> { pendingRevision });
 
-            // Setup comparison: without version = false (different), with version = true (same)
-            _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
-                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<RenderedCodeFile>(), false, It.IsAny<string>()))
-                .ReturnsAsync(false); // Different without version, so it gets deleted
-
+            // Matches when version is considered (considerPackageVersion=true)
             _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
                     It.IsAny<APIRevisionListItemModel>(), It.IsAny<RenderedCodeFile>(), true, It.IsAny<string>()))
-                .ReturnsAsync(true); // Same with version, would match if not deleted
+                .ReturnsAsync(true);
 
             _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
                 .ReturnsAsync(new List<CommentItemModel>());
 
-            _mockApiRevisionsManager.Setup(m => m.SoftDeleteAPIRevisionAsync(
-                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(Task.CompletedTask);
-
-            _mockApiRevisionsManager.Setup(m => m.CreateAPIRevisionAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
-                    It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
-                    It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
-                .ReturnsAsync(newRevision);
-
             var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
                 _testUser, codeFile, "test-label", "test.json", memoryStream, null);
 
-            // Verify revision was deleted
+            // Revision matches → reused, not deleted
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "pending-revision-to-delete"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+                It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
 
-            // Should create new revision instead of returning deleted one (even though it would match with version)
             _mockApiRevisionsManager.Verify(m => m.CreateAPIRevisionAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
                 It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
-                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Once);
+                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never);
 
             apiRevision.Should().NotBeNull();
-            apiRevision.Id.Should().Be("new-revision-id");
+            apiRevision.Id.Should().Be("pending-revision");
         }
 
         [Fact]
@@ -951,6 +929,434 @@ namespace APIViewUnitTests
                     It.Is<APIRevisionListItemModel>(r => r.Id == "rev-v2"),
                     It.IsAny<string>(), It.IsAny<string>()),
                 Times.Never);
+        }
+
+        /// <summary>
+        /// Revisions for a different version are excluded from cleanup entirely.
+        ///
+        /// History (newest first):
+        ///   B3 — pending, v2-beta  (same version as incoming, matches content → reused)
+        ///   B2 — pending, v1-stable  (different version — must never be touched)
+        ///   B1 — pending, v1-stable  (different version — must never be touched)
+        /// </summary>
+        [Fact]
+        public async Task CreateAutomaticRevisionAsync_DifferentVersionRevisions_NeverTouched()
+        {
+            var codeFile = CreateCodeFile("TestPackage", "2.0.0-beta", "C#");
+            using var memoryStream = new MemoryStream();
+
+            var review = new ReviewListItemModel { Id = "review-id", PackageName = "TestPackage", Language = "C#" };
+            var v2BetaVersionModel = new APIVersionModel { Id = "ver-v2-beta" };
+
+            var b1V1 = new APIRevisionListItemModel
+            {
+                Id = "b1-v1stable", ReviewId = "review-id",
+                APIRevisionType = APIRevisionType.Automatic,
+                APIVersionId = "ver-v1-stable",
+                CreatedOn = DateTime.UtcNow.AddDays(-5),
+                Files = [new APICodeFileModel { PackageVersion = "1.0.0" }]
+            };
+
+            var b2V1 = new APIRevisionListItemModel
+            {
+                Id = "b2-v1stable", ReviewId = "review-id",
+                APIRevisionType = APIRevisionType.Automatic,
+                APIVersionId = "ver-v1-stable",
+                CreatedOn = DateTime.UtcNow.AddDays(-3),
+                Files = [new APICodeFileModel { PackageVersion = "1.0.0" }]
+            };
+
+            var b3V2 = new APIRevisionListItemModel
+            {
+                Id = "b3-v2beta", ReviewId = "review-id",
+                APIRevisionType = APIRevisionType.Automatic,
+                APIVersionId = "ver-v2-beta",
+                CreatedOn = DateTime.UtcNow.AddDays(-1),
+                Files = [new APICodeFileModel { PackageVersion = "2.0.0-beta" }]
+            };
+
+            _mockReviewManager.Setup(m => m.GetReviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
+                .ReturnsAsync(review);
+            _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
+                .ReturnsAsync(new List<APIRevisionListItemModel> { b3V2, b2V1, b1V1 });
+            _mockApiVersionsManager.Setup(m => m.GetOrCreateVersionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
+                .ReturnsAsync(v2BetaVersionModel);
+            _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
+                .ReturnsAsync(new List<CommentItemModel>());
+
+            // B3 matches incoming → reused, no new revision created
+            _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
+                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<RenderedCodeFile>(), It.IsAny<bool>(), It.IsAny<string>()))
+                .ReturnsAsync(true);
+
+            (_, APIRevisionListItemModel apiRevision) = await _service.CreateAutomaticRevisionAsync(
+                _testUser, codeFile, "build-label", "test.json", memoryStream, null);
+
+            apiRevision.Should().NotBeNull();
+            apiRevision.Id.Should().Be("b3-v2beta");
+
+            // v1-stable revisions are never even visited — must never be touched
+            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b1-v1stable"),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b2-v1stable"),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        }
+
+        #endregion
+
+        #region Multi-Build Progression Tests
+
+        /// <summary>
+        /// Simulates a realistic sequence of CI builds arriving for the same package:
+        ///
+        /// History (newest first, all same version / version filter disabled):
+        ///   B4 — pending, different content  (most recent build, e.g. new API change)
+        ///   B3 — pending, same content as B4 (duplicate CI run)
+        ///   B2 — pending, same content as B4 (another duplicate)
+        ///   B1 — approved                    (anchor — must never be touched)
+        ///
+        /// Expected outcome when B5 (also same content as B4) arrives:
+        ///   - B4 is kept as the candidate (newest unprotected)
+        ///   - B3 is deleted  (older unprotected)
+        ///   - B2 is deleted  (older unprotected)
+        ///   - B1 is NOT deleted (approved anchor — hard stop)
+        ///   - B5 is NOT created (B4 content matches incoming)
+        ///   - Returned revision is B4
+        /// </summary>
+        [Fact]
+        public async Task CreateAutomaticRevisionAsync_MultiBuildProgression_OnlyNewestPendingKept()
+        {
+            var codeFile = CreateCodeFile("TestPackage", "2.0.0", "C#");
+            using var memoryStream = new MemoryStream();
+
+            var review = new ReviewListItemModel { Id = "review-id", PackageName = "TestPackage", Language = "C#" };
+
+            // B1 - approved anchor (oldest)
+            var b1Approved = new APIRevisionListItemModel
+            {
+                Id = "b1-approved",
+                ReviewId = "review-id",
+                APIRevisionType = APIRevisionType.Automatic,
+                IsApproved = true,
+                IsReleased = false,
+                CreatedOn = DateTime.UtcNow.AddDays(-10),
+                Files = [new APICodeFileModel { PackageVersion = "1.0.0" }]
+            };
+
+            // B2 - pending, same content as incoming (2nd oldest)
+            var b2Pending = new APIRevisionListItemModel
+            {
+                Id = "b2-pending",
+                ReviewId = "review-id",
+                APIRevisionType = APIRevisionType.Automatic,
+                IsApproved = false,
+                IsReleased = false,
+                CreatedOn = DateTime.UtcNow.AddDays(-3),
+                Files = [new APICodeFileModel { PackageVersion = "2.0.0" }]
+            };
+
+            // B3 - pending, same content as incoming (2nd newest)
+            var b3Pending = new APIRevisionListItemModel
+            {
+                Id = "b3-pending",
+                ReviewId = "review-id",
+                APIRevisionType = APIRevisionType.Automatic,
+                IsApproved = false,
+                IsReleased = false,
+                CreatedOn = DateTime.UtcNow.AddDays(-2),
+                Files = [new APICodeFileModel { PackageVersion = "2.0.0" }]
+            };
+
+            // B4 - pending, same content as incoming (newest)
+            var b4Pending = new APIRevisionListItemModel
+            {
+                Id = "b4-pending",
+                ReviewId = "review-id",
+                APIRevisionType = APIRevisionType.Automatic,
+                IsApproved = false,
+                IsReleased = false,
+                CreatedOn = DateTime.UtcNow.AddDays(-1),
+                Files = [new APICodeFileModel { PackageVersion = "2.0.0" }]
+            };
+
+            _mockReviewManager.Setup(m => m.GetReviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
+                .ReturnsAsync(review);
+
+            // Ordered newest first (as OrderByDescending produces)
+            _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
+                .ReturnsAsync(new List<APIRevisionListItemModel> { b4Pending, b3Pending, b2Pending, b1Approved });
+
+            _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
+                .ReturnsAsync(new List<CommentItemModel>());
+
+            _mockApiRevisionsManager.Setup(m => m.SoftDeleteAPIRevisionAsync(
+                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+
+            // B4 matches incoming content (reuse check after cleanup)
+            _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
+                    It.Is<APIRevisionListItemModel>(r => r.Id == "b4-pending"),
+                    It.IsAny<RenderedCodeFile>(), It.IsAny<bool>(), It.IsAny<string>()))
+                .ReturnsAsync(true);
+
+            (_, APIRevisionListItemModel apiRevision) = await _service.CreateAutomaticRevisionAsync(
+                _testUser, codeFile, "build-5-label", "test.json", memoryStream, null);
+
+            // B4 is reused — no new revision created
+            _mockApiRevisionsManager.Verify(m => m.CreateAPIRevisionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
+                It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
+                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never);
+
+            apiRevision.Should().NotBeNull();
+            apiRevision.Id.Should().Be("b4-pending");
+
+            // B3 and B2 (older unprotected) are deleted
+            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b3-pending"),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Once, "B3 should be deleted as an older unprotected revision");
+
+            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b2-pending"),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Once, "B2 should be deleted as an older unprotected revision");
+
+            // B4 (kept as candidate) must NOT be deleted
+            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b4-pending"),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B4 is the candidate and must be kept");
+
+            // B1 (approved anchor) must NOT be deleted
+            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b1-approved"),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B1 is approved and must never be touched");
+        }
+
+        /// <summary>
+        /// Same multi-build history but the incoming build (B5) has a NEW API change (different content).
+        ///
+        /// History (newest first):
+        ///   B4 — pending, old content
+        ///   B3 — pending, old content
+        ///   B2 — pending, old content
+        ///   B1 — approved anchor
+        ///
+        /// Expected outcome when B5 (new content) arrives:
+        ///   - B4 is kept as candidate (newest unprotected — never deleted by cleanup)
+        ///   - B3 and B2 are deleted (older unprotected)
+        ///   - B1 is NOT deleted (approved anchor)
+        ///   - B5 is created as a new revision 
+        /// </summary>
+        [Fact]
+        public async Task CreateAutomaticRevisionAsync_MultiBuildProgression_NewAPIChange_CreatesNewRevision()
+        {
+            var codeFile = CreateCodeFile("TestPackage", "2.0.0", "C#");
+            using var memoryStream = new MemoryStream();
+
+            var review = new ReviewListItemModel { Id = "review-id", PackageName = "TestPackage", Language = "C#" };
+
+            var b1Approved = new APIRevisionListItemModel
+            {
+                Id = "b1-approved",
+                ReviewId = "review-id",
+                APIRevisionType = APIRevisionType.Automatic,
+                IsApproved = true,
+                CreatedOn = DateTime.UtcNow.AddDays(-10),
+                Files = [new APICodeFileModel { PackageVersion = "1.0.0" }]
+            };
+
+            var b2Pending = new APIRevisionListItemModel
+            {
+                Id = "b2-pending",
+                ReviewId = "review-id",
+                APIRevisionType = APIRevisionType.Automatic,
+                IsApproved = false,
+                CreatedOn = DateTime.UtcNow.AddDays(-3),
+                Files = [new APICodeFileModel { PackageVersion = "2.0.0" }]
+            };
+
+            var b3Pending = new APIRevisionListItemModel
+            {
+                Id = "b3-pending",
+                ReviewId = "review-id",
+                APIRevisionType = APIRevisionType.Automatic,
+                IsApproved = false,
+                CreatedOn = DateTime.UtcNow.AddDays(-2),
+                Files = [new APICodeFileModel { PackageVersion = "2.0.0" }]
+            };
+
+            var b4Pending = new APIRevisionListItemModel
+            {
+                Id = "b4-pending",
+                ReviewId = "review-id",
+                APIRevisionType = APIRevisionType.Automatic,
+                IsApproved = false,
+                CreatedOn = DateTime.UtcNow.AddDays(-1),
+                Files = [new APICodeFileModel { PackageVersion = "2.0.0" }]
+            };
+
+            var b5New = new APIRevisionListItemModel { Id = "b5-new", ReviewId = "review-id" };
+
+            _mockReviewManager.Setup(m => m.GetReviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
+                .ReturnsAsync(review);
+
+            _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
+                .ReturnsAsync(new List<APIRevisionListItemModel> { b4Pending, b3Pending, b2Pending, b1Approved });
+
+            _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
+                .ReturnsAsync(new List<CommentItemModel>());
+
+            _mockApiRevisionsManager.Setup(m => m.SoftDeleteAPIRevisionAsync(
+                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+
+            // None of the existing revisions match incoming content (new API change)
+            _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
+                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<RenderedCodeFile>(), It.IsAny<bool>(), It.IsAny<string>()))
+                .ReturnsAsync(false);
+
+            _mockApiRevisionsManager.Setup(m => m.CreateAPIRevisionAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
+                    It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
+                    It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
+                .ReturnsAsync(b5New);
+
+            var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
+                _testUser, codeFile, "build-5-label", "test.json", memoryStream, null);
+
+            apiRevision.Should().NotBeNull();
+            apiRevision.Id.Should().Be("b5-new");
+
+            // B4 is the candidate but doesn't match — deleted before new revision is created
+            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b4-pending"),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Once, "B4 is stale and must be deleted before B5 is created");
+
+            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b3-pending"),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Once, "B3 should be deleted");
+
+            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b2-pending"),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Once, "B2 should be deleted");
+
+            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b1-approved"),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B1 is approved and must never be touched");
+
+            _mockApiRevisionsManager.Verify(m => m.CreateAPIRevisionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
+                It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
+                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Once);
+        }
+
+        /// <summary>
+        /// Pending revisions exist both above and below an approval anchor, and the
+        /// second-newest pending revision has a comment attached (protected).
+        ///
+        /// History (newest first):
+        ///   B4 — pending, no comments
+        ///   B3 — pending, HAS a comment  ← protected
+        ///   B2 — pending, no comments
+        ///   B1 — approved anchor
+        ///
+        /// Expected outcome when B5 (any content) arrives:
+        ///   - B4 is kept as candidate
+        ///   - B3 is hit: protected by comment → hard stop, B2 is never visited
+        ///   - B2 and B1 are NOT deleted
+        /// </summary>
+        [Fact]
+        public async Task CreateAutomaticRevisionAsync_MultiBuildProgression_StopsAtCommentedRevision()
+        {
+            var codeFile = CreateCodeFile("TestPackage", "2.0.0", "C#");
+            using var memoryStream = new MemoryStream();
+
+            var review = new ReviewListItemModel { Id = "review-id", PackageName = "TestPackage", Language = "C#" };
+
+            var b1Approved = new APIRevisionListItemModel
+            {
+                Id = "b1-approved", ReviewId = "review-id",
+                APIRevisionType = APIRevisionType.Automatic,
+                IsApproved = true, CreatedOn = DateTime.UtcNow.AddDays(-10),
+                Files = new List<APICodeFileModel> { new APICodeFileModel { PackageVersion = "2.0.0" } }
+            };
+
+            var b2Pending = new APIRevisionListItemModel
+            {
+                Id = "b2-pending", ReviewId = "review-id",
+                APIRevisionType = APIRevisionType.Automatic,
+                IsApproved = false, CreatedOn = DateTime.UtcNow.AddDays(-3),
+                Files = new List<APICodeFileModel> { new APICodeFileModel { PackageVersion = "2.0.0" } }
+            };
+
+            var b3WithComment = new APIRevisionListItemModel
+            {
+                Id = "b3-with-comment", ReviewId = "review-id",
+                APIRevisionType = APIRevisionType.Automatic,
+                IsApproved = false, CreatedOn = DateTime.UtcNow.AddDays(-2),
+                Files = new List<APICodeFileModel> { new APICodeFileModel { PackageVersion = "2.0.0" } }
+            };
+
+            var b4Pending = new APIRevisionListItemModel
+            {
+                Id = "b4-pending", ReviewId = "review-id",
+                APIRevisionType = APIRevisionType.Automatic,
+                IsApproved = false, CreatedOn = DateTime.UtcNow.AddDays(-1),
+                Files = new List<APICodeFileModel> { new APICodeFileModel { PackageVersion = "2.0.0" } }
+            };
+
+            var b5New = new APIRevisionListItemModel { Id = "b5-new", ReviewId = "review-id" };
+            var comment = new CommentItemModel { APIRevisionId = "b3-with-comment", ReviewId = "review-id" };
+
+            _mockReviewManager.Setup(m => m.GetReviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
+                .ReturnsAsync(review);
+
+            _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
+                .ReturnsAsync(new List<APIRevisionListItemModel> { b4Pending, b3WithComment, b2Pending, b1Approved });
+
+            _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
+                .ReturnsAsync(new List<CommentItemModel> { comment });
+
+            _mockApiRevisionsManager.Setup(m => m.SoftDeleteAPIRevisionAsync(
+                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+
+            // B4 doesn't match; B5 is new content
+            _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
+                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<RenderedCodeFile>(), It.IsAny<bool>(), It.IsAny<string>()))
+                .ReturnsAsync(false);
+
+            _mockApiRevisionsManager.Setup(m => m.CreateAPIRevisionAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
+                    It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
+                    It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
+                .ReturnsAsync(b5New);
+
+            var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
+                _testUser, codeFile, "build-5-label", "test.json", memoryStream, null);
+
+            apiRevision.Should().NotBeNull();
+            apiRevision.Id.Should().Be("b5-new");
+
+            // B4 is the candidate but doesn't match — deleted before new revision is created
+            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b4-pending"),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Once, "B4 is stale and must be deleted before B5 is created");
+
+            // B3 has a comment → hard stop, must NOT be deleted
+            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b3-with-comment"),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B3 has a comment and must be kept");
+
+            // B2 is never reached because B3 caused a hard stop
+            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b2-pending"),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B2 is behind the comment anchor and must not be touched");
+
+            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b1-approved"),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B1 is approved and must never be touched");
         }
 
         #endregion

--- a/src/dotnet/APIView/APIViewUnitTests/AutoReviewServiceTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/AutoReviewServiceTests.cs
@@ -520,112 +520,6 @@ namespace APIViewUnitTests
         #region Deleted Revision Bug Tests
 
         [Fact]
-        public async Task CreateAutomaticRevisionAsync_WhenCandidateDoesntMatch_DeletesCandidateAndCreatesNew()
-        {
-            // Only the newest unprotected revision (the candidate) is deleted when it doesn't match.
-            // Older pending revisions are left alone — handled by the separate cleanup script.
-            var codeFile = CreateCodeFile("TestPackage", "1.0.0", "C#");
-            using var memoryStream = new MemoryStream();
-
-            var existingReview = new ReviewListItemModel
-            {
-                Id = "review-id",
-                PackageName = "TestPackage",
-                Language = "C#"
-            };
-
-            var pendingRevision1 = new APIRevisionListItemModel
-            {
-                Id = "pending-revision-1",
-                ReviewId = "review-id",
-                APIRevisionType = APIRevisionType.Automatic,
-                IsApproved = false,
-                IsReleased = false,
-                CreatedOn = DateTime.UtcNow.AddDays(-3),
-                Files = new List<APICodeFileModel> { new APICodeFileModel { PackageVersion = "0.9.0" } }
-            };
-
-            var pendingRevision2 = new APIRevisionListItemModel
-            {
-                Id = "pending-revision-2",
-                ReviewId = "review-id",
-                APIRevisionType = APIRevisionType.Automatic,
-                IsApproved = false,
-                IsReleased = false,
-                CreatedOn = DateTime.UtcNow.AddDays(-2),
-                Files = new List<APICodeFileModel> { new APICodeFileModel { PackageVersion = "0.9.1" } }
-            };
-
-            var pendingRevision3 = new APIRevisionListItemModel
-            {
-                Id = "pending-revision-3",
-                ReviewId = "review-id",
-                APIRevisionType = APIRevisionType.Automatic,
-                IsApproved = false,
-                IsReleased = false,
-                CreatedOn = DateTime.UtcNow.AddDays(-1),
-                Files = new List<APICodeFileModel> { new APICodeFileModel { PackageVersion = "0.9.2" } }
-            };
-
-            var newRevision = new APIRevisionListItemModel
-            {
-                Id = "new-revision-id",
-                ReviewId = "review-id"
-            };
-
-            _mockReviewManager.Setup(m => m.GetReviewAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
-                .ReturnsAsync(existingReview);
-
-            _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
-                .ReturnsAsync(new List<APIRevisionListItemModel> { pendingRevision3, pendingRevision2, pendingRevision1 });
-
-            // All revisions don't match the new content (so they get deleted)
-            _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
-                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<RenderedCodeFile>(), It.IsAny<bool>(), It.IsAny<string>()))
-                .ReturnsAsync(false);
-
-            _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
-                .ReturnsAsync(new List<CommentItemModel>());
-
-            _mockApiRevisionsManager.Setup(m => m.SoftDeleteAPIRevisionAsync(
-                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(Task.CompletedTask);
-
-            _mockApiRevisionsManager.Setup(m => m.CreateAPIRevisionAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
-                    It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
-                    It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
-                .ReturnsAsync(newRevision);
-
-            var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
-                _testUser, codeFile, "test-label", "test.json", memoryStream, null);
-
-            // Only the candidate (newest = pending-revision-3) is deleted
-            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "pending-revision-3"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Once);
-
-            // Older revisions are left alone
-            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "pending-revision-2"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "pending-revision-1"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-
-            // New revision created because candidate didn't match
-            _mockApiRevisionsManager.Verify(m => m.CreateAPIRevisionAsync(
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
-                It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
-                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Once);
-
-            apiRevision.Should().NotBeNull();
-            apiRevision.Id.Should().Be("new-revision-id");
-        }
-
-        [Fact]
         public async Task CreateAutomaticRevisionAsync_WhenCandidateMatchesAPISurface_ReusesIt()
         {
             // The candidate reuse check compares only API surface (considerPackageVersion=false).
@@ -960,220 +854,73 @@ namespace APIViewUnitTests
         #region Multi-Build Progression Tests
 
         /// <summary>
-        /// When incoming content matches the candidate (newest unprotected), it is reused.
-        /// Older pending revisions are not touched — only the candidate is evaluated.
-        ///
-        /// History (newest first):
-        ///   B4 — pending (candidate — matches incoming)
-        ///   B3 — pending (not the candidate, not touched)
-        ///   B2 — pending (not the candidate, not touched)
-        ///   B1 — approved anchor (not touched)
-        ///
-        /// Expected outcome: B4 reused, nothing deleted, no new revision created.
-        /// </summary>
-        [Fact]
-        public async Task CreateAutomaticRevisionAsync_MultiBuildProgression_OnlyNewestPendingKept()
-        {
-            var codeFile = CreateCodeFile("TestPackage", "2.0.0", "C#");
-            using var memoryStream = new MemoryStream();
-
-            var review = new ReviewListItemModel { Id = "review-id", PackageName = "TestPackage", Language = "C#" };
-
-            // B1 - approved anchor (oldest)
-            var b1Approved = new APIRevisionListItemModel
-            {
-                Id = "b1-approved",
-                ReviewId = "review-id",
-                APIRevisionType = APIRevisionType.Automatic,
-                IsApproved = true,
-                IsReleased = false,
-                CreatedOn = DateTime.UtcNow.AddDays(-10),
-                Files = [new APICodeFileModel { PackageVersion = "1.0.0" }]
-            };
-
-            // B2 - pending, same content as incoming (2nd oldest)
-            var b2Pending = new APIRevisionListItemModel
-            {
-                Id = "b2-pending",
-                ReviewId = "review-id",
-                APIRevisionType = APIRevisionType.Automatic,
-                IsApproved = false,
-                IsReleased = false,
-                CreatedOn = DateTime.UtcNow.AddDays(-3),
-                Files = [new APICodeFileModel { PackageVersion = "2.0.0" }]
-            };
-
-            // B3 - pending, same content as incoming (2nd newest)
-            var b3Pending = new APIRevisionListItemModel
-            {
-                Id = "b3-pending",
-                ReviewId = "review-id",
-                APIRevisionType = APIRevisionType.Automatic,
-                IsApproved = false,
-                IsReleased = false,
-                CreatedOn = DateTime.UtcNow.AddDays(-2),
-                Files = [new APICodeFileModel { PackageVersion = "2.0.0" }]
-            };
-
-            // B4 - pending, same content as incoming (newest)
-            var b4Pending = new APIRevisionListItemModel
-            {
-                Id = "b4-pending",
-                ReviewId = "review-id",
-                APIRevisionType = APIRevisionType.Automatic,
-                IsApproved = false,
-                IsReleased = false,
-                CreatedOn = DateTime.UtcNow.AddDays(-1),
-                Files = [new APICodeFileModel { PackageVersion = "2.0.0" }]
-            };
-
-            _mockReviewManager.Setup(m => m.GetReviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
-                .ReturnsAsync(review);
-
-            // Ordered newest first (as OrderByDescending produces)
-            _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
-                .ReturnsAsync(new List<APIRevisionListItemModel> { b4Pending, b3Pending, b2Pending, b1Approved });
-
-            _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
-                .ReturnsAsync(new List<CommentItemModel>());
-
-            _mockApiRevisionsManager.Setup(m => m.SoftDeleteAPIRevisionAsync(
-                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(Task.CompletedTask);
-
-            // B4 matches incoming content (reuse check after cleanup)
-            _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
-                    It.Is<APIRevisionListItemModel>(r => r.Id == "b4-pending"),
-                    It.IsAny<RenderedCodeFile>(), It.IsAny<bool>(), It.IsAny<string>()))
-                .ReturnsAsync(true);
-
-            (_, APIRevisionListItemModel apiRevision) = await _service.CreateAutomaticRevisionAsync(
-                _testUser, codeFile, "build-5-label", "test.json", memoryStream, null);
-
-            // B4 is reused — no new revision created
-            _mockApiRevisionsManager.Verify(m => m.CreateAPIRevisionAsync(
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
-                It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
-                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never);
-
-            apiRevision.Should().NotBeNull();
-            apiRevision.Id.Should().Be("b4-pending");
-
-            // Nothing deleted — candidate matched and was reused
-            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.IsAny<APIRevisionListItemModel>(),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-        }
-
-        /// <summary>
         /// When incoming content does NOT match the candidate (newest unprotected),
         /// only the candidate is deleted and a new revision is created.
         /// Older pending revisions are not touched.
         ///
         /// History (newest first):
-        ///   B4 — pending (candidate — doesn't match)
-        ///   B3 — pending (not the candidate, not touched)
-        ///   B2 — pending (not the candidate, not touched)
-        ///   B1 — approved anchor (not touched)
+        ///   B2 — pending (candidate — doesn't match → deleted)
+        ///   B1 — pending (older, not the candidate — not touched)
         ///
-        /// Expected outcome: B4 deleted, B5 created, B3/B2/B1 untouched.
+        /// Expected outcome: B2 deleted, B3 created, B1 untouched.
         /// </summary>
         [Fact]
-        public async Task CreateAutomaticRevisionAsync_MultiBuildProgression_NewAPIChange_CreatesNewRevision()
+        public async Task CreateAutomaticRevisionAsync_WhenCandidateDoesntMatch_OnlyCandidateIsDeleted()
         {
             var codeFile = CreateCodeFile("TestPackage", "2.0.0", "C#");
             using var memoryStream = new MemoryStream();
 
             var review = new ReviewListItemModel { Id = "review-id", PackageName = "TestPackage", Language = "C#" };
 
-            var b1Approved = new APIRevisionListItemModel
+            var b1Pending = new APIRevisionListItemModel
             {
-                Id = "b1-approved",
-                ReviewId = "review-id",
+                Id = "b1-pending", ReviewId = "review-id",
                 APIRevisionType = APIRevisionType.Automatic,
-                IsApproved = true,
-                CreatedOn = DateTime.UtcNow.AddDays(-10),
-                Files = [new APICodeFileModel { PackageVersion = "1.0.0" }]
+                IsApproved = false, CreatedOn = DateTime.UtcNow.AddDays(-2),
+                Files = [new APICodeFileModel { PackageVersion = "2.0.0" }]
             };
 
             var b2Pending = new APIRevisionListItemModel
             {
-                Id = "b2-pending",
-                ReviewId = "review-id",
+                Id = "b2-pending", ReviewId = "review-id",
                 APIRevisionType = APIRevisionType.Automatic,
-                IsApproved = false,
-                CreatedOn = DateTime.UtcNow.AddDays(-3),
+                IsApproved = false, CreatedOn = DateTime.UtcNow.AddDays(-1),
                 Files = [new APICodeFileModel { PackageVersion = "2.0.0" }]
             };
 
-            var b3Pending = new APIRevisionListItemModel
-            {
-                Id = "b3-pending",
-                ReviewId = "review-id",
-                APIRevisionType = APIRevisionType.Automatic,
-                IsApproved = false,
-                CreatedOn = DateTime.UtcNow.AddDays(-2),
-                Files = [new APICodeFileModel { PackageVersion = "2.0.0" }]
-            };
-
-            var b4Pending = new APIRevisionListItemModel
-            {
-                Id = "b4-pending",
-                ReviewId = "review-id",
-                APIRevisionType = APIRevisionType.Automatic,
-                IsApproved = false,
-                CreatedOn = DateTime.UtcNow.AddDays(-1),
-                Files = [new APICodeFileModel { PackageVersion = "2.0.0" }]
-            };
-
-            var b5New = new APIRevisionListItemModel { Id = "b5-new", ReviewId = "review-id" };
+            var b3New = new APIRevisionListItemModel { Id = "b3-new", ReviewId = "review-id" };
 
             _mockReviewManager.Setup(m => m.GetReviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
                 .ReturnsAsync(review);
-
             _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
-                .ReturnsAsync(new List<APIRevisionListItemModel> { b4Pending, b3Pending, b2Pending, b1Approved });
-
+                .ReturnsAsync(new List<APIRevisionListItemModel> { b2Pending, b1Pending });
             _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
                 .ReturnsAsync(new List<CommentItemModel>());
-
             _mockApiRevisionsManager.Setup(m => m.SoftDeleteAPIRevisionAsync(
                     It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(Task.CompletedTask);
-
-            // None of the existing revisions match incoming content (new API change)
             _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
                     It.IsAny<APIRevisionListItemModel>(), It.IsAny<RenderedCodeFile>(), It.IsAny<bool>(), It.IsAny<string>()))
                 .ReturnsAsync(false);
-
             _mockApiRevisionsManager.Setup(m => m.CreateAPIRevisionAsync(
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
                     It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
                     It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
-                .ReturnsAsync(b5New);
+                .ReturnsAsync(b3New);
 
             var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
-                _testUser, codeFile, "build-5-label", "test.json", memoryStream, null);
+                _testUser, codeFile, "build-label", "test.json", memoryStream, null);
 
             apiRevision.Should().NotBeNull();
-            apiRevision.Id.Should().Be("b5-new");
-
-            // Only B4 (candidate) is deleted — B3, B2, B1 are not touched
-            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "b4-pending"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Once, "B4 is the candidate and must be deleted");
-
-            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "b3-pending"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B3 is not the candidate and must not be touched");
+            apiRevision.Id.Should().Be("b3-new");
 
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
                 It.Is<APIRevisionListItemModel>(r => r.Id == "b2-pending"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B2 is not the candidate and must not be touched");
+                It.IsAny<string>(), It.IsAny<string>()), Times.Once, "B2 is the candidate and must be deleted");
 
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "b1-approved"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B1 is approved and must never be touched");
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b1-pending"),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B1 is not the candidate and must not be touched");
 
             _mockApiRevisionsManager.Verify(m => m.CreateAPIRevisionAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
@@ -1182,19 +929,19 @@ namespace APIViewUnitTests
         }
 
         /// <summary>
-        /// Protected revisions (commented, approved, released) are skipped when selecting the candidate.
-        /// The first unprotected revision is selected, regardless of what comes after it.
+        /// When the newest revision has a comment it is protected and skipped by <c>FirstOrDefault</c>.
+        /// The next newest unprotected revision becomes the candidate instead.
         ///
         /// History (newest first):
-        ///   B4 — pending, no comments  ← candidate
-        ///   B3 — HAS a comment (protected — skipped by FirstOrDefault)
-        ///   B2 — pending, no comments  (skipped — not the candidate)
+        ///   B4 — HAS a comment  (protected — skipped by FirstOrDefault)
+        ///   B3 — pending, no comments  ← candidate
+        ///   B2 — pending, no comments  (not the candidate)
         ///   B1 — approved anchor       (protected — skipped)
         ///
-        /// Expected outcome: B4 deleted (candidate, doesn't match), B5 created, B3/B2/B1 untouched.
+        /// Expected outcome: B3 deleted (candidate, doesn't match), B5 created, B4/B2/B1 untouched.
         /// </summary>
         [Fact]
-        public async Task CreateAutomaticRevisionAsync_MultiBuildProgression_StopsAtCommentedRevision()
+        public async Task CreateAutomaticRevisionAsync_WhenNewestRevisionHasComment_SkipsItAndSelectsNextAsCandidate()
         {
             var codeFile = CreateCodeFile("TestPackage", "2.0.0", "C#");
             using var memoryStream = new MemoryStream();
@@ -1217,30 +964,31 @@ namespace APIViewUnitTests
                 Files = new List<APICodeFileModel> { new APICodeFileModel { PackageVersion = "2.0.0" } }
             };
 
-            var b3WithComment = new APIRevisionListItemModel
+            var b3Pending = new APIRevisionListItemModel
             {
-                Id = "b3-with-comment", ReviewId = "review-id",
+                Id = "b3-pending", ReviewId = "review-id",
                 APIRevisionType = APIRevisionType.Automatic,
                 IsApproved = false, CreatedOn = DateTime.UtcNow.AddDays(-2),
                 Files = new List<APICodeFileModel> { new APICodeFileModel { PackageVersion = "2.0.0" } }
             };
 
-            var b4Pending = new APIRevisionListItemModel
+            // Newest revision — but protected by a comment, so it is skipped as candidate
+            var b4WithComment = new APIRevisionListItemModel
             {
-                Id = "b4-pending", ReviewId = "review-id",
+                Id = "b4-with-comment", ReviewId = "review-id",
                 APIRevisionType = APIRevisionType.Automatic,
                 IsApproved = false, CreatedOn = DateTime.UtcNow.AddDays(-1),
                 Files = new List<APICodeFileModel> { new APICodeFileModel { PackageVersion = "2.0.0" } }
             };
 
             var b5New = new APIRevisionListItemModel { Id = "b5-new", ReviewId = "review-id" };
-            var comment = new CommentItemModel { APIRevisionId = "b3-with-comment", ReviewId = "review-id" };
+            var comment = new CommentItemModel { APIRevisionId = "b4-with-comment", ReviewId = "review-id" };
 
             _mockReviewManager.Setup(m => m.GetReviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
                 .ReturnsAsync(review);
 
             _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
-                .ReturnsAsync(new List<APIRevisionListItemModel> { b4Pending, b3WithComment, b2Pending, b1Approved });
+                .ReturnsAsync(new List<APIRevisionListItemModel> { b4WithComment, b3Pending, b2Pending, b1Approved });
 
             _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
                 .ReturnsAsync(new List<CommentItemModel> { comment });
@@ -1249,7 +997,7 @@ namespace APIViewUnitTests
                     It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(Task.CompletedTask);
 
-            // B4 doesn't match; B5 is new content
+            // B3 (candidate) doesn't match incoming content
             _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
                     It.IsAny<APIRevisionListItemModel>(), It.IsAny<RenderedCodeFile>(), It.IsAny<bool>(), It.IsAny<string>()))
                 .ReturnsAsync(false);
@@ -1266,15 +1014,15 @@ namespace APIViewUnitTests
             apiRevision.Should().NotBeNull();
             apiRevision.Id.Should().Be("b5-new");
 
-            // B4 (candidate) is deleted before B5 is created
+            // B3 is the candidate (B4 was skipped due to comment) — it must be deleted
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "b4-pending"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Once, "B4 is the candidate and must be deleted");
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b3-pending"),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Once, "B3 is the candidate and must be deleted");
 
-            // B3 has a comment — skipped as candidate, must NOT be deleted
+            // B4 has a comment — it was skipped as candidate and must NOT be deleted
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "b3-with-comment"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B3 has a comment and must not be touched");
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b4-with-comment"),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B4 has a comment and must not be touched");
 
             // B2 is not the candidate and must not be touched
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(

--- a/src/dotnet/APIView/APIViewUnitTests/AutoReviewServiceTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/AutoReviewServiceTests.cs
@@ -646,9 +646,8 @@ namespace APIViewUnitTests
         #region Rolling Build / Package Version Tests
 
         /// <summary>
-        /// Rolling (alpha/nightly) builds produce a new package version every day,
-        /// e.g. 1.4.0-alpha.20201211.0 → 1.4.0-alpha.20201212.0.
-        /// The previous pending revision is always deleted and a fresh one created.
+        /// Rollin builds that re-run with the same version string
+        /// (e.g. a CI retry) delete the previous pending revision and create a fresh one.
         /// Both belong to the same <c>APIVersionId</c> so the v1-stable bucket is never touched.
         /// </summary>
         [Fact]
@@ -660,18 +659,19 @@ namespace APIViewUnitTests
             var review = new ReviewListItemModel { Id = "review-id", PackageName = "TestPackage", Language = "C#" };
             var versionModel = new APIVersionModel { Id = "ver-alpha" };
 
+            // Same version as the incoming build — represents a CI retry or resubmit
             var previousBuild = new APIRevisionListItemModel
             {
-                Id = "alpha-20201211",
+                Id = "alpha-20201212-prev",
                 ReviewId = "review-id",
                 APIRevisionType = APIRevisionType.Automatic,
                 IsApproved = false,
                 APIVersionId = "ver-alpha",
-                CreatedOn = DateTime.UtcNow.AddDays(-1),
-                Files = [new APICodeFileModel { PackageVersion = "1.4.0-alpha.20201211.0" }]
+                CreatedOn = DateTime.UtcNow.AddHours(-1),
+                Files = [new APICodeFileModel { PackageVersion = "1.4.0-alpha.20201212.0" }]
             };
 
-            var newBuild = new APIRevisionListItemModel { Id = "alpha-20201212", ReviewId = "review-id" };
+            var newBuild = new APIRevisionListItemModel { Id = "alpha-20201212-new", ReviewId = "review-id" };
 
             _mockReviewManager.Setup(m => m.GetReviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
                 .ReturnsAsync(review);
@@ -693,9 +693,9 @@ namespace APIViewUnitTests
             var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
                 _testUser, codeFile, "build-label", "test.json", memoryStream, null);
 
-            // Previous build deleted, fresh revision created
+            // Previous build (same version) is deleted; fresh revision created
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "alpha-20201211"),
+                It.Is<APIRevisionListItemModel>(r => r.Id == "alpha-20201212-prev"),
                 It.IsAny<string>(), It.IsAny<string>()), Times.Once);
             _mockApiRevisionsManager.Verify(m => m.CreateAPIRevisionAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
@@ -703,33 +703,27 @@ namespace APIViewUnitTests
                 It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Once);
 
             apiRevision.Should().NotBeNull();
-            apiRevision.Id.Should().Be("alpha-20201212");
+            apiRevision.Id.Should().Be("alpha-20201212-new");
         }
 
-        /// <summary>
-        /// Even when a rolling build uploads identical API surface to the previous day,
-        /// the previous revision is deleted and a new one created — no reuse.
-        /// </summary>
         [Fact]
-        public async Task CreateAutomaticRevisionAsync_RollingAlphaBuild_WithSameAPISurface_StillDeletesAndCreatesNew()
+        public async Task CreateAutomaticRevisionAsync_RollingAlphaBuild_DifferentDailyVersion_OnlyCreatesRevision()
         {
-            // Same API surface as yesterday's build — only the date in the version string differs
-            var codeFile = CreateCodeFile("TestPackage", "1.4.0-alpha.20201212.0", "C#");
+            var codeFile = CreateCodeFile("TestPackage", "1.4.0", "C#");
             using var memoryStream = new MemoryStream();
 
             var review = new ReviewListItemModel { Id = "review-id", PackageName = "TestPackage", Language = "C#" };
             var versionModel = new APIVersionModel { Id = "ver-alpha" };
-
             var previousBuild = new APIRevisionListItemModel
             {
-                Id = "alpha-20201211", ReviewId = "review-id",
+                Id = "beta-20201211", ReviewId = "review-id",
                 APIRevisionType = APIRevisionType.Automatic,
                 IsApproved = false, APIVersionId = "ver-alpha",
                 CreatedOn = DateTime.UtcNow.AddDays(-1),
-                Files = [new APICodeFileModel { PackageVersion = "1.4.0-alpha.20201211.0" }]
+                Files = [new APICodeFileModel { PackageVersion = "1.5.0" }]
             };
 
-            var newBuild = new APIRevisionListItemModel { Id = "alpha-20201212", ReviewId = "review-id" };
+            var newBuild = new APIRevisionListItemModel { Id = "beta-20201212", ReviewId = "review-id" };
 
             _mockReviewManager.Setup(m => m.GetReviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
                 .ReturnsAsync(review);
@@ -751,17 +745,89 @@ namespace APIViewUnitTests
             var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
                 _testUser, codeFile, "build-label", "test.json", memoryStream, null);
 
-            // Identical API surface is not a reason to reuse — must delete old and create new
+            // Different versions — no candidate match, nothing is deleted
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "alpha-20201211"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+                It.IsAny<APIRevisionListItemModel>(),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+
+            // A new revision is still always created
             _mockApiRevisionsManager.Verify(m => m.CreateAPIRevisionAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
                 It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
                 It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Once);
 
             apiRevision.Should().NotBeNull();
-            apiRevision.Id.Should().Be("alpha-20201212");
+            apiRevision.Id.Should().Be("beta-20201212");
+        }
+
+        /// <summary>
+        /// When <c>codeFile.PackageVersion</c> is null, empty, or whitespace, no existing revision
+        /// can ever match the candidate filter (<c>r.PackageVersion == codeFile.PackageVersion</c>
+        /// will be false for any revision that carries a real version string), so nothing is deleted
+        /// and a new revision is always created — and nothing throws.
+        /// </summary>
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public async Task CreateAutomaticRevisionAsync_NullOrEmptyPackageVersion_NothingDeletedNewRevisionCreated(string packageVersion)
+        {
+            var codeFile = new CodeFile
+            {
+                Name = "test", Language = "C#",
+                PackageName = "TestPackage",
+                PackageVersion = packageVersion
+            };
+            using var memoryStream = new MemoryStream();
+
+            var review = new ReviewListItemModel { Id = "review-id", PackageName = "TestPackage", Language = "C#" };
+            var versionModel = new APIVersionModel { Id = "ver-1" };
+
+            var existingRevision = new APIRevisionListItemModel
+            {
+                Id = "existing", ReviewId = "review-id",
+                APIRevisionType = APIRevisionType.Automatic,
+                IsApproved = false, IsReleased = false,
+                CreatedOn = DateTime.UtcNow.AddDays(-1),
+                Files = [new APICodeFileModel { PackageVersion = "1.0.0" }]
+            };
+
+            var newRevision = new APIRevisionListItemModel { Id = "new-rev", ReviewId = "review-id" };
+
+            _mockReviewManager.Setup(m => m.GetReviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
+                .ReturnsAsync(review);
+            _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
+                .ReturnsAsync(new List<APIRevisionListItemModel> { existingRevision });
+            _mockApiVersionsManager.Setup(m => m.GetOrCreateVersionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
+                .ReturnsAsync(versionModel);
+            _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
+                .ReturnsAsync(new List<CommentItemModel>());
+            _mockApiRevisionsManager.Setup(m => m.SoftDeleteAPIRevisionAsync(
+                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+            _mockApiRevisionsManager.Setup(m => m.CreateAPIRevisionAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
+                    It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
+                    It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
+                .ReturnsAsync(newRevision);
+
+            // Must not throw regardless of null/empty/whitespace PackageVersion
+            var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
+                _testUser, codeFile, "test-label", "test.json", memoryStream, null);
+
+            // Existing revision has a real version ("1.0.0") — it will never match null/empty/whitespace
+            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
+                It.IsAny<APIRevisionListItemModel>(),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+
+            // A new revision is always created
+            _mockApiRevisionsManager.Verify(m => m.CreateAPIRevisionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
+                It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
+                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Once);
+
+            apiRevision.Should().NotBeNull();
+            apiRevision.Id.Should().Be("new-rev");
         }
 
         #endregion
@@ -784,14 +850,16 @@ namespace APIViewUnitTests
                 Id = "rev-v1", ReviewId = "review-id",
                 APIRevisionType = APIRevisionType.Automatic, APIVersionId = "ver-v1",
                 IsApproved = false, IsReleased = false,
-                CreatedOn = DateTime.UtcNow.AddDays(-1), Files = new List<APICodeFileModel>()
+                CreatedOn = DateTime.UtcNow.AddDays(-1),
+                Files = [new APICodeFileModel { PackageVersion = "1.0.0" }]
             };
             var revisionV2 = new APIRevisionListItemModel
             {
                 Id = "rev-v2", ReviewId = "review-id",
                 APIRevisionType = APIRevisionType.Automatic, APIVersionId = "ver-v2",
                 IsApproved = false, IsReleased = false,
-                CreatedOn = DateTime.UtcNow.AddDays(-2), Files = new List<APICodeFileModel>()
+                CreatedOn = DateTime.UtcNow.AddDays(-2),
+                Files = [new APICodeFileModel { PackageVersion = "2.0.0" }]
             };
 
             _mockReviewManager.Setup(m => m.GetReviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))

--- a/src/dotnet/APIView/APIViewWeb/LeanModels/ReviewListModels.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanModels/ReviewListModels.cs
@@ -142,7 +142,7 @@ namespace APIViewWeb.LeanModels
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string PackageVersion
         {
-            get => this.Files.First().PackageVersion;
+            get => this.Files?.FirstOrDefault()?.PackageVersion;
         }
         public List<APIRevisionChangeHistoryModel> ChangeHistory { get; set; } = new List<APIRevisionChangeHistoryModel>();
         public APIRevisionType APIRevisionType { get; set; }

--- a/src/dotnet/APIView/APIViewWeb/Managers/AutoReviewService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/AutoReviewService.cs
@@ -48,7 +48,6 @@ public class AutoReviewService : IAutoReviewService
     {
         // Parse package type once at the beginning
         var parsedPackageType = !string.IsNullOrEmpty(packageType) && Enum.TryParse<PackageType>(packageType, true, out var result) ? (PackageType?)result : null;
-        var createNewRevision = true;
         var review = await _reviewManager.GetReviewAsync(packageName: codeFile.PackageName, language: codeFile.Language, isClosed: null);
         var apiRevision = default(APIRevisionListItemModel);
         var renderedCodeFile = new RenderedCodeFile(codeFile);
@@ -102,7 +101,8 @@ public class AutoReviewService : IAutoReviewService
 
                     // Find the newest pending automatic revision to replace.
                     var latestAutomaticAPIRevision = automaticRevisions.FirstOrDefault(
-                        r => !r.IsApproved && !r.IsReleased && !revisionIdsWithComments.Contains(r.Id));
+                        r => !r.IsApproved && !r.IsReleased && !revisionIdsWithComments.Contains(r.Id)
+                        && r.PackageVersion == codeFile.PackageVersion);
 
                     if (latestAutomaticAPIRevision != null)
                     {
@@ -115,11 +115,8 @@ public class AutoReviewService : IAutoReviewService
         {
             review = await _reviewManager.CreateReviewAsync(packageName: codeFile.PackageName, language: codeFile.Language, isClosed: false, packageType: parsedPackageType, crossLanguagePackageId: codeFile.CrossLanguagePackageId);
         }
-        
-        if (createNewRevision)
-        {
-            apiRevision = await _apiRevisionsManager.CreateAPIRevisionAsync(userName: user.GetGitHubLogin(), reviewId: review.Id, apiRevisionType: APIRevisionType.Automatic, label: label, memoryStream: memoryStream, codeFile: codeFile, originalName: originalName, sourceBranch: sourceBranch);
-        }
+
+        apiRevision = await _apiRevisionsManager.CreateAPIRevisionAsync(userName: user.GetGitHubLogin(), reviewId: review.Id, apiRevisionType: APIRevisionType.Automatic, label: label, memoryStream: memoryStream, codeFile: codeFile, originalName: originalName, sourceBranch: sourceBranch);
 
         await _projectsManager.TryLinkReviewToProjectAsync(user.GetGitHubLogin(), review);
 

--- a/src/dotnet/APIView/APIViewWeb/Managers/AutoReviewService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/AutoReviewService.cs
@@ -100,19 +100,11 @@ public class AutoReviewService : IAutoReviewService
                     var comments = await _commentsManager.GetCommentsAsync(review.Id);
                     var revisionIdsWithComments = comments.Select(c => c.APIRevisionId).ToHashSet();
 
-                    // Find the newest pending automatic revision that can be reused or replaced.
+                    // Find the newest pending automatic revision to replace.
                     var latestAutomaticAPIRevision = automaticRevisions.FirstOrDefault(
                         r => !r.IsApproved && !r.IsReleased && !revisionIdsWithComments.Contains(r.Id));
 
-                    // The pre-filter above already scopes candidates to the same APIVersionId, just checking for content
-                    // This allows rolling/nightly builds to reuse the existing revision when the API surface is unchanged.
-                    if (latestAutomaticAPIRevision != null &&
-                        await _apiRevisionsManager.AreAPIRevisionsTheSame(latestAutomaticAPIRevision, renderedCodeFile, false, incomingContentHash))
-                    {
-                        apiRevision = latestAutomaticAPIRevision;
-                        createNewRevision = false;
-                    }
-                    else if (latestAutomaticAPIRevision != null)
+                    if (latestAutomaticAPIRevision != null)
                     {
                         await _apiRevisionsManager.SoftDeleteAPIRevisionAsync(apiRevision: latestAutomaticAPIRevision, notes: "Deleted by Automatic Review Creation...");
                     }

--- a/src/dotnet/APIView/APIViewWeb/Managers/AutoReviewService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/AutoReviewService.cs
@@ -83,31 +83,34 @@ public class AutoReviewService : IAutoReviewService
                     .ToList();
                 if (automaticRevisions.Count > 0)
                 {
-                    var automaticRevisionsQueue = new Queue<APIRevisionListItemModel>(automaticRevisions);
                     var comments = await _commentsManager.GetCommentsAsync(review.Id);
+                    var revisionIdsWithComments = comments.Select(c => c.APIRevisionId).ToHashSet();
                     APIRevisionListItemModel latestAutomaticAPIRevision = null;
-                    
-                    while (automaticRevisionsQueue.Count > 0)
-                    {
-                        latestAutomaticAPIRevision = automaticRevisionsQueue.Dequeue();
 
-                        // Check if we should keep this revision
-                        if (latestAutomaticAPIRevision.IsApproved ||
-                            latestAutomaticAPIRevision.IsReleased ||
-                            await _apiRevisionsManager.AreAPIRevisionsTheSame(latestAutomaticAPIRevision, renderedCodeFile, incomingContentHash: incomingContentHash) ||
-                            comments.Any(c => latestAutomaticAPIRevision.Id == c.APIRevisionId))
+                    foreach (var revision in automaticRevisions)
+                    {
+                        // Hard stop: this revision and everything older is protected — stop processing
+                        if (revision.IsApproved || revision.IsReleased || revisionIdsWithComments.Contains(revision.Id))
                         {
+                            latestAutomaticAPIRevision ??= revision;
                             break;
                         }
 
-                        // Delete this revision
-                        await _apiRevisionsManager.SoftDeleteAPIRevisionAsync(apiRevision: latestAutomaticAPIRevision, notes: "Deleted by Automatic Review Creation...");
-                        latestAutomaticAPIRevision = null;  // Mark as consumed
+                        if (latestAutomaticAPIRevision == null)
+                        {
+                            // First (newest) unprotected revision: keep it as the candidate to reuse or replace
+                            latestAutomaticAPIRevision = revision;
+                        }
+                        else
+                        {
+                            // Older unprotected revision: always delete
+                            await _apiRevisionsManager.SoftDeleteAPIRevisionAsync(apiRevision: revision, notes: "Deleted by Automatic Review Creation...");
+                        }
                     }
 
-                    // We should compare against only latest revision when calling this API from scheduled CI runs
-                    // But any manual pipeline run at release time should compare against all approved revisions to ensure hotfix release doesn't have API change
-                    // If review surface doesn't match with any approved revisions then we will create new revision if it doesn't match pending latest revision
+                    // For release pipeline runs, compare against all approved revisions first to catch hotfix API changes.
+                    // Otherwise, check if the candidate revision (newest unprotected) matches the incoming content.
+                    // If it matches, reuse it. If not, delete the candidate and create a new revision.
 
                     bool considerPackageVersion = !string.IsNullOrWhiteSpace(codeFile.PackageVersion);
 
@@ -128,6 +131,14 @@ public class AutoReviewService : IAutoReviewService
                     {
                         apiRevision = latestAutomaticAPIRevision;
                         createNewRevision = false;
+                    }
+                    else if (latestAutomaticAPIRevision != null &&
+                             !latestAutomaticAPIRevision.IsApproved &&
+                             !latestAutomaticAPIRevision.IsReleased &&
+                             !revisionIdsWithComments.Contains(latestAutomaticAPIRevision.Id))
+                    {
+                        // Candidate doesn't match incoming content and is unprotected — delete it before creating the new revision
+                        await _apiRevisionsManager.SoftDeleteAPIRevisionAsync(apiRevision: latestAutomaticAPIRevision, notes: "Deleted by Automatic Review Creation...");
                     }
                 }
             }

--- a/src/dotnet/APIView/APIViewWeb/Managers/AutoReviewService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/AutoReviewService.cs
@@ -75,43 +75,15 @@ public class AutoReviewService : IAutoReviewService
                     incomingVersionModel = await _apiVersionsManager.GetOrCreateVersionAsync(review.Id, codeFile.PackageVersion);
                 }
 
-                // Delete pending apiRevisions if it is not in approved state before adding new revision
-                // This is to keep only one pending revision since last approval or from initial review revision.
+                // Scope to automatic revisions for the same logical version as the incoming upload.
                 var automaticRevisions = apiRevisions
                     .Where(r => r.APIRevisionType == APIRevisionType.Automatic
                         && (incomingVersionModel == null|| r.APIVersionId == incomingVersionModel.Id || string.IsNullOrEmpty(r.APIVersionId)))
                     .ToList();
                 if (automaticRevisions.Count > 0)
                 {
-                    var comments = await _commentsManager.GetCommentsAsync(review.Id);
-                    var revisionIdsWithComments = comments.Select(c => c.APIRevisionId).ToHashSet();
-                    APIRevisionListItemModel latestAutomaticAPIRevision = null;
-
-                    foreach (var revision in automaticRevisions)
-                    {
-                        // Hard stop: this revision and everything older is protected — stop processing
-                        if (revision.IsApproved || revision.IsReleased || revisionIdsWithComments.Contains(revision.Id))
-                        {
-                            latestAutomaticAPIRevision ??= revision;
-                            break;
-                        }
-
-                        if (latestAutomaticAPIRevision == null)
-                        {
-                            // First (newest) unprotected revision: keep it as the candidate to reuse or replace
-                            latestAutomaticAPIRevision = revision;
-                        }
-                        else
-                        {
-                            // Older unprotected revision: always delete
-                            await _apiRevisionsManager.SoftDeleteAPIRevisionAsync(apiRevision: revision, notes: "Deleted by Automatic Review Creation...");
-                        }
-                    }
-
                     // For release pipeline runs, compare against all approved revisions first to catch hotfix API changes.
-                    // Otherwise, check if the candidate revision (newest unprotected) matches the incoming content.
-                    // If it matches, reuse it. If not, delete the candidate and create a new revision.
-
+                    // Use the full package version in that comparison to distinguish stable releases from pre-release builds.
                     bool considerPackageVersion = !string.IsNullOrWhiteSpace(codeFile.PackageVersion);
 
                     if (compareAllRevisions)
@@ -125,19 +97,23 @@ public class AutoReviewService : IAutoReviewService
                         }
                     }
 
-                    // Only reuse latestAutomaticAPIRevision if one was kept
+                    var comments = await _commentsManager.GetCommentsAsync(review.Id);
+                    var revisionIdsWithComments = comments.Select(c => c.APIRevisionId).ToHashSet();
+
+                    // Find the newest pending automatic revision that can be reused or replaced.
+                    var latestAutomaticAPIRevision = automaticRevisions.FirstOrDefault(
+                        r => !r.IsApproved && !r.IsReleased && !revisionIdsWithComments.Contains(r.Id));
+
+                    // The pre-filter above already scopes candidates to the same APIVersionId, just checking for content
+                    // This allows rolling/nightly builds to reuse the existing revision when the API surface is unchanged.
                     if (latestAutomaticAPIRevision != null &&
-                        await _apiRevisionsManager.AreAPIRevisionsTheSame(latestAutomaticAPIRevision, renderedCodeFile, considerPackageVersion, incomingContentHash))
+                        await _apiRevisionsManager.AreAPIRevisionsTheSame(latestAutomaticAPIRevision, renderedCodeFile, false, incomingContentHash))
                     {
                         apiRevision = latestAutomaticAPIRevision;
                         createNewRevision = false;
                     }
-                    else if (latestAutomaticAPIRevision != null &&
-                             !latestAutomaticAPIRevision.IsApproved &&
-                             !latestAutomaticAPIRevision.IsReleased &&
-                             !revisionIdsWithComments.Contains(latestAutomaticAPIRevision.Id))
+                    else if (latestAutomaticAPIRevision != null)
                     {
-                        // Candidate doesn't match incoming content and is unprotected — delete it before creating the new revision
                         await _apiRevisionsManager.SoftDeleteAPIRevisionAsync(apiRevision: latestAutomaticAPIRevision, notes: "Deleted by Automatic Review Creation...");
                     }
                 }


### PR DESCRIPTION
closes: https://github.com/Azure/azure-sdk-tools/issues/15238

# Changes explained 

## Before

Every time a CI or release pipeline uploaded a new API revision, the service looped through **all** existing automatic revisions from oldest to newest and soft-deleted every one that didn't match the incoming content — stopping only when it found a content match. This had two problems:

1. **Bulk deletion risk.** If a package had accumulated many pending revisions (e.g. from several CI builds while the PR queue was backed up), a single new upload would wipe all of them in one call. A reviewer who had left comments on any of those revisions would lose that context silently, because the loop didn't protect commented revisions.

2. **Rolling builds always created a new revision.** Nightly/alpha builds increment a date in the version string (`1.4.0-alpha.20201211` → `1.4.0-alpha.20201212`) even when the API surface is unchanged. The old code considered the package version string when deciding whether to reuse, so these builds were never considered "the same" — accumulating a new revision every single day.

## After

The logic is simplified and made predictable:

- **One candidate, always replaced.** The service picks only the single newest unprotected automatic revision (skipping approved, released, or commented ones) and soft-deletes it. Everything else is left untouched. Older stale revisions are handled by a separate one-time cleanup script (#15239) rather than silently in-band.

- **No reuse — ever.** The "same content, skip creation" path has been removed. Every upload always produces a fresh revision. This makes the behaviour easy to reason about and avoids the class of bugs where a stale revision was returned as if it were the newly uploaded one.

- **Version scoping is applied once, up front.** Before selecting the candidate, all automatic revisions are filtered to those belonging to the same *logical version* as the incoming upload (using the normalised `APIVersionId`). This means a `1.0.0` upload never touches `2.0.0-beta` revisions, and vice versa, regardless of which code path runs next.

- **Release pipeline path unchanged.** The `compareAllRevisions` fast-path (used during release to detect whether a newly uploaded stable version is already approved) still works exactly as before.