### PR TITLE
Pass package version to release-plan update-release-status CLI command

### DIFF
--- a/eng/common/scripts/Mark-ReleasePlanCompletion.ps1
+++ b/eng/common/scripts/Mark-ReleasePlanCompletion.ps1
@@ -48,7 +48,13 @@ function Process-Package([string]$packageInfoPath)
     } 
 
     Write-Host "Marking release completion for package, name: $PackageName"
-    $releaseInfo = & $AzsdkExePath release-plan update-release-status --package-name $PackageName --language $LanguageDisplayName --status "Released"
+    $PackageVersion = $pkgInfo.Version
+    $releaseArgs = @("release-plan", "update-release-status", "--package-name", $PackageName, "--language", $LanguageDisplayName, "--status", "Released")
+    if ($PackageVersion)
+    {
+        $releaseArgs += @("--package-version", $PackageVersion)
+    }
+    $releaseInfo = & $AzsdkExePath @releaseArgs
     if ($LASTEXITCODE -ne 0)
     {
         ## Not all releases have a release plan. So we should not fail the script even if a release plan is missing.


### PR DESCRIPTION
Update Mark-ReleasePlanCompletion.ps1 to extract the package version from the package info JSON and pass it via --package-version to the azsdk CLI. The version is only passed when available.

Resolves #15267 