### PR TITLE
Temporarily skip rest api specs gh workflow syncing

### DIFF
--- a/eng/pipelines/sync-.github.yml
+++ b/eng/pipelines/sync-.github.yml
@@ -33,7 +33,8 @@ parameters:
     - azure-sdk-for-net
     - azure-sdk-for-python
     - azure-sdk-for-rust
-    - azure-rest-api-specs
+    # TODO: Re-enable syncing to specs repo after we standardize on workflow linting/naming
+    # - azure-rest-api-specs
 
 trigger: none
 


### PR DESCRIPTION
Temporarily skip rest api specs gh workflow syncing. This was added recently to start supporting syncing to https://github.com/Azure/azure-rest-api-specs but it turns out we need to standardize on linting gh workflows otherwise the specs repo CI will block syncs.