### PR TITLE
[APIView] Fix: Identical API revisions not recognized as equivalent due to hash mismatch from late sanitization

### DIFF
--- a/src/dotnet/APIView/APIView/Model/CodeFile.cs
+++ b/src/dotnet/APIView/APIView/Model/CodeFile.cs
@@ -61,9 +61,35 @@ namespace APIView
 
         public static bool IsCollapsibleSectionSSupported(string language) => _collapsibleLanguages.Contains(language);
 
+        /// <summary>
+        /// Normalizes Text-kind token values by replacing embedded newline characters with spaces.
+        /// Called immediately after deserialization so all downstream consumers see clean data.
+        /// </summary>
+        public void SanitizeTokenValues()
+        {
+            if (ReviewLines == null || ReviewLines.Count == 0)
+                return;
+            SanitizeLines(ReviewLines);
+
+            static void SanitizeLines(List<ReviewLine> lines)
+            {
+                foreach (var line in lines)
+                {
+                    foreach (var token in line.Tokens)
+                    {
+                        if (token.Kind == TokenKind.Text && !string.IsNullOrEmpty(token.Value))
+                            token.Value = token.Value.Replace("\r\n", " ").Replace('\r', ' ').Replace('\n', ' ');
+                    }
+                    if (line.Children != null && line.Children.Count > 0)
+                        SanitizeLines(line.Children);
+                }
+            }
+        }
+
         public static async Task<CodeFile> DeserializeAsync(Stream stream, bool hasSections = false)
         {
             var codeFile = await JsonSerializer.DeserializeAsync<CodeFile>(stream, _serializerOptions);
+            codeFile.SanitizeTokenValues();
 
             if (hasSections == false && codeFile.LeafSections == null && IsCollapsibleSectionSSupported(codeFile.Language))
                 hasSections = true;

--- a/src/dotnet/APIView/APIView/Model/CodeFile.cs
+++ b/src/dotnet/APIView/APIView/Model/CodeFile.cs
@@ -77,7 +77,8 @@ namespace APIView
                 {
                     foreach (var token in line.Tokens)
                     {
-                        if (token.Kind == TokenKind.Text && !string.IsNullOrEmpty(token.Value))
+                        if (token.Kind == TokenKind.Text && !string.IsNullOrEmpty(token.Value)
+                            && token.Value.IndexOfAny(['\r', '\n']) >= 0)
                             token.Value = token.Value.Replace("\r\n", " ").Replace('\r', ' ').Replace('\n', ' ');
                     }
                     if (line.Children != null && line.Children.Count > 0)

--- a/src/dotnet/APIView/APIViewUnitTests/CodeFileManagerTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/CodeFileManagerTests.cs
@@ -552,6 +552,57 @@ public class CodeFileManagerTests
         Assert.Equal("NoNewlines", codeFile.ReviewLines[0].Tokens[1].Value);
     }
 
+    [Fact]
+    public async Task CreateCodeFileAsync_SanitizesTokenValues_ReturnedFromLanguageService()
+    {
+        // Verifies that CreateCodeFileAsync calls SanitizeTokenValues on the CodeFile produced
+        // by the language service, so callers receive clean data regardless of parser output.
+        var dirtyCodeFile = new CodeFile
+        {
+            Language = "C#",
+            ReviewLines =
+            [
+                new ReviewLine
+                {
+                    LineId = "L1",
+                    Tokens = [new ReviewToken { Value = "public\r\nclass Foo", Kind = TokenKind.Text }]
+                }
+            ]
+        };
+
+        var manager = new CodeFileManager(
+            new List<LanguageService> { new DirtyCodeFileLanguageService(dirtyCodeFile) },
+            _mockCodeFileRepository.Object,
+            _mockOriginalsRepository.Object,
+            _mockDevopsArtifactRepository.Object,
+            new Mock<ILogger<CodeFileManager>>().Object);
+
+        using var memoryStream = new MemoryStream();
+        var result = await manager.CreateCodeFileAsync("test.cs", runAnalysis: false, memoryStream: memoryStream);
+
+        Assert.NotNull(result);
+        Assert.DoesNotContain('\r', result.ReviewLines[0].Tokens[0].Value);
+        Assert.DoesNotContain('\n', result.ReviewLines[0].Tokens[0].Value);
+        Assert.Equal("public class Foo", result.ReviewLines[0].Tokens[0].Value);
+    }
+
     #endregion
 
+}
+
+internal class DirtyCodeFileLanguageService : LanguageService
+{
+    private readonly CodeFile _codeFile;
+
+    public DirtyCodeFileLanguageService(CodeFile codeFile) => _codeFile = codeFile;
+
+    public override string Name => "C#";
+    public override string[] Extensions => [".cs"];
+    public override string VersionString => "1.0";
+    public override bool CanUpdate(string versionString) => false;
+    public override bool CanConvert(string versionString) => false;
+    public override bool GeneratePipelineRunParams(APIRevisionGenerationPipelineParamModel param) => false;
+    public override CodeFile GetReviewGenPendingCodeFile(string fileName) => null;
+    public override Task<CodeFile> GetCodeFileAsync(string originalName, Stream stream, bool runAnalysis, string crossLanguageMetadata = null)
+        => Task.FromResult(_codeFile);
 }

