### PR TITLE
[APIView] Extract shared ICopilotHttpService for apiview-copilot calls

### DIFF
--- a/src/dotnet/APIView/APIViewUnitTests/APIRevisionsControllerTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/APIRevisionsControllerTests.cs
@@ -1,23 +1,18 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using APIView;
 using APIViewWeb;
 using APIViewWeb.Helpers;
-using APIViewWeb.Hubs;
 using APIViewWeb.LeanControllers;
 using APIViewWeb.LeanModels;
-using APIViewWeb.Managers;
 using APIViewWeb.Managers.Interfaces;
 using APIViewWeb.Models;
 using APIViewWeb.Repositories;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -36,13 +31,6 @@ public class APIRevisionsControllerTests
         _mockLogger = new Mock<ILogger<APIRevisionsTokenAuthController>>();
         _mockApiRevisionsManager = new Mock<IAPIRevisionsManager>();
         _mockBlobCodeFileRepository = new Mock<IBlobCodeFileRepository>();
-
-        Mock<IReviewManager> mockReviewManager = new();
-        Mock<INotificationManager> mockNotificationManager = new();
-        Mock<IHubContext<SignalRHub>> mockSignalRHubContext = new();
-        Mock<IConfiguration> mockConfiguration = new();
-        Mock<IHttpClientFactory> mockHttpClientFactory = new();
-        Mock<IPullRequestManager> mockPullRequestManager = new();
 
         _controller = new APIRevisionsTokenAuthController(
             _mockBlobCodeFileRepository.Object,

--- a/src/dotnet/APIView/APIViewUnitTests/CommentsManagerTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/CommentsManagerTests.cs
@@ -19,11 +19,9 @@ using APIViewWeb.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
-using Moq.Protected;
 using Xunit;
 
 namespace APIViewUnitTests;
@@ -54,9 +52,6 @@ public class CommentsManagerTests
         mockClientProxy.Setup(p => p.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        Mock<IConfiguration> configMock = new();
-        configMock.Setup(c => c["CopilotServiceEndpoint"]).Returns("https://dummy.api/endpoint");
-
         Mock<IOptions<OrganizationOptions>> orgOptionsMock = new();
         orgOptionsMock.Setup(o => o.Value)
             .Returns(new OrganizationOptions { RequiredOrganization = [] });
@@ -82,7 +77,6 @@ public class CommentsManagerTests
 
         Mock<IAuthorizationService> authServiceMock = new();
         Mock<INotificationManager> notificationManagerMock = new();
-        Mock<IHttpClientFactory> httpClientFactoryMock = new();
         Mock<ILogger<CommentsManager>> logger = new();
         Mock<IPermissionsManager> permissionsManagerMock = new();
         permissionsManagerMock.Setup(p => p.GetEffectivePermissionsAsync("architect1")).ReturnsAsync(
@@ -91,32 +85,12 @@ public class CommentsManagerTests
                 Roles = [new GlobalRoleAssignment() { Role = GlobalRole.Admin }]
             });
 
-        Mock<HttpMessageHandler> handlerMock = new();
-        handlerMock
-            .Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK, Content = new StringContent("{}")
-            });
-
         Mock<IBackgroundTaskQueue> backgroundTaskQueueMock = new();
-        Mock<ICopilotAuthenticationService> copilotAuthService = new();
-        copilotAuthService.Setup(c => c.GetAccessTokenAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync("test-token");
         backgroundTaskQueueMock.Setup(q => q.QueueBackgroundWorkItem(It.IsAny<Func<CancellationToken, Task>>()))
             .Callback<Func<CancellationToken, Task>>(workItem =>
             {
                 _ = workItem.Invoke(CancellationToken.None);
             });
-
-        HttpClient httpClient = new(handlerMock.Object);
-        httpClientFactoryMock
-            .Setup(f => f.CreateClient(It.IsAny<string>()))
-            .Returns(httpClient);
 
         authServiceMock.Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<IEnumerable<IAuthorizationRequirement>>()))
             .ReturnsAsync(AuthorizationResult.Success());
@@ -130,13 +104,29 @@ public class CommentsManagerTests
             notificationManagerMock.Object,
             codeFileRepoMock.Object,
             hubContextMock.Object,
-            new CopilotHttpService(configMock.Object, httpClientFactoryMock.Object, copilotAuthService.Object),
+            CreateCopilotHttpServiceMock().Object,
             userProfileCache,
             orgOptionsMock.Object,
             backgroundTaskQueueMock.Object,
             permissionsManagerMock.Object,
             logger.Object
         );
+    }
+
+    private static Mock<ICopilotHttpService> CreateCopilotHttpServiceMock()
+    {
+        Mock<ICopilotHttpService> mock = new();
+        mock.Setup(s => s.SendAsync(
+                It.IsAny<HttpMethod>(),
+                It.IsAny<string>(),
+                It.IsAny<object>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("{}")
+            });
+        return mock;
     }
 
     private ClaimsPrincipal CreateUser(string githubLogin)
@@ -1121,7 +1111,6 @@ public class CommentsManagerTests
         var hubContextMock = new Mock<IHubContext<SignalRHub>>();
         var apiRevisionsManagerMock = new Mock<IAPIRevisionsManager>();
         var backgroundTaskQueueMock = new Mock<IBackgroundTaskQueue>();
-        var copilotAuthServiceMock = new Mock<ICopilotAuthenticationService>();
 
         var mockClients = new Mock<IHubClients>();
         var mockClientProxy = new Mock<IClientProxy>();
