### PR TITLE
[CODEOWNERS] Add a per-repo config to skip check-package

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CheckPackageHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CheckPackageHelperTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Models.Codeowners;
 using Azure.Sdk.Tools.Cli.Models.Responses.Codeowners;
 using Azure.Sdk.Tools.CodeownersUtils.Parsing;
 
@@ -10,7 +11,6 @@ namespace Azure.Sdk.Tools.Cli.Tests.Helpers;
 [TestFixture]
 public class CheckPackageHelperTests
 {
-    private CheckPackageHelper helper;
     private List<CodeownersEntry> entries;
 
     [OneTimeSetUp]
@@ -27,18 +27,16 @@ public class CheckPackageHelperTests
         entries = CodeownersParser.ParseCodeownersFile(fixturePath);
     }
 
-    [SetUp]
-    public void SetUp()
-    {
-        helper = new CheckPackageHelper();
-    }
-
     [Test]
     public void CheckPackage_TwoOwners_ValidServiceOwners_Passes()
     {
+        var helper = new CheckPackageHelper();
+        var ownersConfig = new OwnersConfig();
+
         var result = helper.CheckPackage(
             "sdk/two-owners/Azure.TwoOwners",
-            entries);
+            entries,
+            ownersConfig);
 
         Assert.That(result, Is.Not.Null);
         Assert.That(result.DirectoryPath, Is.EqualTo("sdk/two-owners/Azure.TwoOwners"));
@@ -50,22 +48,74 @@ public class CheckPackageHelperTests
     [Test]
     public void CheckPackage_ThreeOwners_ValidServiceOwners_Passes()
     {
+        var helper = new CheckPackageHelper();
+        var ownersConfig = new OwnersConfig();
+
         var result = helper.CheckPackage(
             "sdk/three-owners/Azure.ThreeOwners",
-            entries);
+            entries,
+            ownersConfig);
 
         Assert.That(result, Is.Not.Null);
         Assert.That(result.Owners.Count, Is.EqualTo(3));
         Assert.That(result.ServiceOwners.Count, Is.GreaterThanOrEqualTo(2));
     }
 
+    [TestCase("/sdk/test/")]
+    [TestCase("/sdk/test/Azure.Test")]
+    public void CheckPackage_SkipGateMatch_PassesWithoutFurtherValidation(string skipGate)
+    {
+        var helper = new CheckPackageHelper();
+        var ownersConfig = new OwnersConfig
+        {
+            SkipGates = [skipGate]
+        };
+
+        var result = helper.CheckPackage(
+            "sdk/test/Azure.Test",
+            CreateEntries(
+                sourceOwners: ["ownerAlice"],
+                serviceOwners: ["serviceOwnerAlice"]),
+            ownersConfig);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.DirectoryPath, Is.EqualTo("sdk/test/Azure.Test"));
+        Assert.That(result.Skipped, Is.True);
+        Assert.That(result.Details, Does.Contain(skipGate));
+        Assert.That(result.Owners, Is.Empty);
+        Assert.That(result.PRLabels, Is.Empty);
+        Assert.That(result.ServiceOwners, Is.Empty);
+    }
+
+    [Test]
+    public void CheckPackage_EmptyOwnersConfig_DoesNotSkipValidation()
+    {
+        var helper = new CheckPackageHelper();
+        var ownersConfig = new OwnersConfig();
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            helper.CheckPackage(
+                "sdk/test/Azure.Test",
+                CreateEntries(
+                    sourceOwners: ["ownerAlice"],
+                    serviceOwners: ["serviceOwnerAlice", "serviceOwnerBob"]),
+                ownersConfig));
+
+        Assert.That(ex.Message, Does.Contain("check-package failed"));
+        Assert.That(ex.Message, Does.Contain("1 unique owner"));
+    }
+
     [Test]
     public void CheckPackage_OneOwner_Throws()
     {
+        var helper = new CheckPackageHelper();
+        var ownersConfig = new OwnersConfig();
+
         var ex = Assert.Throws<InvalidOperationException>(() =>
             helper.CheckPackage(
                 "sdk/one-owner/Azure.OneOwner",
-                entries));
+                entries,
+                ownersConfig));
 
         Assert.That(ex.Message, Does.Contain("check-package failed"));
         Assert.That(ex.Message, Does.Contain("1 unique owner"));
