### PR TITLE
[AVC] Disable generic comments

### DIFF
--- a/packages/python-packages/apiview-copilot/AGENTS.md
+++ b/packages/python-packages/apiview-copilot/AGENTS.md
@@ -40,8 +40,8 @@ AI-powered automated reviewer for Azure SDK API surface reviews. Ingests APIView
 
 The review pipeline in `ApiViewReview.run()` follows these stages:
 1. **Sectioning** — `SectionedDocument` splits the API text into chunks (default 500 lines, 450 for Java/Android).
-2. **Parallel prompt evaluation** — For each section, three prompts run in parallel: guideline review (RAG with language guidelines), context review (RAG with semantic search), and generic review (custom rules).
-3. **Generic comment filtering** — Generic comments are validated against the knowledge base.
+2. **Parallel prompt evaluation** — For each section, prompts run in parallel: guideline review (RAG with language guidelines) and context review (RAG with semantic search). The generic review stage is **disabled** for all languages.
+3. **Generic comment filtering** — Generic comments are validated against the knowledge base (currently skipped since generic review is disabled).
 4. **Deduplication** — Comments on the same line are merged via LLM.
 5. **Hard filtering** — Comments are checked against language-specific filter exceptions and the API outline.
 6. **Pre-existing comment filtering** — New comments are compared against existing human comments on the same lines.

--- a/packages/python-packages/apiview-copilot/AGENTS.md
+++ b/packages/python-packages/apiview-copilot/AGENTS.md
@@ -5,7 +5,7 @@ applyTo: "**"
 
 # APIView Copilot
 
-AI-powered automated reviewer for Azure SDK API surface reviews. Ingests APIView text representations of SDK public APIs, sections them, runs multi-stage LLM prompts (guideline, context, and generic reviews), filters and deduplicates results, and produces structured review comments. Deployed as a **FastAPI** web service on Azure App Service with a CLI (`avc`) for local development.
+AI-powered automated reviewer for Azure SDK API surface reviews. Ingests APIView text representations of SDK public APIs, sections them, runs multi-stage LLM prompts (guideline and context reviews), filters and deduplicates results, and produces structured review comments. Deployed as a **FastAPI** web service on Azure App Service with a CLI (`avc`) for local development.
 
 ## Project Structure
 

--- a/packages/python-packages/apiview-copilot/README.md
+++ b/packages/python-packages/apiview-copilot/README.md
@@ -18,11 +18,12 @@ ENVIRONMENT_NAME="staging"
 
 ## Review Process and Stages
 
-For each section of the APIView, the review process now consists of three distinct stages:
+For each section of the APIView, the review process consists of two prompt stages:
 
 - **Guideline Stage:** Reviews the section against language-specific guidelines.
 - **Context Stage:** Reviews the section using the full context (guidelines, examples, and memories) retrieved for that section.
-- **Generic Stage:** Applies generic review rules and best practices.
+
+> **Note:** A generic review stage previously existed but is now **disabled** for all languages.
 
 ## Creating Reviews
 