@@ -1129,9 +1118,6 @@ public class CommentsManagerTests
         mockClients.Setup(c => c.All).Returns(mockClientProxy.Object);
         mockClientProxy.Setup(p => p.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
-
-        Mock<IConfiguration> configMock = new();
-        configMock.Setup(c => c["CopilotServiceEndpoint"]).Returns("https://dummy.api/endpoint");
 
         Mock<IOptions<OrganizationOptions>> orgOptionsMock = new();
         orgOptionsMock.Setup(o => o.Value)
@@ -1158,30 +1144,8 @@ public class CommentsManagerTests
 
         Mock<IAuthorizationService> authServiceMock = new();
         Mock<INotificationManager> notificationManagerMock = new();
-        Mock<IHttpClientFactory> httpClientFactoryMock = new();
         Mock<IPermissionsManager> permissionsManagerMock = new();
         Mock<ILogger<CommentsManager>> logger = new();
-
-        Mock<HttpMessageHandler> handlerMock = new();
-        handlerMock
-            .Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("{}")
-            });
-
-        copilotAuthServiceMock.Setup(c => c.GetAccessTokenAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync("test-token");
-
-        HttpClient httpClient = new(handlerMock.Object);
-        httpClientFactoryMock
-            .Setup(f => f.CreateClient(It.IsAny<string>()))
-            .Returns(httpClient);
 
         bool backgroundTaskQueued = false;
         backgroundTaskQueueMock.Setup(q => q.QueueBackgroundWorkItem(It.IsAny<Func<CancellationToken, Task>>()))
@@ -1203,7 +1167,7 @@ public class CommentsManagerTests
             notificationManagerMock.Object,
             codeFileRepoMock.Object,
             hubContextMock.Object,
-            new CopilotHttpService(configMock.Object, httpClientFactoryMock.Object, copilotAuthServiceMock.Object),
+            CreateCopilotHttpServiceMock().Object,
             userProfileCache,
             orgOptionsMock.Object,
             backgroundTaskQueueMock.Object,
@@ -1252,7 +1216,6 @@ public class CommentsManagerTests
         hubContextMock.Setup(h => h.Clients).Returns(mockClients.Object);
         mockClients.Setup(c => c.All).Returns(mockClientProxy.Object);
 
-        Mock<IConfiguration> configMock = new();
         Mock<IOptions<OrganizationOptions>> orgOptionsMock = new();
         orgOptionsMock.Setup(o => o.Value).Returns(new OrganizationOptions { RequiredOrganization = [] });
 
@@ -1274,7 +1237,7 @@ public class CommentsManagerTests
             new Mock<INotificationManager>().Object,
             new Mock<IBlobCodeFileRepository>().Object,
             hubContextMock.Object,
-            new CopilotHttpService(configMock.Object, new Mock<IHttpClientFactory>().Object, new Mock<ICopilotAuthenticationService>().Object),
+            CreateCopilotHttpServiceMock().Object,
             userProfileCache,
             orgOptionsMock.Object,
             backgroundTaskQueueMock.Object,
@@ -1317,7 +1280,6 @@ public class CommentsManagerTests
         hubContextMock.Setup(h => h.Clients).Returns(mockClients.Object);
         mockClients.Setup(c => c.All).Returns(mockClientProxy.Object);
 
-        Mock<IConfiguration> configMock = new();
         Mock<IOptions<OrganizationOptions>> orgOptionsMock = new();
         orgOptionsMock.Setup(o => o.Value).Returns(new OrganizationOptions { RequiredOrganization = [] });
 
@@ -1339,7 +1301,7 @@ public class CommentsManagerTests
             new Mock<INotificationManager>().Object,
             new Mock<IBlobCodeFileRepository>().Object,
             hubContextMock.Object,
-            new CopilotHttpService(configMock.Object, new Mock<IHttpClientFactory>().Object, new Mock<ICopilotAuthenticationService>().Object),
+            CreateCopilotHttpServiceMock().Object,
             userProfileCache,
             orgOptionsMock.Object,
             backgroundTaskQueueMock.Object,
@@ -1377,7 +1339,6 @@ public class CommentsManagerTests
         var hubContextMock = new Mock<IHubContext<SignalRHub>>();
         var apiRevisionsManagerMock = new Mock<IAPIRevisionsManager>();
         var backgroundTaskQueueMock = new Mock<IBackgroundTaskQueue>();
-        var copilotAuthServiceMock = new Mock<ICopilotAuthenticationService>();
 
         var mockClients = new Mock<IHubClients>();
         var mockClientProxy = new Mock<IClientProxy>();
@@ -1385,9 +1346,6 @@ public class CommentsManagerTests
         mockClients.Setup(c => c.All).Returns(mockClientProxy.Object);
         mockClientProxy.Setup(p => p.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
-
-        Mock<IConfiguration> configMock = new();
-        configMock.Setup(c => c["CopilotServiceEndpoint"]).Returns("https://dummy.api/endpoint");
 
         Mock<IOptions<OrganizationOptions>> orgOptionsMock = new();
         orgOptionsMock.Setup(o => o.Value)
@@ -1412,28 +1370,6 @@ public class CommentsManagerTests
             userProfileCacheLoggerMock.Object
         );
 
-        Mock<IHttpClientFactory> httpClientFactoryMock = new();
-        Mock<HttpMessageHandler> handlerMock = new();
-        handlerMock
-            .Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("{}")
-            });
-
-        copilotAuthServiceMock.Setup(c => c.GetAccessTokenAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync("test-token");
-
-        HttpClient httpClient = new(handlerMock.Object);
-        httpClientFactoryMock
-            .Setup(f => f.CreateClient(It.IsAny<string>()))
-            .Returns(httpClient);
-
         bool backgroundTaskQueued = false;
         backgroundTaskQueueMock.Setup(q => q.QueueBackgroundWorkItem(It.IsAny<Func<CancellationToken, Task>>()))
             .Callback<Func<CancellationToken, Task>>(workItem =>
@@ -1451,7 +1387,7 @@ public class CommentsManagerTests
             new Mock<INotificationManager>().Object,
             codeFileRepoMock.Object,
             hubContextMock.Object,
-            new CopilotHttpService(configMock.Object, httpClientFactoryMock.Object, copilotAuthServiceMock.Object),
+            CreateCopilotHttpServiceMock().Object,
             userProfileCache,
             orgOptionsMock.Object,
             backgroundTaskQueueMock.Object,
@@ -1497,7 +1433,6 @@ public class CommentsManagerTests
         var hubContextMock = new Mock<IHubContext<SignalRHub>>();
         var apiRevisionsManagerMock = new Mock<IAPIRevisionsManager>();
         var backgroundTaskQueueMock = new Mock<IBackgroundTaskQueue>();
-        var copilotAuthServiceMock = new Mock<ICopilotAuthenticationService>();
 
         var mockClients = new Mock<IHubClients>();
         var mockClientProxy = new Mock<IClientProxy>();
@@ -1505,9 +1440,6 @@ public class CommentsManagerTests
         mockClients.Setup(c => c.All).Returns(mockClientProxy.Object);
         mockClientProxy.Setup(p => p.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
-
-        Mock<IConfiguration> configMock = new();
-        configMock.Setup(c => c["CopilotServiceEndpoint"]).Returns("https://dummy.api/endpoint");
 
         Mock<IOptions<OrganizationOptions>> orgOptionsMock = new();
         orgOptionsMock.Setup(o => o.Value)
@@ -1532,28 +1464,6 @@ public class CommentsManagerTests
             userProfileCacheLoggerMock.Object
         );
 
-        Mock<IHttpClientFactory> httpClientFactoryMock = new();
-        Mock<HttpMessageHandler> handlerMock = new();
-        handlerMock
-            .Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("{}")
-            });
-
-        copilotAuthServiceMock.Setup(c => c.GetAccessTokenAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync("test-token");
-
-        HttpClient httpClient = new(handlerMock.Object);
-        httpClientFactoryMock
-            .Setup(f => f.CreateClient(It.IsAny<string>()))
-            .Returns(httpClient);
-
         int notificationCount = 0;
         backgroundTaskQueueMock.Setup(q => q.QueueBackgroundWorkItem(It.IsAny<Func<CancellationToken, Task>>()))
             .Callback<Func<CancellationToken, Task>>(workItem =>
@@ -1571,7 +1481,7 @@ public class CommentsManagerTests
             new Mock<INotificationManager>().Object,
             codeFileRepoMock.Object,
             hubContextMock.Object,
-            new CopilotHttpService(configMock.Object, httpClientFactoryMock.Object, copilotAuthServiceMock.Object),
+            CreateCopilotHttpServiceMock().Object,
             userProfileCache,
             orgOptionsMock.Object,
             backgroundTaskQueueMock.Object,
@@ -1701,7 +1611,6 @@ public class CommentsManagerTests
         var hubContextMock = new Mock<IHubContext<SignalRHub>>();
         var apiRevisionsManagerMock = new Mock<IAPIRevisionsManager>();
         var backgroundTaskQueueMock = new Mock<IBackgroundTaskQueue>();
-        var copilotAuthServiceMock = new Mock<ICopilotAuthenticationService>();
 
         var mockClients = new Mock<IHubClients>();
         var mockClientProxy = new Mock<IClientProxy>();
@@ -1709,9 +1618,6 @@ public class CommentsManagerTests
         mockClients.Setup(c => c.All).Returns(mockClientProxy.Object);
         mockClientProxy.Setup(p => p.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
-
-        Mock<IConfiguration> configMock = new();
-        configMock.Setup(c => c["CopilotServiceEndpoint"]).Returns("https://dummy.api/endpoint");
 
         Mock<IOptions<OrganizationOptions>> orgOptionsMock = new();
         orgOptionsMock.Setup(o => o.Value)
@@ -1736,28 +1642,6 @@ public class CommentsManagerTests
             userProfileCacheLoggerMock.Object
         );
 
-        Mock<IHttpClientFactory> httpClientFactoryMock = new();
-        Mock<HttpMessageHandler> handlerMock = new();
-        handlerMock
-            .Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("{}")
-            });
-
-        copilotAuthServiceMock.Setup(c => c.GetAccessTokenAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync("test-token");
-
-        HttpClient httpClient = new(handlerMock.Object);
-        httpClientFactoryMock
-            .Setup(f => f.CreateClient(It.IsAny<string>()))
-            .Returns(httpClient);
-
         int notificationCount = 0;
         backgroundTaskQueueMock.Setup(q => q.QueueBackgroundWorkItem(It.IsAny<Func<CancellationToken, Task>>()))
             .Callback<Func<CancellationToken, Task>>(workItem =>
@@ -1775,7 +1659,7 @@ public class CommentsManagerTests
             new Mock<INotificationManager>().Object,
             codeFileRepoMock.Object,
             hubContextMock.Object,
-            new CopilotHttpService(configMock.Object, httpClientFactoryMock.Object, copilotAuthServiceMock.Object),
+            CreateCopilotHttpServiceMock().Object,
             userProfileCache,
             orgOptionsMock.Object,
             backgroundTaskQueueMock.Object,
@@ -1844,7 +1728,6 @@ public class CommentsManagerTests
         var hubContextMock = new Mock<IHubContext<SignalRHub>>();
         var apiRevisionsManagerMock = new Mock<IAPIRevisionsManager>();
         var backgroundTaskQueueMock = new Mock<IBackgroundTaskQueue>();
-        var copilotAuthServiceMock = new Mock<ICopilotAuthenticationService>();
 
         var mockClients = new Mock<IHubClients>();
         var mockClientProxy = new Mock<IClientProxy>();
@@ -1852,9 +1735,6 @@ public class CommentsManagerTests
         mockClients.Setup(c => c.All).Returns(mockClientProxy.Object);
         mockClientProxy.Setup(p => p.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
-
-        Mock<IConfiguration> configMock = new();
-        configMock.Setup(c => c["CopilotServiceEndpoint"]).Returns("https://dummy.api/endpoint");
 
         Mock<IOptions<OrganizationOptions>> orgOptionsMock = new();
         orgOptionsMock.Setup(o => o.Value)
@@ -1879,28 +1759,6 @@ public class CommentsManagerTests
             userProfileCacheLoggerMock.Object
         );
 
-        Mock<IHttpClientFactory> httpClientFactoryMock = new();
-        Mock<HttpMessageHandler> handlerMock = new();
-        handlerMock
-            .Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("{}")
-            });
-
-        copilotAuthServiceMock.Setup(c => c.GetAccessTokenAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync("test-token");
-
-        HttpClient httpClient = new(handlerMock.Object);
-        httpClientFactoryMock
-            .Setup(f => f.CreateClient(It.IsAny<string>()))
-            .Returns(httpClient);
-
         int notificationCount = 0;
         backgroundTaskQueueMock.Setup(q => q.QueueBackgroundWorkItem(It.IsAny<Func<CancellationToken, Task>>()))
             .Callback<Func<CancellationToken, Task>>(workItem =>
@@ -1918,7 +1776,7 @@ public class CommentsManagerTests
             new Mock<INotificationManager>().Object,
             codeFileRepoMock.Object,
             hubContextMock.Object,
-            new CopilotHttpService(configMock.Object, httpClientFactoryMock.Object, copilotAuthServiceMock.Object),
+            CreateCopilotHttpServiceMock().Object,
             userProfileCache,
             orgOptionsMock.Object,
             backgroundTaskQueueMock.Object,

--- a/src/dotnet/APIView/APIViewUnitTests/CommentsManagerTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/CommentsManagerTests.cs
@@ -130,13 +130,11 @@ public class CommentsManagerTests
             notificationManagerMock.Object,
             codeFileRepoMock.Object,
             hubContextMock.Object,
-            httpClientFactoryMock.Object,
+            new CopilotHttpService(configMock.Object, httpClientFactoryMock.Object, copilotAuthService.Object),
             userProfileCache,
-            configMock.Object,
             orgOptionsMock.Object,
             backgroundTaskQueueMock.Object,
             permissionsManagerMock.Object,
-            copilotAuthService.Object,
             logger.Object
         );
     }