@@ -75,10 +125,14 @@ public class CheckPackageHelperTests
     [Test]
     public void CheckPackage_NoPrLabels_Throws()
     {
+        var helper = new CheckPackageHelper();
+        var ownersConfig = new OwnersConfig();
+
         var ex = Assert.Throws<InvalidOperationException>(() =>
             helper.CheckPackage(
                 "sdk/no-labels/Azure.NoLabels",
-                entries));
+                entries,
+                ownersConfig));
 
         Assert.That(ex.Message, Does.Contain("check-package failed"));
         Assert.That(ex.Message, Does.Contain("No PR labels"));
@@ -87,10 +141,14 @@ public class CheckPackageHelperTests
     [Test]
     public void CheckPackage_ZeroServiceOwners_Throws()
     {
+        var helper = new CheckPackageHelper();
+        var ownersConfig = new OwnersConfig();
+
         var ex = Assert.Throws<InvalidOperationException>(() =>
             helper.CheckPackage(
                 "sdk/zero-svc-owners/Azure.ZeroSvcOwners",
-                entries));
+                entries,
+                ownersConfig));
 
         Assert.That(ex.Message, Does.Contain("check-package failed"));
         Assert.That(ex.Message, Does.Contain("service owner"));
@@ -99,10 +157,14 @@ public class CheckPackageHelperTests
     [Test]
     public void CheckPackage_NoMatchingServiceLabel_Throws()
     {
+        var helper = new CheckPackageHelper();
+        var ownersConfig = new OwnersConfig();
+
         var ex = Assert.Throws<InvalidOperationException>(() =>
             helper.CheckPackage(
                 "sdk/no-svc-match/Azure.NoSvcMatch",
-                entries));
+                entries,
+                ownersConfig));
 
         Assert.That(ex.Message, Does.Contain("check-package failed"));
         Assert.That(ex.Message, Does.Contain("No service label entry found"));
@@ -111,10 +173,14 @@ public class CheckPackageHelperTests
     [Test]
     public void CheckPackage_InsufficientServiceOwners_Throws()
     {
+        var helper = new CheckPackageHelper();
+        var ownersConfig = new OwnersConfig();
+
         var ex = Assert.Throws<InvalidOperationException>(() =>
             helper.CheckPackage(
                 "sdk/insufficient-svc/Azure.InsufficientSvc",
-                entries));
+                entries,
+                ownersConfig));
 
         Assert.That(ex.Message, Does.Contain("check-package failed"));
         Assert.That(ex.Message, Does.Contain("1 unique service owner"));
@@ -123,10 +189,14 @@ public class CheckPackageHelperTests
     [Test]
     public void CheckPackage_NoMatchingPath_Throws()
     {
+        var helper = new CheckPackageHelper();
+        var ownersConfig = new OwnersConfig();
+
         var ex = Assert.Throws<InvalidOperationException>(() =>
             helper.CheckPackage(
                 "sdk/does-not-exist/Azure.NonExistent",
-                entries));
+                entries,
+                ownersConfig));
 
         Assert.That(ex.Message, Does.Contain("check-package failed"));
         Assert.That(ex.Message, Does.Contain("No CODEOWNERS entry matches path"));
@@ -135,10 +205,14 @@ public class CheckPackageHelperTests
     [Test]
     public void CheckPackage_ServiceLabelSupersetDoesNotMatch_Throws()
     {
+        var helper = new CheckPackageHelper();
+        var ownersConfig = new OwnersConfig();
+
         var ex = Assert.Throws<InvalidOperationException>(() =>
             helper.CheckPackage(
                 "sdk/superset-match/Azure.SupersetMatch",
-                entries));
+                entries,
+                ownersConfig));
 
         Assert.That(ex.Message, Does.Contain("check-package failed"));
         Assert.That(ex.Message, Does.Contain("No service label entry found"));
@@ -147,9 +221,13 @@ public class CheckPackageHelperTests
     [Test]
     public void CheckPackage_MultiplePrLabels_ExactServiceLabelMatch_Passes()
     {
+        var helper = new CheckPackageHelper();
+        var ownersConfig = new OwnersConfig();
+
         var result = helper.CheckPackage(
             "sdk/multi-label/Azure.MultiLabel",
-            entries);
+            entries,
+            ownersConfig);
 
         Assert.That(result, Is.Not.Null);
         Assert.That(result.PRLabels.Count, Is.EqualTo(2));
