### PR TITLE
[AVC] Update golang filter

### DIFF
--- a/packages/python-packages/apiview-copilot/metadata/golang/filter.yaml
+++ b/packages/python-packages/apiview-copilot/metadata/golang/filter.yaml
@@ -1,3 +1,5 @@
 exceptions: |
   1. DO NOT make comments that don't actually identify a problem.
   2. DO NOT comment on lack of documentation comments
+  3. DO NOT suggest changing error code constant string values to match the constant name's capitalization. Error code values are wire-format strings defined by the service and must not be altered.
+  4. DO NOT suggest renaming functions that use "WithNoCredential" to "WithoutCredential". The "NoCredential" naming is the established Go SDK pattern.


### PR DESCRIPTION
Filter additions based on a review of feedback collected during April 2026.

**Rule 3 added:** DO NOT suggest changing error code constant string values to match the constant name's capitalization. Error code values are wire-format strings defined by the service and must not be altered.

**Rule 4 added:** DO NOT suggest renaming functions that use 'WithNoCredential' to 'WithoutCredential'. The 'NoCredential' naming is the established Go SDK pattern.

**Evidence:** 2 downvoted comments from jhendrixMSFT on the azblob review (1 FactuallyIncorrect, 1 AcceptedSDKPattern).