### PR TITLE
[APIView] Reapply severity filter when comment severity changes (#14990)

### DIFF
--- a/src/dotnet/APIView/ClientSPA/src/app/_components/conversations/conversations.component.spec.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/conversations/conversations.component.spec.ts
@@ -656,6 +656,33 @@ describe('ConversationComponent', () => {
 
       expect(component.comments[0].severity).toBe(CommentSeverity.Question);
     });
+
+    it('should reapply the active severity filter when a comment severity changes (#14990)', () => {
+      // Build a thread whose first comment severity is "mustFix"; it should match the
+      // active "mustfix" filter chip.
+      const sharedComment = { id: 'comment-1', severity: 'mustFix' } as CommentItemModel;
+      component.comments = [sharedComment];
+
+      const thread: any = {
+        isResolvedCommentThread: false,
+        comments: [sharedComment],
+      };
+      component.commentThreads = new Map();
+      component.commentThreads.set('rev-1', [thread]);
+      component.apiRevisionsWithComments = [{ id: 'rev-1' } as APIRevision];
+
+      component.filterStatus = 'all';
+      component.filterSeverities = new Set(['mustfix']);
+      component.filterKinds.clear();
+      component.applyFilters();
+      expect(component.filteredThreadCount).toBe(1);
+
+      // Simulate a severity change to a value not in the active filter set.
+      commentsService.notifySeverityChanged('comment-1', CommentSeverity.Suggestion);
+
+      // The thread should now be filtered out without requiring the user to toggle filters.
+      expect(component.filteredThreadCount).toBe(0);
+    });
   });
 
   describe('Filter pipeline (applyFilters / threadMatchesFilters)', () => {

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/conversations/conversations.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/conversations/conversations.component.ts
@@ -120,6 +120,10 @@ export class ConversationsComponent implements OnChanges, OnDestroy {
       const comment = this.comments.find(c => c.id === commentId);
       if (comment) {
         comment.severity = newSeverity;
+        // Severity affects which threads match the active severity filter and whether the
+        // Unknown chip is relevant, so reapply filters to keep the displayed list in sync.
+        this.updateUnknownSeverityFilterVisibility();
+        this.applyFilters();
         this.changeDetectorRef.markForCheck();
       }
     });


### PR DESCRIPTION
Fixes #14990

## Problem
In the Conversations panel, applying a severity filter and then changing a comment's severity to a value not in the active filter left the thread visible. The user had to manually toggle a filter to refresh the view.

## Root cause
The `severityChanged$` subscription in `ConversationsComponent.ngOnInit` updated `comment.severity` and called `markForCheck()` but never recomputed `filteredCommentThreads`. The displayed list is derived in `applyFilters()` and the Unknown chip visibility in `updateUnknownSeverityFilterVisibility()`; neither ran on a severity change.

## Fix
After mutating the comment's severity, call `updateUnknownSeverityFilterVisibility()` and `applyFilters()` so the panel reflects the new severity against the active filter immediately - matching the behavior already used by `setStatusFilter`, `toggleSeverityFilter`, and `toggleKindFilter`.

## Tests
Added a regression test in `conversations.component.spec.ts` that:
1. Sets up a thread whose severity matches the active `mustfix` filter.
2. Verifies it is visible (`filteredThreadCount === 1`).
3. Emits a `severityChanged$` for that comment with `Suggestion`.
4. Verifies the thread is filtered out (`filteredThreadCount === 0`) without any further user action.

All 44 tests in the spec pass locally (`npx vitest run`).