### PR TITLE
Update `PR` and `release` operations to optionally support Github App

### DIFF
--- a/eng/common/pipelines/templates/steps/create-pull-request.yml
+++ b/eng/common/pipelines/templates/steps/create-pull-request.yml
@@ -1,5 +1,6 @@
-# Expects azuresdk-github-pat is set to the PAT for azure-sdk
-# Expects the buildtools to be cloned
+# Expects AuthToken to be a valid GitHub token.
+# Defaults to azuresdk-github-pat for backwards compatibility.
+# New callers should pass AuthToken: $(GH_TOKEN) after calling login-to-github.yml.
 
 parameters:
   BaseBranchName: $(Build.SourceBranch)
@@ -21,6 +22,10 @@ parameters:
   SkipCheckingForChanges: false
   CloseAfterOpenForTesting: false
   OpenAsDraft: false
+  AuthToken: $(azuresdk-github-pat)
+  # PushAuthToken: for cross-org pushes (pushing to PROwner's fork in a different org).
+  # Defaults to AuthToken when not specified.
+  PushAuthToken: ''
 
 steps:
 - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
@@ -34,6 +39,7 @@ steps:
     WorkingDirectory: ${{ parameters.WorkingDirectory }}
     ScriptDirectory: ${{ parameters.ScriptDirectory }}
     SkipCheckingForChanges: ${{ parameters.SkipCheckingForChanges }}
+    AuthToken: ${{ coalesce(parameters.PushAuthToken, parameters.AuthToken) }}
 
 - task: PowerShell@2
   displayName: Create pull request
@@ -48,7 +54,7 @@ steps:
       -BaseBranch "${{ parameters.BaseBranchName }}"
       -PROwner "${{ parameters.PROwner }}"
       -PRBranch "${{ parameters.PRBranchName }}"
-      -AuthToken "$(azuresdk-github-pat)"
+      -AuthToken "${{ parameters.AuthToken }}"
       -PRTitle "${{ parameters.PRTitle }}"
       -PRBody "${{ coalesce(parameters.PRBody, parameters.CommitMsg, parameters.PRTitle) }}"
       -PRLabels "${{ parameters.PRLabels }}"

--- a/eng/common/pipelines/templates/steps/create-pull-request.yml
+++ b/eng/common/pipelines/templates/steps/create-pull-request.yml
@@ -1,6 +1,6 @@
 # Expects AuthToken to be a valid GitHub token.
 # Defaults to azuresdk-github-pat for backwards compatibility.
-# New callers should pass AuthToken: $(GH_TOKEN) after calling login-to-github.yml.
+# New callers should pass AuthToken: '' to auto-login via login-to-github.yml.
 
 parameters:
   BaseBranchName: $(Build.SourceBranch)
@@ -28,6 +28,13 @@ parameters:
   PushAuthToken: ''
 
 steps:
+- ${{ if eq(parameters.AuthToken, '') }}:
+  - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+    parameters:
+      TokenOwners:
+        - ${{ parameters.RepoOwner }}
+      ScriptDirectory: ${{ parameters.ScriptDirectory }}
+
 - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
   parameters:
     BaseRepoBranch: ${{ parameters.PRBranchName }}
@@ -39,7 +46,7 @@ steps:
     WorkingDirectory: ${{ parameters.WorkingDirectory }}
     ScriptDirectory: ${{ parameters.ScriptDirectory }}
     SkipCheckingForChanges: ${{ parameters.SkipCheckingForChanges }}
-    AuthToken: ${{ coalesce(parameters.PushAuthToken, parameters.AuthToken) }}
+    AuthToken: ${{ coalesce(parameters.PushAuthToken, parameters.AuthToken, '$(GH_TOKEN)') }}
 
 - task: PowerShell@2
   displayName: Create pull request
@@ -54,7 +61,7 @@ steps:
       -BaseBranch "${{ parameters.BaseBranchName }}"
       -PROwner "${{ parameters.PROwner }}"
       -PRBranch "${{ parameters.PRBranchName }}"
-      -AuthToken "${{ parameters.AuthToken }}"
+      -AuthToken "${{ coalesce(parameters.AuthToken, '$(GH_TOKEN)') }}"
       -PRTitle "${{ parameters.PRTitle }}"
       -PRBody "${{ coalesce(parameters.PRBody, parameters.CommitMsg, parameters.PRTitle) }}"
       -PRLabels "${{ parameters.PRLabels }}"

--- a/eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+++ b/eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
@@ -8,6 +8,7 @@ parameters:
   ScriptDirectory: eng/common/scripts
   NpmConfigUserConfig: ''
   NpmConfigRegistry: ''
+  AuthToken: $(azuresdk-github-pat)
 
 steps:
 - task: PowerShell@2
@@ -24,7 +25,7 @@ steps:
     pwsh: true
   timeoutInMinutes: 5
   env:
-    GH_TOKEN: $(azuresdk-github-pat)
+    GH_TOKEN: ${{ parameters.AuthToken }}
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     ${{ if ne(parameters.NpmConfigUserConfig, '') }}:
       npm_config_userconfig: ${{ parameters.NpmConfigUserConfig }}

--- a/eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+++ b/eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
@@ -11,6 +11,13 @@ parameters:
   AuthToken: $(azuresdk-github-pat)
 
 steps:
