### PR TITLE
Add support for optional target directory for snippet replacement

### DIFF
--- a/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/Azure.Sdk.Tools.SnippetGenerator.Tests.csproj
+++ b/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/Azure.Sdk.Tools.SnippetGenerator.Tests.csproj
@@ -34,6 +34,15 @@
       <None Update="TestData\MarkdownOnlyNoSpace.md">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
+      <None Update="TestData\SnippetTarget\TargetPathTest.md">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+    </ItemGroup>
+
+    <ItemGroup>
+      <Compile Update="TestData\SnippetSource\TargetPathSnippets.cs">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Compile>
     </ItemGroup>
 
 </Project>

--- a/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/DirectoryProcessorTests.cs
+++ b/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/DirectoryProcessorTests.cs
@@ -76,5 +76,25 @@ namespace Azure.Sdk.Tools.SnippetGenerator.Tests
 
             StringAssert.Contains("var greeting = \"Hello from a separate directory!\";", result);
         }
+
+        [Test]
+        public async System.Threading.Tasks.Task TargetPathUsedForReplacementsWithoutExplicitFiles()
+        {
+            var basePath = Path.Join(TestContext.CurrentContext.TestDirectory, "TestData");
+            var snippetDir = Path.Join(basePath, "SnippetSource");
+            var targetDir = Path.Join(basePath, "SnippetTarget");
+            var mdFile = Path.Join(targetDir, "TargetPathTest.md");
+
+            // Reset the markdown file to its original state
+            File.WriteAllText(mdFile, "```C# Snippet:TargetPathSnippet\n```\n");
+
+            // ProcessAsync with no file list should enumerate targetDir and find TargetPathTest.md
+            var sut = new DirectoryProcessor(snippetDir, targetDir);
+            await sut.ProcessAsync();
+
+            var result = File.ReadAllText(mdFile);
+
+            StringAssert.Contains("var greeting = \"Hello from a separate directory!\";", result);
+        }
     }
 }

--- a/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/DirectoryProcessorTests.cs
+++ b/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/DirectoryProcessorTests.cs
@@ -56,5 +56,25 @@ namespace Azure.Sdk.Tools.SnippetGenerator.Tests
             StringAssert.Contains("var x = 1;", result);
             StringAssert.Contains("var y = 2;", result);
         }
+
+        [Test]
+        public async System.Threading.Tasks.Task TargetPathUsedForReplacements()
+        {
+            var basePath = Path.Join(TestContext.CurrentContext.TestDirectory, "TestData");
+            var snippetDir = Path.Join(basePath, "SnippetSource");
+            var targetDir = Path.Join(basePath, "SnippetTarget");
+            var mdFile = Path.Join(targetDir, "TargetPathTest.md");
+
+            // Reset the markdown file to its original state
+            File.WriteAllText(mdFile, "```C# Snippet:TargetPathSnippet\n```\n");
+
+            // Snippets discovered from snippetDir, replacements applied in targetDir
+            var sut = new DirectoryProcessor(snippetDir, targetDir);
+            await sut.ProcessAsync(new[] { mdFile });
+
+            var result = File.ReadAllText(mdFile);
+
+            StringAssert.Contains("var greeting = \"Hello from a separate directory!\";", result);
+        }
     }
 }

--- a/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/ProgramTests.cs
+++ b/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/ProgramTests.cs
@@ -90,5 +90,109 @@ namespace Azure.Sdk.Tools.SnippetGenerator.Tests
                 Directory.Delete(targetPath, true);
             }
         }
