### PR TITLE
[AVC] Update python filter

### DIFF
--- a/packages/python-packages/apiview-copilot/metadata/python/filter.yaml
+++ b/packages/python-packages/apiview-copilot/metadata/python/filter.yaml
@@ -22,3 +22,4 @@ exceptions: |
   21. DO NOT suggest renaming parameters or attributes named `type`, `id`, or `object` to avoid shadowing Python built-ins. These are established Azure SDK patterns.
   22. DO NOT suggest uppercasing or quoting `Literal` type annotation values. The enum-name-uppercase guideline applies only to `Enum` class member names, not to `Literal` string values which must match the service wire format.
   23. DO NOT suggest adding an explicit `timeout` parameter to methods that already accept `**kwargs`. Timeout is passed through `**kwargs` in the Azure SDK for Python.
+  24. DO NOT suggest typing model parameters as `Union[ModelType, Mapping[str, Any]]` in generated code. Generated models type parameters with the model class only; dict-input flexibility is handled at runtime, not in the type signature.


### PR DESCRIPTION
Filter additions based on a review of feedback collected during April 2026.

**Rule 24 added:** DO NOT suggest typing model parameters as `Union[ModelType, Mapping[str, Any]]` in generated code. Generated models type parameters with the model class only; dict-input flexibility is handled at runtime, not in the type signature.

**Evidence:** 2 downvoted comments (OutdatedGuideline) from annatisch on the Planetary Computer SDK review. The `python-models-input-dict` guideline does not apply to generated code type annotations.