### PR TITLE
[APIView] Remove info icon from diagnostics badge

### DIFF
--- a/src/dotnet/APIView/ClientSPA/src/app/_components/shared/comment-thread/comment-thread.component.html
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/shared/comment-thread/comment-thread.component.html
@@ -89,9 +89,6 @@
                         <!-- Diagnostic Badge -->
                         <span *ngIf="isDiagnostic(comment)" class="diagnostic-badge-custom ms-2">
                             <i class="bi bi-exclamation-triangle-fill me-1"></i>Diagnostic
-                            <i class="pi pi-info-circle ms-1"
-                               title="Diagnostic comments are generated from the source code. They can only be resolved or have their severity changed by fixing or suppressing the diagnostic in the source code."
-                               style="cursor: pointer;"></i>
                         </span>
                     </div>
                 </ng-template>

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/shared/comment-thread/comment-thread.component.scss
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/shared/comment-thread/comment-thread.component.scss
@@ -26,7 +26,6 @@
         border-color: color-mix(in srgb, var(--diagnostic-accent-color) 54%, var(--border-color));
         color: var(--diagnostic-accent-color);
         .bi { font-size: .7rem; }
-        .pi { font-size: .8rem; margin: .2rem 0 0 .25rem; }
     }
 
     .related-comments-btn { background: none; border: none; padding: 0; }


### PR DESCRIPTION
## Fixes #15273

The diagnostics badge on comments had a circled "i" (info) icon that looked clickable but did nothing when clicked. Unlike the AI-generated badge (which opens an info popover on click), the diagnostic badge's info icon only showed a browser-native `title` tooltip.

### Changes

- **comment-thread.component.html** — Removed the `<i class="pi pi-info-circle">` element from the diagnostic badge. The badge now shows only the warning triangle icon + "Diagnostic" text.
- **comment-thread.component.scss** — Removed the now-unused `.pi` style rule from `.diagnostic-badge-custom`.

### Before
`▲ Diagnostic ⓘ` (info icon looks clickable but has no action)
<img width="1512" height="633" alt="image" src="https://github.com/user-attachments/assets/8d27a172-e828-481b-b815-725b865bd635" />


### After  
`▲ Diagnostic` (clean badge, no misleading icon)
<img width="1404" height="658" alt="image" src="https://github.com/user-attachments/assets/eac00b7f-d1ba-48e5-b4d4-a4c6d9acc0d9" />