@@ -159,9 +237,13 @@ public class CheckPackageHelperTests
     [Test]
     public void CheckPackage_ReverseOrderMatching_LastEntryWins()
     {
+        var helper = new CheckPackageHelper();
+        var ownersConfig = new OwnersConfig();
+
         var result = helper.CheckPackage(
             "sdk/reverse-test/Azure.ReverseTest",
-            entries);
+            entries,
+            ownersConfig);
 
         Assert.That(result, Is.Not.Null);
         Assert.That(result.Owners.Count, Is.EqualTo(3));
@@ -172,9 +254,13 @@ public class CheckPackageHelperTests
     [Test]
     public void CheckPackage_ServiceOwners_ThreeOwners_Passes()
     {
+        var helper = new CheckPackageHelper();
+        var ownersConfig = new OwnersConfig();
+
         var result = helper.CheckPackage(
             "sdk/three-owners/Azure.ThreeOwners",
-            entries);
+            entries,
+            ownersConfig);
 
         Assert.That(result, Is.Not.Null);
         Assert.That(result.ServiceOwners.Count, Is.EqualTo(3));
@@ -183,6 +269,8 @@ public class CheckPackageHelperTests
     [Test]
     public void CheckPackage_ServiceOwnerSearch_LastMatchingEntryWins()
     {
+        var helper = new CheckPackageHelper();
+        var ownersConfig = new OwnersConfig();
         var entries = new List<CodeownersEntry>
         {
             new()
@@ -205,7 +293,8 @@ public class CheckPackageHelperTests
 
         var result = helper.CheckPackage(
             "sdk/test/Azure.Test",
-            entries);
+            entries,
+            ownersConfig);
 
         Assert.That(result, Is.Not.Null);
         Assert.That(result.ServiceOwners, Is.EquivalentTo(new[] { "serviceOwnerAlice", "serviceOwnerBob" }));
@@ -214,6 +303,8 @@ public class CheckPackageHelperTests
     [Test]
     public void CheckPackage_ServiceAttentionLabel_IsIgnoredDuringServiceOwnerMatch()
     {
+        var helper = new CheckPackageHelper();
+        var ownersConfig = new OwnersConfig();
         var entries = CreateEntries(
             sourceOwners: ["ownerAlice", "ownerBob"],
             serviceOwners: ["serviceOwnerAlice", "serviceOwnerBob"],
@@ -221,7 +312,8 @@ public class CheckPackageHelperTests
 
         var result = helper.CheckPackage(
             "sdk/test/Azure.Test",
-            entries);
+            entries,
+            ownersConfig);
 
         Assert.That(result, Is.Not.Null);
         Assert.That(result.ServiceOwners, Is.EquivalentTo(new[] { "serviceOwnerAlice", "serviceOwnerBob" }));
@@ -231,6 +323,8 @@ public class CheckPackageHelperTests
     [Test]
     public void CheckPackage_UnresolvedTeamAliasInSourceOwners_DoesNotCountTowardMinimum_Throws()
     {
+        var helper = new CheckPackageHelper();
+        var ownersConfig = new OwnersConfig();
         var entries = CreateEntries(
             sourceOwners: ["ownerAlice", "Azure/unresolved-team"],
             serviceOwners: ["serviceOwnerAlice", "serviceOwnerBob"]);
@@ -238,7 +332,8 @@ public class CheckPackageHelperTests
         var ex = Assert.Throws<InvalidOperationException>(() =>
             helper.CheckPackage(
                 "sdk/test/Azure.Test",
-                entries));
+                entries,
+                ownersConfig));
 
         Assert.That(ex.Message, Does.Contain("check-package failed"));
         Assert.That(ex.Message, Does.Contain("1 unique owner"));
@@ -248,6 +343,8 @@ public class CheckPackageHelperTests
     [Test]
     public void CheckPackage_UnresolvedTeamAliasInServiceOwners_DoesNotCountTowardMinimum_Throws()
     {
+        var helper = new CheckPackageHelper();
+        var ownersConfig = new OwnersConfig();
         var entries = CreateEntries(
             sourceOwners: ["ownerAlice", "ownerBob"],
             serviceOwners: ["serviceOwnerAlice", "Azure/unresolved-team"]);
@@ -255,7 +352,8 @@ public class CheckPackageHelperTests
         var ex = Assert.Throws<InvalidOperationException>(() =>
             helper.CheckPackage(
                 "sdk/test/Azure.Test",
-                entries));
+                entries,
+                ownersConfig));
 
         Assert.That(ex.Message, Does.Contain("check-package failed"));
         Assert.That(ex.Message, Does.Contain("1 unique service owner"));
