### PR TITLE
[APIView] Fix unreadable placeholder text in dark theme feedback dialog

### DIFF
--- a/src/dotnet/APIView/ClientSPA/src/app/_components/shared/ai-comment-feedback-dialog/ai-comment-feedback-dialog.component.scss
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/shared/ai-comment-feedback-dialog/ai-comment-feedback-dialog.component.scss
@@ -72,6 +72,11 @@
             color: var(--base-text-color);
             border-color: var(--border-color);
 
+            &::placeholder {
+                color: var(--text-muted-color);
+                opacity: 1;
+            }
+
             &:focus {
                 border-color: var(--primary-color);
                 box-shadow: 0 0 0 1px var(--primary-color);


### PR DESCRIPTION
The 'Provide additional feedback' textarea in the AI comment feedback dialog used the browser default placeholder color, which becomes nearly invisible against the dark dialog background. Style the placeholder with --text-muted-color (matching the related-comments-dialog and ai-comment-delete-dialog) and force opacity:1 so the hint text is readable in both light and dark themes. Fixes #15446.

Before:
<img width="813" height="1003" alt="image" src="https://github.com/user-attachments/assets/d97b1c31-0fb5-4b0c-b16c-355d0b7b7b40" />

After:
<img width="843" height="1038" alt="image" src="https://github.com/user-attachments/assets/037ac623-392d-4cdf-ab39-21509cf61e7b" />