+
+        [Test]
+        public void OnExecuteAsync_ThrowsWhenBasePathDoesNotExist()
+        {
+            var program = new Program
+            {
+                BasePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()),
+                TargetPath = Path.GetTempPath()
+            };
+
+            Assert.ThrowsAsync<DirectoryNotFoundException>(async () => await program.OnExecuteAsync());
+        }
+
+        [Test]
+        public void OnExecuteAsync_ThrowsWhenTargetPathDoesNotExist()
+        {
+            var basePath = Directory.CreateDirectory(
+                Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())).FullName;
+
+            try
+            {
+                var program = new Program
+                {
+                    BasePath = basePath,
+                    TargetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
+                };
+
+                Assert.ThrowsAsync<DirectoryNotFoundException>(program.OnExecuteAsync);
+            }
+            finally
+            {
+                Directory.Delete(basePath, recursive: true);
+            }
+        }
+
+        [Test]
+        public async Task OnExecuteAsync_TargetPathDefaultsToBasePathWhenNull()
+        {
+            var basePath = Directory.CreateDirectory(
+                Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())).FullName;
+
+            try
+            {
+                var program = new Program
+                {
+                    BasePath = basePath,
+                    TargetPath = null
+                };
+
+                // Should not throw the directory-not-found exception since target falls back to BasePath.
+                await program.OnExecuteAsync();
+            }
+            finally
+            {
+                Directory.Delete(basePath, recursive: true);
+            }
+        }
+
+        [Test]
+        public async Task OnExecuteAsync_ProcessesEachSubdirectoryWhenBaseDirectoryIsSdk()
+        {
+            var root = Directory.CreateDirectory(
+                Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())).FullName;
+            var sdkDir = Directory.CreateDirectory(Path.Combine(root, "sdk")).FullName;
+            Directory.CreateDirectory(Path.Combine(sdkDir, "serviceA"));
+            Directory.CreateDirectory(Path.Combine(sdkDir, "serviceB"));
+
+            try
+            {
+                var program = new Program
+                {
+                    BasePath = sdkDir,
+                    TargetPath = sdkDir
+                };
+
+                await program.OnExecuteAsync();
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Test]
+        public async Task OnExecuteAsync_ProcessesSingleDirectoryWhenBaseDirectoryIsNotSdk()
+        {
+            var basePath = Directory.CreateDirectory(
+                Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "notSdk")).FullName;
+
+            try
+            {
+                var program = new Program
+                {
+                    BasePath = basePath,
+                    TargetPath = basePath
+                };
+
+                await program.OnExecuteAsync();
+            }
+            finally
+            {
+                Directory.Delete(Directory.GetParent(basePath)!.FullName, recursive: true);
+            }
+        }
     }
 }

--- a/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/ProgramTests.cs
+++ b/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/ProgramTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Azure.Sdk.Tools.SnippetGenerator.Tests
+{
+    public class ProgramTests
+    {
+        [Test]
+        public void OnExecuteAsync_NonExistentBasePath_ThrowsDirectoryNotFoundException()
+        {
+            var program = new Program
+            {
+                BasePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
+            };
+
+            var ex = Assert.ThrowsAsync<DirectoryNotFoundException>(async () => await program.OnExecuteAsync());
+            StringAssert.Contains("base path", ex.Message);
+        }
+
+        [Test]
+        public void OnExecuteAsync_NonExistentTargetPath_ThrowsDirectoryNotFoundException()
+        {
+            var basePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(basePath);
+
+            try
+            {
+                var program = new Program
+                {
+                    BasePath = basePath,
+                    TargetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
+                };
+
+                var ex = Assert.ThrowsAsync<DirectoryNotFoundException>(async () => await program.OnExecuteAsync());
+                StringAssert.Contains("target path", ex.Message);
+            }
+            finally
+            {
+                Directory.Delete(basePath, true);
+            }
+        }
+
+        [Test]
+        public void OnExecuteAsync_ValidPaths_DoesNotThrow()
+        {
+            var basePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(basePath);
+
+            try
+            {
+                var program = new Program
+                {
+                    BasePath = basePath
+                };
+
+                Assert.DoesNotThrowAsync(async () => await program.OnExecuteAsync());
+            }
+            finally
+            {
+                Directory.Delete(basePath, true);
+            }
+        }
+
+        [Test]
+        public void OnExecuteAsync_ValidBaseAndTargetPaths_DoesNotThrow()
+        {
+            var basePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var targetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(basePath);
+            Directory.CreateDirectory(targetPath);
+
+            try
+            {
+                var program = new Program
+                {
+                    BasePath = basePath,
+                    TargetPath = targetPath
+                };
+
+                Assert.DoesNotThrowAsync(async () => await program.OnExecuteAsync());
+            }
+            finally
+            {
+                Directory.Delete(basePath, true);
+                Directory.Delete(targetPath, true);
+            }
+        }
+    }
+}

