### PR TITLE
[azsdk-cli] Resolve npm exec binaries directly from node_modules for NpmOptions

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/NpmOptionsTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/NpmOptionsTests.cs
@@ -81,7 +81,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Helpers
         }
 
         [Test]
-        public void Constructor_WithPrefix_NoPackageJson_BuildsExecWithPrefix()
+        public void Constructor_WithPrefix_BinaryNotInNodeModulesBin_FallsBackToNpmExec()
         {
             var options = new NpmOptions(prefix: tempDir, args: ["tsp-client", "init"]);
 
@@ -101,66 +101,55 @@ namespace Azure.Sdk.Tools.Cli.Tests.Helpers
         }
 
         [Test]
-        public void Constructor_WithPrefix_PackageJsonWithDependencies_IncludesPackageFlags()
+        public void Constructor_WithPrefix_BinaryExistsInNodeModulesBin_ResolvesDirectly()
         {
-            File.WriteAllText(
-                Path.Combine(tempDir, "package.json"),
-                """
-                {
-                    "dependencies": {
-                        "@azure-tools/typespec-client-generator-cli": "^1.0.0",
-                        "@azure-tools/typespec-autorest": "^0.40.0"
-                    }
-                }
-                """);
+            var binDir = Path.Combine(tempDir, "node_modules", ".bin");
+            Directory.CreateDirectory(binDir);
 
-            var options = new NpmOptions(prefix: tempDir, args: ["tsp-client", "init"]);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // Create a .cmd shim like npm does on Windows
+                var cmdPath = Path.Combine(binDir, "tsp-client.cmd");
+                File.WriteAllText(cmdPath, "@echo off");
 
-            Assert.That(options.Args, Does.Contain("--package=@azure-tools/typespec-client-generator-cli"));
-            Assert.That(options.Args, Does.Contain("--package=@azure-tools/typespec-autorest"));
-            Assert.That(options.Args, Does.Contain("--prefix"));
-            Assert.That(options.Args, Does.Contain(tempDir));
-            Assert.That(options.Args, Does.Contain("--"));
-            Assert.That(options.Args, Does.Contain("tsp-client"));
-            Assert.That(options.Args, Does.Contain("init"));
+                var options = new NpmOptions(prefix: tempDir, args: ["tsp-client", "init"]);
+
+                // On Windows, ProcessOptions wraps with cmd.exe /C
+                Assert.That(options.Command, Is.EqualTo(ProcessOptions.CMD));
+                Assert.That(options.Args, Does.Contain(cmdPath));
+                Assert.That(options.Args, Does.Contain("init"));
+                Assert.That(options.Args, Has.No.Member("tsp-client"));
+                Assert.That(options.Args, Has.No.Member("exec"));
+            }
+            else
+            {
+                var binPath = Path.Combine(binDir, "tsp-client");
+                File.WriteAllText(binPath, "#!/bin/sh");
+
+                var options = new NpmOptions(prefix: tempDir, args: ["tsp-client", "init"]);
+
+                Assert.That(options.Command, Is.EqualTo(binPath));
+                Assert.That(options.Args, Is.EqualTo(new[] { "init" }));
+            }
         }
 
         [Test]
-        public void Constructor_WithPrefix_PackageJsonWithEmptyDependencies_FallsBackToNoPackageFlags()
+        public void Constructor_WithPrefix_BinaryResolved_ArgsSkipBinaryName()
         {
-            File.WriteAllText(
-                Path.Combine(tempDir, "package.json"),
-                """
-                {
-                    "dependencies": {}
-                }
-                """);
+            var binDir = Path.Combine(tempDir, "node_modules", ".bin");
+            Directory.CreateDirectory(binDir);
 
-            var options = new NpmOptions(prefix: tempDir, args: ["tsp-client", "init"]);
+            var shimName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? "my-tool.cmd" : "my-tool";
+            File.WriteAllText(Path.Combine(binDir, shimName), "stub");
 
-            Assert.That(options.Args, Has.No.Member("--package="));
-            Assert.That(options.Args, Does.Contain("--prefix"));
-            Assert.That(options.Args, Does.Contain(tempDir));
-        }
+            var options = new NpmOptions(prefix: tempDir, args: ["my-tool", "--flag", "value"]);
 