--- a/src/dotnet/APIView/APIViewUnitTests/CodeFileManagerTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/CodeFileManagerTests.cs
@@ -414,12 +414,57 @@ public class CodeFileManagerTests
         Assert.False(_codeFileManager.AreAPICodeFilesTheSame(new RenderedCodeFile(fileA), new RenderedCodeFile(fileB)));
     }
 
+    [Fact]
+    public async Task ComputeAPIContentHashAsync_ProducesSameHash_AfterDeserializeAsync_AsPreCleanTokens()
+    {
+        // DeserializeAsync must sanitize tokens before returning so that any caller who
+        // immediately calls ComputeAPIContentHashAsync sees the same hash as the stored hash
+        // on existing revisions (which were computed from sanitized data).
+        var original = new CodeFile
+        {
+            Language = "C#",
+            ReviewLines =
+            [
+                new ReviewLine
+                {
+                    LineId = "L1",
+                    Tokens = [new ReviewToken("public\r\nclass Foo", TokenKind.Text)]
+                }
+            ]
+        };
+
+        // Simulate the pipeline: parser emits CodeFile → serialized to blob → loaded back
+        using var stream = new MemoryStream();
+        await original.SerializeAsync(stream);
+        stream.Position = 0;
+        var deserialized = await CodeFile.DeserializeAsync(stream); // must sanitize
+
+        string hashDeserialized = await _codeFileManager.ComputeAPIContentHashAsync(deserialized);
+
+        // Same logical content but authored with already-clean tokens (\r\n → single space)
+        var clean = new CodeFile
+        {
+            Language = "C#",
+            ReviewLines =
+            [
+                new ReviewLine
+                {
+                    LineId = "L1",
+                    Tokens = [new ReviewToken("public class Foo", TokenKind.Text)]
+                }
+            ]
+        };
+        string hashClean = await _codeFileManager.ComputeAPIContentHashAsync(clean);
+
+        Assert.Equal(hashClean, hashDeserialized);
+    }
+
     #endregion
 
     #region Token Sanitization Tests
 
     [Fact]
-    public async Task CreateReviewCodeFileModel_SanitizesNewlinesInTreeTokenValues()
+    public void SanitizeTokenValues_NormalizesNewlinesInTextTokens()
     {
         var codeFile = new CodeFile
         {
@@ -443,9 +488,7 @@ public class CodeFileManagerTests
             ]
         };
 
-        using var memoryStream = new MemoryStream();
-
-        await _codeFileManager.CreateReviewCodeFileModel("api-rev-1", memoryStream, codeFile);
+        codeFile.SanitizeTokenValues();
 
         string value = codeFile.ReviewLines[0].Tokens[0].Value;
         Assert.Equal("     This package contains clients.     For details see README.md   ", value);
@@ -454,7 +497,7 @@ public class CodeFileManagerTests
     }
 
     [Fact]
-    public async Task CreateReviewCodeFileModel_SanitizesOnlyNestedTextTokens()
+    public void SanitizeTokenValues_OnlyNormalizesTextKindTokens()
     {
         var codeFile = new CodeFile
         {
@@ -477,16 +520,14 @@ public class CodeFileManagerTests
             ]
         };
 
-        using var memoryStream = new MemoryStream();
-
-        await _codeFileManager.CreateReviewCodeFileModel("api-rev-3", memoryStream, codeFile);
+        codeFile.SanitizeTokenValues();
 
         Assert.Equal("Parent\ntoken", codeFile.ReviewLines[0].Tokens[0].Value);
         Assert.Equal("Child token value", codeFile.ReviewLines[0].Children[0].Tokens[0].Value);
     }
 
     [Fact]
-    public async Task CreateReviewCodeFileModel_DoesNotModifyTreeTokenWithoutNewlines()
+    public void SanitizeTokenValues_DoesNotModifyTokensWithoutNewlines()
     {
         var codeFile = new CodeFile
         {
@@ -505,9 +546,7 @@ public class CodeFileManagerTests
             ]
         };
 
