### PR TITLE
prepare-release-plan skill updates

### DIFF
--- a/.github/skills/azsdk-common-prepare-release-plan/SKILL.md
+++ b/.github/skills/azsdk-common-prepare-release-plan/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   distribution: shared
 description: "Create and manage release plan work items for Azure SDK releases across languages. **UTILITY SKILL**. USE FOR: \"create release plan\", \"update release plan\", \"link SDK PR to plan\", \"namespace approval\", \"check release plan status\". DO NOT USE FOR: SDK code generation, pipeline troubleshooting, API review feedback. INVOKES: azure-sdk-mcp:azsdk_create_release_plan, azure-sdk-mcp:azsdk_get_release_plan, azure-sdk-mcp:azsdk_link_sdk_pull_request_to_release_plan."
 compatibility:
-  requires: "azure-sdk-mcp server, API spec PR in Azure/azure-rest-api-specs"
+  requires: "azure-sdk-mcp server, API spec PR, or TypeSpec project path"
 ---
 
 # Prepare Release Plan
@@ -26,8 +26,8 @@ compatibility:
 
 ## Steps
 
-1. **Prerequisites** — Check for API spec PR; prompt if unavailable.
-2. **Check Existing** — Query by plan number or spec PR link.
+1. **Prerequisites** — Check for API spec PR link or a TypeSpec project path; prompt if unavailable.
+2. **Check Existing** — Query by release plan number or spec PR link (do not query by work item ID).
 3. **Gather Info** — Collect Service Tree IDs, timeline. See [details](references/release-plan-details.md).
 4. **Create** — Run `azure-sdk-mcp:azsdk_create_release_plan`.
 5. **Namespace** — For mgmt plane first releases, link approval issue.
@@ -36,9 +36,10 @@ compatibility:
 ## Examples
 
 - "Create a release plan for my spec PR"
+- "Create a release plan for my TypeSpec project"
 - "Link my SDK PR to release plan"
 
 ## Troubleshooting
 
 - Requires `azure-sdk-mcp` server; no CLI fallback.
-- If creation fails, verify spec PR URL and Service Tree IDs.
+- If creation fails, verify Service Tree IDs and the provided spec PR URL or TypeSpec project path.

--- a/.github/skills/azsdk-common-sdk-release/SKILL.md
+++ b/.github/skills/azsdk-common-sdk-release/SKILL.md
@@ -22,6 +22,7 @@ compatibility:
 
 1. **Collect Info** — Get `packageName` and `language` from the user. Optionally get `branch` (defaults to main).
 2. **Check Readiness** — Run `azure-sdk-mcp:azsdk_release_sdk` with `checkReady: true` to verify API review approval, changelog, package name approval, and release date.
+  - If APIView approval is pending display the link or guidance to find the link if not provided.
 3. **Review Results** — If not ready, display failing checks and guide user to resolve.
 4. **Trigger Release** — Once ready, run `azure-sdk-mcp:azsdk_release_sdk` with `checkReady: false`. Show pipeline link and inform user they must approve the release stage.
 

--- a/eng/common/instructions/azsdk-tools/typespec-to-sdk.instructions.md
+++ b/eng/common/instructions/azsdk-tools/typespec-to-sdk.instructions.md
@@ -71,7 +71,7 @@ Follow the steps in #file:.github/skills/azsdk-common-generate-sdk-locally/SKILL
 3. Prompt the user to provide the API spec pull request link if not already available in the current context.
 4. If unsure, check if a release plan already exists for API spec pull request.
 5. Prompt user to find the service id and product id in service tree `aka.ms/st` and provide them. Stress the importance of correct service id and product id for proper release plan creation.
-6. If a new release plan is needed, refer to #file:.github/skills/azsdk-common-prepare-release-plan/SKILL.md to create a release plan using the spec pull request. API spec pull request is required to create a release plan.
+6. If a new release plan is needed, refer to #file:.github/skills/azsdk-common-prepare-release-plan/SKILL.md to create a release plan using the spec pull request or TypeSpec project path.
 7. Prompt user to change spec PR to ready for review: "Please change the spec pull request to ready for review status"
 8. Suggest users to follow the instructions on spec PR to get approval from API reviewers and merge the spec PR.
 9. Link SDK pull requests to the release plan.

