### PR TITLE
[APIView Copilot] Fix stray-backtick rendering in Report Issue body

### DIFF
--- a/packages/python-packages/apiview-copilot/prompts/report_issue/generate_issue.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/report_issue/generate_issue.prompty
@@ -81,9 +81,20 @@ Respond with strict JSON matching the provided schema:
 
       ## Context
       Bullet list of the relevant context: review link, language, the
-      offending element id, the comment that triggered the report, and
-      a short fenced code block of the relevant snippet if one was
-      provided. Use the actual values you were given.
+      offending element id, and a short fenced code block of the
+      relevant snippet if one was provided. Use the actual values you
+      were given.
+
+      When a comment text was provided, render it as a Markdown
+      blockquote on the line(s) immediately after the bullet list, like
+      this:
+
+          > original comment text here, exactly as given
+
+      **Never wrap the comment text in inline backticks (`` ` ``) or in
+      a fenced code block.** Comment text often contains Markdown links
+      or backticks of its own, and inline-code-wrapping it produces
+      broken rendering. A blockquote preserves it faithfully.
 
       ## Details
       The user's report rewritten into clear, complete sentences. Fix
@@ -104,8 +115,9 @@ Hard rules:
 
 * Do not include the user's free-form description verbatim in `## Summary`
   or `## Details` — rewrite it. The `## Context` section should quote
-  factual values (review link, language, element id, comment text, code
-  snippet) exactly as given.
+  factual values (review link, language, element id, code snippet)
+  exactly as given. The comment text goes in a blockquote (see above),
+  never in inline backticks.
 * Do not invent details (review IDs, names, error codes, dates).
 * Address the body to the engineer who will fix the issue, not to the
   reporter. Do not write instructions like "please try X and report back".


### PR DESCRIPTION
## What

Update the `generate_issue.prompty` Context section so the LLM renders the AVC comment text as a Markdown **blockquote** instead of wrapping it in inline backticks.

## Why

The previous prompt asked the model to "quote factual values exactly as given," and the LLM interpreted "comment text" the same way as the other values: by wrapping it in single backticks. AVC comments commonly contain Markdown links (e.g. the `[Details](url)` guideline link) and span multiple lines. When you wrap that in a single pair of inline backticks:

- the closing backtick lands in the wrong place,
- the `[Details](url)` link gets parsed as a real link,
- a literal stray backtick is rendered after it,
- newlines collapse.

Reproducer: tjprescott/azure-sdk-tools#37 (filed via the new APIView Report Issue dialog before this fix).

## Fix

In `prompts/report_issue/generate_issue.prompty`:

- `## Context` instructions: drop "the comment that triggered the report" from the bullet list and instead specify a Markdown blockquote (`> ...`) on the line(s) immediately after the bullets.
- Hard rules: explicitly forbid wrapping comment text in inline backticks (or a fenced block).
- Code snippets continue to use a fenced block (safe, since fenced blocks don't parse Markdown inside them).

## Verified

Reran the same comment locally against the updated prompt — output: tjprescott/azure-sdk-tools#38. The comment now renders as a proper blockquote with a working `[Details]` link and no stray characters.

/cc @tjprescott