@@ -1205,13 +1203,11 @@ public class CommentsManagerTests
             notificationManagerMock.Object,
             codeFileRepoMock.Object,
             hubContextMock.Object,
-            httpClientFactoryMock.Object,
+            new CopilotHttpService(configMock.Object, httpClientFactoryMock.Object, copilotAuthServiceMock.Object),
             userProfileCache,
-            configMock.Object,
             orgOptionsMock.Object,
             backgroundTaskQueueMock.Object,
             permissionsManagerMock.Object,
-            copilotAuthServiceMock.Object,
             logger.Object
         );
 
@@ -1278,13 +1274,11 @@ public class CommentsManagerTests
             new Mock<INotificationManager>().Object,
             new Mock<IBlobCodeFileRepository>().Object,
             hubContextMock.Object,
-            new Mock<IHttpClientFactory>().Object,
+            new CopilotHttpService(configMock.Object, new Mock<IHttpClientFactory>().Object, new Mock<ICopilotAuthenticationService>().Object),
             userProfileCache,
-            configMock.Object,
             orgOptionsMock.Object,
             backgroundTaskQueueMock.Object,
             new Mock<IPermissionsManager>().Object,
-            new Mock<ICopilotAuthenticationService>().Object,
             new Mock<ILogger<CommentsManager>>().Object
         );
 
@@ -1345,13 +1339,11 @@ public class CommentsManagerTests
             new Mock<INotificationManager>().Object,
             new Mock<IBlobCodeFileRepository>().Object,
             hubContextMock.Object,
-            new Mock<IHttpClientFactory>().Object,
+            new CopilotHttpService(configMock.Object, new Mock<IHttpClientFactory>().Object, new Mock<ICopilotAuthenticationService>().Object),
             userProfileCache,
-            configMock.Object,
             orgOptionsMock.Object,
             backgroundTaskQueueMock.Object,
             new Mock<IPermissionsManager>().Object,
-            new Mock<ICopilotAuthenticationService>().Object,
             new Mock<ILogger<CommentsManager>>().Object
         );
 
@@ -1459,13 +1451,11 @@ public class CommentsManagerTests
             new Mock<INotificationManager>().Object,
             codeFileRepoMock.Object,
             hubContextMock.Object,
-            httpClientFactoryMock.Object,
+            new CopilotHttpService(configMock.Object, httpClientFactoryMock.Object, copilotAuthServiceMock.Object),
             userProfileCache,
-            configMock.Object,
             orgOptionsMock.Object,
             backgroundTaskQueueMock.Object,
             new Mock<IPermissionsManager>().Object,
-            copilotAuthServiceMock.Object,
             new Mock<ILogger<CommentsManager>>().Object
         );
 
@@ -1581,13 +1571,11 @@ public class CommentsManagerTests
             new Mock<INotificationManager>().Object,
             codeFileRepoMock.Object,
             hubContextMock.Object,
-            httpClientFactoryMock.Object,
+            new CopilotHttpService(configMock.Object, httpClientFactoryMock.Object, copilotAuthServiceMock.Object),
             userProfileCache,
-            configMock.Object,
             orgOptionsMock.Object,
             backgroundTaskQueueMock.Object,
             new Mock<IPermissionsManager>().Object,
-            copilotAuthServiceMock.Object,
             new Mock<ILogger<CommentsManager>>().Object
         );
 
@@ -1787,13 +1775,11 @@ public class CommentsManagerTests
             new Mock<INotificationManager>().Object,
             codeFileRepoMock.Object,
             hubContextMock.Object,
-            httpClientFactoryMock.Object,
+            new CopilotHttpService(configMock.Object, httpClientFactoryMock.Object, copilotAuthServiceMock.Object),
             userProfileCache,
-            configMock.Object,
             orgOptionsMock.Object,
             backgroundTaskQueueMock.Object,
             new Mock<IPermissionsManager>().Object,
-            copilotAuthServiceMock.Object,
             new Mock<ILogger<CommentsManager>>().Object
         );
 
@@ -1932,13 +1918,11 @@ public class CommentsManagerTests
             new Mock<INotificationManager>().Object,
             codeFileRepoMock.Object,
             hubContextMock.Object,
-            httpClientFactoryMock.Object,
+            new CopilotHttpService(configMock.Object, httpClientFactoryMock.Object, copilotAuthServiceMock.Object),
             userProfileCache,
-            configMock.Object,
             orgOptionsMock.Object,
             backgroundTaskQueueMock.Object,
             new Mock<IPermissionsManager>().Object,
-            copilotAuthServiceMock.Object,
             new Mock<ILogger<CommentsManager>>().Object
         );
 

--- a/src/dotnet/APIView/APIViewUnitTests/CopilotPollingBackgroundHostedServiceTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/CopilotPollingBackgroundHostedServiceTests.cs
@@ -4,10 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
-using System.Text;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using APIViewWeb.Helpers;
@@ -19,10 +16,8 @@ using APIViewWeb.Models;
 using APIViewWeb.Repositories;
 using APIViewWeb.Services;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Moq.Protected;
 using Xunit;
 
 namespace APIViewUnitTests
@@ -32,12 +27,8 @@ namespace APIViewUnitTests
         private readonly Mock<IAPIRevisionsManager> _mockApiRevisionsManager;
         private readonly Mock<ICosmosCommentsRepository> _mockCommentsRepository;
         private readonly Mock<IHubContext<SignalRHub>> _mockSignalRHubContext;
-        private readonly Mock<ICopilotAuthenticationService> _mockCopilotAuth;
         private readonly Mock<ILogger<CopilotJobProcessor>> _mockLogger;
-        private readonly Mock<HttpMessageHandler> _mockHttpMessageHandler;
-        private readonly Mock<IConfiguration> _mockConfiguration;
-        private readonly Mock<IHttpClientFactory> _mockHttpClientFactory;
-        private readonly HttpClient _httpClient;
+        private readonly Mock<ICopilotHttpService> _mockCopilotHttp;
         private readonly CopilotJobProcessor _processor;
 
         public CopilotPollingBackgroundHostedServiceTests()
@@ -45,29 +36,15 @@ namespace APIViewUnitTests
             _mockApiRevisionsManager = new Mock<IAPIRevisionsManager>();
             _mockCommentsRepository = new Mock<ICosmosCommentsRepository>();
             _mockSignalRHubContext = new Mock<IHubContext<SignalRHub>>();
-            _mockCopilotAuth = new Mock<ICopilotAuthenticationService>();   
             _mockLogger = new Mock<ILogger<CopilotJobProcessor>>();