--- a/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/TestData/SnippetSource/TargetPathSnippets.cs
+++ b/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/TestData/SnippetSource/TargetPathSnippets.cs
@@ -1,0 +1,15 @@
+using NUnit.Framework;
+
+namespace Azure.Sdk.Tools.SnippetGenerator.TestData
+{
+    public class TargetPathSnippets
+    {
+        [Test]
+        public void TargetPathSnippet()
+        {
+            #region Snippet:TargetPathSnippet
+            var greeting = "Hello from a separate directory!";
+            #endregion
+        }
+    }
+}

--- a/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/TestData/SnippetSource/TargetPathSnippets.cs
+++ b/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/TestData/SnippetSource/TargetPathSnippets.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 
 namespace Azure.Sdk.Tools.SnippetGenerator.TestData
@@ -9,6 +10,7 @@ namespace Azure.Sdk.Tools.SnippetGenerator.TestData
         {
             #region Snippet:TargetPathSnippet
             var greeting = "Hello from a separate directory!";
+            Console.WriteLine(greeting);
             #endregion
         }
     }

--- a/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/TestData/SnippetTarget/TargetPathTest.md
+++ b/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/TestData/SnippetTarget/TargetPathTest.md
@@ -1,0 +1,2 @@
+```C# Snippet:TargetPathSnippet
+```

