### PR TITLE
[tsp authoring] Fix benchmark readme

### DIFF
--- a/.github/skills/azure-typespec-author/evaluate/README.md
+++ b/.github/skills/azure-typespec-author/evaluate/README.md
@@ -1,10 +1,10 @@
 # Azure TypeSpec Author Skill Evaluations
 
-This directory contains [Vally](https://vally.dev) evaluation cases for the `azure-typespec-author` skill.
+This directory contains [Vally](https://aka.ms/vally) evaluation cases for the `azure-typespec-author` skill.
 
 ## Prerequisites
 
-- [Vally CLI](https://vally.dev/docs/getting-started) installed globally: `npm install -g vally`
+- [Vally CLI](https://literate-engine-r3wnl4v.pages.github.io/get-started/) installed globally: `npm install -g @microsoft/vally-cli`
 - The `azsdk-cli` MCP server built: `dotnet build tools/azsdk-cli/Azure.Sdk.Tools.Cli`
 - An API key for the model configured (e.g., Anthropic or OpenAI key via environment variable)
 
@@ -36,15 +36,15 @@ vally eval --eval-spec evals/001001.eval.yaml --output-dir ./result-001001 --wor
 
 Test suites are defined in `.vally.yaml` under the `suites` key. Available suites:
 
-| Suite | Description |
-|---|---|
-| `versioning` | All versioning cases (001xxx) |
-| `version-evolution` | Version evolution subset |
-| `armtemplate` | ARM template cases (002xxx) |
+| Suite                  | Description                           |
+| ---------------------- | ------------------------------------- |
+| `versioning`           | All versioning cases (001xxx)         |
+| `version-evolution`    | Version evolution subset              |
+| `armtemplate`          | ARM template cases (002xxx)           |
 | `longrunningoperation` | Long-running operation cases (003xxx) |
-| `decorators` | Decorator cases (004xxx) |
-| `warning` | Warning cases (005xxx) |
-| `all` | Every eval case |
+| `decorators`           | Decorator cases (004xxx)              |
+| `warning`              | Warning cases (005xxx)                |
+| `all`                  | Every eval case                       |
 
 Run a suite by name:
 

--- a/.github/skills/azure-typespec-author/evaluate/README.md
+++ b/.github/skills/azure-typespec-author/evaluate/README.md
@@ -4,7 +4,7 @@ This directory contains [Vally](https://aka.ms/vally) evaluation cases for the `
 
 ## Prerequisites
 
-- [Vally CLI](https://literate-engine-r3wnl4v.pages.github.io/get-started/) installed globally: `npm install -g @microsoft/vally-cli`
+- [Vally CLI](https://aka.ms/vally) installed globally: `npm install -g @microsoft/vally-cli`
 - The `azsdk-cli` MCP server built: `dotnet build tools/azsdk-cli/Azure.Sdk.Tools.Cli`
 - An API key for the model configured (e.g., Anthropic or OpenAI key via environment variable)
 


### PR DESCRIPTION
vally.dev docs cause a connection timed out error, the aka.ms link points to the proper documentation. Likewise fixing the npm install command to use the correct package name