### PR TITLE
Add do-not-use-future-annotations pylint checker (C4777)

### DIFF
--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/CHANGELOG.md
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `remove-deprecated-iscoroutinefunction` check
 - Add `do-not-use-logging-directly` check
 - Add `no-cross-package-private-import` check
+- Add `do-not-use-future-annotations` check (C4777) to flag `from __future__ import annotations`
 
 ## 0.5.7 (2025-07-15)
 - Bug fix for `do-not-use-logging-exception` checker

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 
 """
-Pylint custom checkers for SDK guidelines: C4717 - C4776
+Pylint custom checkers for SDK guidelines: C4717 - C4777
 """
 
 import os
@@ -3728,6 +3728,36 @@ class NoCrossPackagePrivateImport(BaseChecker):
             )
 
 
+class DoNotUseFutureAnnotations(BaseChecker):
+    """Rule to check that `from __future__ import annotations` is not used.
+    This import changes all annotations to strings at runtime, which can
+    impact performance and break runtime type introspection used by the SDK.
+    """
+
+    name = "do-not-use-future-annotations"
+    priority = -1
+    msgs = {
+        "C4777": (
+            "Do not use `from __future__ import annotations`. This impacts runtime behavior"
+            " and performance. See details:"
+            " https://azure.github.io/azure-sdk/python_design.html",
+            "do-not-use-future-annotations",
+            "Do not use `from __future__ import annotations` in SDK code.",
+        ),
+    }
+
+    def visit_importfrom(self, node):
+        """Check for `from __future__ import annotations`."""
+        if node.modname == "__future__":
+            for name, _ in node.names:
+                if name == "annotations":
+                    self.add_message(
+                        msgid="do-not-use-future-annotations",
+                        node=node,
+                        confidence=None,
+                    )
+
+
 # if a linter is registered in this function then it will be checked with pylint
 def register(linter):
     linter.register_checker(ClientsDoNotUseStaticMethods(linter))
@@ -3783,3 +3813,4 @@ def register(linter):
     linter.register_checker(DoNotStoreSecretsInTestVariables(linter))
     linter.register_checker(DoNotUseLoggingDirectly(linter))
     linter.register_checker(NoCrossPackagePrivateImport(linter))
+    linter.register_checker(DoNotUseFutureAnnotations(linter))

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/do_not_use_future_annotations_acceptable.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/do_not_use_future_annotations_acceptable.py
@@ -1,0 +1,11 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+
+# Acceptable - no __future__ annotations import
+import os
+import typing
+
+# Acceptable - other __future__ imports are fine
+from __future__ import division

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/do_not_use_future_annotations_violation.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/do_not_use_future_annotations_violation.py
@@ -1,0 +1,8 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+
+from __future__ import annotations  # This should be flagged
+
+import os

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
@@ -4665,3 +4665,52 @@ class TestNoCrossPackagePrivateImport(pylint.testutils.CheckerTestCase):
         importfrom_node = setup.body[10]
         with self.assertNoMessages():
             self.checker.visit_importfrom(importfrom_node)
+
+
+class TestDoNotUseFutureAnnotations(pylint.testutils.CheckerTestCase):
+    """Test that `from __future__ import annotations` is flagged."""
+
+    CHECKER_CLASS = checker.DoNotUseFutureAnnotations
+
+    def test_acceptable_no_future_annotations(self):
+        file = open(
+            os.path.join(
+                TEST_FOLDER,
+                "test_files",
+                "do_not_use_future_annotations_acceptable.py",
+            )
+        )
+        node = astroid.parse(file.read())
+        file.close()
+        with self.assertNoMessages():
+            for child in node.body:
+                if isinstance(child, astroid.node_classes.ImportFrom):
+                    self.checker.visit_importfrom(child)
+
+    def test_violation_future_annotations(self):
+        file = open(
+            os.path.join(
+                TEST_FOLDER,
+                "test_files",
+                "do_not_use_future_annotations_violation.py",
+            )
+        )
+        node = astroid.parse(file.read())
+        file.close()
+        import_node = [
+            child
+            for child in node.body
+            if isinstance(child, astroid.node_classes.ImportFrom)
+            and child.modname == "__future__"
+        ][0]
+        with self.assertAddsMessages(
+            pylint.testutils.MessageTest(
+                msg_id="do-not-use-future-annotations",
+                line=import_node.lineno,
+                node=import_node,
+                col_offset=import_node.col_offset,
+                end_line=import_node.end_lineno,
+                end_col_offset=import_node.end_col_offset,
+            ),
+        ):
+            self.checker.visit_importfrom(import_node)


### PR DESCRIPTION
## Fixes https://github.com/Azure/azure-sdk-tools/issues/3610

Adds a new pylint checker `DoNotUseFutureAnnotations` (C4777) that flags usage of `from __future__ import annotations`.

### Changes
- New checker class in `pylint_guidelines_checker.py`
- Test files for violation and acceptable cases
- Test class in `test_pylint_custom_plugins.py` (2 tests)
- Updated CHANGELOG.md