--- a/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator/DirectoryProcessor.cs
+++ b/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator/DirectoryProcessor.cs
@@ -20,6 +20,7 @@ namespace Azure.Sdk.Tools.SnippetGenerator
     {
         private const string _snippetPrefix = "Snippet:";
         private readonly string _directory;
+        private readonly string _targetDirectory;
         private readonly Lazy<Task<List<Snippet>>> _snippets;
         private static readonly Regex _markdownOnlyRegex = new Regex(
             @"(?<indent>\s*)//@@ ?(?<line>.*)",
@@ -32,9 +33,10 @@ namespace Azure.Sdk.Tools.SnippetGenerator
         private UTF8Encoding _utf8EncodingWithoutBOM;
         private static string[] _snippetPreprocessorSymbols = new [] {"SNIPPET"};
 
-        public DirectoryProcessor(string directory)
+        public DirectoryProcessor(string directory, string targetDirectory = null)
         {
             _directory = directory;
+            _targetDirectory = targetDirectory ?? directory;
             _snippets = new Lazy<Task<List<Snippet>>>(DiscoverSnippetsAsync);
         }
 
@@ -43,8 +45,8 @@ namespace Azure.Sdk.Tools.SnippetGenerator
             if (files is null)
             {
                 List<string> discoveredFiles = new();
-                discoveredFiles.AddRange(Directory.EnumerateFiles(_directory, "*.md", SearchOption.AllDirectories));
-                discoveredFiles.AddRange(Directory.EnumerateFiles(_directory, "*.cs", SearchOption.AllDirectories));
+                discoveredFiles.AddRange(Directory.EnumerateFiles(_targetDirectory, "*.md", SearchOption.AllDirectories));
+                discoveredFiles.AddRange(Directory.EnumerateFiles(_targetDirectory, "*.cs", SearchOption.AllDirectories));
 
                 files = discoveredFiles;
             }

--- a/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator/Program.cs
+++ b/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -41,10 +41,7 @@ namespace Azure.Sdk.Tools.SnippetGenerator
                 var tasks = new List<Task<IEnumerable<string>>>();
                 foreach (var sdkDir in Directory.GetDirectories(BasePath))
                 {
-                    var targetDir = TargetPath != null
-                        ? Path.Combine(targetPath, new DirectoryInfo(sdkDir).Name)
-                        : sdkDir;
-                    tasks.Add(new DirectoryProcessor(sdkDir, targetDir).ProcessAsync());
+                    tasks.Add(new DirectoryProcessor(sdkDir, targetPath).ProcessAsync());
                 }
 
                 await Task.WhenAll(tasks);

--- a/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator/Program.cs
+++ b/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator/Program.cs
@@ -26,12 +26,12 @@ namespace Azure.Sdk.Tools.SnippetGenerator
             var targetPath = TargetPath ?? BasePath;
             var baseDirectory = new DirectoryInfo(BasePath).Name;
             
-            if( Directory.Exists(BasePath) == false)
+            if (Directory.Exists(BasePath) == false)
             {
                 throw new DirectoryNotFoundException($"The specified base path '{BasePath}' does not exist.");
             }
 
-            if( Directory.Exists(targetPath) == false)
+            if (Directory.Exists(targetPath) == false)
             {
                 throw new DirectoryNotFoundException($"The specified target path '{targetPath}' does not exist.");
             }

--- a/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator/Program.cs
+++ b/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator/Program.cs
@@ -15,6 +15,7 @@ namespace Azure.Sdk.Tools.SnippetGenerator
     public class Program
     {
         [Option(ShortName = "b")] public string BasePath { get; set; }
+        [Option(ShortName = "t")] public string TargetPath { get; set; }
         [Option(ShortName = "sm")] public bool StrictMode { get; set; }
 
         public async Task OnExecuteAsync()
@@ -22,13 +23,17 @@ namespace Azure.Sdk.Tools.SnippetGenerator
             List<string> unUsedSnippets = null;
             Stopwatch sw = new Stopwatch();
             sw.Start();
+            var targetPath = TargetPath ?? BasePath;
             var baseDirectory = new DirectoryInfo(BasePath).Name;
             if (baseDirectory.Equals("sdk"))
             {
                 var tasks = new List<Task<IEnumerable<string>>>();
                 foreach (var sdkDir in Directory.GetDirectories(BasePath))
                 {
-                    tasks.Add(new DirectoryProcessor(sdkDir).ProcessAsync());
+                    var targetDir = TargetPath != null
+                        ? Path.Combine(targetPath, new DirectoryInfo(sdkDir).Name)
+                        : sdkDir;
+                    tasks.Add(new DirectoryProcessor(sdkDir, targetDir).ProcessAsync());
                 }
 
                 await Task.WhenAll(tasks);
@@ -38,7 +43,7 @@ namespace Azure.Sdk.Tools.SnippetGenerator
             }
             else
             {
-                unUsedSnippets = (await new DirectoryProcessor(BasePath).ProcessAsync()).ToList();
+                unUsedSnippets = (await new DirectoryProcessor(BasePath, targetPath).ProcessAsync()).ToList();
             }
             Console.WriteLine();
             if (unUsedSnippets.Any())

--- a/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator/Program.cs
+++ b/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator/Program.cs
@@ -25,6 +25,17 @@ namespace Azure.Sdk.Tools.SnippetGenerator
             sw.Start();
             var targetPath = TargetPath ?? BasePath;
             var baseDirectory = new DirectoryInfo(BasePath).Name;
+            
+            if( Directory.Exists(BasePath) == false)
+            {
+                throw new DirectoryNotFoundException($"The specified base path '{BasePath}' does not exist.");
+            }
+
+            if( Directory.Exists(targetPath) == false)
+            {
+                throw new DirectoryNotFoundException($"The specified target path '{targetPath}' does not exist.");
+            }
+
             if (baseDirectory.Equals("sdk"))
             {
                 var tasks = new List<Task<IEnumerable<string>>>();


### PR DESCRIPTION
Allow for an optional -t param to set a target directory.  This allows the snippet tool to search the -b (base) directory for snippet and a -t (target) directory for replacements.

Original functionality is not affected.