### PR TITLE
Github tokens are not cross-org, update `create-pull-request.yml`

### DIFF
--- a/eng/common/pipelines/templates/steps/create-pull-request.yml
+++ b/eng/common/pipelines/templates/steps/create-pull-request.yml
@@ -70,5 +70,6 @@ steps:
       -UserReviewers "${{ parameters.GHReviewers }}"
       -TeamReviewers "${{ parameters.GHTeamReviewers }}"
       -Assignees "${{ parameters.GHAssignees }}"
+      -MaintainerCanModify $${{ eq(parameters.PROwner, parameters.RepoOwner) }}
       -CloseAfterOpenForTesting $${{ coalesce(parameters.CloseAfterOpenForTesting, 'false') }}
       -OpenAsDraft $${{ parameters.OpenAsDraft }}

--- a/eng/common/scripts/Submit-PullRequest.ps1
+++ b/eng/common/scripts/Submit-PullRequest.ps1
@@ -29,6 +29,10 @@ List of github teams to add as reviewers
 .PARAMETER Assignees
 Users to assign to the PR after opening. Users should be a comma-separated list
 with no preceding `@` symbol (e.g. "user1,usertwo,user3")
+.PARAMETER MaintainerCanModify
+Whether to allow maintainers of the base repo to push to the PR branch.
+Set to false for cross-fork PRs where the token lacks permission to grant
+collaborator access on the fork.
 .PARAMETER CloseAfterOpenForTesting
 Close the PR after opening to save on CI resources and prevent alerts to code
 owners, assignees, requested reviewers, or others.
@@ -73,6 +77,8 @@ param(
 
   [boolean]$OpenAsDraft=$false,
 
+  [boolean]$MaintainerCanModify=$true,
+
   [boolean]$AddBuildSummary=($null -ne $env:SYSTEM_TEAMPROJECTID)
 )
 
@@ -114,7 +120,7 @@ else {
       -Head "${PROwner}:${PRBranch}" `
       -Base $BaseBranch `
       -Body $PRBody `
-      -Maintainer_Can_Modify $true `
+      -Maintainer_Can_Modify $MaintainerCanModify `
       -Draft:$OpenAsDraft `
       -AuthToken $AuthToken
 


### PR DESCRIPTION
To account for this fact.

Related to #9842

This is worth a discussion @weshaggard . I think this is just one of those "we're using a single token that is scoped". I've given serious thought to granting `azure-sdk-write` `collaborator` on all of the `azure-sdk` forks, which would do the same thing as `MaintainerCanModify` does.

The issue is, you need to be authed to the target repo (in case of -pr, to even see the repo to submit the PR), AND you need a token with `collaborator` on the SOURCE of the pullrequest, because `maintainer_can_modify` implies something about the token's access level.