@@ -265,13 +363,16 @@ public class CheckPackageHelperTests
     [Test]
     public void CheckPackage_UnresolvedTeamAliases_AreFilteredFromSuccessfulResponse()
     {
+        var helper = new CheckPackageHelper();
+        var ownersConfig = new OwnersConfig();
         var entries = CreateEntries(
             sourceOwners: ["ownerAlice", "ownerBob", "Azure/unresolved-team"],
             serviceOwners: ["serviceOwnerAlice", "serviceOwnerBob", "Azure/unresolved-team"]);
 
         var result = helper.CheckPackage(
             "sdk/test/Azure.Test",
-            entries);
+            entries,
+            ownersConfig);
 
         Assert.That(result, Is.Not.Null);
         Assert.That(result.Owners, Is.EquivalentTo(new[] { "ownerAlice", "ownerBob" }));
@@ -281,10 +382,14 @@ public class CheckPackageHelperTests
     [Test]
     public void CheckPackage_EmptyEntries_Throws()
     {
+        var helper = new CheckPackageHelper();
+        var ownersConfig = new OwnersConfig();
+
         var ex = Assert.Throws<ArgumentException>(() =>
             helper.CheckPackage(
                 "sdk/test",
-                new List<CodeownersEntry>()));
+                new List<CodeownersEntry>(),
+                ownersConfig));
 
         Assert.That(ex.Message, Does.Contain("empty"));
     }
@@ -292,8 +397,11 @@ public class CheckPackageHelperTests
     [Test]
     public void CheckPackage_NullDirectoryPath_Throws()
     {
+        var helper = new CheckPackageHelper();
+        var ownersConfig = new OwnersConfig();
+
         Assert.Throws<ArgumentException>(() =>
-            helper.CheckPackage(null!, entries));
+            helper.CheckPackage(null!, entries, ownersConfig));
     }
 
     private static List<CodeownersEntry> CreateEntries(
@@ -318,4 +426,5 @@ public class CheckPackageHelperTests
             }
         ];
     }
+
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Config/CodeownersToolsTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Config/CodeownersToolsTests.cs
@@ -9,6 +9,7 @@ using Azure.Sdk.Tools.Cli.Tests.Mocks.Services;
 using Azure.Sdk.Tools.Cli.Tools.Config;
 using Azure.Sdk.Tools.Cli.Models.Responses.Codeowners;
 using Azure.Sdk.Tools.CodeownersUtils.Caches;
+using Azure.Sdk.Tools.CodeownersUtils.Parsing;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Tools.Config
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CheckPackageHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/CheckPackageHelper.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Sdk.Tools.Cli.Models.Codeowners;
 using Azure.Sdk.Tools.Cli.Models.Responses.Codeowners;
 using Azure.Sdk.Tools.CodeownersUtils.Parsing;
 using Azure.Sdk.Tools.CodeownersUtils.Utils;
@@ -18,11 +19,13 @@ public interface ICheckPackageHelper
     /// Pre-parsed CODEOWNERS entries from <see cref="CodeownersParser"/>. This helper relies on parser behavior
     /// such as metadata block parsing and attempted team expansion when evaluating owners and labels.
     /// </param>
+    /// <param name="ownersConfig">Repository-level owner configuration used to control skip gates.</param>
     /// <returns>A <see cref="CheckPackageResponse"/> on success.</returns>
     /// <exception cref="InvalidOperationException">Thrown when validation fails.</exception>
     CheckPackageResponse CheckPackage(
         string directoryPath,
-        List<CodeownersEntry> codeownersEntries);
+        List<CodeownersEntry> codeownersEntries,
+        OwnersConfig ownersConfig);
 }
 
 public class CheckPackageHelper : ICheckPackageHelper
