### PR TITLE
Fix Go type aliases for modules with a major version

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Languages/GoLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/GoLanguageService.cs
@@ -17,7 +17,7 @@ namespace APIViewWeb
         public override string Name { get; } = "Go";
         public override string [] Extensions { get; } = { ".gosource" };
         public override string ProcessName { get; } = "apiviewgo";
-        public override string VersionString { get; } = "0.2";
+        public override string VersionString { get; } = "0.3";
 
         public GoLanguageService(TelemetryClient telemetryClient) : base(telemetryClient)
         {

--- a/src/go/cmd/api_view_test.go
+++ b/src/go/cmd/api_view_test.go
@@ -201,10 +201,10 @@ func TestAliasDefinitions(t *testing.T) {
 			sourceName: "github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_external_alias_source.Foo",
 		},
 		{
-			diagLevel:  CodeDiagnosticLevelWarning,
+			diagLevel:  CodeDiagnosticLevelInfo,
 			name:       "internal_package_major_version",
 			path:       "testdata/test_alias_export_major_version",
-			sourceName: "github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_alias_export_major_version/internal/exported.Foo",
+			sourceName: "internal/exported.Foo",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/src/go/cmd/api_view_test.go
+++ b/src/go/cmd/api_view_test.go
@@ -200,6 +200,12 @@ func TestAliasDefinitions(t *testing.T) {
 			path:       "testdata/test_external_alias_exporter",
 			sourceName: "github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_external_alias_source.Foo",
 		},
+		{
+			diagLevel:  CodeDiagnosticLevelWarning,
+			name:       "internal_package_major_version",
+			path:       "testdata/test_alias_export_major_version",
+			sourceName: "github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_alias_export_major_version/internal/exported.Foo",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			p, err := filepath.Abs(test.path)

--- a/src/go/cmd/module.go
+++ b/src/go/cmd/module.go
@@ -78,7 +78,17 @@ func NewModule(dir string) (*Module, error) {
 		Packages: map[string]*Pkg{},
 	}
 
-	baseImportPath := path.Dir(m.ModFile.Module.Mod.Path) + "/"
+	// baseImportPath contains the module identity *minus* the module's root package.
+	// e.g. for module github.com/foo/bar the value will be github.com/foo/
+	// the package name is concatenated to this value after its creation.
+	var baseImportPath string
+	if versionReg.MatchString(m.ModFile.Module.Mod.Path) {
+		// we need to strip off the version suffix AND the package name
+		baseImportPath = path.Dir(path.Dir(m.ModFile.Module.Mod.Path))
+	} else {
+		baseImportPath = path.Dir(m.ModFile.Module.Mod.Path)
+	}
+	baseImportPath += "/"
 	if baseImportPath == "./" {
 		// this is a relative path in the tests, so remove this prefix.
 		// if not, then the package name added below won't match the imported packages.

--- a/src/go/cmd/pkg.go
+++ b/src/go/cmd/pkg.go
@@ -110,6 +110,14 @@ func (p *Pkg) Index() {
 	}
 }
 
+// returns p.modulePath minus any major version suffix
+func (p *Pkg) unversionedModulePath() string {
+	if versionReg.MatchString(p.modulePath) {
+		return path.Dir(p.modulePath)
+	}
+	return p.modulePath
+}
+
 func (p *Pkg) indexFile(f *ast.File) {
 	// map import aliases to full import paths e.g. "shared" => "github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 	imports := map[string]string{}
@@ -187,7 +195,7 @@ func (p *Pkg) indexFile(f *ast.File) {
 				if ident, ok := t.X.(*ast.Ident); ok {
 					if impPath, ok := imports[ident.Name]; ok {
 						// alias in the same module could use type navigator directly
-						if _, _, found := strings.Cut(impPath, p.modulePath); found && !strings.Contains(impPath, "internal") {
+						if _, _, found := strings.Cut(impPath, p.unversionedModulePath()); found && !strings.Contains(impPath, "internal") {
 							expr := p.getText(t.Pos(), t.End())
 							p.c.addSimpleType(*p, x.Name.Name, p.Name(), expr, imports)
 						}
@@ -306,8 +314,8 @@ func (pkg Pkg) addTypeNavigator(oriVal string, imports map[string]string) string
 			// find exact import path of a type
 			if impPath, ok := imports[splits[0]]; ok {
 				// judge if import path is in the module
-				if _, after, found := strings.Cut(impPath, pkg.modulePath); found {
-					return fmt.Sprintf("<%s.%s>%s", path.Base(pkg.modulePath)+after, splits[1], oriVal)
+				if _, after, found := strings.Cut(impPath, pkg.unversionedModulePath()); found {
+					return fmt.Sprintf("<%s.%s>%s", path.Base(pkg.unversionedModulePath())+after, splits[1], oriVal)
 				}
 			}
 			return oriVal
@@ -345,7 +353,7 @@ func (a *TypeAlias) Resolve(def typeDef) error {
 	level := CodeDiagnosticLevelInfo
 	originalName := a.QualifiedName
 	// if the definition is in the same module as the alias, strip the module path from the diagnostic message
-	if _, after, found := strings.Cut(a.QualifiedName, a.Package.modulePath); found {
+	if _, after, found := strings.Cut(a.QualifiedName, a.Package.unversionedModulePath()); found {
 		// after is e.g. "/internal/log.Event" or ".StatusType"
 		originalName = after[1:]
 	} else {

--- a/src/go/cmd/pkg.go
+++ b/src/go/cmd/pkg.go
@@ -113,12 +113,24 @@ func (p *Pkg) Index() {
 func (p *Pkg) indexFile(f *ast.File) {
 	// map import aliases to full import paths e.g. "shared" => "github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 	imports := map[string]string{}
+	modulePathReplacement := ""
+	if versionReg.MatchString(p.modulePath) {
+		// the module has a major version suffix. we need to remove that from the
+		// sub-package's path. the reason being that we index packages without the
+		// major version suffix (see module.go@NewModule) to avoid noise in the
+		// diff across major versions. so, if we don't also remove it here, we will
+		// fail to look up cross package references (e.g. type aliases)
+		modulePathReplacement = path.Dir(p.modulePath)
+	}
 	for _, imp := range f.Imports {
-		p := strings.Trim(imp.Path.Value, `"`)
+		pkgPath := strings.Trim(imp.Path.Value, `"`)
+		if modulePathReplacement != "" {
+			pkgPath = strings.ReplaceAll(pkgPath, p.modulePath, modulePathReplacement)
+		}
 		if imp.Name != nil {
-			imports[imp.Name.String()] = p
+			imports[imp.Name.String()] = pkgPath
 		} else {
-			imports[filepath.Base(p)] = p
+			imports[filepath.Base(pkgPath)] = pkgPath
 		}
 	}
 

--- a/src/go/cmd/testdata/test_alias_export_major_version/go.mod
+++ b/src/go/cmd/testdata/test_alias_export_major_version/go.mod
@@ -1,0 +1,3 @@
+module github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_alias_export_major_version/v2
+
+go 1.18

--- a/src/go/cmd/testdata/test_alias_export_major_version/internal/exported/source.go
+++ b/src/go/cmd/testdata/test_alias_export_major_version/internal/exported/source.go
@@ -1,0 +1,5 @@
+package exported
+
+type Foo struct{
+	Bar string
+}

--- a/src/go/cmd/testdata/test_alias_export_major_version/test.go
+++ b/src/go/cmd/testdata/test_alias_export_major_version/test.go
@@ -1,0 +1,5 @@
+package test_alias_export
+
+import "github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_alias_export_major_version/v2/internal/exported"
+
+type Foo = exported.Foo


### PR DESCRIPTION
Calculating the base import path didn't account for a major version suffix, resulting in the wrong name.
Remove the major version suffix from qualified type import paths. This ensures that the module and imports index use the same keys.