-        [Test]
-        public void Constructor_WithPrefix_PackageJsonWithoutDependenciesKey_FallsBackToNoPackageFlags()
-        {
-            File.WriteAllText(
-                Path.Combine(tempDir, "package.json"),
-                """
-                {
-                    "name": "test-package",
-                    "version": "1.0.0"
-                }
-                """);
-
-            var options = new NpmOptions(prefix: tempDir, args: ["run", "build"]);
-
-            var argsStr = string.Join(" ", options.Args);
-            Assert.That(argsStr, Does.Not.Contain("--package="));
-            Assert.That(options.Args, Does.Contain("--prefix"));
-            Assert.That(options.Args, Does.Contain(tempDir));
+            // The binary name should be stripped; only remaining args are passed
+            Assert.That(options.Args, Does.Contain("--flag"));
+            Assert.That(options.Args, Does.Contain("value"));
+            Assert.That(options.Args, Has.No.Member("exec"));
+            Assert.That(options.Args, Has.No.Member("--prefix"));
         }
 
         [Test]
@@ -222,51 +211,39 @@ namespace Azure.Sdk.Tools.Cli.Tests.Helpers
         }
 
         [Test]
-        public void Constructor_WithPrefix_PackageJsonWithSingleDependency_IncludesSinglePackageFlag()
+        public void Constructor_WithNullPrefix_BuildsExecDashDashArgs()
         {
-            File.WriteAllText(
-                Path.Combine(tempDir, "package.json"),
-                """
-                {
-                    "dependencies": {
-                        "typescript": "^5.0.0"
-                    }
-                }
-                """);
+            var options = new NpmOptions(prefix: null, args: ["tsp-client", "init"]);
 
-            var options = new NpmOptions(prefix: tempDir, args: ["tsc"]);
-
-            Assert.That(options.Args, Does.Contain("--package=typescript"));
-            Assert.That(options.Args, Does.Contain("--"));
-            Assert.That(options.Args, Does.Contain("tsc"));
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.That(options.Args, Does.Contain("exec"));
+                Assert.That(options.Args, Does.Contain("--"));
+                Assert.That(options.Args, Does.Contain("tsp-client"));
+                Assert.That(options.Args, Does.Contain("init"));
+                Assert.That(options.Args, Has.No.Member("--prefix"));
+            }
+            else
+            {
+                Assert.That(options.Args, Is.EqualTo(new[] { "exec", "--", "tsp-client", "init" }));
+            }
         }
 
         [Test]
-        public void Constructor_PackageFlagsAppearBeforeSeparator()
+        public void Constructor_WithPrefix_BinaryWithNoExtraArgs_ResolvesWithEmptyArgs()
         {
-            File.WriteAllText(
-                Path.Combine(tempDir, "package.json"),
-                """
-                {
-                    "dependencies": {
-                        "pkg-a": "1.0.0",
-                        "pkg-b": "2.0.0"
-                    }
-                }
-                """);
+            var binDir = Path.Combine(tempDir, "node_modules", ".bin");
+            Directory.CreateDirectory(binDir);
 
-            var options = new NpmOptions(prefix: tempDir, args: ["my-bin"]);
+            var shimName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? "my-tool.cmd" : "my-tool";
+            File.WriteAllText(Path.Combine(binDir, shimName), "stub");
 
-            var argsList = options.Args;
-            var separatorIndex = argsList.IndexOf("--");
-            var pkgAIndex = argsList.IndexOf("--package=pkg-a");
-            var pkgBIndex = argsList.IndexOf("--package=pkg-b");
+            var options = new NpmOptions(prefix: tempDir, args: ["my-tool"]);
 
-            Assert.That(separatorIndex, Is.GreaterThan(-1), "Args should contain '--' separator");
-            Assert.That(pkgAIndex, Is.GreaterThan(-1), "Args should contain --package=pkg-a");
-            Assert.That(pkgBIndex, Is.GreaterThan(-1), "Args should contain --package=pkg-b");
-            Assert.That(pkgAIndex, Is.LessThan(separatorIndex), "--package flags should appear before '--'");
-            Assert.That(pkgBIndex, Is.LessThan(separatorIndex), "--package flags should appear before '--'");
+            // Only the binary name was provided, so remaining args should be empty
+            Assert.That(options.Args, Has.No.Member("my-tool"));
+            Assert.That(options.Args, Has.No.Member("exec"));
         }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/NpmOptionsTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/NpmOptionsTests.cs