@@ -35,15 +38,27 @@ public class CheckPackageHelper : ICheckPackageHelper
     /// </summary>
     public CheckPackageResponse CheckPackage(
         string directoryPath,
-        List<CodeownersEntry> codeownersEntries)
+        List<CodeownersEntry> codeownersEntries,
+        OwnersConfig ownersConfig)
     {
         if (string.IsNullOrWhiteSpace(directoryPath))
         {
             throw new ArgumentException("Directory path is required.", nameof(directoryPath));
         }
-        if (codeownersEntries == null || codeownersEntries.Count == 0)
+        if (codeownersEntries.Count == 0)
         {
             throw new ArgumentException("CODEOWNERS entries list is empty.", nameof(codeownersEntries));
+        }
+
+        var matchedSkipGate = FindMatchingSkipGate(directoryPath, ownersConfig);
+        if (matchedSkipGate != null)
+        {
+            return new CheckPackageResponse
+            {
+                DirectoryPath = directoryPath,
+                Skipped = true,
+                Details = $"Matched skipGates entry '{matchedSkipGate}' in {OwnersConfig.RelativePath}.",
+            };
         }
 
         var matchedEntry = FindMatchingEntry(directoryPath, codeownersEntries);
@@ -81,30 +96,19 @@ public class CheckPackageHelper : ICheckPackageHelper
     /// </summary>
     internal static CodeownersEntry FindMatchingEntry(string directoryPath, List<CodeownersEntry> entries)
     {
-        // Build the set of target paths to try: the original path, and if it doesn't
-        // end with '/', also try with a trailing slash appended. CODEOWNERS directory
-        // patterns like /sdk/foo/ only match paths *under* that directory, so
-        // "sdk/foo/" will match but "sdk/foo" will not.
-        var pathsToTry = new List<string> { directoryPath };
+        string[] targetPaths = [directoryPath];
         if (!directoryPath.EndsWith("/"))
         {
-            pathsToTry.Add(directoryPath + "/");
+            targetPaths = [directoryPath, $"{directoryPath}/"];
         }
 
         for (int i = entries.Count - 1; i >= 0; i--)
         {
             var entry = entries[i];
-            if (string.IsNullOrWhiteSpace(entry.PathExpression))
+            if (!string.IsNullOrWhiteSpace(entry.PathExpression) &&
+                targetPaths.Any(targetPath => DirectoryUtils.PathExpressionMatchesTargetPath(entry.PathExpression, targetPath)))
             {
-                continue;
-            }
-
-            foreach (var targetPath in pathsToTry)
-            {
-                if (DirectoryUtils.PathExpressionMatchesTargetPath(entry.PathExpression, targetPath))
-                {
-                    return entry;
-                }
+                return entry;
             }
         }
 
@@ -159,6 +163,12 @@ public class CheckPackageHelper : ICheckPackageHelper
             $"check-package failed for path '{matchedEntry.PathExpression}': " +
             $"No service label entry found whose labels are fully contained within PR labels " +
             $"[{string.Join(", ", matchedEntry.PRLabels)}].");
+    }
+
+    internal static string? FindMatchingSkipGate(string directoryPath, OwnersConfig ownersConfig)
+    {
+        return ownersConfig.SkipGates
+            .FirstOrDefault(skipGate => DirectoryUtils.PathExpressionMatchesTargetPath(skipGate, directoryPath));
     }
 
     /// <summary>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Codeowners/OwnersConfig.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Codeowners/OwnersConfig.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.Sdk.Tools.Cli.Models.Codeowners;
