### PR TITLE
Fix stresswatcher release

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-publish-net.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-publish-net.yml
@@ -92,7 +92,7 @@ stages:
 
         - task: PowerShell@2
           displayName: 'Post to github release'
-          condition: and(succeeded(), eq('${{ parameters.ShouldPublishExecutables }}', 'true'))
+          condition: and(succeeded(), eq(${{ parameters.ShouldPublishExecutables }}, true))
           inputs:
             targetType: filePath
             # todo, move this local script from the build tools repo as well

--- a/eng/pipelines/templates/stages/archetype-sdk-publish-net.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-publish-net.yml
@@ -92,6 +92,7 @@ stages:
 
         - task: PowerShell@2
           displayName: 'Post to github release'
+          condition: and(succeeded(), eq(parameters.ShouldPostBinaries, 'true'))
           inputs:
             targetType: filePath
             # todo, move this local script from the build tools repo as well

--- a/eng/pipelines/templates/stages/archetype-sdk-publish-net.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-publish-net.yml
@@ -92,7 +92,7 @@ stages:
 
         - task: PowerShell@2
           displayName: 'Post to github release'
-          condition: and(succeeded(), eq(parameters.ShouldPostBinaries, 'true'))
+          condition: and(succeeded(), eq(parameters.ShouldPublishExecutables, 'true'))
           inputs:
             targetType: filePath
             # todo, move this local script from the build tools repo as well

--- a/eng/pipelines/templates/stages/archetype-sdk-publish-net.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-publish-net.yml
@@ -92,7 +92,7 @@ stages:
 
         - task: PowerShell@2
           displayName: 'Post to github release'
-          condition: and(succeeded(), eq(parameters.ShouldPublishExecutables, 'true'))
+          condition: and(succeeded(), eq('${{ parameters.ShouldPublishExecutables }}', 'true'))
           inputs:
             targetType: filePath
             # todo, move this local script from the build tools repo as well


### PR DESCRIPTION
We shouldn't attempt to post files to a github release if `ShouldPublishExecutables` is set to false. 

Related to debugging of #9842