### PR TITLE
Add analyzer error routing to classifier and MCP guidance in NextSteps

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/DotnetErrorDrivenPatchTemplate.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/DotnetErrorDrivenPatchTemplate.cs
@@ -190,10 +190,19 @@ public class DotnetErrorDrivenPatchTemplate(
         **DO NOT** try to fix these cascading errors individually (e.g., by removing method calls,
         rewriting method bodies, or adding new members). Just rename the class declaration and the file.
 
-        ### 7. IGNORE ANALYZER RULES
-        Ignore analyzer warnings and errors with codes like `AZC0007`, `SA1517`, or any `AZC*`/`SA*`
-        prefixed codes. These are style/design analyzers, not compilation errors. Do NOT add constructors,
-        reformat code, or make any changes to satisfy analyzer rules.
+        ### 7. IGNORE STYLE ANALYZER RULES (SA*)
+        Ignore style analyzer warnings and errors with codes prefixed `SA*` (e.g., `SA1517`).
+        These are code style rules, not compilation errors. Do NOT reformat code to satisfy them.
+
+        ### 8. HANDLE AZURE SDK ANALYZER RULES (AZC*) CAREFULLY
+        Azure SDK analyzer errors (codes prefixed `AZC*`) are NOT style rules — they enforce SDK design guidelines.
+        - **AZC0012, AZC0030, AZC0034, AZC0035**: These are naming/type rules that should have been resolved
+          via TypeSpec decorators earlier in the pipeline. If they still appear here, do NOT attempt to fix them
+          in customization code. They require TypeSpec decorator changes (@@clientName, @@usage) that must be
+          applied upstream. Leave them for manual intervention.
+        - **All other AZC codes** (AZC0002-AZC0021, AZC0100+, AZC0150): These are SDK design guidelines
+          (convenience methods, parameter patterns, subclient factories). Do NOT add constructors, methods, or
+          restructure code to satisfy them — they require intentional API design decisions.
 
         """;
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/DotnetErrorDrivenPatchTemplate.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/DotnetErrorDrivenPatchTemplate.cs
@@ -197,8 +197,9 @@ public class DotnetErrorDrivenPatchTemplate(
 
         ### 8. HANDLE AZURE SDK ANALYZER RULES (AZC*) CAREFULLY
         Azure SDK analyzer errors (codes prefixed `AZC*`) are NOT style rules — they enforce SDK design guidelines.
-        - **If the error is in custom/handwritten code** (NOT in a Generated folder): do NOT fix it. The developer
-          intentionally wrote that code and chose to deviate from guidelines. Ignore these errors entirely.
+        - **If the error is in custom/handwritten code** (NOT in a Generated folder): do NOT fix it automatically.
+          The developer should update their custom code to align with Azure SDK guidelines, but that is their
+          responsibility — not something to patch here.
         - **AZC0012, AZC0030, AZC0034, AZC0035**: These are naming/type rules that should have been resolved
           via TypeSpec decorators earlier in the pipeline. If they still appear here, do NOT attempt to fix them
           in customization code. They require TypeSpec decorator changes (@@clientName, @@usage) that must be

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/DotnetErrorDrivenPatchTemplate.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/DotnetErrorDrivenPatchTemplate.cs
@@ -197,6 +197,8 @@ public class DotnetErrorDrivenPatchTemplate(
 
         ### 8. HANDLE AZURE SDK ANALYZER RULES (AZC*) CAREFULLY
         Azure SDK analyzer errors (codes prefixed `AZC*`) are NOT style rules — they enforce SDK design guidelines.
+        - **If the error is in custom/handwritten code** (NOT in a Generated folder): do NOT fix it. The developer
+          intentionally wrote that code and chose to deviate from guidelines. Ignore these errors entirely.
         - **AZC0012, AZC0030, AZC0034, AZC0035**: These are naming/type rules that should have been resolved
           via TypeSpec decorators earlier in the pipeline. If they still appear here, do NOT attempt to fix them
           in customization code. They require TypeSpec decorator changes (@@clientName, @@usage) that must be

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/DotnetErrorDrivenPatchTemplate.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/DotnetErrorDrivenPatchTemplate.cs
@@ -190,9 +190,10 @@ public class DotnetErrorDrivenPatchTemplate(
         **DO NOT** try to fix these cascading errors individually (e.g., by removing method calls,
         rewriting method bodies, or adding new members). Just rename the class declaration and the file.
 
-        ### 7. IGNORE STYLE ANALYZER RULES (SA*)
-        Ignore style analyzer warnings and errors with codes prefixed `SA*` (e.g., `SA1517`).
-        These are code style rules, not compilation errors. Do NOT reformat code to satisfy them.
+        ### 7. DO NOT FIX STYLE ANALYZER RULES (SA*)
+        Style analyzer warnings and errors with codes prefixed `SA*` (e.g., `SA1517`) are code style rules,
+        not compilation errors. Do NOT attempt to fix them here — they require manual intervention.
+        Leave them for manual review; the error message itself is explanatory enough for a developer to act on.
 
         ### 8. HANDLE AZURE SDK ANALYZER RULES (AZC*) CAREFULLY
         Azure SDK analyzer errors (codes prefixed `AZC*`) are NOT style rules — they enforce SDK design guidelines.

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/FeedbackClassificationTemplate.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/FeedbackClassificationTemplate.cs
@@ -185,16 +185,18 @@ public class FeedbackClassificationTemplate : BasePromptTemplate
         what changed, but do NOT instruct editing the generated file. The automated patch agent
         will locate and fix the correct customization file.
 
-        **Azure SDK Analyzer Errors (AZC codes):**
-        When a feedback item contains an AZC analyzer error code, first determine WHERE the error originates:
+        **.NET Azure SDK Analyzer Errors (AZC/SA codes):**
+        These analyzer rules apply ONLY to .NET packages. When a feedback item contains an AZC or SA
+        analyzer error code from a .NET build, first determine WHERE the error originates:
 
-        **CRITICAL: Errors in custom/handwritten code (NOT generated code) should be classified as SUCCESS.**
-        If an AZC or SA error originates from a file in a customization directory (e.g., .NET partial classes
-        in non-Generated folders, Java `*Customization.java`, Python `*_patch.py`), this means the code was
-        written intentionally by a developer who chose not to follow Azure SDK guidelines. Do NOT fix it.
-        Classify as **SUCCESS** with a Reason like: "Analyzer error in custom code — this appears to be an
-        intentional design decision. Recommend reviewing the Azure SDK guidelines and obtaining architect
-        approval if deviating from conventions for a unique scenario."
+        **CRITICAL: Errors in custom/handwritten code (NOT generated code) should be classified as
+        REQUIRES_MANUAL_INTERVENTION.** If an AZC or SA error originates from a customization file
+        (e.g., .NET partial classes in non-Generated folders), this means the developer wrote code that
+        does not align with Azure SDK guidelines. Do NOT attempt to fix it automatically — but DO flag it.
+        Classify as **REQUIRES_MANUAL_INTERVENTION** with a Reason like: "Analyzer error [CODE] in custom
+        code — custom code should be updated to align with Azure SDK design guidelines. Review the guidelines
+        at https://azure.github.io/azure-sdk/dotnet_introduction.html and obtain architect approval if
+        deviating from conventions for a unique scenario."
 
         For analyzer errors in GENERATED code, use the following routing table:
 
@@ -213,9 +215,10 @@ public class FeedbackClassificationTemplate : BasePromptTemplate
         Do NOT classify unknown AZC codes as CODE_CUSTOMIZATION — they represent SDK design guidelines
         that require intentional human decisions about API shape.
 
-        **Style Analyzer Errors (SA codes):**
+        **Style Analyzer Errors (SA codes) — .NET only:**
         When a feedback item contains an `SA*` code (e.g., SA1517, SA1000):
-        - If the error is in **custom/handwritten code**: classify as **SUCCESS** (same logic as AZC in custom code above).
+        - If the error is in **custom code**: classify as **REQUIRES_MANUAL_INTERVENTION** with guidance
+          to update custom code to align with Azure SDK style guidelines.
         - If the error is in **generated code**: classify as **REQUIRES_MANUAL_INTERVENTION**. Include the SA code
           and your best recommendation for how to resolve it based on the error message.
         """;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/FeedbackClassificationTemplate.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/FeedbackClassificationTemplate.cs
@@ -186,7 +186,17 @@ public class FeedbackClassificationTemplate : BasePromptTemplate
         will locate and fix the correct customization file.
 
         **Azure SDK Analyzer Errors (AZC codes):**
-        When a feedback item contains an AZC analyzer error code, use the following routing table:
+        When a feedback item contains an AZC analyzer error code, first determine WHERE the error originates:
+
+        **CRITICAL: Errors in custom/handwritten code (NOT generated code) should be classified as SUCCESS.**
+        If an AZC or SA error originates from a file in a customization directory (e.g., .NET partial classes
+        in non-Generated folders, Java `*Customization.java`, Python `*_patch.py`), this means the code was
+        written intentionally by a developer who chose not to follow Azure SDK guidelines. Do NOT fix it.
+        Classify as **SUCCESS** with a Reason like: "Analyzer error in custom code — this appears to be an
+        intentional design decision. Recommend reviewing the Azure SDK guidelines and obtaining architect
+        approval if deviating from conventions for a unique scenario."
+
+        For analyzer errors in GENERATED code, use the following routing table:
 
         | Code    | Description                  | Classification          | Action                                                       |
         |---------|------------------------------|-------------------------|--------------------------------------------------------------|
@@ -204,10 +214,10 @@ public class FeedbackClassificationTemplate : BasePromptTemplate
         that require intentional human decisions about API shape.
 
         **Style Analyzer Errors (SA codes):**
-        When a feedback item contains an `SA*` code (e.g., SA1517, SA1000), classify as
-        **REQUIRES_MANUAL_INTERVENTION**. These are code style rules that should be fixed but cannot be
-        addressed via TypeSpec decorators or automated patching. In the Reason, include the SA code and
-        your best recommendation for how to resolve it based on the error message.
+        When a feedback item contains an `SA*` code (e.g., SA1517, SA1000):
+        - If the error is in **custom/handwritten code**: classify as **SUCCESS** (same logic as AZC in custom code above).
+        - If the error is in **generated code**: classify as **REQUIRES_MANUAL_INTERVENTION**. Include the SA code
+          and your best recommendation for how to resolve it based on the error message.
         """;
     }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/FeedbackClassificationTemplate.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/FeedbackClassificationTemplate.cs
@@ -219,8 +219,9 @@ public class FeedbackClassificationTemplate : BasePromptTemplate
         When a feedback item contains an `SA*` code (e.g., SA1517, SA1000):
         - If the error is in **custom code**: classify as **REQUIRES_MANUAL_INTERVENTION** with guidance
           to update custom code to align with Azure SDK style guidelines.
-        - If the error is in **generated code**: classify as **REQUIRES_MANUAL_INTERVENTION**. Include the SA code
-          and your best recommendation for how to resolve it based on the error message.
+        - If the error is in **generated code**: classify as **REQUIRES_MANUAL_INTERVENTION**. This indicates
+          a bug in the code generator. In the Reason, note that this is a generator bug and recommend filing
+          an issue against the emitter/generator that produced the code.
         """;
     }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/FeedbackClassificationTemplate.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/FeedbackClassificationTemplate.cs