+
+/// <summary>
+/// Repository-level owner configuration found at <c>.github/owners-config.json</c>.
+/// Used to configure repo-level behavior for owner information, such as skip gates
+/// applied during package ownership validation.
+/// </summary>
+public class OwnersConfig
+{
+    public const string RelativePath = ".github/owners-config.json";
+
+    private List<string> _skipGates = [];
+
+    [JsonPropertyName("skipGates")]
+    public List<string> SkipGates
+    {
+        get => _skipGates;
+        set => _skipGates = value ?? [];
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Codeowners/CheckPackageResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Codeowners/CheckPackageResponse.cs
@@ -14,6 +14,14 @@ public class CheckPackageResponse : CommandResponse
     [JsonPropertyName("directory_path")]
     public string DirectoryPath { get; set; } = string.Empty;
 
+    [JsonPropertyName("skipped")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool Skipped { get; set; }
+
+    [JsonPropertyName("details")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Details { get; set; }
+
     [JsonPropertyName("owners")]
     public List<string> Owners { get; set; } = new();
 
@@ -30,6 +38,16 @@ public class CheckPackageResponse : CommandResponse
     {
         var sb = new StringBuilder();
         sb.AppendLine($"Path: {DirectoryPath}");
+        if (Skipped)
+        {
+            sb.AppendLine("Skipped: True");
+            if (!string.IsNullOrWhiteSpace(Details))
+            {
+                sb.AppendLine($"Details: {Details}");
+            }
+            return sb.ToString();
+        }
+
         sb.AppendLine($"Owners: {string.Join(", ", Owners)}");
         sb.AppendLine($"PR Labels: {string.Join(", ", PRLabels)}");
         sb.AppendLine($"Service Labels: {string.Join(", ", ServiceLabels)}");

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.CommandLine;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 
 using ModelContextProtocol.Server;
@@ -49,7 +50,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
             Required = false,
         };
 
-        // Generate command options
+        // Repo-scoped command options
         private readonly Option<string> repoRootOption = new("--repo-root")
         {
             Description = "Path to the repository root (default: repo root of current directory)",
@@ -157,7 +158,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
 
         private readonly Option<string> codeownersCacheOption = new("--codeowners-cache")
         {
-            Description = "Local filesystem path to a rendered CODEOWNERS cache file (overrides --repo-derived URL)",
+            Description = "Local filesystem path to a rendered CODEOWNERS cache file (overrides inferred cache lookup)",
             Required = false,
         };
 
@@ -250,7 +251,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
             },
             new(checkPackageCommandName, "Check that a package has sufficient owners, PR labels, and service owners from a CODEOWNERS cache file")
             {
-                directoryPathOption, optionalRepoOption, codeownersCacheOption,
+                directoryPathOption, codeownersCacheOption, repoRootOption,
             },
             new McpCommand(updateCacheCommandName, "Run the CODEOWNERS cache update pipeline", CodeownerUpdateCacheToolName),
         ];
@@ -346,8 +347,8 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
             {
                 var directoryPath = parseResult.GetValue(directoryPathOption);
                 var cachePath = parseResult.GetValue(codeownersCacheOption);
-                var repo = parseResult.GetValue(optionalRepoOption);
-                return await CheckPackage(directoryPath!, cachePath, repo, ct);
+                var repoRoot = parseResult.GetValue(repoRootOption);
+                return await CheckPackage(directoryPath!, cachePath, repoRoot!, ct);
             }
 
             if (command == updateCacheCommandName)
@@ -504,18 +505,21 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
         /// <summary>
         /// Validates that a package has sufficient owners, PR labels, and service owners
         /// by reading from a CODEOWNERS cache. Uses --codeowners-cache if specified,
-        /// otherwise builds a blob URL from --repo (explicit or inferred from git remote).
+        /// otherwise builds a blob URL from the repo inferred from --repo-root.
         /// </summary>
         [McpServerTool(Name = CodeownerCheckPackageToolName), Description("Check that a package has sufficient owners, PR labels, and service owners from a CODEOWNERS cache file.")]
         public async Task<CommandResponse> CheckPackage(
             string directoryPath,
             string? codeownersCachePath = null,
-            string? repo = null,
+            string repoRoot = ".",
             CancellationToken ct = default)
         {
             try
             {
-                string cacheSource;
+                var resolvedRepoRoot = await gitHelper.DiscoverRepoRootAsync(repoRoot, ct);
+                var resolvedRepo = await gitHelper.GetRepoFullNameAsync(resolvedRepoRoot, ct: ct);
+                
+                string cacheSource = $"{CacheBaseUrl}/{resolvedRepo.ToLowerInvariant()}/CODEOWNERS.cache";
                 if (!string.IsNullOrEmpty(codeownersCachePath))
                 {
                     if (!File.Exists(codeownersCachePath))
@@ -527,29 +531,58 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
                     }
                     cacheSource = codeownersCachePath;
                 }
-                else
-                {
-                    repo = await ResolveRepo(repo, ct);
-                    // repo is "Azure/azure-sdk-for-net" → split to build URL
-                    var parts = repo.Split('/');
-                    if (parts.Length != 2)
-                    {
-                        return new DefaultCommandResponse
-                        {
-                            ResponseError = $"Invalid repo format '{repo}'. Expected '<owner>/<repo>'."
-                        };
-                    }
-                    cacheSource = $"{CacheBaseUrl}/{parts[0].ToLowerInvariant()}/{parts[1]}/CODEOWNERS.cache";
-                }
 
                 var entries = CodeownersParser.ParseCodeownersFile(cacheSource);
+                var ownersConfig = LoadOwnersConfig(resolvedRepoRoot);
 
-                return checkPackageHelper.CheckPackage(directoryPath, entries);
+                return checkPackageHelper.CheckPackage(directoryPath, entries, ownersConfig);
             }
             catch (Exception ex)
             {
                 logger.LogError(ex, "check-package failed");
                 return new DefaultCommandResponse { ResponseError = ex.Message };
+            }
+        }
+
+        private static OwnersConfig LoadOwnersConfig(string repoRoot)
+        {
+            var config = new OwnersConfig();
+            var configPath = Path.Combine(repoRoot, OwnersConfig.RelativePath);
+            if (File.Exists(configPath))
+            {
+                try
+                {
+                    config = JsonSerializer.Deserialize<OwnersConfig>(File.ReadAllText(configPath))
+                        ?? throw new InvalidOperationException($"Failed to parse owners config file '{configPath}'.");
+                    ThrowIfSkipGateExpresionsInvalid(config.SkipGates, configPath);
+                }
+                catch (JsonException ex)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to parse owners config file '{configPath}': {ex.Message}",
+                        ex);
+                }
+            }
+
+            return config;
+        }
+
+        private static void ThrowIfSkipGateExpresionsInvalid(List<string> skipGates, string configPath)
+        {
+            foreach (var skipGate in skipGates)
+            {
+                if (string.IsNullOrWhiteSpace(skipGate))
+                {
+                    throw new InvalidOperationException(
+                        $"owners-config file '{configPath}' contains an empty skipGates entry.");
+                }
+
+                if (!DirectoryUtils.IsValidCodeownersPathExpression(skipGate))
+                {
+                    throw new InvalidOperationException(
+                        $"owners-config file '{configPath}' contains invalid skipGates entry '{skipGate}'. " +
+                        "Entries must be valid CODEOWNERS path expressions.");
+                }
             }
         }
 

