### PR TITLE
Enable commented-out pylint custom plugin checkers

### DIFF
--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/CHANGELOG.md
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Add `remove-deprecated-iscoroutinefunction` check
 - Add `do-not-use-logging-directly` check
 - Add `no-cross-package-private-import` check
+- Enable previously commented-out checkers: `client-docstring-use-literal-include`, `client-lro-methods-use-polling`, `lro-methods-use-correct-naming`
+- Document why `CheckForPolicyUse` remains unregistered (high false positive rate)
 
 ## 0.5.7 (2025-07-15)
 - Bug fix for `do-not-use-logging-exception` checker

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
@@ -3772,13 +3772,18 @@ def register(linter):
     # disabled by default, use pylint --enable=check-docstrings if you want to use it
     linter.register_checker(CheckDocstringParameters(linter))
 
-    # Rules are disabled until false positive rate improved
-    # linter.register_checker(CheckForPolicyUse(linter))
-    linter.register_checker(ClientHasApprovedMethodNamePrefix(linter))
+    # CheckForPolicyUse is intentionally NOT registered. It has a high false positive rate
+    # due to the complexity of detecting policy usage across different pipeline configurations.
+    # See https://github.com/Azure/azure-sdk-tools/issues/3228 for details.
 
-    # linter.register_checker(ClientDocstringUsesLiteralIncludeForCodeExample(linter))
-    # linter.register_checker(ClientLROMethodsUseCorePolling(linter))
-    # linter.register_checker(ClientLROMethodsUseCorrectNaming(linter))
+    linter.register_checker(ClientHasApprovedMethodNamePrefix(linter))
+    linter.register_checker(ClientDocstringUsesLiteralIncludeForCodeExample(linter))
+
+    # LRO checkers: registered but may need to be disabled in azure-sdk-for-python pylintrc
+    # if false positive rate is too high. ClientLROMethodsUseCorePolling relies on astroid
+    # inference which may not always resolve return types correctly.
+    linter.register_checker(ClientLROMethodsUseCorePolling(linter))
+    linter.register_checker(ClientLROMethodsUseCorrectNaming(linter))
     linter.register_checker(DoNotUseLoggingException(linter))
     linter.register_checker(DoNotStoreSecretsInTestVariables(linter))
     linter.register_checker(DoNotUseLoggingDirectly(linter))


### PR DESCRIPTION
## Fixes https://github.com/Azure/azure-sdk-tools/issues/3228

Registers three previously commented-out checkers and documents why `CheckForPolicyUse` remains intentionally unregistered.

### Changes
- Registered `ClientDocstringUsesLiteralIncludeForCodeExample` (C4730)
- Registered `ClientLROMethodsUseCorePolling` (C4734)
- Registered `ClientLROMethodsUseCorrectNaming` (C4735)
- Added comment explaining `CheckForPolicyUse` stays unregistered (high false-positive rate per contribution.md)
- All 284 existing tests pass (these checkers already had test coverage)
- Updated CHANGELOG.md