@@ -202,6 +202,12 @@ public class FeedbackClassificationTemplate : BasePromptTemplate
 
         Do NOT classify unknown AZC codes as CODE_CUSTOMIZATION — they represent SDK design guidelines
         that require intentional human decisions about API shape.
+
+        **Style Analyzer Errors (SA codes):**
+        When a feedback item contains an `SA*` code (e.g., SA1517, SA1000), classify as
+        **REQUIRES_MANUAL_INTERVENTION**. These are code style rules that should be fixed but cannot be
+        addressed via TypeSpec decorators or automated patching. In the Reason, include the SA code and
+        your best recommendation for how to resolve it based on the error message.
         """;
     }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/FeedbackClassificationTemplate.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/FeedbackClassificationTemplate.cs
@@ -184,6 +184,24 @@ public class FeedbackClassificationTemplate : BasePromptTemplate
         references a renamed or removed symbol. In your Reason, identify the failing symbol and
         what changed, but do NOT instruct editing the generated file. The automated patch agent
         will locate and fix the correct customization file.
+
+        **Azure SDK Analyzer Errors (AZC codes):**
+        When a feedback item contains an AZC analyzer error code, use the following routing table:
+
+        | Code    | Description                  | Classification          | Action                                                       |
+        |---------|------------------------------|-------------------------|--------------------------------------------------------------|
+        | AZC0012 | Generic type name violation  | TSP_APPLICABLE          | Add `@@clientName(Type, "SpecificName", "csharp")` decorator |
+        | AZC0030 | Model naming suffix          | TSP_APPLICABLE          | Add `@@clientName(Model, "NameWithSuffix", "csharp")`        |
+        | AZC0034 | Type name conflict           | TSP_APPLICABLE          | Add `@@clientName(Type, "UniqueNonConflictingName", "csharp")`|
+        | AZC0035 | Missing model factory method | TSP_APPLICABLE          | Add `@@usage(Model, Usage.output)` decorator                 |
+
+        For any OTHER AZC code not in the table above (e.g., AZC0002-AZC0021, AZC0100+, AZC0150), classify as
+        **REQUIRES_MANUAL_INTERVENTION**. In the Reason, include:
+        1. The specific AZC code and what it means
+        2. A brief explanation of what fix is needed (e.g., "Add a protected parameterless constructor for mocking")
+
+        Do NOT classify unknown AZC codes as CODE_CUSTOMIZATION — they represent SDK design guidelines
+        that require intentional human decisions about API shape.
         """;
     }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/CustomizedCodeUpdateTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/CustomizedCodeUpdateTool.cs