--- a/tools/azsdk-cli/docs/specs/8-operations-codeowners-management.spec.md
+++ b/tools/azsdk-cli/docs/specs/8-operations-codeowners-management.spec.md
@@ -144,22 +144,42 @@ Two command groups are documented:
 Inputs:
 
 - `--directory-path` (required): relative path from repo root to the package directory.
-- `--repo` (optional): `owner/repo` repository identity. If omitted, the command resolves the current git repo.
-- `--codeowners-cache` (optional): local filesystem path to a CODEOWNERS cache file. When specified, it overrides repo-derived cache lookup.
+- `--codeowners-cache` (optional): local filesystem path to a CODEOWNERS cache file. When specified, it overrides inferred cache lookup.
+- `--repo-root` (optional): local repository root used to infer the repository identity and load `.github/owners-config.json`. If omitted, `check-package` resolves the repo root from the current path.
+- optional local config: `<repoRoot>/.github/owners-config.json` may define `skipGates`, a list of CODEOWNERS-style path expressions (leading `/` required). Use `/sdk/foo/` to skip a service directory subtree or `/sdk/foo/package` to skip one direct directory path. If one matches the directory being checked, `check-package` short-circuits and succeeds for that path.
+
+Per-repo config file:
+
+```json
+{
+  "skipGates": [
+    "/sdk/extensions/",
+    "/sdk/foo/package"
+  ]
+}
+```
+
+Implementation notes:
+
+- `OwnersConfig` models the per-repo file at `.github/owners-config.json`.
+- `CodeownersTool` loads and validates that file once per `check-package` invocation, then passes the deserialized `OwnersConfig` into `ICheckPackageHelper`.
+- `ICheckPackageHelper` operates only on parsed CODEOWNERS entries plus `OwnersConfig`; it does not perform file I/O for repo config.
+- `skipGates` are validated as CODEOWNERS path expressions during config load.
+- skip-gate matching uses the provided `directoryPath` as-is. Use `/sdk/foo/` to skip a service subtree or `/sdk/foo/package` to skip one direct package directory.
 
 Cache resolution:
 
 - If `--codeowners-cache` is provided, validation reads that local file directly. This is mostly useful for testing.
-- Otherwise, validation resolves the repo and reads:
-  `https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/cache/<owner-lower>/<repo>/CODEOWNERS.cache`
+- Otherwise, validation resolves the repo from the repo root and reads:
+  `https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/cache/<repo-full-name-lower>/CODEOWNERS.cache`
 
 Pipeline requirements for producing the cache:
 
 1. Render `.github/CODEOWNERS`.
 2. Export the named section(s) required for validation using `config codeowners export-section`.
-3. Upload the exported content to `azure-sdk-write-teams/cache/<owner-lower>/<repo>/CODEOWNERS.cache`.
+3. Upload the exported content to `azure-sdk-write-teams/cache/<repo-full-name-lower>/CODEOWNERS.cache`.
 