@@ -1,0 +1,292 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Runtime.InteropServices;
+using Azure.Sdk.Tools.Cli.Helpers;
+
+namespace Azure.Sdk.Tools.Cli.Tests.Helpers
+{
+    internal class NpmOptionsTests
+    {
+        private string tempDir;
+
+        [SetUp]
+        public void Setup()
+        {
+            tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(tempDir);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+
+        [Test]
+        public void ShortName_WithoutPrefix_ReturnsNpm()
+        {
+            var options = new NpmOptions(prefix: null, args: ["tsp-client", "init"]);
+
+            Assert.That(options.ShortName, Is.EqualTo("npm"));
+        }
+
+        [Test]
+        public void ShortName_WithPrefix_ReturnsNpmDashDirectoryName()
+        {
+            var prefixPath = Path.Combine(tempDir, "my-tool");
+            Directory.CreateDirectory(prefixPath);
+
+            var options = new NpmOptions(prefix: prefixPath, args: ["run", "build"]);
+
+            Assert.That(options.ShortName, Is.EqualTo("npm-my-tool"));
+        }
+
+        [Test]
+        public void Prefix_WithPrefixConstructor_SetsPrefixProperty()
+        {
+            var options = new NpmOptions(prefix: tempDir, args: ["run", "build"]);
+
+            Assert.That(options.Prefix, Is.EqualTo(tempDir));
+        }
+
+        [Test]
+        public void Prefix_WithArgsOnlyConstructor_PrefixIsNull()
+        {
+            var options = new NpmOptions(args: ["install"]);
+
+            Assert.That(options.Prefix, Is.Null);
+        }
+
+        [Test]
+        public void Constructor_WithNullPrefix_BuildsExecDashDashArgs()
+        {
+            var options = new NpmOptions(prefix: null, args: ["tsp-client", "init"]);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // On Windows, args are wrapped with /C npm ...
+                Assert.That(options.Args, Does.Contain("exec"));
+                Assert.That(options.Args, Does.Contain("--"));
+                Assert.That(options.Args, Does.Contain("tsp-client"));
+                Assert.That(options.Args, Does.Contain("init"));
+                Assert.That(options.Args, Has.No.Member("--prefix"));
+            }
+            else
+            {
+                Assert.That(options.Args, Is.EqualTo(new[] { "exec", "--", "tsp-client", "init" }));
+            }
+        }
+
+        [Test]
+        public void Constructor_WithEmptyPrefix_BuildsExecDashDashArgs()
+        {
+            var options = new NpmOptions(prefix: "", args: ["run", "build"]);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.That(options.Args, Does.Contain("exec"));
+                Assert.That(options.Args, Does.Contain("--"));
+                Assert.That(options.Args, Does.Contain("run"));
+                Assert.That(options.Args, Does.Contain("build"));
+                Assert.That(options.Args, Has.No.Member("--prefix"));
+            }
+            else
+            {
+                Assert.That(options.Args, Is.EqualTo(new[] { "exec", "--", "run", "build" }));
+            }
+        }
+
+        [Test]
+        public void Constructor_WithPrefix_NoPackageJson_BuildsExecWithPrefix()
+        {
+            var options = new NpmOptions(prefix: tempDir, args: ["tsp-client", "init"]);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.That(options.Args, Does.Contain("exec"));
+                Assert.That(options.Args, Does.Contain("--prefix"));
+                Assert.That(options.Args, Does.Contain(tempDir));
+                Assert.That(options.Args, Does.Contain("--"));
+                Assert.That(options.Args, Does.Contain("tsp-client"));
+                Assert.That(options.Args, Does.Contain("init"));
+            }
+            else
+            {
+                Assert.That(options.Args, Is.EqualTo(new[] { "exec", "--prefix", tempDir, "--", "tsp-client", "init" }));
+            }
+        }
+
+        [Test]
+        public void Constructor_WithPrefix_PackageJsonWithDependencies_IncludesPackageFlags()
+        {
+            File.WriteAllText(
+                Path.Combine(tempDir, "package.json"),
+                """
+                {
+                    "dependencies": {
+                        "@azure-tools/typespec-client-generator-cli": "^1.0.0",
+                        "@azure-tools/typespec-autorest": "^0.40.0"
+                    }
+                }
+                """);
+
+            var options = new NpmOptions(prefix: tempDir, args: ["tsp-client", "init"]);
+
+            Assert.That(options.Args, Does.Contain("--package=@azure-tools/typespec-client-generator-cli"));
+            Assert.That(options.Args, Does.Contain("--package=@azure-tools/typespec-autorest"));
+            Assert.That(options.Args, Does.Contain("--prefix"));
+            Assert.That(options.Args, Does.Contain(tempDir));
+            Assert.That(options.Args, Does.Contain("--"));
+            Assert.That(options.Args, Does.Contain("tsp-client"));
+            Assert.That(options.Args, Does.Contain("init"));
+        }
+
+        [Test]
+        public void Constructor_WithPrefix_PackageJsonWithEmptyDependencies_FallsBackToNoPackageFlags()
+        {
+            File.WriteAllText(
+                Path.Combine(tempDir, "package.json"),
+                """
+                {
+                    "dependencies": {}
+                }
+                """);
+
+            var options = new NpmOptions(prefix: tempDir, args: ["tsp-client", "init"]);
+
+            Assert.That(options.Args, Has.No.Member("--package="));
+            Assert.That(options.Args, Does.Contain("--prefix"));
+            Assert.That(options.Args, Does.Contain(tempDir));
+        }
+
+        [Test]
+        public void Constructor_WithPrefix_PackageJsonWithoutDependenciesKey_FallsBackToNoPackageFlags()
+        {
+            File.WriteAllText(
+                Path.Combine(tempDir, "package.json"),
+                """
+                {
+                    "name": "test-package",
+                    "version": "1.0.0"
+                }
+                """);
+
+            var options = new NpmOptions(prefix: tempDir, args: ["run", "build"]);
+
+            var argsStr = string.Join(" ", options.Args);
+            Assert.That(argsStr, Does.Not.Contain("--package="));
+            Assert.That(options.Args, Does.Contain("--prefix"));
+            Assert.That(options.Args, Does.Contain(tempDir));
+        }
+
+        [Test]
+        public void Constructor_ArgsOnly_PassesArgsDirectlyToNpm()
+        {
+            var options = new NpmOptions(args: ["install"]);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.That(options.Args, Does.Contain("install"));
+            }
+            else
+            {
+                Assert.That(options.Args, Is.EqualTo(new[] { "install" }));
+            }
+        }
+
+        [Test]
+        public void Constructor_WithWorkingDirectory_SetsWorkingDirectory()
+        {
+            var options = new NpmOptions(
+                prefix: null,
+                args: ["run", "build"],
+                workingDirectory: tempDir);
+
+            Assert.That(options.WorkingDirectory, Is.EqualTo(tempDir));
+        }
+
+        [Test]
+        public void Constructor_WithTimeout_SetsTimeout()
+        {
+            var timeout = TimeSpan.FromMinutes(5);
+
+            var options = new NpmOptions(
+                prefix: null,
+                args: ["run", "build"],
+                timeout: timeout);
+
+            Assert.That(options.Timeout, Is.EqualTo(timeout));
+        }
+
+        [Test]
+        public void Constructor_WithDefaultTimeout_UsesTwoMinutes()
+        {
+            var options = new NpmOptions(prefix: null, args: ["run", "build"]);
+
+            Assert.That(options.Timeout, Is.EqualTo(TimeSpan.FromMinutes(2)));
+        }
+
+        [Test]
+        public void Constructor_WithLogOutputStreamFalse_SetsLogOutputStream()
+        {
+            var options = new NpmOptions(
+                prefix: null,
+                args: ["run", "build"],
+                logOutputStream: false);
+
+            Assert.That(options.LogOutputStream, Is.False);
+        }
+
+        [Test]
+        public void Constructor_WithPrefix_PackageJsonWithSingleDependency_IncludesSinglePackageFlag()
+        {
+            File.WriteAllText(
+                Path.Combine(tempDir, "package.json"),
+                """
+                {
+                    "dependencies": {
+                        "typescript": "^5.0.0"
+                    }
+                }
+                """);
+
+            var options = new NpmOptions(prefix: tempDir, args: ["tsc"]);
+
+            Assert.That(options.Args, Does.Contain("--package=typescript"));
+            Assert.That(options.Args, Does.Contain("--"));
+            Assert.That(options.Args, Does.Contain("tsc"));
+        }
+
+        [Test]
+        public void Constructor_PackageFlagsAppearBeforeSeparator()
+        {
+            File.WriteAllText(
+                Path.Combine(tempDir, "package.json"),
+                """
+                {
+                    "dependencies": {
+                        "pkg-a": "1.0.0",
+                        "pkg-b": "2.0.0"
+                    }
+                }
+                """);
+
+            var options = new NpmOptions(prefix: tempDir, args: ["my-bin"]);
+
+            var argsList = options.Args;
+            var separatorIndex = argsList.IndexOf("--");
+            var pkgAIndex = argsList.IndexOf("--package=pkg-a");
+            var pkgBIndex = argsList.IndexOf("--package=pkg-b");
+
+            Assert.That(separatorIndex, Is.GreaterThan(-1), "Args should contain '--' separator");
+            Assert.That(pkgAIndex, Is.GreaterThan(-1), "Args should contain --package=pkg-a");
+            Assert.That(pkgBIndex, Is.GreaterThan(-1), "Args should contain --package=pkg-b");
+            Assert.That(pkgAIndex, Is.LessThan(separatorIndex), "--package flags should appear before '--'");
+            Assert.That(pkgBIndex, Is.LessThan(separatorIndex), "--package flags should appear before '--'");
+        }
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/NpmOptionsTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/NpmOptionsTests.cs
@@ -62,26 +62,6 @@ namespace Azure.Sdk.Tools.Cli.Tests.Helpers
         }
 
         [Test]
