### PR TITLE
[AVC] Update dotnet filter

### DIFF
--- a/packages/python-packages/apiview-copilot/metadata/dotnet/filter.yaml
+++ b/packages/python-packages/apiview-copilot/metadata/dotnet/filter.yaml
@@ -9,3 +9,4 @@ exceptions: |
   8. DO NOT question RequestContent/RequestContext overloads on protocol methods.
   9. DO NOT suggest adding a 'Create' prefix to model factory methods or replacing them with a builder pattern.
   10. DO NOT suggest renaming or refactoring serialization methods such as JsonModelCreateCore, or suggest consolidating serialization logic across models. These are accepted generated patterns.
+  11. DO NOT suggest hiding or removing Equals(object) overrides on extensible enum structs. These overrides are part of the accepted struct equality pattern.


### PR DESCRIPTION
Filter additions based on a review of feedback collected during April 2026.

**Rule 11 added:** DO NOT suggest hiding or removing Equals(object) overrides on extensible enum structs. These overrides are part of the accepted struct equality pattern.

**Evidence:** 2 downvoted comments (AcceptedSDKPattern) from christothes.

**Note:** The remaining 53 feedback items were already covered by existing rules 7 (implicit operators) and 10 (serialization consolidation). Those comments predate the current filter rules.