--- a/packages/python-packages/apiview-copilot/docs/api-review.md
+++ b/packages/python-packages/apiview-copilot/docs/api-review.md
@@ -7,7 +7,7 @@ This document describes the full API review pipeline implemented in `src/_apivie
 When a review is requested, the `ApiViewReview` class:
 
 1. Splits the API text into sections
-2. Runs three LLM prompt types in parallel across all sections
+2. Runs two LLM prompt types in parallel across all sections (guideline and context)
 3. Filters, deduplicates, and scores the resulting comments
 4. Returns a sorted, deduplicated list of `Comment` objects
 

--- a/packages/python-packages/apiview-copilot/docs/api-review.md
+++ b/packages/python-packages/apiview-copilot/docs/api-review.md
@@ -34,7 +34,7 @@ The pipeline supports two **review modes**:
 
 ### Stage 2 — Parallel Prompt Evaluation
 
-For each section, **three prompts run concurrently** in a thread pool. Each prompt type targets a different source of review knowledge:
+For each section, prompts run concurrently in a thread pool. Each prompt type targets a different source of review knowledge. Currently only **two prompts** run per section (guideline and context); the generic review is disabled for all languages (see Stage 2c).
 
 #### 2a — Guideline Review (`guidelines_review.prompty` / `guidelines_diff_review.prompty`)
 
@@ -60,9 +60,13 @@ For each section, **three prompts run concurrently** in a thread pool. Each prom
 
 **Output:** Comments flagged as `is_generic = True`. These undergo additional filtering in Stage 3.
 
+> **Note:** The generic review stage is **disabled for all languages**. Only the guideline and context reviews run. Stages that operate exclusively on generic comments (Stage 3) are effectively no-ops.
+
 ---
 
 ### Stage 3 — Generic Comment Filtering
+
+> **Note:** This stage is effectively skipped for all languages because the generic review prompt (Stage 2c) is disabled, so no generic comments exist to filter.
 
 **Purpose:** Generic comments are less anchored to documented guidelines and carry higher false-positive risk. This stage validates each generic comment against the knowledge base before keeping it.
 

--- a/packages/python-packages/apiview-copilot/src/_apiview_reviewer.py
+++ b/packages/python-packages/apiview-copilot/src/_apiview_reviewer.py
@@ -324,9 +324,6 @@ class ApiViewReview:
             self.logger.error(f"Error executing {task_name}: {str(e)}")
             return None
 
-    # Languages for which the generic review stage is disabled
-    SKIP_GENERIC_LANGUAGES = ["dotnet", "java", "typescript"]
-
     def _generate_comments(self):
         """
         Generate comments for the API view by submitting jobs in parallel.
@@ -334,7 +331,7 @@ class ApiViewReview:
         guideline_tag = "guideline"
         generic_tag = "generic"
         context_tag = "context"
-        skip_generic = self.language in self.SKIP_GENERIC_LANGUAGES
+        skip_generic = True  # Generic review is disabled for all languages
 
         sectioned_doc = self._create_sectioned_document()
 

--- a/packages/python-packages/apiview-copilot/src/_apiview_reviewer.py
+++ b/packages/python-packages/apiview-copilot/src/_apiview_reviewer.py
@@ -400,7 +400,6 @@ class ApiViewReview:
                 status_array=prompt_status,
             )
 
-            # Generic prompt (skipped for languages in SKIP_GENERIC_LANGUAGES)
             if not skip_generic:
                 generic_metadata = self._load_generic_metadata()
                 generic_key = f"{generic_tag}_{section_idx}"
@@ -900,12 +899,13 @@ class ApiViewReview:
             )
             self._print_comment_counts()
 
-            # Run generic comments through a filter
-            start_time = time()
-            self._filter_generic_comments()
-            end_time = time()
-            self._print_message(f"  Generic comments filtered in {end_time - start_time:.2f} seconds.")
-            self._print_comment_counts()
+            # Run generic comments through a filter (skip if none exist)
+            if any(c.is_generic for c in self.results.comments):
+                start_time = time()
+                self._filter_generic_comments()
+                end_time = time()
+                self._print_message(f"  Generic comments filtered in {end_time - start_time:.2f} seconds.")
+                self._print_comment_counts()
 
             # Track time for _deduplicate_comments
             deduplicate_start_time = time()

--- a/packages/python-packages/apiview-copilot/src/_apiview_reviewer.py
+++ b/packages/python-packages/apiview-copilot/src/_apiview_reviewer.py
@@ -324,6 +324,9 @@ class ApiViewReview:
             self.logger.error(f"Error executing {task_name}: {str(e)}")
             return None
 
+    # Languages for which the generic review stage is disabled
+    SKIP_GENERIC_LANGUAGES = ["dotnet", "java", "typescript"]
+
     def _generate_comments(self):
         """
         Generate comments for the API view by submitting jobs in parallel.
@@ -331,6 +334,7 @@ class ApiViewReview:
         guideline_tag = "guideline"
         generic_tag = "generic"
         context_tag = "context"
+        skip_generic = self.language in self.SKIP_GENERIC_LANGUAGES
 
         sectioned_doc = self._create_sectioned_document()
 
@@ -352,7 +356,8 @@ class ApiViewReview:
         # Set up progress tracking
         self._print_message("Processing sections: ", overwrite=True)
 
-        total_prompts = len(sections_to_process) * 3  # 3 prompts per section
+        prompts_per_section = 2 if skip_generic else 3
+        total_prompts = len(sections_to_process) * prompts_per_section
         prompt_status = [False] * total_prompts
 
         # Set up keyboard interrupt handler for more responsive cancellation (only in main thread)
@@ -394,31 +399,33 @@ class ApiViewReview:
                     "content": section.numbered(),
                 },
                 task_name=guideline_key,
-                status_idx=idx * 3,
+                status_idx=idx * prompts_per_section,
                 status_array=prompt_status,
             )
 
-            # Generic prompt
-            generic_metadata = self._load_generic_metadata()
-            generic_key = f"{generic_tag}_{section_idx}"
-            all_futures[generic_key] = self.executor.submit(
-                self._execute_prompt_task,
-                folder="api_review",
-                filename=generic_prompt_file,
-                inputs={
-                    "language": get_language_pretty_name(self.language),
-                    "custom_rules": generic_metadata["custom_rules"],
-                    "content": section.numbered(),
-                },
-                task_name=generic_key,
-                status_idx=(idx * 3) + 1,
-                status_array=prompt_status,
-            )
+            # Generic prompt (skipped for languages in SKIP_GENERIC_LANGUAGES)
+            if not skip_generic:
+                generic_metadata = self._load_generic_metadata()
+                generic_key = f"{generic_tag}_{section_idx}"
+                all_futures[generic_key] = self.executor.submit(
+                    self._execute_prompt_task,
+                    folder="api_review",
+                    filename=generic_prompt_file,
+                    inputs={
+                        "language": get_language_pretty_name(self.language),
+                        "custom_rules": generic_metadata["custom_rules"],
+                        "content": section.numbered(),
+                    },
+                    task_name=generic_key,
+                    status_idx=(idx * prompts_per_section) + 1,
+                    status_array=prompt_status,
+                )
 
             # Context prompt
             context_key = f"{context_tag}_{section_idx}"
             context = self._retrieve_context(str(section))
             context_string = context.to_markdown() if context else ""
+            context_status_offset = 2 if not skip_generic else 1
             all_futures[context_key] = self.executor.submit(
                 self._execute_prompt_task,
                 folder="api_review",
@@ -429,7 +436,7 @@ class ApiViewReview:
                     "content": section.numbered(),
                 },
                 task_name=context_key,
-                status_idx=(idx * 3) + 2,
+                status_idx=(idx * prompts_per_section) + context_status_offset,
                 status_array=prompt_status,
             )
 

--- a/packages/python-packages/apiview-copilot/tests/generate_comments_test.py
+++ b/packages/python-packages/apiview-copilot/tests/generate_comments_test.py
@@ -1,0 +1,130 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+# pylint: disable=missing-class-docstring,missing-function-docstring,redefined-outer-name,unused-argument,protected-access
+
+"""
+Tests for _generate_comments prompt scheduling in ApiViewReview.
+"""
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Mock azure dependencies before importing
+sys.modules["azure.cosmos"] = MagicMock()
+sys.modules["azure.cosmos.exceptions"] = MagicMock()
+sys.modules["azure.ai.inference"] = MagicMock()
+sys.modules["azure.ai.inference.models"] = MagicMock()
+
+from src._apiview_reviewer import ApiViewReview
+
+
+# A minimal API surface that produces exactly 1 section
+SMALL_API = "namespace Foo {\\n  class Bar {\\n  }\\n}"
+
+# A response with no comments
+EMPTY_RESPONSE = json.dumps({"comments": []})
+
+
+@pytest.fixture
+def review(monkeypatch):
+    """Create an ApiViewReview with all external dependencies mocked."""
+    mock_search = MagicMock()
+    mock_search.language_guidelines = MagicMock(results=[])
+    mock_search.search_all.return_value = MagicMock(results=[])
+    mock_search.build_context.return_value = MagicMock(to_markdown=lambda: "")
+
+    mock_settings = MagicMock()
+
+    with patch("src._apiview_reviewer.SearchManager", return_value=mock_search), patch(
+        "src._apiview_reviewer.SettingsManager", return_value=mock_settings
+    ):
+        r = ApiViewReview(target=SMALL_API, base=None, language="python")
+    # Replace the prompt runner with a mock that returns empty comments
+    r.run_prompt = MagicMock(return_value=EMPTY_RESPONSE)
+    return r
+
+
+class TestGenerateCommentsPromptScheduling:
+    """Verify that _generate_comments submits the correct prompt tasks."""
+
+    def test_full_mode_submits_guideline_and_context_only(self, review):
+        """With generic review disabled, only guideline and context prompts should run."""
+        review._generate_comments()
+
+        # Collect all prompt filenames that were submitted
+        submitted_filenames = [call.kwargs["filename"] for call in review.run_prompt.call_args_list]
+
+        assert "guidelines_review.prompty" in submitted_filenames
+        assert "context_review.prompty" in submitted_filenames
+        assert "generic_review.prompty" not in submitted_filenames
+
+    def test_full_mode_submits_two_prompts_per_section(self, review):
+        """Each section should produce exactly 2 prompt calls (guideline + context)."""
+        review._generate_comments()
+
+        # The small API fits in one section, so we expect exactly 2 calls
+        assert review.run_prompt.call_count == 2
+
+    def test_diff_mode_submits_guideline_and_context_only(self, monkeypatch):
+        """Diff mode should also submit only guideline and context prompts."""
+        mock_search = MagicMock()
+        mock_search.language_guidelines = MagicMock(results=[])
+        mock_search.search_all.return_value = MagicMock(results=[])
+        mock_search.build_context.return_value = MagicMock(to_markdown=lambda: "")
+
+        mock_settings = MagicMock()
+
+        with patch("src._apiview_reviewer.SearchManager", return_value=mock_search), patch(
+            "src._apiview_reviewer.SettingsManager", return_value=mock_settings
+        ):
+            r = ApiViewReview(
+                target="namespace Foo {\\n  class Bar {\\n    void baz();\\n  }\\n}",
+                base="namespace Foo {\\n  class Bar {\\n  }\\n}",
+                language="java",
+            )
+        r.run_prompt = MagicMock(return_value=EMPTY_RESPONSE)
+
+        r._generate_comments()
+
+        submitted_filenames = [call.kwargs["filename"] for call in r.run_prompt.call_args_list]
+
+        assert "guidelines_diff_review.prompty" in submitted_filenames
+        assert "context_diff_review.prompty" in submitted_filenames
+        assert "generic_diff_review.prompty" not in submitted_filenames
+        # Exactly 2 prompts per section
+        assert r.run_prompt.call_count == 2
+
+    def test_multiple_sections_submit_two_prompts_each(self, monkeypatch):
+        """Multiple sections should each get exactly 2 prompts."""
+        mock_search = MagicMock()
+        mock_search.language_guidelines = MagicMock(results=[])
+        mock_search.search_all.return_value = MagicMock(results=[])
+        mock_search.build_context.return_value = MagicMock(to_markdown=lambda: "")
+
+        mock_settings = MagicMock()
+
+        # Generate an API surface large enough to produce multiple sections (>500 lines)
+        lines = ["namespace Foo {"]
+        for i in range(600):
+            lines.append(f"  void method_{i}();")
+        lines.append("}")
+        large_api = "\\n".join(lines)
+
+        with patch("src._apiview_reviewer.SearchManager", return_value=mock_search), patch(
+            "src._apiview_reviewer.SettingsManager", return_value=mock_settings
+        ):
+            r = ApiViewReview(target=large_api, base=None, language="python")
+        r.run_prompt = MagicMock(return_value=EMPTY_RESPONSE)
+
+        r._generate_comments()
+
+        # Should have submitted 2 prompts for each section
+        assert r._chunk_count > 1
+        assert r.run_prompt.call_count == r._chunk_count * 2


### PR DESCRIPTION
The generic comments stage seems to be adding more noise than value for all languages except (arguably) Python. This PR temporarily disables them.

Closes #15375 