@@ -3,6 +3,7 @@
 using System.CommandLine;
 using System.ComponentModel;
 using System.Text;
+using System.Text.RegularExpressions;
 using Azure.Sdk.Tools.Cli.CopilotAgents;
 using Azure.Sdk.Tools.Cli.Commands;
 using Azure.Sdk.Tools.Cli.Helpers;
@@ -322,6 +323,9 @@ public class CustomizedCodeUpdateTool : LanguageMcpTool
 
         // ── Early exit cases based on first classification ──
 
+        // Append analyzer-specific MCP guidance before any early return
+        AppendAnalyzerGuidanceIfNeeded(manualInterventions);
+
         // Nothing was classified as tsp applicable and at least some feedback requires manual intervention
         if (tspApplicable == 0 && codeCustomizations == 0 && manualChanges > 0)
         {
@@ -424,6 +428,9 @@ public class CustomizedCodeUpdateTool : LanguageMcpTool
                 }
             }
         }
+
+        // Re-append analyzer guidance after Pass 2 may have added new manual intervention items
+        AppendAnalyzerGuidanceIfNeeded(manualInterventions);
 
         // Build for error context if no build happened yet (pure CODE_CUSTOMIZATION path or regen failed)
         if (!buildSucceeded && buildError == null)
@@ -684,6 +691,44 @@ public class CustomizedCodeUpdateTool : LanguageMcpTool
             || host.EndsWith(".apiview.dev", StringComparison.OrdinalIgnoreCase)
             || host.Equals("apiviewstagingtest.com", StringComparison.OrdinalIgnoreCase)
             || host.EndsWith(".apiviewstagingtest.com", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static readonly Regex AnalyzerCodePattern = new(@"\bAZC\d{4}\b", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Appends MCP guidance to the manual interventions list when Azure SDK analyzer errors are detected.
+    /// Provides two options: using the GeneratorAgent MCP tools (if available) or manual resolution.
+    /// This method is idempotent — it will not append guidance if it has already been added.
+    /// </summary>
+    internal static void AppendAnalyzerGuidanceIfNeeded(List<string> manualInterventions)
+    {
+        if (manualInterventions.Count == 0)
+        {
+            return;
+        }
+
+        // Check if guidance was already appended (idempotency)
+        if (manualInterventions.Any(item => item.StartsWith("[Analyzer Fix Option")))
+        {
+            return;
+        }
+
+        var hasAnalyzerCodes = manualInterventions.Any(item => AnalyzerCodePattern.IsMatch(item));
+        if (!hasAnalyzerCodes)
+        {
+            return;
+        }
+
+        manualInterventions.Add(
+            "[Analyzer Fix Option A] If the Azure.GeneratorAgent MCP server tools are available in your environment " +
+            "(e.g., when working directly in the azure-sdk-for-net repo), use the `build_and_classify` tool to get " +
+            "deterministic fix suggestions, then apply them with `batch_fix`. These tools can automatically resolve " +
+            "many AZC analyzer errors.");
+        manualInterventions.Add(
+            "[Analyzer Fix Option B] If MCP tools are not available (e.g., when working from the specs repo or a " +
+            "different context), apply the fixes manually based on the guidance in the Reason field above. For naming " +
+            "rules (AZC0012, AZC0030, AZC0034, AZC0035), add the appropriate @@clientName or @@usage decorator in " +
+            "client.tsp. For other AZC rules, refer to the Azure SDK design guidelines.");
     }
 
 }


### PR DESCRIPTION
There are several in flight projects related to this in the .NET repo. There were two projects that were supposed to make it so these errors would not need to be fixed here, but since neither of those two projects are fully delivered, we need something to close this gap in the mean time.

- Enhance FeedbackClassificationTemplate with AZC code routing table (AZC0012/0030/0034/0035 -> TSP_APPLICABLE, others -> MANUAL_INTERVENTION)
- Split patch template Rule 7: SA* still ignored, AZC* handled explicitly
- Add AppendAnalyzerGuidanceIfNeeded() with dual-option NextSteps footer pointing to GeneratorAgent MCP tools (Option A) or manual fix (Option B)