### PR TITLE
Add documentation on pylint/mypy checker overlap

### DIFF
--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/CHANGELOG.md
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `remove-deprecated-iscoroutinefunction` check
 - Add `do-not-use-logging-directly` check
 - Add `no-cross-package-private-import` check
+- Add documentation on pylint/mypy overlap and recommendations for when to use each tool
 
 ## 0.5.7 (2025-07-15)
 - Bug fix for `do-not-use-logging-exception` checker

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/README.md
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/README.md
@@ -77,3 +77,23 @@ To disable a pylint error, add a comment like this to your code:
 ```
 
 If you encounter a false positive, use the disable command to suppress the pylint error.
+
+## Overlap with mypy
+
+Some pylint checkers cover areas that also overlap with mypy type checking. Below is a summary
+of which tools cover what, and recommendations for when to use each:
+
+| Check area | Pylint rule(s) | mypy equivalent | Recommendation |
+|------------|----------------|-----------------|----------------|
+| Missing type annotations | C4722 `client-method-missing-type-annotations` | `--disallow-untyped-defs` | Use **pylint** for SDK-specific annotation style (type comments vs annotations). Use **mypy** for general type correctness. |
+| Return type checking | C4741 `docstring-missing-return`, C4742 `docstring-missing-rtype` | `--warn-return-any` | Use **pylint** for docstring return documentation. Use **mypy** for return type inference. |
+| Overload consistency | C4765 `invalid-use-of-overload` | `@overload` signature checking | Use **both**. Pylint catches async/sync mismatch that mypy may miss when return types are absent. |
+| Parameter types in docstrings | C4739-C4743 `docstring-*` | N/A | **Pylint only** — mypy does not check docstring parameter documentation. |
+| Naming conventions | C4727 `client-incorrect-naming-convention`, C4751 `name-too-long` | N/A | **Pylint only** — mypy does not enforce naming. |
+| Import restrictions | C4749, C4753, C4755-C4764 | N/A | **Pylint only** — these are SDK-specific import rules. |
+
+**General guidance:**
+- **mypy** is best for type correctness, inference, and generic type checking.
+- **pylint (this plugin)** is best for SDK-specific conventions, docstring quality, naming, and import rules.
+- There is minimal actual overlap — most pylint rules here check SDK conventions that mypy cannot enforce.
+- When both tools flag the same code, the pylint rule typically checks a different aspect (e.g., docstring vs type annotation).


### PR DESCRIPTION
## Fixes https://github.com/Azure/azure-sdk-tools/issues/3226

Adds documentation analyzing the overlap between custom pylint checkers and mypy, with a comparison table and recommendations.

### Key Finding
There is minimal actual overlap — most pylint rules check SDK-specific conventions (docstrings, naming, imports) that mypy cannot enforce. The two tools are complementary.

### Changes
- Added "Overlap with mypy" section to README.md with comparison table
- Updated CHANGELOG.md