### PR TITLE
not ignore error when build sample in the JS SDK validation pipeline

### DIFF
--- a/tools/js-sdk-release-tools/src/common/rushUtils.ts
+++ b/tools/js-sdk-release-tools/src/common/rushUtils.ts
@@ -136,7 +136,7 @@ export async function tryBuildSamples(packageDirectory: string, sdkRepoRoot: str
   const cwd = packageDirectory;
   const options = { ...runCommandOptions, cwd };
   const modularSDKType = getModularSDKType(packageDirectory);
-  let errorAsWarning = runMode !== RunMode.Release;
+  let errorAsWarning = runMode !== RunMode.Release && runMode !== RunMode.SpecPullRequest;
   if (modularSDKType === ModularSDKType.DataPlane) {
     errorAsWarning = true;
   }


### PR DESCRIPTION
fixes https://github.com/Azure/azure-sdk-tools/issues/15586

test pipeline: https://dev.azure.com/azure-sdk/public/_build/results?buildId=6278082&view=logs&j=83516c17-6666-5250-abde-63983ce72a49&t=00be4b52-4a63-5865-8e02-c61723ad0692
<img width="1628" height="832" alt="image" src="https://github.com/user-attachments/assets/9e318c15-ac74-4c17-a579-a6d6b9b82c4b" />