-            _mockHttpMessageHandler = new Mock<HttpMessageHandler>();
-
-            _mockConfiguration = new Mock<IConfiguration>();
-            _mockConfiguration.Setup(x => x["CopilotServiceEndpoint"])
-                .Returns("https://test-copilot-endpoint.com");
-
-            _mockHttpClientFactory = new Mock<IHttpClientFactory>();
-            _httpClient = new HttpClient(_mockHttpMessageHandler.Object);
-            _mockHttpClientFactory
-                .Setup(f => f.CreateClient(It.IsAny<string>()))
-                .Returns(_httpClient);
+            _mockCopilotHttp = new Mock<ICopilotHttpService>();
 
             // Setup SignalR mock
             var mockClientProxy = new Mock<IClientProxy>();
             _mockSignalRHubContext.Setup(x => x.Clients.All).Returns(mockClientProxy.Object);
 
             _processor = new CopilotJobProcessor(
-                new CopilotHttpService(
-                    _mockConfiguration.Object,
-                    _mockHttpClientFactory.Object,
-                    _mockCopilotAuth.Object),
+                _mockCopilotHttp.Object,
                 _mockApiRevisionsManager.Object,
                 _mockCommentsRepository.Object,
                 _mockSignalRHubContext.Object,
@@ -259,9 +236,10 @@ namespace APIViewUnitTests
         {
             AIReviewJobInfoModel jobInfo = CreateTestJobInfo();
 
-            _mockHttpMessageHandler.Protected()
-                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(),
-                    ItExpr.IsAny<CancellationToken>())
+            _mockCopilotHttp
+                .Setup(x => x.GetAsync<AIReviewJobPolledResponseModel>(
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new HttpRequestException("Network error"));
 
             var exception = await Assert.ThrowsAsync<HttpRequestException>(() => _processor.ProcessJobAsync(jobInfo));
@@ -315,17 +293,11 @@ namespace APIViewUnitTests
 
         private void SetupHttpClientForSuccessfulPolling(AIReviewJobPolledResponseModel pollResponse)
         {
-            string jsonResponse = JsonSerializer.Serialize(pollResponse);
-            var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent(jsonResponse, Encoding.UTF8, "application/json")
-            };
-
-            _mockHttpMessageHandler.Protected()
-                .Setup<Task<HttpResponseMessage>>("SendAsync",
-                    ItExpr.IsAny<HttpRequestMessage>(),
-                    ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(httpResponseMessage);
+            _mockCopilotHttp
+                .Setup(x => x.GetAsync<AIReviewJobPolledResponseModel>(
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(pollResponse);
         }
 
         private void VerifySignalRCalled()

--- a/src/dotnet/APIView/APIViewUnitTests/CopilotPollingBackgroundHostedServiceTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/CopilotPollingBackgroundHostedServiceTests.cs
@@ -64,11 +64,12 @@ namespace APIViewUnitTests
             _mockSignalRHubContext.Setup(x => x.Clients.All).Returns(mockClientProxy.Object);
 
             _processor = new CopilotJobProcessor(
-                _mockConfiguration.Object,
-                _mockHttpClientFactory.Object,
+                new CopilotHttpService(
+                    _mockConfiguration.Object,
+                    _mockHttpClientFactory.Object,
+                    _mockCopilotAuth.Object),
                 _mockApiRevisionsManager.Object,
                 _mockCommentsRepository.Object,
-                _mockCopilotAuth.Object,
                 _mockSignalRHubContext.Object,
                 _mockLogger.Object);
         }

--- a/src/dotnet/APIView/APIViewUnitTests/NamespaceApprovalTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/NamespaceApprovalTests.cs
@@ -105,12 +105,10 @@ namespace APIViewUnitTests
                 mockLanguageServices.Object,
                 _telemetryClient,
                 mockCodeFileManager.Object,
-                _mockConfiguration.Object,
-                mockHttpClientFactory.Object,
+                new CopilotHttpService(_mockConfiguration.Object, mockHttpClientFactory.Object, mockCopilotAuth.Object),
                 mockPollingJobQueueManager.Object,
                 _mockNotificationManager.Object,
                 _mockPullRequestsRepository.Object,
-                mockCopilotAuth.Object,
                 _mockLogger.Object);
 
             _testTimestamp = DateTime.UtcNow;
@@ -529,12 +527,10 @@ namespace APIViewUnitTests
                 mockLanguageServices.Object,
                 _telemetryClient,
                 mockCodeFileManager.Object,
-                _mockConfiguration.Object,
-                mockHttpClientFactory.Object,
+                new CopilotHttpService(_mockConfiguration.Object, mockHttpClientFactory.Object, mockCopilotAuth.Object),
                 mockPollingJobQueueManager.Object,
                 _mockNotificationManager.Object,
                 _mockPullRequestsRepository.Object,
-                mockCopilotAuth.Object,
                 _mockLogger.Object);
 
             var reviewId = "feature-disabled-test";

--- a/src/dotnet/APIView/APIViewUnitTests/NamespaceApprovalTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/NamespaceApprovalTests.cs
@@ -21,7 +21,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
-using System.Net.Http;
 using APIViewWeb.Services;
 using Moq;
 using Xunit;
@@ -86,9 +85,8 @@ namespace APIViewUnitTests
             var mockSignalRHubContext = new Mock<IHubContext<SignalRHub>>();
             var mockLanguageServices = new Mock<IEnumerable<LanguageService>>();
             var mockCodeFileManager = new Mock<ICodeFileManager>();
-            var mockHttpClientFactory = new Mock<IHttpClientFactory>();
+            var mockCopilotHttp = new Mock<ICopilotHttpService>();
             var mockPollingJobQueueManager = new Mock<IPollingJobQueueManager>();
-            var mockCopilotAuth = new Mock<ICopilotAuthenticationService>();
 
             // Initialize ReviewManager with required dependencies
             // SignalR hub is mocked for testing but notifications are handled separately
@@ -105,7 +103,7 @@ namespace APIViewUnitTests
                 mockLanguageServices.Object,
                 _telemetryClient,
                 mockCodeFileManager.Object,
-                new CopilotHttpService(_mockConfiguration.Object, mockHttpClientFactory.Object, mockCopilotAuth.Object),
+                mockCopilotHttp.Object,
                 mockPollingJobQueueManager.Object,
                 _mockNotificationManager.Object,
                 _mockPullRequestsRepository.Object,
@@ -511,9 +509,8 @@ namespace APIViewUnitTests
             var mockSignalRHubContext = new Mock<IHubContext<SignalRHub>>();
             var mockLanguageServices = new Mock<IEnumerable<LanguageService>>();
             var mockCodeFileManager = new Mock<ICodeFileManager>();
-            var mockHttpClientFactory = new Mock<IHttpClientFactory>();
+            var mockCopilotHttp = new Mock<ICopilotHttpService>();
             var mockPollingJobQueueManager = new Mock<IPollingJobQueueManager>();
-            var mockCopilotAuth = new Mock<ICopilotAuthenticationService>();
 
             var disabledReviewManager = new ReviewManager(
                 _mockAuthorizationService.Object,
@@ -527,7 +524,7 @@ namespace APIViewUnitTests
                 mockLanguageServices.Object,
                 _telemetryClient,
                 mockCodeFileManager.Object,
-                new CopilotHttpService(_mockConfiguration.Object, mockHttpClientFactory.Object, mockCopilotAuth.Object),
+                mockCopilotHttp.Object,
                 mockPollingJobQueueManager.Object,
                 _mockNotificationManager.Object,
                 _mockPullRequestsRepository.Object,

--- a/src/dotnet/APIView/APIViewUnitTests/NamespaceReviewRequestTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/NamespaceReviewRequestTests.cs
@@ -104,12 +104,10 @@ namespace APIViewUnitTests
                 mockLanguageServices,
                 _telemetryClient,
                 _mockCodeFileManager.Object,
-                _mockConfiguration.Object,
-                _mockHttpClientFactory.Object,
+                new CopilotHttpService(_mockConfiguration.Object, _mockHttpClientFactory.Object, _mockCopilotAuth.Object),
                 _mockPollingJobQueueManager.Object,
                 _mockNotificationManager.Object,
                 _mockPullRequestsRepository.Object,
-                _mockCopilotAuth.Object,
                 _mockManagerLogger.Object);
 
             // Create controller that uses the real ReviewManager

--- a/src/dotnet/APIView/APIViewUnitTests/NamespaceReviewRequestTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/NamespaceReviewRequestTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using APIView.Identity;
@@ -49,9 +48,8 @@ namespace APIViewUnitTests
         private readonly Mock<INotificationManager> _mockNotificationManager;
         private readonly Mock<IAuthorizationService> _mockAuthorizationService;
         private readonly Mock<ICodeFileManager> _mockCodeFileManager;
-        private readonly Mock<IHttpClientFactory> _mockHttpClientFactory;
+        private readonly Mock<ICopilotHttpService> _mockCopilotHttp;
         private readonly Mock<IPollingJobQueueManager> _mockPollingJobQueueManager;
-        private readonly Mock<ICopilotAuthenticationService> _mockCopilotAuth;
         private readonly TelemetryClient _telemetryClient;
         private readonly ReviewsController _controller;
         private readonly ReviewManager _reviewManager;
@@ -74,9 +72,8 @@ namespace APIViewUnitTests
             _mockNotificationManager = new Mock<INotificationManager>();
             _mockAuthorizationService = new Mock<IAuthorizationService>();
             _mockCodeFileManager = new Mock<ICodeFileManager>();
-            _mockHttpClientFactory = new Mock<IHttpClientFactory>();
+            _mockCopilotHttp = new Mock<ICopilotHttpService>();
             _mockPollingJobQueueManager = new Mock<IPollingJobQueueManager>();
-            _mockCopilotAuth = new Mock<ICopilotAuthenticationService>();
 
             _telemetryClient = new TelemetryClient(new TelemetryConfiguration());
 
@@ -104,7 +101,7 @@ namespace APIViewUnitTests
                 mockLanguageServices,
                 _telemetryClient,
                 _mockCodeFileManager.Object,
-                new CopilotHttpService(_mockConfiguration.Object, _mockHttpClientFactory.Object, _mockCopilotAuth.Object),
+                _mockCopilotHttp.Object,
                 _mockPollingJobQueueManager.Object,
                 _mockNotificationManager.Object,
                 _mockPullRequestsRepository.Object,

--- a/src/dotnet/APIView/APIViewUnitTests/ReviewManagerApprovalNotificationTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/ReviewManagerApprovalNotificationTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using APIView;
@@ -16,7 +15,6 @@ using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -109,7 +107,7 @@ public class ReviewManagerApprovalNotificationTests
             mocks.LanguageServices,
             mocks.TelemetryClient,
             mocks.CodeFileManager.Object,
-            new CopilotHttpService(mocks.Configuration.Object, mocks.HttpClientFactory.Object, mocks.CopilotAuth.Object),
+            mocks.CopilotHttp.Object,
             mocks.PollingJobQueueManager.Object,
             mocks.NotificationManager.Object,
             mocks.PullRequestsRepository.Object,
@@ -130,12 +128,10 @@ public class ReviewManagerApprovalNotificationTests
         public Mock<IHubContext<SignalRHub>> SignalRHubContext { get; } = new();
         public TelemetryClient TelemetryClient { get; } = new(new TelemetryConfiguration());
         public Mock<ICodeFileManager> CodeFileManager { get; } = new();
-        public Mock<IConfiguration> Configuration { get; } = new();
-        public Mock<IHttpClientFactory> HttpClientFactory { get; } = new();
+        public Mock<ICopilotHttpService> CopilotHttp { get; } = new();
         public Mock<IPollingJobQueueManager> PollingJobQueueManager { get; } = new();
         public Mock<INotificationManager> NotificationManager { get; } = new();
         public Mock<ICosmosPullRequestsRepository> PullRequestsRepository { get; } = new();
-        public Mock<ICopilotAuthenticationService> CopilotAuth { get; } = new();
         public Mock<ILogger<ReviewManager>> Logger { get; } = new();
         public IEnumerable<LanguageService> LanguageServices { get; } = new List<LanguageService>();
     }

