### PR TITLE
Transition `docindex` to PAT

### DIFF
--- a/eng/common/pipelines/templates/jobs/docindex.yml
+++ b/eng/common/pipelines/templates/jobs/docindex.yml
@@ -16,6 +16,8 @@ jobs:
         workingDirectory: $(Build.BinariesDirectory)
         displayName: Download and Extract DocFX
 
+      - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+
       - task: AzureCLI@2
         displayName: 'Generate Doc Index'
         inputs:
@@ -66,5 +68,5 @@ jobs:
           arguments: >
             -PRBranchName "gh-pages"
             -CommitMsg "Auto-generated docs from SHA(s) $(Build.SourceVersion)"
-            -GitUrl "https://$(azuresdk-github-pat)@github.com/$(Build.Repository.Name).git"
+            -GitUrl "https://x-access-token:$(GH_TOKEN)@github.com/$(Build.Repository.Name).git"
             -PushArgs "--force"


### PR DESCRIPTION
Related to #9842

[Confirmed working properly](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6224172&view=logs&j=5e8cddd4-765d-5046-f31f-2d7d6b215293&t=a0fc70ba-ed82-5e67-1311-076aa09f267f)

The `repo-specific` changes that happen in the second leg of all the `docindex` builds will need to be updated as well. That can come after.