### PR TITLE
Handle 403 from APIView with VPN/login guidance for SdkReleaseTool

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/SdkReleaseToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/SdkReleaseToolTests.cs
@@ -139,5 +139,30 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.Package
             Assert.That(result, Is.Not.Null);
             Assert.That(result.ReleaseStatusDetails, Does.Contain("https://apiview.dev"));
         }
+
+        [Test]
+        public async Task TestCheckReadyWithApiViewNotApproved_Returns403Message()
+        {
+            var packageName = "Azure.Security.KeyVault.Secrets";
+            var language = ".NET";
+
+            devOpsService.ConfiguredAPIViewStatus = "Pending";
+            mockApiViewService
+                .Setup(x => x.GetReviewUrlByPackageAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new HttpRequestException(
+                    "Received 403 Forbidden from APIView. Please make sure you are logged in to Azure (run 'az login') and connected to the Microsoft VPN.",
+                    null,
+                    System.Net.HttpStatusCode.Forbidden));
+
+            var result = await sdkReleaseTool.ReleasePackageAsync(packageName, language, "main", checkReady: true);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ReleaseStatusDetails, Does.Contain("not ready for release"));
+                Assert.That(result.ReleaseStatusDetails, Does.Contain("az login"));
+                Assert.That(result.ReleaseStatusDetails, Does.Contain("VPN"));
+            });
+        }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/APIView/APIViewService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/APIView/APIViewService.cs
@@ -273,6 +273,13 @@ public class APIViewService : IAPIViewService
             var json = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(result);
             return json.GetProperty("url").GetString();
         }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Forbidden)
+        {
+            throw new HttpRequestException(
+                "Received 403 Forbidden from APIView. Please make sure you are logged in to Azure (run 'az login') and connected to the Microsoft VPN.",
+                ex,
+                HttpStatusCode.Forbidden);
+        }
         catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
         {
             return null;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkReleaseTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkReleaseTool.cs
@@ -261,6 +261,10 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
                                 }
                             }
                         }
+                        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Forbidden)
+                        {
+                            package.PackageReadinessDetails += $"Failed to retrieve APIView URL: {ex.Message} ";
+                        }
                         catch (Exception ex)
                         {
                             logger.LogWarning(ex, "Failed to resolve APIView URL for package '{PackageName}' in language '{Language}'.", packageName, language);


### PR DESCRIPTION
When APIView returns a 403 (due to not being on VPN or not logged in via az login), surface a clear error message to the user instead of a generic failure.