### PR TITLE
[APIView] Python APIViews are not regenerating after parser updates

### DIFF
--- a/src/dotnet/APIView/APIViewUnitTests/APIRevisionsManagerTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/APIRevisionsManagerTests.cs
@@ -381,7 +381,7 @@ public class APIRevisionsManagerTests
 
     private void SetupMocksForUpdate(string revisionId, string fileId, CodeFile existingCodeFile, CodeFile newCodeFile)
     {
-        MemoryStream originalStream = new();
+        MemoryStream originalStream = new(new byte[] { 0x50, 0x4B, 0x03, 0x04 }); // non-empty placeholder
 
         _mockOriginalsRepository
             .Setup(x => x.GetOriginalAsync(fileId))

--- a/src/dotnet/APIView/APIViewUnitTests/APIRevisionsManagerTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/APIRevisionsManagerTests.cs
@@ -322,6 +322,74 @@ public class APIRevisionsManagerTests
             Times.Never);
     }
 
+    [Fact]
+    public async Task UpdateAPIRevisionAsync_SkipsRevision_WhenOriginalIsEmpty()
+    {
+        APIRevisionListItemModel revision = CreateTestRevision();
+
+        _mockOriginalsRepository
+            .Setup(x => x.GetOriginalAsync(revision.Files[0].FileId))
+            .ReturnsAsync(new MemoryStream()); // empty stream
+
+        await _manager.UpdateAPIRevisionAsync(revision, _testLanguageService, false);
+
+        // GetCodeFileAsync should never be called because we skip on empty original
+        Assert.Null(_testLanguageService.CapturedCrossLanguageMetadataJson);
+        _mockAPIRevisionsRepository.Verify(
+            x => x.UpsertAPIRevisionAsync(It.IsAny<APIRevisionListItemModel>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetAPIRevisionAsync_TriggersPipeline_WhenIsReviewGenByPipelineIsTrue()
+    {
+        const string revisionId = "pipeline-revision-id";
+        const string reviewId = "pipeline-review-id";
+
+        var revision = new APIRevisionListItemModel
+        {
+            Id = revisionId,
+            ReviewId = reviewId,
+            Language = "Python",
+            Files = new List<APICodeFileModel>
+            {
+                new() { FileId = "file-id", FileName = "azure_test-1.0.0-py3-none-any.whl", HasOriginal = true, VersionString = "1.0.0", Language = "Python" }
+            }
+        };
+
+        var review = new ReviewListItemModel { Id = reviewId, Language = "Python" };
+
+        _testLanguageService.IsReviewGenByPipeline = true;
+        try
+        {
+            _mockAPIRevisionsRepository
+                .Setup(r => r.GetAPIRevisionAsync(revisionId))
+                .ReturnsAsync(revision);
+            _mockReviewsRepository
+                .Setup(r => r.GetReviewAsync(reviewId))
+                .ReturnsAsync(review);
+            _mockOriginalsRepository
+                .Setup(x => x.GetContainerUrl())
+                .Returns("https://test.blob.core.windows.net/originals");
+            _mockDevopsArtifactRepository
+                .Setup(x => x.RunPipeline(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+
+            await _manager.GetAPIRevisionAsync(revisionId);
+
+            _mockDevopsArtifactRepository.Verify(
+                x => x.RunPipeline(
+                    It.Is<string>(s => s.Contains("Python")),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()),
+                Times.Once);
+        }
+        finally
+        {
+            _testLanguageService.IsReviewGenByPipeline = false;
+        }
+    }
+
     #region APIVersionId Tests
 
     [Fact]

--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -1004,6 +1004,12 @@ namespace APIViewWeb.Managers
                 try
                 {
                     var fileOriginal = await _originalsRepository.GetOriginalAsync(file.FileId);
+                    if (fileOriginal.Length == 0)
+                    {
+                        _telemetryClient.TrackTrace($"Skipping update of {revision.Language} revision with id {revision.Id}: original file is empty.");
+                        continue;
+                    }
+
                     if (string.IsNullOrEmpty(file.FileName))
                     {
                         _telemetryClient.TrackTrace($"Revision does not have original file name to update API revision. Revision Id: {revision.Id}");
@@ -1533,8 +1539,21 @@ namespace APIViewWeb.Managers
             var languageService = LanguageServiceHelpers.GetLanguageService(codeFileDetails.Language, _languageServices);
             if (languageService != null && languageService.CanUpdate(codeFileDetails.VersionString))
             {
-                await UpdateAPIRevisionAsync(revisionModel, languageService, false);
-                revisionModel = await _apiRevisionsRepository.GetAPIRevisionAsync(revisionModel.Id);
+                if (languageService.IsReviewGenByPipeline)
+                {
+                    // For pipeline-based languages (e.g. Python), trigger the external pipeline
+                    // instead of running the parser locally.
+                    if (codeFileDetails.HasOriginal && !string.IsNullOrEmpty(codeFileDetails.FileName))
+                    {
+                        var review = await _reviewsRepository.GetReviewAsync(revisionModel.ReviewId);
+                        await GenerateAPIRevisionInExternalResource(review, revisionModel.Id, codeFileDetails.FileId, codeFileDetails.FileName, revisionModel.Language);
+                    }
+                }
+                else
+                {
+                    await UpdateAPIRevisionAsync(revisionModel, languageService, false);
+                    revisionModel = await _apiRevisionsRepository.GetAPIRevisionAsync(revisionModel.Id);
+                }
             }
             else if (languageService != null && languageService.CanConvert(codeFileDetails.VersionString) &&  codeFileDetails.ParserStyle == ParserStyle.Flat)
             {

--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -1004,7 +1004,7 @@ namespace APIViewWeb.Managers
                 try
                 {
                     var fileOriginal = await _originalsRepository.GetOriginalAsync(file.FileId);
-                    if (fileOriginal.Length == 0)
+                    if (fileOriginal.CanSeek && fileOriginal.Length == 0)
                     {
                         _telemetryClient.TrackTrace($"Skipping update of {revision.Language} revision with id {revision.Id}: original file is empty.");
                         continue;
@@ -1545,8 +1545,16 @@ namespace APIViewWeb.Managers
                     // instead of running the parser locally.
                     if (codeFileDetails.HasOriginal && !string.IsNullOrEmpty(codeFileDetails.FileName))
                     {
-                        var review = await _reviewsRepository.GetReviewAsync(revisionModel.ReviewId);
-                        await GenerateAPIRevisionInExternalResource(review, revisionModel.Id, codeFileDetails.FileId, codeFileDetails.FileName, revisionModel.Language);
+                        try
+                        {
+                            var review = await _reviewsRepository.GetReviewAsync(revisionModel.ReviewId);
+                            await GenerateAPIRevisionInExternalResource(review, revisionModel.Id, codeFileDetails.FileId, codeFileDetails.FileName, revisionModel.Language);
+                        }
+                        catch (Exception ex)
+                        {
+                            _telemetryClient.TrackTrace($"Failed to trigger pipeline upgrade for {revisionModel.Language} revision with id {revisionModel.Id}");
+                            _telemetryClient.TrackException(ex);
+                        }
                     }
                 }
                 else

--- a/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
@@ -823,27 +823,29 @@ namespace APIViewWeb.Managers
                     foreach (var review in reviews)
                     {
                         var revisions = await _apiRevisionsManager.GetAPIRevisionsAsync(review.Id);
-                        foreach (var revision in revisions)
+                        foreach (var revision in revisions.Where(r => !r.IsDeleted))
                         {
-                            if (
-                                revision.Files.First().HasOriginal &&
-                                LanguageServiceHelpers.GetLanguageService(revision.Language, _languageServices)?.CanUpdate(revision.Files.First().VersionString) == true)
+                            APICodeFileModel firstFile = revision.Files.First();
+                            if (!firstFile.HasOriginal || LanguageServiceHelpers.GetLanguageService(revision.Language, _languageServices)
+                                    ?.CanUpdate(firstFile.VersionString) != true)
                             {
-                                var requestTelemetry = new RequestTelemetry { Name = $"Updating {review.Language} Review with id: {review.Id}"  };
-                                var operation = _telemetryClient.StartOperation(requestTelemetry);
-                                try
-                                {
-                                    await Task.Delay(100);
-                                    await _apiRevisionsManager.UpdateAPIRevisionAsync(revision, languageService, verifyUpgradabilityOnly);
-                                }
-                                catch (Exception e)
-                                {
-                                    _telemetryClient.TrackException(e);
-                                }
-                                finally
-                                {
-                                    _telemetryClient.StopOperation(operation);
-                                }
+                                continue;
+                            }
+
+                            var requestTelemetry = new RequestTelemetry { Name = $"Updating {review.Language} Review with id: {review.Id}"  };
+                            var operation = _telemetryClient.StartOperation(requestTelemetry);
+                            try
+                            {
+                                await Task.Delay(100);
+                                await _apiRevisionsManager.UpdateAPIRevisionAsync(revision, languageService, verifyUpgradabilityOnly);
+                            }
+                            catch (Exception e)
+                            {
+                                _telemetryClient.TrackException(e);
+                            }
+                            finally
+                            {
+                                _telemetryClient.StopOperation(operation);
                             }
                         }
                     }
@@ -962,7 +964,7 @@ namespace APIViewWeb.Managers
                     try
                     {
                         var revisions = await _apiRevisionsManager.GetAPIRevisionsAsync(review.Id);
-                        foreach (var revision in revisions)
+                        foreach (var revision in revisions.Where(r => !r.IsDeleted))
                         {
                             foreach (var file in revision.Files)
                             {


### PR DESCRIPTION
closes: https://github.com/Azure/azure-sdk-tools/issues/15382

### Background

When a parser version is updated, the system attempts to update all existing revisions. If any fail, the next time a stale revision is opened, the system detects it is out of date and tries to update it again — but this time locally. For Python (where `IsReviewGenByPipeline = true`), the local update path fails because the Python executable is not available on the App Service host.

### Fixes

- **Skip deleted revisions** during background batch processing to avoid wasted work on soft-deleted content.
- **Skip revisions whose original file is empty** — a 0-byte blob causes a `BadZipFile` error downstream; these are now detected early and skipped with a telemetry trace.
- **Fix `UpgradeAPIRevisionIfRequired` for pipeline-based languages** — when `IsReviewGenByPipeline` is true, the method now triggers the external ADO pipeline instead of attempting a local parse. The user sees the current revision immediately; the updated one becomes available after the pipeline completes.