### PR TITLE
ci(tsp-client-tests): pin contents: read

### DIFF
--- a/.github/workflows/tsp-client-tests.yml
+++ b/.github/workflows/tsp-client-tests.yml
@@ -12,6 +12,9 @@ on:
       - .github/workflows/tsp-client-tests.yml
       - tools/tsp-client/**
 
+permissions:
+  contents: read
+
 jobs:
   tsp-client:
     strategy:


### PR DESCRIPTION
Round out workflow-level least-privilege in this repo. `tsp-client-tests.yml` was the last workflow under `.github/workflows/` without a top-level `permissions:` block - all 11 siblings already declare one (e.g. `eng-common-tsp-client-test.yml`, `event.yml`, `scheduled-event-processor.yml`).

The job only does `actions/checkout`, `actions/setup-node`, and `npm ci / build / test / format:check` against `tools/tsp-client`. No GitHub API surface, so `contents: read` is the right scope.

YAML re-parsed locally. No behavior change.