-        public void Constructor_WithNullPrefix_BuildsExecDashDashArgs()
-        {
-            var options = new NpmOptions(prefix: null, args: ["tsp-client", "init"]);
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                // On Windows, args are wrapped with /C npm ...
-                Assert.That(options.Args, Does.Contain("exec"));
-                Assert.That(options.Args, Does.Contain("--"));
-                Assert.That(options.Args, Does.Contain("tsp-client"));
-                Assert.That(options.Args, Does.Contain("init"));
-                Assert.That(options.Args, Has.No.Member("--prefix"));
-            }
-            else
-            {
-                Assert.That(options.Args, Is.EqualTo(new[] { "exec", "--", "tsp-client", "init" }));
-            }
-        }
-
-        [Test]
         public void Constructor_WithEmptyPrefix_BuildsExecDashDashArgs()
         {
             var options = new NpmOptions(prefix: "", args: ["run", "build"]);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Process/Options/NpmOptions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Process/Options/NpmOptions.cs
@@ -25,9 +25,9 @@ public class NpmOptions : ProcessOptions, IProcessOptions
     /// <summary>
     /// Initializes a new instance of the <see cref="NpmOptions"/> class for running 'npm exec' commands with an optional prefix.
     /// </summary>
-    /// <param name="prefix">The npm prefix path. If provided, runs 'npm exec --prefix {prefix} -- {args}'. 
-    /// If null or empty, runs 'npm exec -- {args}'.</param>
-    /// <param name="args">The arguments to pass after the 'npm exec --' separator.</param>
+    /// <param name="prefix">The npm prefix path. If provided, resolves the binary from {prefix}/node_modules/.bin
+    /// and invokes it directly. If null or empty, runs 'npm exec -- {args}'.</param>
+    /// <param name="args">The arguments to pass. The first element is the binary name (e.g., "tsp-client").</param>
     /// <param name="logOutputStream">Whether to log the output stream. Defaults to true.</param>
     /// <param name="workingDirectory">The working directory for the command. Defaults to current directory.</param>
     /// <param name="timeout">The timeout for the command. Defaults to 2 minutes.</param>
@@ -37,7 +37,12 @@ public class NpmOptions : ProcessOptions, IProcessOptions
         bool logOutputStream = true,
         string? workingDirectory = null,
         TimeSpan? timeout = null
-    ) : this(BuildArgs(prefix, args), logOutputStream, workingDirectory, timeout)
+    ) : base(
+        ResolveBinCommand(prefix, args) ?? NPM,
+        ResolveBinArgs(prefix, args),
+        logOutputStream,
+        workingDirectory,
+        timeout)
     {
         Prefix = prefix;
     }
