### PR TITLE
Update-DocsMsToc.ps1 - Use powershell-yaml 0.4.12, include fixes for breaking behavior change

### DIFF
--- a/eng/common/scripts/Update-DocsMsToc.ps1
+++ b/eng/common/scripts/Update-DocsMsToc.ps1
@@ -55,7 +55,10 @@ param(
 . $PSScriptRoot/common.ps1
 . $PSScriptRoot/Helpers/PSModule-Helpers.ps1
 
-Install-ModuleIfNotInstalled "powershell-yaml" "0.4.7" | Import-Module
+Install-ModuleIfNotInstalled "powershell-yaml" "0.4.12" | Import-Module
+
+$loadedModule = Get-Module powershell-yaml
+Write-Host "powershell-yaml version loaded: $($loadedModule.Version) from $($loadedModule.ModuleBase)"
 
 Set-StrictMode -Version 3
 
@@ -68,8 +71,11 @@ function GetPackageNode($package) {
   return [PSCustomObject]@{
     name     = $packageInfo.PackageTocHeader
     href     = $packageInfo.PackageLevelReadmeHref
-    # This is always one package and it must be an array
-    children = $packageInfo.TocChildren
+    # This is always one package and it must be an array.
+    # Cast to [string[]] to strip PSObject wrapping added by Sort-Object,
+    # which causes ConvertTo-Yaml to serialize string properties (e.g. Length)
+    # instead of string values.
+    children = [string[]]$packageInfo.TocChildren
   };
 }
 


### PR DESCRIPTION
Example run with fixed behavior: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6189035&view=logs&j=dc056dfc-c0cf-5958-c8c4-8da4f91a3739&t=d08ed1f2-0ec2-5498-48a9-682643d126ca