### PR TITLE
[APIView] Bug: VssConnection recreated on every Azure DevOps API call

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
@@ -108,11 +108,12 @@ namespace APIViewWeb.Repositories
                 var tokenResult = await GetAccessTokenAsync();
                 var vssToken = new VssAadToken("Bearer", tokenResult.Token);
                 var connection = new VssConnection(new Uri("https://dev.azure.com/azure-sdk/"), new VssAadCredential(vssToken));
-                // Dispose the previous connection before replacing it (VssConnection is IDisposable).
-                var previous = Volatile.Read(ref _cachedConnectionEntry);
-                // Refresh 5 minutes before the token actually expires.
-                Volatile.Write(ref _cachedConnectionEntry, new CachedConnection(connection, tokenResult.ExpiresOn.AddMinutes(-5)));
-                previous?.Connection.Dispose();
+                var refreshTime = tokenResult.ExpiresOn.AddMinutes(-5);
+                if (refreshTime < DateTimeOffset.UtcNow)
+                {
+                    refreshTime = DateTimeOffset.UtcNow;
+                }
+                Volatile.Write(ref _cachedConnectionEntry, new CachedConnection(connection, refreshTime));
                 return connection;
             }
             finally

--- a/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
@@ -133,7 +133,7 @@ namespace APIViewWeb.Repositories
 
         private async Task<HttpResponseMessage> GetFromDevopsAsync(string request)
         {
-            var httpClient = new HttpClient();            
+            using var httpClient = new HttpClient();
             var accessToken = (await GetAccessTokenAsync()).Token;
             httpClient.DefaultRequestHeaders.Accept.Clear();
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
@@ -27,6 +27,7 @@ namespace APIViewWeb.Repositories
         private readonly TelemetryClient _telemetryClient;
         private CachedConnection _cachedConnectionEntry;
         private readonly SemaphoreSlim _connectionLock = new SemaphoreSlim(1, 1);
+        private int _disposed = 0;
 
         public DevopsArtifactRepository(IConfiguration configuration, TelemetryClient telemetryClient)
         {
@@ -37,6 +38,10 @@ namespace APIViewWeb.Repositories
 
         public void Dispose()
         {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
             _cachedConnectionEntry?.Connection.Dispose();
             _connectionLock.Dispose();
         }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
@@ -19,13 +19,13 @@ using System.Threading.Tasks;
 
 namespace APIViewWeb.Repositories
 {
-    public class DevopsArtifactRepository : IDevopsArtifactRepository
+    public class DevopsArtifactRepository : IDevopsArtifactRepository, IDisposable
     {
+        private sealed record CachedConnection(VssConnection Connection, DateTimeOffset ExpiresAt);
         private readonly IConfiguration _configuration;
         private readonly string _hostUrl;
         private readonly TelemetryClient _telemetryClient;
-        private VssConnection _cachedConnection;
-        private DateTimeOffset _connectionExpiresAt = DateTimeOffset.MinValue;
+        private CachedConnection _cachedConnectionEntry;
         private readonly SemaphoreSlim _connectionLock = new SemaphoreSlim(1, 1);
 
         public DevopsArtifactRepository(IConfiguration configuration, TelemetryClient telemetryClient)
@@ -33,6 +33,12 @@ namespace APIViewWeb.Repositories
             _configuration = configuration;
             _hostUrl = _configuration["APIVIew-Host-Url"];
             _telemetryClient = telemetryClient;
+        }
+
+        public void Dispose()
+        {
+            _cachedConnectionEntry?.Connection.Dispose();
+            _connectionLock.Dispose();
         }
 
         public async Task<Stream> DownloadPackageArtifact(string repoName, string buildId, string artifactName, string filePath, string project, string format= "file")
@@ -82,30 +88,32 @@ namespace APIViewWeb.Repositories
 
         private async Task<VssConnection> CreateVssConnection()
         {
-            // Fast path: return cached connection if token is still valid
-            if (_cachedConnection != null && DateTimeOffset.UtcNow < _connectionExpiresAt)
+            // Fast path: single volatile read of the immutable snapshot — no torn struct reads.
+            var entry = Volatile.Read(ref _cachedConnectionEntry);
+            if (entry != null && DateTimeOffset.UtcNow < entry.ExpiresAt)
             {
-                return _cachedConnection;
+                return entry.Connection;
             }
 
             await _connectionLock.WaitAsync();
             try
             {
-                // Re-check under lock to avoid double initialization
-                if (_cachedConnection != null && DateTimeOffset.UtcNow < _connectionExpiresAt)
+                // Re-check under lock to avoid double initialization.
+                entry = Volatile.Read(ref _cachedConnectionEntry);
+                if (entry != null && DateTimeOffset.UtcNow < entry.ExpiresAt)
                 {
-                    return _cachedConnection;
+                    return entry.Connection;
                 }
 
-                var credential = Helpers.CredentialProvider.GetAzureCredential();
-                var tokenRequestContext = new TokenRequestContext(VssAadSettings.DefaultScopes);
-                var tokenResult = await credential.GetTokenAsync(tokenRequestContext, CancellationToken.None);
-
-                var token = new VssAadToken("Bearer", tokenResult.Token);
-                _cachedConnection = new VssConnection(new Uri("https://dev.azure.com/azure-sdk/"), new VssAadCredential(token));
-                // Refresh 5 minutes before the token actually expires
-                _connectionExpiresAt = tokenResult.ExpiresOn.AddMinutes(-5);
-                return _cachedConnection;
+                var tokenResult = await GetAccessTokenAsync();
+                var vssToken = new VssAadToken("Bearer", tokenResult.Token);
+                var connection = new VssConnection(new Uri("https://dev.azure.com/azure-sdk/"), new VssAadCredential(vssToken));
+                // Dispose the previous connection before replacing it (VssConnection is IDisposable).
+                var previous = Volatile.Read(ref _cachedConnectionEntry);
+                // Refresh 5 minutes before the token actually expires.
+                Volatile.Write(ref _cachedConnectionEntry, new CachedConnection(connection, tokenResult.ExpiresOn.AddMinutes(-5)));
+                previous?.Connection.Dispose();
+                return connection;
             }
             finally
             {
@@ -113,20 +121,19 @@ namespace APIViewWeb.Repositories
             }
         }
 
-        private async Task<string> getAccessToken()
+        private async Task<AccessToken> GetAccessTokenAsync()
         {
-            // APIView deployed instances uses managed identity to authenticate requests to Azure DevOps.
-            // For local testing, CLI-based credentials are used to create token
+            // APIView deployed instances use managed identity to authenticate to Azure DevOps.
+            // For local testing, CLI-based credentials are used.
             var credential = Helpers.CredentialProvider.GetAzureCredential();
             var tokenRequestContext = new TokenRequestContext(VssAadSettings.DefaultScopes);
-            var token = await credential.GetTokenAsync(tokenRequestContext, CancellationToken.None);
-            return token.Token;
+            return await credential.GetTokenAsync(tokenRequestContext, CancellationToken.None);
         }
 
         private async Task<HttpResponseMessage> GetFromDevopsAsync(string request)
         {
             var httpClient = new HttpClient();            
-            var accessToken = await getAccessToken();
+            var accessToken = (await GetAccessTokenAsync()).Token;
             httpClient.DefaultRequestHeaders.Accept.Clear();
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);

--- a/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
@@ -24,6 +24,9 @@ namespace APIViewWeb.Repositories
         private readonly IConfiguration _configuration;
         private readonly string _hostUrl;
         private readonly TelemetryClient _telemetryClient;
+        private VssConnection _cachedConnection;
+        private DateTimeOffset _connectionExpiresAt = DateTimeOffset.MinValue;
+        private readonly SemaphoreSlim _connectionLock = new SemaphoreSlim(1, 1);
 
         public DevopsArtifactRepository(IConfiguration configuration, TelemetryClient telemetryClient)
         {
@@ -79,9 +82,35 @@ namespace APIViewWeb.Repositories
 
         private async Task<VssConnection> CreateVssConnection()
         {
-            var accessToken = await getAccessToken();
-            var token = new VssAadToken("Bearer", accessToken);
-            return new VssConnection(new Uri("https://dev.azure.com/azure-sdk/"), new VssAadCredential(token));
+            // Fast path: return cached connection if token is still valid
+            if (_cachedConnection != null && DateTimeOffset.UtcNow < _connectionExpiresAt)
+            {
+                return _cachedConnection;
+            }
+
+            await _connectionLock.WaitAsync();
+            try
+            {
+                // Re-check under lock to avoid double initialization
+                if (_cachedConnection != null && DateTimeOffset.UtcNow < _connectionExpiresAt)
+                {
+                    return _cachedConnection;
+                }
+
+                var credential = Helpers.CredentialProvider.GetAzureCredential();
+                var tokenRequestContext = new TokenRequestContext(VssAadSettings.DefaultScopes);
+                var tokenResult = await credential.GetTokenAsync(tokenRequestContext, CancellationToken.None);
+
+                var token = new VssAadToken("Bearer", tokenResult.Token);
+                _cachedConnection = new VssConnection(new Uri("https://dev.azure.com/azure-sdk/"), new VssAadCredential(token));
+                // Refresh 5 minutes before the token actually expires
+                _connectionExpiresAt = tokenResult.ExpiresOn.AddMinutes(-5);
+                return _cachedConnection;
+            }
+            finally
+            {
+                _connectionLock.Release();
+            }
         }
 
         private async Task<string> getAccessToken()


### PR DESCRIPTION
CreateVssConnection was instantiating a **new `VssConnection` on every call*

### Fix

Cache the `VssConnection` instance. The token expiry from the credential response is used to determine when the cache must be refreshed (5-minute buffer before actual expiry). A `SemaphoreSlim` guards against concurrent initialization races using a double-checked locking pattern.

After the first request, all subsequent calls skip the disk cache load, the location service network call, and the resource location dictionary construction entirely.

### Context
This was found by a code optimization suggestion on App Insights 
<img width="1633" height="311" alt="image" src="https://github.com/user-attachments/assets/02188f00-904c-4986-b603-3a7fffada4c1" />
