### PR TITLE
Add marketplace.json

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1,0 +1,27 @@
+{
+    "name": "azure-sdk-plugins",
+    "metadata": {
+        "description": "A collection of plugins, agents, and skills for Azure SDK development.",
+        "version": "1.0.0",
+        "pluginRoot": "./plugins"
+    },
+    "owner": {
+        "name": "Azure SDK Team",
+        "email": "azsdk@microsoft.com"
+    },
+    "plugins": [
+        {
+            "name": "azure-sdk-tools",
+            "description": "Azure SDK Tools plugin - for Azure SDK development including generation, build, test, release planning, and pipeline management.",
+            "version": "1.0.0",
+            "strict": true,
+            "keywords": [
+                "azure",
+                "sdk",
+                "mcp",
+                "azure-sdk"
+            ],
+            "source": "./azure-sdk-tools"
+        }
+    ]
+}


### PR DESCRIPTION
Since direct installs of plugins have been deprecated by GitHub Copilot, a marketplace will soon be needed for plugin installation.

Instead of creating a brand new marketplace repo, let's add this file which will allow us to use this repo as a marketplace to enable the Azure SDK Tools plugin installation.

Installation would become:
`copilot plugin marketplace add Azure/azure-sdk-tools`
then
`copilot plugin install azure-sdk-tools@azure-sdk-plugins`

We can evaluate if we need a dedicated marketplace repo at a later time.

