### PR TITLE
[AVC] Fix get_comments_in_date_range bottleneck

### DIFF
--- a/packages/python-packages/apiview-copilot/cli.py
+++ b/packages/python-packages/apiview-copilot/cli.py
@@ -2095,8 +2095,7 @@ def analyze_comments(language: str, start_date: str, end_date: str, environment:
     """
     Analyze APIView comments by language and date window, output count, unique authors, and theme analysis via Prompty.
     """
-    raw_comments = get_comments_in_date_range(start_date, end_date, environment=environment)
-    filtered = [c for c in raw_comments if c.get("CommentSource") != "Diagnostic" and c.get("IsDeleted") != True]
+    filtered = get_comments_in_date_range(start_date, end_date, environment=environment)
 
     allowed_commenters = get_approvers(language=resolve_language(language)[1])
 

--- a/packages/python-packages/apiview-copilot/src/_apiview.py
+++ b/packages/python-packages/apiview-copilot/src/_apiview.py
@@ -247,8 +247,9 @@ def get_active_reviews(
     metadata: list[ActiveReviewMetadata] = []
 
     # Get comments in the date range, excluding Diagnostic comments
-    raw_comments = get_comments_in_date_range(start_date, end_date, environment=environment, select_fields=select_fields)
-    comments = [c for c in raw_comments if c.get("CommentSource") != "Diagnostic"]
+    comments = get_comments_in_date_range(
+        start_date, end_date, environment=environment, select_fields=select_fields
+    )
 
     # Extract unique review IDs and revision IDs from comments
     review_ids = set()
@@ -269,7 +270,7 @@ def get_active_reviews(
                 review_to_revisions[review_id].add(revision_id)
 
     if not review_ids:
-        return metadata, raw_comments
+        return metadata, comments
 
     # Query Reviews container for review metadata
     reviews_container = get_apiview_cosmos_client(container_name="Reviews", environment=environment)
@@ -388,7 +389,7 @@ def get_active_reviews(
         omit_lower = {l.lower() for l in omit_languages}
         metadata = [r for r in metadata if r.language.lower() not in omit_lower]
 
-    return metadata, raw_comments
+    return metadata, comments
 
 
 def get_active_review_ids(start_date: str, end_date: str, environment: str = "production") -> list:
@@ -415,7 +416,12 @@ def get_active_review_ids(start_date: str, end_date: str, environment: str = "pr
 
 
 def get_comments_in_date_range(
-    start_date: str, end_date: str, environment: str = "production", select_fields: Optional[list[str]] = None
+    start_date: str,
+    end_date: str,
+    environment: str = "production",
+    select_fields: Optional[list[str]] = None,
+    include_diagnostics: bool = False,
+    include_deleted: bool = False,
 ) -> list:
     """
     Retrieves all comments created within the specified date range in the given environment.
@@ -423,6 +429,8 @@ def get_comments_in_date_range(
 
     Args:
         select_fields: Optional list of field names to select. If None, uses the default full field list.
+        include_diagnostics: If False, excludes comments where CommentSource is 'Diagnostic' at the query level.
+        include_deleted: If False, excludes comments where IsDeleted is true at the query level.
     """
     start_iso = to_iso8601(start_date)
     end_iso = to_iso8601(end_date, end_of_day=True)
@@ -432,9 +440,15 @@ def get_comments_in_date_range(
     else:
         select_clause = ", ".join(APIVIEW_COMMENT_SELECT_FIELDS)
 
+    where_clause = "c.CreatedOn >= @start_date AND c.CreatedOn <= @end_date"
+    if not include_diagnostics:
+        where_clause += " AND c.CommentSource != 'Diagnostic'"
+    if not include_deleted:
+        where_clause += " AND (NOT IS_DEFINED(c.IsDeleted) OR c.IsDeleted = false)"
+
     comments_client = get_apiview_cosmos_client(container_name="Comments", environment=environment)
     result = comments_client.query_items(
-        query=f"SELECT {select_clause} FROM c WHERE c.CreatedOn >= @start_date AND c.CreatedOn <= @end_date",
+        query=f"SELECT {select_clause} FROM c WHERE {where_clause}",
         parameters=[
             {"name": "@start_date", "value": start_iso},
             {"name": "@end_date", "value": end_iso},

--- a/packages/python-packages/apiview-copilot/src/_apiview.py
+++ b/packages/python-packages/apiview-copilot/src/_apiview.py
@@ -247,8 +247,9 @@ def get_active_reviews(
     metadata: list[ActiveReviewMetadata] = []
 
     # Get comments in the date range, excluding Diagnostic comments
+    # include_deleted=True because metrics calculations need deleted comments for deleted_* bucket counts
     comments = get_comments_in_date_range(
-        start_date, end_date, environment=environment, select_fields=select_fields
+        start_date, end_date, environment=environment, select_fields=select_fields, include_deleted=True
     )
 
     # Extract unique review IDs and revision IDs from comments

--- a/packages/python-packages/apiview-copilot/src/_comment_bucket_trends.py
+++ b/packages/python-packages/apiview-copilot/src/_comment_bucket_trends.py
@@ -180,13 +180,12 @@ def build_language_comment_bucket_reports(
     if "CreatedOn" not in select_fields:
         select_fields.append("CreatedOn")
 
-    all_raw_comments = get_comments_in_date_range(
+    non_diag = get_comments_in_date_range(
         full_start.isoformat(),
         full_end.isoformat(),
         environment=environment,
         select_fields=select_fields,
     )
-    non_diag = [comment for comment in all_raw_comments if comment.get("CommentSource") != "Diagnostic"]
 
     review_ids: set[str] = set()
     revision_ids: set[str] = set()
@@ -226,7 +225,7 @@ def build_language_comment_bucket_reports(
         reviews, month_comments = _build_month_metadata(
             start_date,
             end_date,
-            all_raw_comments,
+            non_diag,
             review_results,
             revision_results,
         )

--- a/packages/python-packages/apiview-copilot/src/_comment_bucket_trends.py
+++ b/packages/python-packages/apiview-copilot/src/_comment_bucket_trends.py
@@ -185,6 +185,7 @@ def build_language_comment_bucket_reports(
         full_end.isoformat(),
         environment=environment,
         select_fields=select_fields,
+        include_deleted=True,
     )
 
     review_ids: set[str] = set()

--- a/packages/python-packages/apiview-copilot/tests/apiview_test.py
+++ b/packages/python-packages/apiview-copilot/tests/apiview_test.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-# pylint: disable=missing-class-docstring,missing-function-docstring,redefined-outer-name,unused-argument
+# pylint: disable=missing-class-docstring,missing-function-docstring,redefined-outer-name,unused-argument,no-member
 
 """
 Tests for resolve_package function in _apiview.py.
@@ -19,7 +19,7 @@ import pytest
 sys.modules["azure.cosmos"] = MagicMock()
 sys.modules["azure.cosmos.exceptions"] = MagicMock()
 
-from src._apiview import get_active_reviews, get_ai_comment_feedback, get_version_type, resolve_package
+from src._apiview import get_active_reviews, get_ai_comment_feedback, get_comments_in_date_range, get_version_type, resolve_package
 
 
 class TestGetVersionType:
@@ -663,3 +663,50 @@ class TestGetAiCommentFeedback:
             results = get_ai_comment_feedback(None, "2026-01-01", "2026-01-31")
 
             assert all(c["Language"] == "" for c in results)
+
+
+class TestGetCommentsInDateRange:
+    """Tests for get_comments_in_date_range query construction."""
+
+    def _call_and_capture_query(self, **kwargs):
+        """Call get_comments_in_date_range and return the query string passed to query_items."""
+        with patch("src._apiview.get_apiview_cosmos_client") as mock_client:
+            mock_container = MagicMock()
+            mock_container.query_items.return_value = iter([])
+            mock_client.return_value = mock_container
+
+            get_comments_in_date_range("2026-01-01", "2026-01-31", **kwargs)
+
+            mock_container.query_items.assert_called_once()
+            return mock_container.query_items.call_args[1]["query"]
+
+    def test_default_excludes_diagnostics_and_deleted(self):
+        query = self._call_and_capture_query()
+        assert "CommentSource != 'Diagnostic'" in query
+        assert "IsDeleted" in query
+
+    def test_include_diagnostics_true_omits_diagnostic_filter(self):
+        query = self._call_and_capture_query(include_diagnostics=True)
+        assert "Diagnostic" not in query
+
+    def test_include_diagnostics_false_adds_diagnostic_filter(self):
+        query = self._call_and_capture_query(include_diagnostics=False)
+        assert "CommentSource != 'Diagnostic'" in query
+
+    def test_include_deleted_true_omits_deleted_filter(self):
+        query = self._call_and_capture_query(include_deleted=True)
+        assert "IsDeleted = false" not in query
+
+    def test_include_deleted_false_adds_deleted_filter(self):
+        query = self._call_and_capture_query(include_deleted=False)
+        assert "IsDeleted = false" in query
+
+    def test_both_include_flags_true(self):
+        query = self._call_and_capture_query(include_diagnostics=True, include_deleted=True)
+        where_clause = query.split("WHERE", 1)[1]
+        assert "Diagnostic" not in where_clause
+        assert "IsDeleted" not in where_clause
+
+    def test_select_fields_used_in_query(self):
+        query = self._call_and_capture_query(select_fields=["id", "CreatedOn"])
+        assert query.startswith("SELECT c.id, c.CreatedOn FROM c")


### PR DESCRIPTION
Allows smart defaults for excluding diagnostics and deleted comments. 

Previously, we were retrieving ALL comments which is very expensive, and them filtering them in memory afterwards. This allows much faster queries by filtering out deleted and/or diagnostic comments in the query itself. 