### PR TITLE
[APIView] Fix flaky E2E test for adding comments with hidden line numbers

### DIFF
--- a/src/dotnet/APIView/ClientSPA/ui-tests/tests/review-page/code-panel-interaction.spec.ts
+++ b/src/dotnet/APIView/ClientSPA/ui-tests/tests/review-page/code-panel-interaction.spec.ts
@@ -169,10 +169,7 @@ test.describe('Code Panel - Page Options Toggles', () => {
 
     await commentBtn.click();
 
-    await page.waitForSelector('app-comment-thread', { timeout: 5000 });
-    const threadsAfter = await page.locator('app-comment-thread').count();
-
-    expect(threadsAfter).toBeGreaterThan(threadsBefore);
+    await expect(page.locator('app-comment-thread')).toHaveCount(threadsBefore + 1, { timeout: 5000 });
   });
 
   test('should toggle comments visibility on and off', async ({ page }) => {


### PR DESCRIPTION
## Fix flaky E2E test: "should allow adding comments when line numbers are hidden"

This test was intermittently failing in CI (e.g. [build #6206596](https://dev.azure.com/azure-sdk/public/_build/results?buildId=6206596)).

### Root Cause

The test counted `app-comment-thread` elements before and after clicking the add-comment button, then asserted `threadsAfter > threadsBefore`. However, between clicking and counting, it used `waitForSelector('app-comment-thread')` — which returned **immediately** because there was already an existing comment thread on the page. The new thread hadn't rendered yet, so both counts were equal (1 == 1).

### Fix

Replace `waitForSelector` + manual count comparison with Playwright's `toHaveCount(threadsBefore + 1)`, which automatically retries until the expected count is reached (up to the 5s timeout). This is the idiomatic Playwright pattern for waiting on element count changes.