--- a/eng/common/instructions/azsdk-tools/typespec-to-sdk.instructions.md
+++ b/eng/common/instructions/azsdk-tools/typespec-to-sdk.instructions.md
@@ -71,7 +71,7 @@ Follow the steps in #file:.github/skills/azsdk-common-generate-sdk-locally/SKILL
 3. Prompt the user to provide the API spec pull request link if not already available in the current context.
 4. If unsure, check if a release plan already exists for API spec pull request.
 5. Prompt user to find the service id and product id in service tree `aka.ms/st` and provide them. Stress the importance of correct service id and product id for proper release plan creation.
-6. If a new release plan is needed, refer to #file:.github/skills/azsdk-common-prepare-release-plan/SKILL.md to create a release plan using the spec pull request or TypeSpec project path.
+6. If a new release plan is needed, refer to #file:.github/skills/azsdk-common-prepare-release-plan/SKILL.md to create a release plan using the spec pull request. API spec pull request is required to create a release plan.
 7. Prompt user to change spec PR to ready for review: "Please change the spec pull request to ready for review status"
 8. Suggest users to follow the instructions on spec PR to get approval from API reviewers and merge the spec PR.
 9. Link SDK pull requests to the release plan.

--- a/plugins/azure-sdk-tools/skills/prepare-release-plan/SKILL.md
+++ b/plugins/azure-sdk-tools/skills/prepare-release-plan/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   distribution: shared
 description: "Create and manage release plan work items for Azure SDK releases across languages. **UTILITY SKILL**. USE FOR: \"create release plan\", \"update release plan\", \"link SDK PR to plan\", \"namespace approval\", \"check release plan status\". DO NOT USE FOR: SDK code generation, pipeline troubleshooting, API review feedback. INVOKES: azure-sdk-mcp:azsdk_create_release_plan, azure-sdk-mcp:azsdk_get_release_plan, azure-sdk-mcp:azsdk_link_sdk_pull_request_to_release_plan."
 compatibility:
-  requires: "azure-sdk-mcp server, API spec PR in Azure/azure-rest-api-specs"
+  requires: "azure-sdk-mcp server, API spec PR, or TypeSpec project path"
 ---
 
 # Prepare Release Plan
@@ -26,8 +26,8 @@ compatibility:
 
 ## Steps
 
-1. **Prerequisites** — Check for API spec PR; prompt if unavailable.
-2. **Check Existing** — Query by plan number or spec PR link.
+1. **Prerequisites** — Check for API spec PR link or a TypeSpec project path; prompt if unavailable.
+2. **Check Existing** — Query by release plan number or spec PR link (do not query by work item ID).
 3. **Gather Info** — Collect Service Tree IDs, timeline. See [details](references/release-plan-details.md).
 4. **Create** — Run `azure-sdk-mcp:azsdk_create_release_plan`.
 5. **Namespace** — For mgmt plane first releases, link approval issue.
@@ -36,9 +36,10 @@ compatibility:
 ## Examples
 
 - "Create a release plan for my spec PR"
+- "Create a release plan for my TypeSpec project"
 - "Link my SDK PR to release plan"
 
 ## Troubleshooting
 
 - Requires `azure-sdk-mcp` server; no CLI fallback.
-- If creation fails, verify spec PR URL and Service Tree IDs.
+- If creation fails, verify Service Tree IDs and the provided spec PR URL or TypeSpec project path.

--- a/plugins/azure-sdk-tools/skills/sdk-release/SKILL.md
+++ b/plugins/azure-sdk-tools/skills/sdk-release/SKILL.md
@@ -22,6 +22,7 @@ compatibility:
 
 1. **Collect Info** — Get `packageName` and `language` from the user. Optionally get `branch` (defaults to main).
 2. **Check Readiness** — Run `azure-sdk-mcp:azsdk_release_sdk` with `checkReady: true` to verify API review approval, changelog, package name approval, and release date.
+  - If APIView approval is pending display the link or guidance to find the link if not provided.
 3. **Review Results** — If not ready, display failing checks and guide user to resolve.
 4. **Trigger Release** — Once ready, run `azure-sdk-mcp:azsdk_release_sdk` with `checkReady: false`. Show pipeline link and inform user they must approve the release stage.
 


### PR DESCRIPTION
- Update prepare-release-plan SKILL.md wording to avoid querying release plan by work item id. 
- APIView Link instructions when checking package readiness.
- Make spec PR optional when creating/updating a release plan. 

Resolves #15218
Resolves #15118
Resolves #14613

A couple items were just pending on instruction changes so made it all into one. 