@@ -56,36 +61,53 @@ public class NpmOptions : ProcessOptions, IProcessOptions
         TimeSpan? timeout = null
     ) : base("npm", args, logOutputStream, workingDirectory, timeout) {}
 
-    private static string[] BuildArgs(string? prefix, string[] args)
+    /// <summary>
+    /// Resolves the binary command from node_modules/.bin when a prefix is provided
+    /// and the binary exists locally. Returns null to fall back to npm.
+    /// On Windows, prefers the .cmd shim; on Unix, uses the script directly.
+    /// </summary>
+    private static string? ResolveBinCommand(string? prefix, string[] args)
     {
+        if (!string.IsNullOrEmpty(prefix) && args.Length > 0)
+        {
+            var binName = args[0];
+            var binDir = Path.Combine(prefix, "node_modules", ".bin");
+
+            // On Windows, npm creates .cmd shims that cmd.exe can execute
+            var cmdPath = Path.Combine(binDir, binName + ".cmd");
+            if (File.Exists(cmdPath))
+            {
+                return cmdPath;
+            }
+
+            // On Unix, the script is directly executable
+            var binPath = Path.Combine(binDir, binName);
+            if (File.Exists(binPath))
+            {
+                return binPath;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Builds the argument array. When the binary is resolved directly from
+    /// node_modules/.bin, returns the remaining args (skipping the binary name).
+    /// Otherwise, falls back to "npm exec" with the original args.
+    /// </summary>
+    private static string[] ResolveBinArgs(string? prefix, string[] args)
+    {
+        // If the binary can be resolved directly, return just the remaining args
+        if (ResolveBinCommand(prefix, args) != null)
+        {
+            return args.Skip(1).ToArray();
+        }
+
+        // Fall back to npm exec
         if (string.IsNullOrEmpty(prefix))
         {
             return ["exec", "--", .. args];
         }
-
-        // When a prefix is provided, resolve the binary from node_modules/.bin directly.
-        // Using "npm exec --prefix <dir> -- <bin>" causes npm to try to fetch a package
-        // named <bin> from the registry when .npmrc is specified, which fails when the binary name differs from
-        // the npm package name (e.g., "tsp-client" binary from "@azure-tools/typespec-client-generator-cli").
-        // Reading the package.json to find the actual providing package and adding --package= avoids this.
-        var packageJsonPath = Path.Combine(prefix, "package.json");
-        if (File.Exists(packageJsonPath))
-        {
-            var packageJson = System.Text.Json.JsonDocument.Parse(File.ReadAllText(packageJsonPath));
-            if (packageJson.RootElement.TryGetProperty("dependencies", out var deps))
-            {
-                var packages = new List<string>();
-                foreach (var dep in deps.EnumerateObject())
-                {
-                    packages.Add($"--package={dep.Name}");
-                }
-                if (packages.Count > 0)
-                {
-                    return ["exec", "--prefix", prefix, .. packages, "--", .. args];
-                }
-            }
-        }
-
         return ["exec", "--prefix", prefix, "--", .. args];
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Process/Options/NpmOptions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Process/Options/NpmOptions.cs
@@ -65,6 +65,8 @@ public class NpmOptions : ProcessOptions, IProcessOptions
     /// Resolves the binary command from node_modules/.bin when a prefix is provided
     /// and the binary exists locally. Returns null to fall back to npm.
     /// On Windows, prefers the .cmd shim; on Unix, uses the script directly.
+    /// This is to solve the issue when '.npmrc' is specified, where npm would try to
+    /// resolve the package from the feed but the command name is not the package name.
     /// </summary>
     private static string? ResolveBinCommand(string? prefix, string[] args)
     {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Process/Options/NpmOptions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Process/Options/NpmOptions.cs
@@ -62,6 +62,30 @@ public class NpmOptions : ProcessOptions, IProcessOptions
         {
             return ["exec", "--", .. args];
         }
+
+        // When a prefix is provided, resolve the binary from node_modules/.bin directly.
+        // Using "npm exec --prefix <dir> -- <bin>" causes npm to try to fetch a package
+        // named <bin> from the registry when .npmrc is specified, which fails when the binary name differs from
+        // the npm package name (e.g., "tsp-client" binary from "@azure-tools/typespec-client-generator-cli").
+        // Reading the package.json to find the actual providing package and adding --package= avoids this.
+        var packageJsonPath = Path.Combine(prefix, "package.json");
+        if (File.Exists(packageJsonPath))
+        {
+            var packageJson = System.Text.Json.JsonDocument.Parse(File.ReadAllText(packageJsonPath));
+            if (packageJson.RootElement.TryGetProperty("dependencies", out var deps))
+            {
+                var packages = new List<string>();
+                foreach (var dep in deps.EnumerateObject())
+                {
+                    packages.Add($"--package={dep.Name}");
+                }
+                if (packages.Count > 0)
+                {
+                    return ["exec", "--prefix", prefix, .. packages, "--", .. args];
+                }
+            }
+        }
+
         return ["exec", "--prefix", prefix, "--", .. args];
     }
 }


### PR DESCRIPTION
Fixed npm error when '.npmrc' is specified:
```
Running command [npm exec --prefix /mnt/vss/_work/1/s/azure-sdk-for-rust/eng/common/tsp-client -- tsp-client init --update-if-exists --tsp-config /mnt/vss/_work/1/s/azure-rest-api-specs/specification/keyvault/data-plane/Keys/tspconfig.yaml --repo Azure/azure-rest-api-specs] with timeout 30 minutes in /mnt/vss/_work/1/s/azure-sdk-for-rust
----------
[npm-tsp-client] npm error code E404
[npm-tsp-client] npm error 404 Not Found - GET https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/tsp-client - The package 'tsp-client' was not found in feed 'azure-sdk-for-js'
[npm-tsp-client] npm error 404
[npm-tsp-client] npm error 404  'tsp-client@*' is not in this registry.
```

This pull request introduces comprehensive unit tests for the `NpmOptions` class and refactors its construction logic to more robustly resolve binaries from `node_modules/.bin` when a prefix is provided. This is the solve the issues when '.npmrc' is specified, npm would try to resolve the package from the feed but the command name is not the package name.

**Enhancements to binary resolution and argument construction:**

* Refactored `NpmOptions` so that, when a `prefix` is provided and the binary exists in `node_modules/.bin`, the command is resolved to that binary directly (preferring `.cmd` shims on Windows), and only the remaining arguments are passed; otherwise, it falls back to using `npm exec`.

* Added a comprehensive test suite `NpmOptionsTests` covering all major construction scenarios