### PR TITLE
Add ability to exclude artifacts from CODEOWNERS verification in ci.yml

### DIFF
--- a/eng/common/pipelines/templates/steps/verify-codeowners.yml
+++ b/eng/common/pipelines/templates/steps/verify-codeowners.yml
@@ -4,6 +4,7 @@ parameters:
     default: $(Build.ArtifactStagingDirectory)/PackageInfo
   - name: Artifacts
     type: object
+    default: []
   - name: Repo
     type: string
     default: $(Build.Repository.Name)

--- a/eng/common/pipelines/templates/steps/verify-codeowners.yml
+++ b/eng/common/pipelines/templates/steps/verify-codeowners.yml
@@ -2,6 +2,8 @@ parameters:
   - name: ArtifactPath
     type: string
     default: $(Build.ArtifactStagingDirectory)/PackageInfo
+  - name: Artifacts
+    type: object
   - name: Repo
     type: string
     default: $(Build.Repository.Name)
@@ -29,4 +31,5 @@ steps:
         -AzsdkPath '$(AZSDK)'
         -PackageInfoDirectory '${{ parameters.ArtifactPath }}'
         -SdkTypes ${{ join(',', parameters.SdkTypes) }}
+        -ArtifactsJson '${{ convertToJson(parameters.Artifacts) }}'
         -Repo '${{ parameters.Repo }}'

--- a/eng/common/scripts/Test-CodeownersForArtifacts.ps1
+++ b/eng/common/scripts/Test-CodeownersForArtifacts.ps1
@@ -3,6 +3,7 @@ param(
     [string] $AzsdkPath,
     [string] $PackageInfoDirectory,
     [array] $SdkTypes,
+    [string] $ArtifactsJson,
     [string] $Repo
 )
 
@@ -12,9 +13,24 @@ Set-StrictMode -Version 3
 $ErrorActionPreference = 'Stop'
 
 $failedPackages = @()
+$excludedArtifacts = @()
+$artifacts = $ArtifactsJson | ConvertFrom-Json
+
+foreach ($artifact in $artifacts) {
+    if ($artifact.PSObject.Properties.Name -contains "skipCodeownersVerification" -and $artifact.skipCodeownersVerification) {
+        $excludedArtifacts += $artifact.Name
+    }
+}
+
+Write-Host "Excluded artifacts: $($excludedArtifacts -join ', ')"
 
 foreach ($pkgPropertiesFile in Get-ChildItem -Path $PackageInfoDirectory -Filter '*.json' -File) {
     $pkgProperties = Get-Content -Raw -Path $pkgPropertiesFile | ConvertFrom-Json
+
+    if ($excludedArtifacts -contains $pkgProperties.Name) {
+        Write-Host "Skipping package: $($pkgProperties.Name) $($pkgProperties.DirectoryPath) because it is in the list of artifacts to exclude from validation."
+        continue
+    }
     if ($SdkTypes -notcontains $pkgProperties.SdkType) {
         Write-Host "Skipping package: $($pkgProperties.Name) $($pkgProperties.DirectoryPath) because its SdkType '$($pkgProperties.SdkType)' is not in the list of SdkTypes to validate."
         continue


### PR DESCRIPTION
Example pipeline with skipping enabled for a package: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6215935&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=6b39eeeb-8630-577b-6174-f2bee8ec791c&l=113

> Skipping package: Azure.Template sdk/template/Azure.Template because it is in the list of artifacts to exclude from validation.