-        using var memoryStream = new MemoryStream();
-
-        await _codeFileManager.CreateReviewCodeFileModel("api-rev-3a", memoryStream, codeFile);
+        codeFile.SanitizeTokenValues();
 
         Assert.Equal("    ", codeFile.ReviewLines[0].Tokens[0].Value);
         Assert.Equal("NoNewlines", codeFile.ReviewLines[0].Tokens[1].Value);

--- a/src/dotnet/APIView/APIViewWeb/Managers/CodeFileManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/CodeFileManager.cs
@@ -194,6 +194,7 @@ namespace APIViewWeb.Managers
                 memoryStream,
                 runAnalysis);
             }
+            codeFile?.SanitizeTokenValues();
             return codeFile;
         }
 
@@ -218,8 +219,6 @@ namespace APIViewWeb.Managers
                 await _originalsRepository.UploadOriginalAsync(reviewCodeFileModel.FileId, memoryStream);
             }
             
-            SanitizeTokenValues(codeFile);
-
             await _codeFileRepository.UpsertCodeFileAsync(apiRevisionId, reviewCodeFileModel.FileId, codeFile);
             reviewCodeFileModel.ContentHash = await ComputeAPIContentHashAsync(codeFile);
             return reviewCodeFileModel;
@@ -318,54 +317,6 @@ namespace APIViewWeb.Managers
             file.PackageVersion = codeFile.PackageVersion;
             file.CrossLanguagePackageId = codeFile.CrossLanguageMetadata != null ? codeFile.CrossLanguageMetadata.CrossLanguagePackageId : codeFile.CrossLanguagePackageId;
             file.ParserStyle = (codeFile.ReviewLines.Count > 0) ? ParserStyle.Tree : ParserStyle.Flat;
-        }
-
-        /// <summary>
-        /// Sanitizes tree-style token values in the CodeFile by removing embedded newlines.
-        /// Legacy flat tokens are intentionally left unchanged.
-        /// </summary>
-        private static void SanitizeTokenValues(CodeFile codeFile)
-        {
-            // Tree-style (ReviewToken is a class, so mutate in place)
-            if (codeFile.ReviewLines != null && codeFile.ReviewLines.Count > 0)
-            {
-                SanitizeReviewLines(codeFile.ReviewLines);
-            }
-        }
-
-        /// <summary>
-        /// Recursively sanitizes token values in ReviewLines and their children.
-        /// ReviewToken is a reference type, so mutations are applied in place.
-        /// </summary>
-        private static void SanitizeReviewLines(List<ReviewLine> lines)
-        {
-            foreach (var line in lines)
-            {
-                foreach (var token in line.Tokens)
-                {
-                    if (token.Kind == TokenKind.Text && !string.IsNullOrEmpty(token.Value))
-                        token.Value = NormalizeTokenValue(token.Value);
-                }
-                if (line.Children != null && line.Children.Count > 0)
-                {
-                    SanitizeReviewLines(line.Children);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Normalizes a token value by replacing all newline characters (both \r\n and \n\r)
-        /// with single spaces, then trimming leading/trailing whitespace.
-        /// </summary>
-        private static string NormalizeTokenValue(string value)
-        {
-            if (string.IsNullOrEmpty(value))
-                return value;
-
-            return value
-                .Replace("\r\n", " ")
-                .Replace('\r', ' ')
-                .Replace('\n', ' ');
         }
     }
 }


### PR DESCRIPTION
closes: #15473

## Problem

Two API revisions with identical API surfaces were not being identified as equivalent — `AreAPIRevisionsTheSame` always returned `false` even when nothing had changed. As a side effect, approvals and auto-generated comments were never carried forward to new automatic revisions, causing release pipelines to fail.

## Root Cause

Introduced in commit `775571e` ("APIView Sanitize text tokens of newlines on ingestion"). That commit added `SanitizeTokenValues` inside `CreateReviewCodeFileModel`, which mutated `CodeFile` tokens in-place. Since `AutoReviewService` computed `incomingContentHash` *before* this mutation, it was always stale — the stored hashes on existing revisions were computed from sanitized data, but `incomingContentHash` was from unsanitized data, so they never matched.

## Fix

Moved sanitization to **CodeFile birth**:
- `CodeFile.DeserializeAsync` now calls `SanitizeTokenValues` immediately after deserialization
- `CodeFileManager.CreateCodeFileAsync` calls it after the language service generates a CodeFile
- Removed sanitization from `CreateReviewCodeFileModel` — it now receives already-clean data

Added a regression guard test (`ComputeAPIContentHashAsync_ProducesSameHash_AfterDeserializeAsync_AsPreCleanTokens`) that would have caught the original bug.