--- a/src/dotnet/APIView/APIViewUnitTests/ReviewManagerApprovalNotificationTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/ReviewManagerApprovalNotificationTests.cs
@@ -109,12 +109,10 @@ public class ReviewManagerApprovalNotificationTests
             mocks.LanguageServices,
             mocks.TelemetryClient,
             mocks.CodeFileManager.Object,
-            mocks.Configuration.Object,
-            mocks.HttpClientFactory.Object,
+            new CopilotHttpService(mocks.Configuration.Object, mocks.HttpClientFactory.Object, mocks.CopilotAuth.Object),
             mocks.PollingJobQueueManager.Object,
             mocks.NotificationManager.Object,
             mocks.PullRequestsRepository.Object,
-            mocks.CopilotAuth.Object,
             mocks.Logger.Object);
 
         return (reviewManager, mocks);

--- a/src/dotnet/APIView/APIViewUnitTests/ReviewManagerCopilotJobTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/ReviewManagerCopilotJobTests.cs
@@ -58,12 +58,10 @@ public class ReviewManagerCopilotJobTests
             _mocks.LanguageServices,
             _mocks.TelemetryClient,
             _mocks.CodeFileManager.Object,
-            _mocks.Configuration.Object,
-            _mocks.HttpClientFactory.Object,
+            new CopilotHttpService(_mocks.Configuration.Object, _mocks.HttpClientFactory.Object, _mocks.CopilotAuth.Object),
             _mocks.PollingJobQueueManager.Object,
             _mocks.NotificationManager.Object,
             _mocks.PullRequestsRepository.Object,
-            _mocks.CopilotAuth.Object,
             _mocks.Logger.Object
         );
     }

--- a/src/dotnet/APIView/APIViewUnitTests/ReviewManagerDeleteTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/ReviewManagerDeleteTests.cs
@@ -14,10 +14,8 @@ using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
-using System.Net.Http;
 using Xunit;
 
 namespace APIViewUnitTests;
@@ -172,7 +170,7 @@ public class ReviewManagerDeleteTests
             mocks.LanguageServices,
             mocks.TelemetryClient,
             mocks.CodeFileManager.Object,
-            new CopilotHttpService(mocks.Configuration.Object, mocks.HttpClientFactory.Object, mocks.CopilotAuth.Object),
+            mocks.CopilotHttp.Object,
             mocks.PollingJobQueueManager.Object,
             mocks.NotificationManager.Object,
             mocks.PullRequestsRepository.Object,
@@ -193,12 +191,10 @@ public class ReviewManagerDeleteTests
         public Mock<IHubContext<SignalRHub>> SignalRHubContext { get; } = new();
         public TelemetryClient TelemetryClient { get; } = new(new TelemetryConfiguration());
         public Mock<ICodeFileManager> CodeFileManager { get; } = new();
-        public Mock<IConfiguration> Configuration { get; } = new();
-        public Mock<IHttpClientFactory> HttpClientFactory { get; } = new();
+        public Mock<ICopilotHttpService> CopilotHttp { get; } = new();
         public Mock<IPollingJobQueueManager> PollingJobQueueManager { get; } = new();
         public Mock<INotificationManager> NotificationManager { get; } = new();
         public Mock<ICosmosPullRequestsRepository> PullRequestsRepository { get; } = new();
-        public Mock<ICopilotAuthenticationService> CopilotAuth { get; } = new();
         public Mock<ILogger<ReviewManager>> Logger { get; } = new();
         public IEnumerable<LanguageService> LanguageServices { get; } = new List<LanguageService>();
     }

--- a/src/dotnet/APIView/APIViewUnitTests/ReviewManagerDeleteTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/ReviewManagerDeleteTests.cs
@@ -172,12 +172,10 @@ public class ReviewManagerDeleteTests
             mocks.LanguageServices,
             mocks.TelemetryClient,
             mocks.CodeFileManager.Object,
-            mocks.Configuration.Object,
-            mocks.HttpClientFactory.Object,
+            new CopilotHttpService(mocks.Configuration.Object, mocks.HttpClientFactory.Object, mocks.CopilotAuth.Object),
             mocks.PollingJobQueueManager.Object,
             mocks.NotificationManager.Object,
             mocks.PullRequestsRepository.Object,
-            mocks.CopilotAuth.Object,
             mocks.Logger.Object
         );
         return (reviewManager, mocks);

--- a/src/dotnet/APIView/APIViewUnitTests/ReviewManagerGenerateAIReviewTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/ReviewManagerGenerateAIReviewTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using APIView;
@@ -17,7 +16,6 @@ using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -125,7 +123,7 @@ public class ReviewManagerGenerateAIReviewTests
             mocks.LanguageServices,
             mocks.TelemetryClient,
             mocks.CodeFileManager.Object,
-            new CopilotHttpService(mocks.Configuration.Object, mocks.HttpClientFactory.Object, mocks.CopilotAuth.Object),
+            mocks.CopilotHttp.Object,
             mocks.PollingJobQueueManager.Object,
             mocks.NotificationManager.Object,
             mocks.PullRequestsRepository.Object,
@@ -166,12 +164,10 @@ public class ReviewManagerGenerateAIReviewTests
         public Mock<IHubContext<SignalRHub>> SignalRHubContext { get; } = new();
         public TelemetryClient TelemetryClient { get; } = new(new TelemetryConfiguration());
         public Mock<ICodeFileManager> CodeFileManager { get; } = new();
-        public Mock<IConfiguration> Configuration { get; } = new();
-        public Mock<IHttpClientFactory> HttpClientFactory { get; } = new();
+        public Mock<ICopilotHttpService> CopilotHttp { get; } = new();
         public Mock<IPollingJobQueueManager> PollingJobQueueManager { get; } = new();
         public Mock<INotificationManager> NotificationManager { get; } = new();
         public Mock<ICosmosPullRequestsRepository> PullRequestsRepository { get; } = new();
-        public Mock<ICopilotAuthenticationService> CopilotAuth { get; } = new();
         public Mock<ILogger<ReviewManager>> Logger { get; } = new();
         public IEnumerable<LanguageService> LanguageServices { get; } = new List<LanguageService>();
     }

--- a/src/dotnet/APIView/APIViewUnitTests/ReviewManagerGenerateAIReviewTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/ReviewManagerGenerateAIReviewTests.cs
@@ -125,12 +125,10 @@ public class ReviewManagerGenerateAIReviewTests
             mocks.LanguageServices,
             mocks.TelemetryClient,
             mocks.CodeFileManager.Object,
-            mocks.Configuration.Object,
-            mocks.HttpClientFactory.Object,
+            new CopilotHttpService(mocks.Configuration.Object, mocks.HttpClientFactory.Object, mocks.CopilotAuth.Object),
             mocks.PollingJobQueueManager.Object,
             mocks.NotificationManager.Object,
             mocks.PullRequestsRepository.Object,
-            mocks.CopilotAuth.Object,
             mocks.Logger.Object
         );
         return (reviewManager, mocks);

--- a/src/dotnet/APIView/APIViewUnitTests/ReviewSearchTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/ReviewSearchTests.cs
@@ -44,9 +44,10 @@ public class ReviewSearchTests
         package = new ReviewSearch(
             _mockReviewManager.Object,
             _mockApiRevisionsManager.Object,
-            _mockCopilotAuthService.Object,
-            _mockHttpClientFactory.Object,
-            _mockConfiguration.Object,
+            new CopilotHttpService(
+                _mockConfiguration.Object,
+                _mockHttpClientFactory.Object,
+                _mockCopilotAuthService.Object),
             _mockLogger.Object);
     }
 

