### PR TITLE
Pass Npm Config to CSpell

### DIFF
--- a/eng/common/pipelines/templates/steps/check-spelling.yml
+++ b/eng/common/pipelines/templates/steps/check-spelling.yml
@@ -11,6 +11,11 @@
 #                           check for errors which would prevent release (i.e. 
 #                           public API surface).
 #
+# NpmConfigUserConfig - Optional path to a user npm config file to use when invoking
+#                       npm commands in the context of this step. If specified, this
+#                       will be set as the npm_config_userconfig environment variable
+#                       so that npm uses the provided config file instead of the default
+#                       user config.
 # This check recognizes the setting of variable "Skip.SpellCheck"
 # if set to 'true', spellchecking will not be invoked.
 
@@ -22,6 +27,9 @@ parameters:
     type: string
     default: ./.vscode/cspell.json
   - name: ScriptToValidateUpgrade
+    type: string
+    default: ''
+  - name: NpmConfigUserConfig
     type: string
     default: ''
 
@@ -38,6 +46,9 @@ steps:
           -CspellConfigPath ${{ parameters.CspellConfigPath }}
           -ExitWithError:(!$${{ parameters.ContinueOnError }})
         pwsh: true
+      env:
+        ${{ if ne(parameters.NpmConfigUserConfig, '') }}:
+          npm_config_userconfig: ${{ parameters.NpmConfigUserConfig }}
     - ${{ if ne('', parameters.ScriptToValidateUpgrade) }}:
       - pwsh: |
           $changedFiles = ./eng/common/scripts/get-changedfiles.ps1


### PR DESCRIPTION
- Allow `npm_config_userconfig` to be passed to cspell step