### PR TITLE
[APIView] Fix comments not retaining line break formatting

### DIFF
--- a/src/dotnet/APIView/ClientSPA/src/app/_components/shared/comment-thread/comment-thread.component.scss
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/shared/comment-thread/comment-thread.component.scss
@@ -177,7 +177,7 @@
 
     .rendered-comment-content {
         overflow-wrap: anywhere;
-        white-space: normal;
+        white-space: pre-line;
         pre { max-width: 100%; white-space: pre-wrap; background-color: var(--editor-bg-color); border: 1px solid var(--border-color); border-radius: 5px;
             code { background-color: var(--editor-bg-color);
                 .line-actions { text-align: right; white-space: nowrap; display: inline-block; cursor: pointer; width: 20px; padding-inline-end: 15px; position: sticky; left: 0; background-color: inherit; color: var(--base-text-color);

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/shared/related-comments-dialog/related-comments-dialog.component.scss
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/shared/related-comments-dialog/related-comments-dialog.component.scss
@@ -62,6 +62,7 @@
 .rendered-comment-content {
   font-size: 0.95rem;
   line-height: 1.4;
+  white-space: pre-line;
 
   p {
     margin-bottom: 0.4rem;


### PR DESCRIPTION
Resolves: https://github.com/Azure/azure-sdk-tools/issues/15236

Edit view: 
<img width="1900" height="532" alt="image" src="https://github.com/user-attachments/assets/e316dd3b-3ff6-4160-99da-e46eb9ff57f0" />

**Before** Saved/submitted view:
<img width="1846" height="250" alt="image" src="https://github.com/user-attachments/assets/42ed4e3a-a657-4dd7-be00-412d39cf42ce" />

**After** Saved/submitted view:
<img width="1035" height="405" alt="image" src="https://github.com/user-attachments/assets/52b7238b-5c30-4c15-b041-4857d36caf84" />