+- ${{ if eq(parameters.AuthToken, '') }}:
+  - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+    parameters:
+      TokenOwners:
+        - ${{ split(parameters.RepoId, '/')[0] }}
+      ScriptDirectory: ${{ parameters.ScriptDirectory }}
+
 - task: PowerShell@2
   displayName: 'Verify Package Tags and Create Git Releases'
   inputs:
@@ -25,7 +32,7 @@ steps:
     pwsh: true
   timeoutInMinutes: 5
   env:
-    GH_TOKEN: ${{ parameters.AuthToken }}
+    GH_TOKEN: ${{ coalesce(parameters.AuthToken, '$(GH_TOKEN)') }}
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     ${{ if ne(parameters.NpmConfigUserConfig, '') }}:
       npm_config_userconfig: ${{ parameters.NpmConfigUserConfig }}

--- a/eng/common/pipelines/templates/steps/git-push-changes.yml
+++ b/eng/common/pipelines/templates/steps/git-push-changes.yml
@@ -11,6 +11,13 @@ parameters:
   AuthToken: $(azuresdk-github-pat)
 
 steps:
+- ${{ if eq(parameters.AuthToken, '') }}:
+  - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+    parameters:
+      TokenOwners:
+        - ${{ parameters.TargetRepoOwner }}
+      ScriptDirectory: ${{ parameters.ScriptDirectory }}
+
 - task: PowerShell@2
   displayName: Check for changes
   condition: and(succeeded(), eq(${{ parameters.SkipCheckingForChanges }}, false))
@@ -32,7 +39,7 @@ steps:
 - template: /eng/common/pipelines/templates/steps/emit-rate-limit-metrics.yml
   parameters:
     GitHubUser: azure-sdk
-    GitHubToken: ${{ parameters.AuthToken }}
+    GitHubToken: ${{ coalesce(parameters.AuthToken, '$(GH_TOKEN)') }}
 
 - task: PowerShell@2
   displayName: Push changes
@@ -44,6 +51,6 @@ steps:
     arguments: >
       -PRBranchName "${{ parameters.BaseRepoBranch }}"
       -CommitMsg "${{ parameters.CommitMsg }}"
-      -GitUrl "https://x-access-token:${{ parameters.AuthToken }}@github.com/${{ parameters.BaseRepoOwner }}/$(RepoNameWithoutOwner).git"
+      -GitUrl "https://x-access-token:${{ coalesce(parameters.AuthToken, '$(GH_TOKEN)') }}@github.com/${{ parameters.BaseRepoOwner }}/$(RepoNameWithoutOwner).git"
       -PushArgs "${{ parameters.PushArgs }}"
       -SkipCommit $${{ parameters.SkipCheckingForChanges }}

--- a/eng/common/pipelines/templates/steps/git-push-changes.yml
+++ b/eng/common/pipelines/templates/steps/git-push-changes.yml
@@ -8,6 +8,7 @@ parameters:
   WorkingDirectory: $(System.DefaultWorkingDirectory)'
   ScriptDirectory: eng/common/scripts
   SkipCheckingForChanges: false
+  AuthToken: $(azuresdk-github-pat)
 
 steps:
 - task: PowerShell@2
@@ -31,7 +32,7 @@ steps:
 - template: /eng/common/pipelines/templates/steps/emit-rate-limit-metrics.yml
   parameters:
     GitHubUser: azure-sdk
-    GitHubToken: $(azuresdk-github-pat)
+    GitHubToken: ${{ parameters.AuthToken }}
 
 - task: PowerShell@2
   displayName: Push changes
@@ -43,6 +44,6 @@ steps:
     arguments: >
       -PRBranchName "${{ parameters.BaseRepoBranch }}"
       -CommitMsg "${{ parameters.CommitMsg }}"
-      -GitUrl "https://$(azuresdk-github-pat)@github.com/${{ parameters.BaseRepoOwner }}/$(RepoNameWithoutOwner).git"
+      -GitUrl "https://x-access-token:${{ parameters.AuthToken }}@github.com/${{ parameters.BaseRepoOwner }}/$(RepoNameWithoutOwner).git"
       -PushArgs "${{ parameters.PushArgs }}"
       -SkipCommit $${{ parameters.SkipCheckingForChanges }}

--- a/eng/common/pipelines/templates/steps/git-push-changes.yml
+++ b/eng/common/pipelines/templates/steps/git-push-changes.yml
@@ -5,7 +5,7 @@ parameters:
   TargetRepoOwner: Azure
   TargetRepoName: $(Build.Repository.Name)
   PushArgs:
-  WorkingDirectory: $(System.DefaultWorkingDirectory)'
+  WorkingDirectory: $(System.DefaultWorkingDirectory)
   ScriptDirectory: eng/common/scripts
   SkipCheckingForChanges: false
   AuthToken: $(azuresdk-github-pat)


### PR DESCRIPTION
The difference here, is that I can get this merged without affecting the bunch of satellite repo callsites of `create-pull-request` or `create-tags-and-git-release.yml`.

Doing it this way means that I can get a safe phased rollout where we are explicitly updating to pass the new token in the new locations. Then after it's all working passing `GH_TOKEN` explicitly, it'll be an easy one-shot pr to move the default of `$(azure-sdk-pat)` to `$(GH_TOKEN)`.

Pipelines will take advantage of new default logic by removing `$(azure-sdk-pat)` from their variable group.

These assumptions are tested and confirmed working in [this python - template release](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6235053&view=results)

Related to #9842