### PR TITLE
user Devops artifact for azure-macp evals

### DIFF
--- a/tools/ai-evals/azure-mcp/run.py
+++ b/tools/ai-evals/azure-mcp/run.py
@@ -2,6 +2,7 @@ import os
 import asyncio
 import pathlib
 import json
+import argparse
 from typing import Any
 
 # set before azure.ai.evaluation import to make PF output less noisy
@@ -68,9 +69,16 @@ client = AzureOpenAI(
     ),
 )
 
-server_params = StdioServerParameters(
-    command="npx", args=["-y", "@azure/mcp@latest", "server", "start"], env=None
-)
+def get_server_params() -> StdioServerParameters:
+    npmrc_path = os.getenv("npm_config_userconfig") or os.getenv("NPM_CONFIG_USERCONFIG")
+    env = None
+    if npmrc_path:
+        env = os.environ.copy()
+        env["npm_config_userconfig"] = npmrc_path
+
+    return StdioServerParameters(
+        command="npx", args=["-y", "@azure/mcp@latest", "server", "start"], env=env
+    )
 
 
 def reshape_tools(
@@ -105,7 +113,7 @@ def reshape_tool_definitions(
 async def call_mcp_tool(
     tool_call: chat.ChatCompletionMessageToolCall, function_args: dict[str, Any]
 ) -> CallToolResult:
-    async with stdio_client(server_params) as (read, write):
+    async with stdio_client(get_server_params()) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
             await session.list_tools()
@@ -224,7 +232,7 @@ def evaluate_azure_mcp(query: str, expected_tool_calls: list):
 
 
 async def get_tools() -> list[dict[str, Any]]:
-    async with stdio_client(server_params) as (read, write):
+    async with stdio_client(get_server_params()) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
 
@@ -244,6 +252,13 @@ async def get_tools() -> list[dict[str, Any]]:
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--npmrc-path")
+    args = parser.parse_args()
+
+    if args.npmrc_path:
+        os.environ["npm_config_userconfig"] = args.npmrc_path
+
     azure_ai_project: AzureAIProject = {
         "subscription_id": os.environ["AZURE_SUBSCRIPTION_ID"],
         "resource_group_name": os.environ["AZURE_FOUNDRY_RESOURCE_GROUP"],

--- a/tools/ai-evals/azure-mcp/tests.yml
+++ b/tools/ai-evals/azure-mcp/tests.yml
@@ -23,6 +23,12 @@ extends:
               os: linux
 
             steps:
+              - task: PipAuthenticate@1
+                displayName: 'Pip Authenticate to feed'
+                inputs:
+                  artifactFeeds: 'public/azure-sdk-for-python'
+                  onlyAddExtraIndex: false
+
               - template: /eng/pipelines/templates/steps/use-python-version.yml
                 parameters:
                   versionSpec: '${{ parameters.PythonVersion }}'

--- a/tools/ai-evals/azure-mcp/tests.yml
+++ b/tools/ai-evals/azure-mcp/tests.yml
@@ -14,6 +14,8 @@ extends:
           - template: /eng/pipelines/templates/variables/image.yml
         jobs:
           - job: 'Build'
+            variables:
+              npmrcPath: $(Agent.TempDirectory)/azure-mcp/.npmrc
 
             pool:
               name: $(LINUXPOOL)
@@ -35,6 +37,10 @@ extends:
                 displayName: 'Install Test Requirements'
                 workingDirectory: $(Build.SourcesDirectory)/tools/ai-evals/azure-mcp
 
+              - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+                parameters:
+                  npmrcPath: $(npmrcPath)
+
               - task: AzureCLI@2
                 displayName: Run Evals (AzureCLI@2)
                 inputs:
@@ -48,7 +54,7 @@ extends:
                     # Verify the context
                     az account show --query '{subscription:name,tenant:tenantId}'
 
-                    python tools/ai-evals/azure-mcp/run.py
+                    python tools/ai-evals/azure-mcp/run.py --npmrc-path "$(npmrcPath)"
 
                     exit $?
                 env:


### PR DESCRIPTION
- Ensures the Azure MCP eval pipeline supports Network isolation by resolving the npm package from the Azure DevOps feed via an authenticated .npmrc. This updates the eval script and pipeline wiring so @azure/mcp is installed from the internal feed in isolated environments.
- Also add authenticated python devOps feed for us in resolving python packages.