-Current pipeline usage exports the `Client Libraries` section and uploads it as `cache/azure/<repo>/CODEOWNERS.cache`.
+Current pipeline usage exports the `Client Libraries` section and uploads it as `cache/azure/azure-sdk-for-net/CODEOWNERS.cache`.
 
 Validation rules:
 
@@ -277,7 +297,7 @@ In this example, `Storage` exists as a label entity but is not attached to the p
 - Package entries are generated from selecting the latest `Package` work item by version and hydrated related owners/labels/label-owners.
 - Service-level path entries are generated from unlinked `Label Owner` records with non-empty `RepoPath`.
 - Pathless metadata entries are grouped by service-label set from unlinked `Label Owner` records with empty `RepoPath`.
-- Validation cache artifacts can be produced by exporting named sections from rendered CODEOWNERS. The current pipeline exports `Client Libraries` and uploads the result to `azure-sdk-write-teams/cache/<owner-lower>/<repo>/CODEOWNERS.cache`.
+- Validation cache artifacts can be produced by exporting named sections from rendered CODEOWNERS. The current pipeline exports `Client Libraries` and uploads the result to `azure-sdk-write-teams/cache/<repo-full-name-lower>/CODEOWNERS.cache`.
 - Original owner collections are preserved in generated `CodeownersEntry` via:
   - `OriginalSourceOwners`
   - `OriginalServiceOwners`
@@ -307,9 +327,10 @@ Sorting is implemented in `CodeownersEntrySorter.cs`.
 CodeownersTool
   -> resolves repo and arguments
   -> delegates view/add/remove/generate/export logic to helpers
-  -> for check-package, resolves cache source (local file or blob URL)
+  -> for check-package, resolves repo root, infers repo, then resolves cache source (local file or blob URL)
+  -> loads and validates optional .github/owners-config.json into OwnersConfig
   -> parses CODEOWNERS cache with CodeownersParser
-  -> validates package ownership via ICheckPackageHelper
+  -> validates package ownership via ICheckPackageHelper using parsed entries plus OwnersConfig
   -> helpers query/update Azure DevOps via IDevOpsService
   -> helpers query/validate GitHub identities or teams via IGitHubService
 
@@ -576,14 +597,25 @@ azsdk config codeowners export-section --codeowners-path .github/CODEOWNERS --se
 **Command:**
 
 ```bash
-azsdk config codeowners check-package --directory-path sdk/storage/Azure.Storage.Blobs --repo Azure/azure-sdk-for-net
+azsdk config codeowners check-package --repo-root /path/to/azure-sdk-for-net --directory-path sdk/storage/Azure.Storage.Blobs
 ```
 
 **Options:**
 
 - `--directory-path <relative-path>`: Relative path from repo root to the package directory.
-- `--repo <owner/name>`: Optional repository identity. If omitted, the current git repo is used to derive the cache URL.
-- `--codeowners-cache <path>`: Optional local cache file path. Overrides repo-derived cache lookup.
+- `--codeowners-cache <path>`: Optional local cache file path. Overrides inferred cache lookup.
+- `--repo-root <path>`: Optional repository root path used to infer the repo identity and read `.github/owners-config.json`. Defaults to the current path.
+
+**Per-repo config file:**
+
+```json
+{
+  "skipGates": [
+    "/sdk/extensions/",
+    "/sdk/foo/package"
+  ]
+}
+```
 
 **Expected Output:**
 
@@ -599,7 +631,8 @@ Service Owners: owner3, owner4
 
 ```text
 Error: CODEOWNERS cache file not found: <path>
-Error: Invalid repo format '<repo>'. Expected '<owner>/<repo>'.
+Error: Failed to parse owners config file '<repoRoot>/.github/owners-config.json': <json error>
+Error: owners-config file '<repoRoot>/.github/owners-config.json' contains invalid skipGates entry '<entry>'. Entries must be valid CODEOWNERS path expressions.
 Error: check-package failed: <validation failure>
 ```
 


### PR DESCRIPTION
Check a repo-level config file to skip validation. This is mostly useful for SDK-owned packages that have different rules for release and PR gates. This information is not represented in DevOps work items and differs per-repo. 

Other options not implemented here and evaluated by the tool: 
* Behavior configs that can be distributed throughout the codebase (e.g. `/sdk/extensions/owners.config.json`) 