--- a/src/dotnet/APIView/APIViewWeb/HostedServices/CopilotJobProcessor.cs
+++ b/src/dotnet/APIView/APIViewWeb/HostedServices/CopilotJobProcessor.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Text;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using APIViewWeb.Helpers;
@@ -15,37 +12,30 @@ using APIViewWeb.Models;
 using APIViewWeb.Repositories;
 using APIViewWeb.Services;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace APIViewWeb.HostedServices
 {
     public class CopilotJobProcessor : ICopilotJobProcessor
     {
-        private readonly string _copilotEndpoint;
-        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ICopilotHttpService _copilotHttp;
         private readonly IAPIRevisionsManager _apiRevisionsManager;
         private readonly ICosmosCommentsRepository _commentsRepository;
-        private readonly ICopilotAuthenticationService _copilotAuthService;
         private readonly IHubContext<SignalRHub> _signalRHubContext;
         private readonly ILogger<CopilotJobProcessor> _logger;
 
         private const string SummarySource = "summary";
 
         public CopilotJobProcessor(
-            IConfiguration configuration,
-            IHttpClientFactory httpClientFactory,
+            ICopilotHttpService copilotHttp,
             IAPIRevisionsManager apiRevisionsManager,
             ICosmosCommentsRepository commentsRepository,
-            ICopilotAuthenticationService copilotAuthService,
             IHubContext<SignalRHub> signalRHubContext,
             ILogger<CopilotJobProcessor> logger)
         {
-            _copilotEndpoint = configuration["CopilotServiceEndpoint"];
-            _httpClientFactory = httpClientFactory;
+            _copilotHttp = copilotHttp;
             _apiRevisionsManager = apiRevisionsManager;
             _commentsRepository = commentsRepository;
-            _copilotAuthService = copilotAuthService;
             _signalRHubContext = signalRHubContext;
             _logger = logger;
         }
@@ -58,24 +48,15 @@ namespace APIViewWeb.HostedServices
             try
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                
-                var client = _httpClientFactory.CreateClient();
-                var pollUrl = $"{_copilotEndpoint}/api-review/{jobInfo.JobId}";
+
+                var pollPath = $"api-review/{jobInfo.JobId}";
                 var poller = new Poller();
-                
+
                 var result = await poller.PollAsync(
                     operation: async () =>
                     {
                         cancellationToken.ThrowIfCancellationRequested();
-                        
-                        using var request = new HttpRequestMessage(HttpMethod.Get, pollUrl);
-                        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", await _copilotAuthService.GetAccessTokenAsync(cancellationToken));
-
-                        HttpResponseMessage response = await client.SendAsync(request, cancellationToken);
-                        response.EnsureSuccessStatusCode();
-                        string pollResponseString = await response.Content.ReadAsStringAsync(cancellationToken);
-                        AIReviewJobPolledResponseModel pollResponse = JsonSerializer.Deserialize<AIReviewJobPolledResponseModel>(pollResponseString);
-                        return pollResponse;
+                        return await _copilotHttp.GetAsync<AIReviewJobPolledResponseModel>(pollPath, cancellationToken);
                     },
                     isComplete: response => (response.Status != "InProgress"),
                     initialInterval: 120, // Two minutes

--- a/src/dotnet/APIView/APIViewWeb/LeanControllers/APIRevisionsController.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanControllers/APIRevisionsController.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text.Json;
 using System.Threading.Tasks;
 using APIViewWeb.Extensions;
 using APIViewWeb.Helpers;
@@ -16,7 +13,6 @@ using APIViewWeb.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace APIViewWeb.LeanControllers
@@ -28,23 +24,19 @@ namespace APIViewWeb.LeanControllers
         private readonly IReviewManager _reviewManager;
         private readonly INotificationManager _notificationManager;
         private readonly IHubContext<SignalRHub> _signalRHubContext;
-        private readonly string _copilotEndpoint;
-        private readonly IHttpClientFactory _httpClientFactory;
-        private readonly ICopilotAuthenticationService _copilotAuthService;
+        private readonly ICopilotHttpService _copilotHttp;
 
         public APIRevisionsController(ILogger<APIRevisionsController> logger,
             IReviewManager reviewManager, IPullRequestManager pullRequestManager,
-            IAPIRevisionsManager apiRevisionsManager, INotificationManager notificationManager, IConfiguration configuration,
-            IHubContext<SignalRHub> signalRHub, IHttpClientFactory httpClientFactory, ICopilotAuthenticationService copilotAuthService)
+            IAPIRevisionsManager apiRevisionsManager, INotificationManager notificationManager,
+            IHubContext<SignalRHub> signalRHub, ICopilotHttpService copilotHttp)
         {
             _logger = logger;
             _apiRevisionsManager = apiRevisionsManager;
             _reviewManager = reviewManager;
             _notificationManager = notificationManager;
             _signalRHubContext = signalRHub;
-            _copilotEndpoint = configuration["CopilotServiceEndpoint"];
-            _httpClientFactory = httpClientFactory;
-            _copilotAuthService = copilotAuthService;
+            _copilotHttp = copilotHttp;
         }
 
         /// <summary>
@@ -100,16 +92,8 @@ namespace APIViewWeb.LeanControllers
                     if (apiRevision != null && apiRevision.CopilotReviewInProgress)
                     {
                         // If Copilot review is in progress let verify that this is not due to a dropped background job
-                        var pollUrl = $"{_copilotEndpoint}/api-review/{apiRevision.CopilotReviewJobId}";
-                        var client = _httpClientFactory.CreateClient();
-                        
-                        var request = new HttpRequestMessage(HttpMethod.Get, pollUrl);
-                        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", await _copilotAuthService.GetAccessTokenAsync());
-                        
-                        HttpResponseMessage response = await client.SendAsync(request);
-                        response.EnsureSuccessStatusCode();
-                        var pollResponseString = await response.Content.ReadAsStringAsync();
-                        var pollResponse = JsonSerializer.Deserialize<AIReviewJobPolledResponseModel>(pollResponseString);
+                        var pollResponse = await _copilotHttp.GetAsync<AIReviewJobPolledResponseModel>(
+                            $"api-review/{apiRevision.CopilotReviewJobId}");
                         if (pollResponse.Status != "InProgress")
                         {
                             apiRevision.CopilotReviewInProgress = false;

--- a/src/dotnet/APIView/APIViewWeb/Managers/CommentsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/CommentsManager.cs
@@ -318,7 +318,7 @@ namespace APIViewWeb.Managers
                     HttpMethod.Post, agentMentionEndPoint, mentionRequest);
                 clientResponse.EnsureSuccessStatusCode();
                 string clientResponseContent = await clientResponse.Content.ReadAsStringAsync();
-                AgentChatResponse agentChatResponse = System.Text.Json.JsonSerializer.Deserialize<AgentChatResponse>(clientResponseContent);
+                AgentChatResponse agentChatResponse = JsonSerializer.Deserialize<AgentChatResponse>(clientResponseContent);
                 if (agentChatResponse != null)
                 {
                     await AddAgentComment(comment, agentChatResponse.Response);

--- a/src/dotnet/APIView/APIViewWeb/Managers/CommentsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/CommentsManager.cs
@@ -23,7 +23,6 @@ using APIViewWeb.Repositories;
 using APIViewWeb.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -37,13 +36,11 @@ namespace APIViewWeb.Managers
         private readonly ICosmosCommentsRepository _commentsRepository;
         private readonly ICosmosReviewRepository _reviewRepository;
         private readonly INotificationManager _notificationManager;
-        private readonly IConfiguration _configuration;
         private readonly IBlobCodeFileRepository _codeFileRepository;
         private readonly IHubContext<SignalRHub> _signalRHubContext;
-        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ICopilotHttpService _copilotHttp;
         private readonly ILogger<CommentsManager> _logger;
         private readonly IBackgroundTaskQueue _backgroundTaskQueue;
-        private readonly ICopilotAuthenticationService _copilotAuthService;
         private readonly IPermissionsManager _permissionsManager;
 
         public readonly UserProfileCache _userProfileCache;
@@ -59,13 +56,11 @@ namespace APIViewWeb.Managers
             INotificationManager notificationManager,
             IBlobCodeFileRepository codeFileRepository,
             IHubContext<SignalRHub> signalRHubContext,
-            IHttpClientFactory httpClientFactory,
+            ICopilotHttpService copilotHttp,
             UserProfileCache userProfileCache,
-            IConfiguration configuration,
             IOptions<OrganizationOptions> options,
             IBackgroundTaskQueue backgroundTaskQueue,
             IPermissionsManager permissionsManager,
-            ICopilotAuthenticationService copilotAuthService,
             ILogger<CommentsManager> logger)
         {
             _apiRevisionsManager = apiRevisionsManager;
@@ -76,12 +71,10 @@ namespace APIViewWeb.Managers
             _notificationManager = notificationManager;
             _codeFileRepository = codeFileRepository;
             _signalRHubContext = signalRHubContext;
-            _httpClientFactory = httpClientFactory;
+            _copilotHttp = copilotHttp;
             _userProfileCache = userProfileCache;
-            _configuration = configuration;
             _Options = options.Value;
             _backgroundTaskQueue = backgroundTaskQueue;
-            _copilotAuthService = copilotAuthService;
             _permissionsManager = permissionsManager;
             _logger = logger;
 
@@ -320,22 +313,12 @@ namespace APIViewWeb.Managers
                     SourceCommentId = comment.Id
                 };
 
-                string agentMentionEndPoint = $"{_configuration["CopilotServiceEndpoint"]}/api-review/mention";
-                var request = new HttpRequestMessage(HttpMethod.Post, agentMentionEndPoint)
-                {
-                    Content = new StringContent(
-                        System.Text.Json.JsonSerializer.Serialize(mentionRequest),
-                        Encoding.UTF8,
-                        "application/json")
-                };
-
-                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", await _copilotAuthService.GetAccessTokenAsync(cancellationToken));
-
-                var client = _httpClientFactory.CreateClient();
-                var clientResponse = await client.SendAsync(request);
+                string agentMentionEndPoint = $"api-review/mention";
+                using HttpResponseMessage clientResponse = await _copilotHttp.SendAsync(
+                    HttpMethod.Post, agentMentionEndPoint, mentionRequest);
                 clientResponse.EnsureSuccessStatusCode();
                 string clientResponseContent = await clientResponse.Content.ReadAsStringAsync();
-                AgentChatResponse agentChatResponse = JsonSerializer.Deserialize<AgentChatResponse>(clientResponseContent);
+                AgentChatResponse agentChatResponse = System.Text.Json.JsonSerializer.Deserialize<AgentChatResponse>(clientResponseContent);
                 if (agentChatResponse != null)
                 {
                     await AddAgentComment(comment, agentChatResponse.Response);
@@ -767,19 +750,8 @@ namespace APIViewWeb.Managers
                     SourceCommentId = comment.Id
                 };
 
-                string agentMentionEndPoint = $"{_configuration["CopilotServiceEndpoint"]}/api-review/mention";
-                var request = new HttpRequestMessage(HttpMethod.Post, agentMentionEndPoint)
-                {
-                    Content = new StringContent(
-                        JsonSerializer.Serialize(mentionRequest),
-                        Encoding.UTF8,
-                        "application/json")
-                };
-
-                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", await _copilotAuthService.GetAccessTokenAsync(cancellationToken));
-
-                var client = _httpClientFactory.CreateClient();
-                var clientResponse = await client.SendAsync(request, cancellationToken);
+                using HttpResponseMessage clientResponse = await _copilotHttp.SendAsync(
+                    HttpMethod.Post, "api-review/mention", mentionRequest, cancellationToken);
                 clientResponse.EnsureSuccessStatusCode();
 
                 _logger.LogInformation("Feedback sent to Copilot for AI comment {CommentId} in review {ReviewId}", comment.Id, comment.ReviewId);

--- a/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
@@ -6,10 +6,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using APIView;
@@ -25,7 +23,6 @@ using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace APIViewWeb.Managers
@@ -43,12 +40,10 @@ namespace APIViewWeb.Managers
         private readonly IEnumerable<LanguageService> _languageServices;
         private readonly TelemetryClient _telemetryClient;
         private readonly ICodeFileManager _codeFileManager;
-        private readonly IConfiguration _configuration;
-        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ICopilotHttpService _copilotHttp;
         private readonly IPollingJobQueueManager _pollingJobQueueManager;
         private readonly INotificationManager _notificationManager;
         private readonly ICosmosPullRequestsRepository _pullRequestsRepository;
-        private readonly ICopilotAuthenticationService _copilotAuthService;
         private readonly ILogger<ReviewManager> _logger;
 
         public ReviewManager (
@@ -63,12 +58,10 @@ namespace APIViewWeb.Managers
             IEnumerable<LanguageService> languageServices,
             TelemetryClient telemetryClient, 
             ICodeFileManager codeFileManager,
-            IConfiguration configuration, 
-            IHttpClientFactory httpClientFactory, 
+            ICopilotHttpService copilotHttp,
             IPollingJobQueueManager pollingJobQueueManager,
             INotificationManager notificationManager,
             ICosmosPullRequestsRepository pullRequestsRepository,
-            ICopilotAuthenticationService copilotAuthService,
             ILogger<ReviewManager> logger)
         {
             _authorizationService = authorizationService;
@@ -82,12 +75,10 @@ namespace APIViewWeb.Managers
             _languageServices = languageServices;
             _telemetryClient = telemetryClient;
             _codeFileManager = codeFileManager;
-            _configuration = configuration;
-            _httpClientFactory = httpClientFactory;
+            _copilotHttp = copilotHttp;
             _pollingJobQueueManager = pollingJobQueueManager;
             _notificationManager = notificationManager;
             _pullRequestsRepository = pullRequestsRepository;
-            _copilotAuthService = copilotAuthService;
             _logger = logger;
         }
 
@@ -570,10 +561,6 @@ namespace APIViewWeb.Managers
                 diagnostics = AgentHelpers.BuildDiagnosticsForAgent(activeCodeFile.CodeFile.Diagnostics.ToList(), activeCodeFile);
             }
 
-            var copilotEndpoint = _configuration["CopilotServiceEndpoint"];
-            var startUrl = $"{copilotEndpoint}/api-review/start";
-            var client = _httpClientFactory.CreateClient();
-            
             var payload = new Dictionary<string, object>
             {
                 { "language", LanguageServiceHelpers.GetLanguageAliasForCopilotService(activeApiRevision.Language, activeCodeFile.CodeFile.LanguageVariant) },
@@ -595,19 +582,10 @@ namespace APIViewWeb.Managers
             try {
                 _logger.LogInformation("Starting Copilot job for ReviewId: {ReviewId}, APIRevisionId: {APIRevisionId}, Language: {Language}", 
                     reviewId, activeApiRevision.Id, activeApiRevision.Language);
-                
 
-                var request = new HttpRequestMessage(HttpMethod.Post, startUrl)
-                {
-                    Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json")
-                };
-                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", await _copilotAuthService.GetAccessTokenAsync());
-                
-                var response = await client.SendAsync(request);
-                response.EnsureSuccessStatusCode();
-                var responseString = await response.Content.ReadAsStringAsync();
-                var jobStartedResponse = JsonSerializer.Deserialize<AIReviewJobStartedResponseModel>(responseString);
-                
+                var jobStartedResponse = await _copilotHttp.PostAsync<AIReviewJobStartedResponseModel>(
+                    "api-review/start", payload);
+
                 _logger.LogInformation("Copilot job started successfully. JobId: {JobId}, ReviewId: {ReviewId}, APIRevisionId: {APIRevisionId}", 
                     jobStartedResponse.JobId, reviewId, activeApiRevision.Id);
                 
@@ -656,10 +634,6 @@ namespace APIViewWeb.Managers
 
             language = LanguageServiceHelpers.GetLanguageAliasForCopilotService(language);
 
-            string copilotEndpoint = _configuration["CopilotServiceEndpoint"];
-            string startUrl = $"{copilotEndpoint}/api-review/start";
-            HttpClient client = _httpClientFactory.CreateClient();
-
             var payload = new Dictionary<string, object> { { "target", strippedTarget }, { "language", language } };
 
             if (!string.IsNullOrEmpty(request.Base))
@@ -682,13 +656,8 @@ namespace APIViewWeb.Managers
             {
                 _logger.LogInformation("Starting AVC review job via API. Language: {Language}", language);
 
-                using var httpRequest = new HttpRequestMessage(HttpMethod.Post, startUrl)
-                {
-                    Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json")
-                };
-                httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", await _copilotAuthService.GetAccessTokenAsync());
-
-                using HttpResponseMessage response = await client.SendAsync(httpRequest);
+                using HttpResponseMessage response = await _copilotHttp.SendAsync(
+                    HttpMethod.Post, "api-review/start", payload);
                 string responseString = await response.Content.ReadAsStringAsync();
 
                 if (!response.IsSuccessStatusCode)
@@ -697,7 +666,7 @@ namespace APIViewWeb.Managers
                     throw new HttpRequestException($"Copilot service returned {(int)response.StatusCode}: {responseString}", null, response.StatusCode);
                 }
 
-                AIReviewJobStartedResponseModel jobStartedResponse = JsonSerializer.Deserialize<AIReviewJobStartedResponseModel>(responseString);
+                AIReviewJobStartedResponseModel jobStartedResponse = System.Text.Json.JsonSerializer.Deserialize<AIReviewJobStartedResponseModel>(responseString);
                 
                 _logger.LogInformation("AVC review job started successfully. JobId: {JobId}", jobStartedResponse.JobId);
                 return jobStartedResponse;
@@ -719,21 +688,10 @@ namespace APIViewWeb.Managers
                 throw new ArgumentException("Job ID is required.", nameof(jobId));
             }
 
-            string copilotEndpoint = _configuration["CopilotServiceEndpoint"];
-            string pollUrl = $"{copilotEndpoint}/api-review/{jobId}";
-            HttpClient client = _httpClientFactory.CreateClient();
-
             try
             {
                 _logger.LogInformation("Polling AVC review job status. JobId: {JobId}", jobId);
-
-                using var request = new HttpRequestMessage(HttpMethod.Get, pollUrl);
-                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", await _copilotAuthService.GetAccessTokenAsync());
-
-                HttpResponseMessage response = await client.SendAsync(request);
-                response.EnsureSuccessStatusCode();
-                string responseString = await response.Content.ReadAsStringAsync();
-                return JsonSerializer.Deserialize<AIReviewJobPolledResponseModel>(responseString);
+                return await _copilotHttp.GetAsync<AIReviewJobPolledResponseModel>($"api-review/{jobId}");
             }
             catch (Exception e)
             {

--- a/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using APIView;
@@ -666,7 +667,7 @@ namespace APIViewWeb.Managers
                     throw new HttpRequestException($"Copilot service returned {(int)response.StatusCode}: {responseString}", null, response.StatusCode);
                 }
 
-                AIReviewJobStartedResponseModel jobStartedResponse = System.Text.Json.JsonSerializer.Deserialize<AIReviewJobStartedResponseModel>(responseString);
+                AIReviewJobStartedResponseModel jobStartedResponse = JsonSerializer.Deserialize<AIReviewJobStartedResponseModel>(responseString);
                 
                 _logger.LogInformation("AVC review job started successfully. JobId: {JobId}", jobStartedResponse.JobId);
                 return jobStartedResponse;

--- a/src/dotnet/APIView/APIViewWeb/Managers/ReviewSearch.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/ReviewSearch.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 using System.Web;
 using APIViewWeb.LeanModels;
@@ -60,7 +61,7 @@ public class ReviewSearch : IReviewSearch
             }
 
             string responseBody = await response.Content.ReadAsStringAsync();
-            return System.Text.Json.JsonSerializer.Deserialize<ResolvePackageResponse>(responseBody);
+            return JsonSerializer.Deserialize<ResolvePackageResponse>(responseBody);
         }
 
 

--- a/src/dotnet/APIView/APIViewWeb/Managers/ReviewSearch.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/ReviewSearch.cs
@@ -3,16 +3,12 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Net.Http.Json;
-using System.Text.Json;
 using System.Threading.Tasks;
 using System.Web;
 using APIViewWeb.LeanModels;
 using APIViewWeb.Managers.Interfaces;
 using APIViewWeb.Models;
 using APIViewWeb.Services;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace APIViewWeb.Managers;
@@ -22,25 +18,18 @@ public class ReviewSearch : IReviewSearch
     private readonly IAPIRevisionsManager _apiRevisionsManager;
     private readonly ILogger<ReviewSearch> _logger;
     private readonly IReviewManager _reviewManager;
-    private readonly ICopilotAuthenticationService _copilotAuthService;
-    private readonly IHttpClientFactory _httpClientFactory;
-    private readonly string _copilotEndpoint;
+    private readonly ICopilotHttpService _copilotHttp;
 
     public ReviewSearch(
         IReviewManager reviewManager,
         IAPIRevisionsManager apiRevisionsManager,
-        ICopilotAuthenticationService copilotAuthService,
-        IHttpClientFactory httpClientFactory,
-        IConfiguration configuration,
+        ICopilotHttpService copilotHttp,
         ILogger<ReviewSearch> logger)
     {
         _reviewManager = reviewManager;
         _apiRevisionsManager = apiRevisionsManager;
-        _copilotAuthService = copilotAuthService;
-        _httpClientFactory = httpClientFactory;
+        _copilotHttp = copilotHttp;
         _logger = logger;
-
-        _copilotEndpoint = configuration["CopilotServiceEndpoint"];
     }
 
     public async Task<ResolvePackageResponse> ResolvePackageQuery(
@@ -61,19 +50,17 @@ public class ReviewSearch : IReviewSearch
         ReviewListItemModel review = await _reviewManager.GetReviewAsync(language, packageQuery, null);
         if (review == null)
         {
-            var client = _httpClientFactory.CreateClient();
-
-            using var request = new HttpRequestMessage(HttpMethod.Post, $"{_copilotEndpoint}/api-review/resolve-package");
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", await _copilotAuthService.GetAccessTokenAsync());
-            request.Content = JsonContent.Create(new { packageQuery, language });
-
-            var response = await client.SendAsync(request);
+            using HttpResponseMessage response = await _copilotHttp.SendAsync(
+                HttpMethod.Post,
+                "api-review/resolve-package",
+                new { packageQuery, language });
             if (!response.IsSuccessStatusCode)
             {
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<ResolvePackageResponse>();
+            string responseBody = await response.Content.ReadAsStringAsync();
+            return System.Text.Json.JsonSerializer.Deserialize<ResolvePackageResponse>(responseBody);
         }
 
 

--- a/src/dotnet/APIView/APIViewWeb/Services/CopilotHttpService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Services/CopilotHttpService.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+
+namespace APIViewWeb.Services
+{
+    public class CopilotHttpService : ICopilotHttpService
+    {
+        private readonly string _endpoint;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ICopilotAuthenticationService _authService;
+
+        public CopilotHttpService(
+            IConfiguration configuration,
+            IHttpClientFactory httpClientFactory,
+            ICopilotAuthenticationService authService)
+        {
+            _endpoint = configuration["CopilotServiceEndpoint"];
+            _httpClientFactory = httpClientFactory;
+            _authService = authService;
+        }
+
+        public async Task<TResponse> GetAsync<TResponse>(string path, CancellationToken cancellationToken = default)
+        {
+            using HttpResponseMessage response = await SendAsync(HttpMethod.Get, path, body: null, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            string responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            return JsonSerializer.Deserialize<TResponse>(responseBody);
+        }
+
+        public async Task<TResponse> PostAsync<TResponse>(string path, object body, CancellationToken cancellationToken = default)
+        {
+            using HttpResponseMessage response = await SendAsync(HttpMethod.Post, path, body, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            string responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            return JsonSerializer.Deserialize<TResponse>(responseBody);
+        }
+
+        public async Task PostAsync(string path, object body, CancellationToken cancellationToken = default)
+        {
+            using HttpResponseMessage response = await SendAsync(HttpMethod.Post, path, body, cancellationToken);
+            response.EnsureSuccessStatusCode();
+        }
+
+        public async Task<HttpResponseMessage> SendAsync(HttpMethod method, string path, object body = null, CancellationToken cancellationToken = default)
+        {
+            string url = BuildUrl(path);
+            using var request = new HttpRequestMessage(method, url);
+            if (body != null)
+            {
+                request.Content = new StringContent(
+                    JsonSerializer.Serialize(body),
+                    Encoding.UTF8,
+                    "application/json");
+            }
+            request.Headers.Authorization = new AuthenticationHeaderValue(
+                "Bearer", await _authService.GetAccessTokenAsync(cancellationToken));
+
+            HttpClient client = _httpClientFactory.CreateClient();
+            return await client.SendAsync(request, cancellationToken);
+        }
+
+        private string BuildUrl(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return _endpoint;
+            }
+            return $"{_endpoint.TrimEnd('/')}/{path.TrimStart('/')}";
+        }
+    }
+}

--- a/src/dotnet/APIView/APIViewWeb/Services/Interfaces/ICopilotHttpService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Services/Interfaces/ICopilotHttpService.cs
@@ -1,0 +1,44 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace APIViewWeb.Services
+{
+    /// <summary>
+    /// Centralized HTTP client for talking to the apiview-copilot service.
+    /// Owns endpoint resolution, bearer-token injection, HttpClient lifecycle,
+    /// and JSON (de)serialization so individual call sites do not have to
+    /// duplicate that plumbing.
+    /// </summary>
+    public interface ICopilotHttpService
+    {
+        /// <summary>
+        /// Issues a GET to <paramref name="path"/> (relative to the configured
+        /// CopilotServiceEndpoint), throws on non-success, and deserializes the
+        /// response body into <typeparamref name="TResponse"/>.
+        /// </summary>
+        Task<TResponse> GetAsync<TResponse>(string path, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Issues a POST to <paramref name="path"/> with <paramref name="body"/>
+        /// serialized as JSON, throws on non-success, and deserializes the
+        /// response body into <typeparamref name="TResponse"/>.
+        /// </summary>
+        Task<TResponse> PostAsync<TResponse>(string path, object body, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Issues a POST to <paramref name="path"/> with <paramref name="body"/>
+        /// serialized as JSON and throws on non-success. Use when the response
+        /// body is not needed.
+        /// </summary>
+        Task PostAsync(string path, object body, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends an arbitrary request and returns the raw <see cref="HttpResponseMessage"/>.
+        /// The endpoint base is prepended to <paramref name="path"/> and the bearer
+        /// token is attached automatically. The caller is responsible for
+        /// disposing the returned response and for handling non-success status codes.
+        /// </summary>
+        Task<HttpResponseMessage> SendAsync(HttpMethod method, string path, object body = null, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/dotnet/APIView/APIViewWeb/Startup.cs
+++ b/src/dotnet/APIView/APIViewWeb/Startup.cs
@@ -117,6 +117,7 @@ namespace APIViewWeb
 
             services.AddHttpClient();
             services.AddSingleton<ICopilotAuthenticationService, CopilotAuthenticationService>();
+            services.AddSingleton<ICopilotHttpService, CopilotHttpService>();
             services.AddSingleton<IPollingJobQueueManager, PollingJobQueueManager>();
             services.AddSingleton<ICopilotJobProcessor, CopilotJobProcessor>();
             services.AddSingleton<IBlobCodeFileRepository, BlobCodeFileRepository>();


### PR DESCRIPTION
## Summary
Extracts a single ICopilotHttpService that owns endpoint resolution, bearer-token injection, `HttpClient` lifecycle, and JSON (de)serialization for talking to the apiview-copilot service. Removes the duplicated plumbing from 8 call sites across 5 files.

Motivated by review feedback on #15347 — the new `AgentController` would have been the 6th place duplicating this same dance.

## Changes

### New
- `src/dotnet/APIView/APIViewWeb/Services/Interfaces/ICopilotHttpService.cs` — interface with `GetAsync<T>`, `PostAsync<T>`, `PostAsync`, and a raw `SendAsync` escape-hatch.
- `src/dotnet/APIView/APIViewWeb/Services/CopilotHttpService.cs` — implementation. Reads `CopilotServiceEndpoint`, attaches bearer from `ICopilotAuthenticationService`, uses `IHttpClientFactory.CreateClient()`.

### DI
- `Startup.cs` — registers `ICopilotHttpService` as a singleton next to `ICopilotAuthenticationService`.

### Migrated call sites (8 across 5 files)
| File | Sites | Endpoint |
|---|---|---|
| `Managers/ReviewManager.cs` | 3 | `POST api-review/start` ×2, `GET api-review/{jobId}` |
| `Managers/CommentsManager.cs` | 2 | `POST api-review/mention` ×2 |
| `HostedServices/CopilotJobProcessor.cs` | 1 | `GET api-review/{jobId}` (poll loop) |
| `LeanControllers/APIRevisionsController.cs` | 1 | `GET api-review/{jobId}` (drop-detection) |
| `Managers/ReviewSearch.cs` | 1 | `POST api-review/resolve-package` |

For each class, dropped the ctor params that are now only used through the new service: `IConfiguration`, `IHttpClientFactory`, `ICopilotAuthenticationService`. Verified by grep that those deps weren't used for anything else in those classes (`CommentsManager` keeps `System.Net.Http.Headers` — it's used by an unrelated GitHub call).

### Tests
9 test files updated. To minimize churn, each ctor call now constructs a real `CopilotHttpService` from the existing `Configuration` / `HttpClientFactory` / `CopilotAuth` mocks, so the existing `HttpMessageHandler.Protected().Setup(SendAsync, ...)` plumbing keeps working unchanged. No test logic was modified.

## Verification
- `dotnet build APIViewWeb.csproj` — clean.
- `dotnet test APIViewUnitTests.csproj` — 790 passed.

## Out of scope (intentional follow-ups)
- `AgentController.ReportIssueAsync` (added by #15347) will adopt this service in a follow-up commit on that branch — `AgentController` doesn't exist on `main` yet, so it's not migrated here.
- `CommentsManager.LoadTaggableUsers` still does `new HttpClient()` for the GitHub public-members API. That's a different concern (not copilot) and would benefit from its own factory-based refactor.
- `CopilotJobProcessor` still has a hand-rolled `Poller`; could be Polly. Not in scope.