### PR TITLE
Split github workflow and github skills sync into two pipelines

### DIFF
--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -6,8 +6,8 @@ with TypeSpec API specifications and Azure SDK generation.
 
 Shared skills (those distributed to other Azure SDK repositories) are identified by
 `distribution: shared` in their SKILL.md frontmatter metadata block and use the
-`azsdk-common-` directory prefix. This prefix enables the `sync-.github.yml` pipeline
-to match and distribute them to all subscribed language SDK repos.
+`azsdk-common-` directory prefix. This prefix enables the `sync-.github-skills.yml`
+pipeline to match and distribute them to all subscribed language SDK repos.
 
 ---
 

--- a/doc/engsys_workflows_and_skills.md
+++ b/doc/engsys_workflows_and_skills.md
@@ -10,28 +10,33 @@ Any updates to files in the `.github/workflows` directory should be made in the 
 
 Any updates to directories matching the pattern `.github/skills/azsdk-common-*` should be made in the [azure-sdk-tools](https://github.com/azure/azure-sdk-tools) repo.
 
-All changes made will cause a PR to be created in all subscribed azure-sdk language repos which will blindly replace all contents of the `.github/workflows` directory and skills directories in that repo. For that reason do **NOT** make changes to files in this directory in the azure-sdk or individual azure-sdk languages repos as they will be overwritten the next time an update is taken from their corresponding directories in the azure-sdk-tools repository.
+All changes made through the sync pipelines will cause PRs to be created in subscribed azure-sdk language repos which will blindly replace the synced files or directories in those repos. For that reason do **NOT** make changes to these files in the azure-sdk or individual azure-sdk language repos as they will be overwritten the next time an update is taken from the corresponding directory in the azure-sdk-tools repository.
+
+## Pipelines
+
+- [`tools - sync-.github`][workflow-yml] syncs selected files from `.github/workflows/`, including `post-apiview.yml` and `protected-files.yml`.
+- [`tools - sync-.github-skills`][skills-yml] syncs shared skills from `.github/skills/azsdk-common-*`.
 
 ## Workflow
 
-When you create a PR against `azure-sdk-tools` repo that changes contents of the `.github/workflows` directory or `.github/skills/azsdk-common-*`, the PR
-triggers an [`tools - sync-.github` pipeline][pipeline] that will mirror all changes the corresponding directories in the language repositories. The pipeline also triggers language-repository-specific tests for you to review. This process of mirroring involves multiple stages and requires your manual reviews & approvals before the changes are fully reflected to the language repositories. Your approval is needed first to allow automatic creation of PRs, then to allow them being merged on your behalf.
+When you create a PR against `azure-sdk-tools` that changes synced workflow targets in `.github/workflows` or shared skills in `.github/skills/azsdk-common-*`, the matching sync pipeline is triggered automatically and mirrors those changes into the subscribed language repositories. The pipeline also triggers language-repository-specific tests for you to review. This process of mirroring involves multiple stages and requires your manual reviews and approvals before the changes are fully reflected to the language repositories. Your approval is needed first to allow automatic creation of PRs, then to allow them being merged on your behalf.
 
 This process is set up in such a way to make it easier for changes to be tested in azure-sdk and each individual language repo before merging the changes in the `azure-sdk-tools` repo. The workflow is explained below:
 
-1. You create a PR (let's call it here the **Tools PR**) in the `azure-sdk-tools` repo with changes to the `.github/workflows` or `.github/skills/azsdk-common-*` directories.
-2. The [`tools - sync-.github` pipeline][pipeline] is automatically triggered for the **Tools PR**.
-3. That pipeline creates branches mirroring your changes, one branch in azure-sdk and one per each language repository to whose `.github` directory the changes are mirrored. You can use these branches to run your tests on these repos. The pipeline also queues test runs for template pipelines for each repo. These help you test your changes in the **Tools PR**.  All of this is done in `Create Sync` stage (display name: `Sync .github Directory`) [of the pipeline sync-.github.yml file][yml], specifically, the logic lives in `template: ./templates/steps/sync-directory.yml`.
+1. You create a PR (let's call it here the **Tools PR**) in the `azure-sdk-tools` repo with changes to the synced workflow files in `.github/workflows` and/or `.github/skills/azsdk-common-*`.
+2. The matching sync pipeline is automatically triggered for the **Tools PR**:
+   - [`tools - sync-.github`][workflow-yml] for the synced workflow targets in `.github/workflows`.
+   - [`tools - sync-.github-skills`][skills-yml] for `.github/skills/azsdk-common-*` changes.
+   - If your PR changes both areas, both pipelines will run.
+3. Each triggered pipeline creates branches mirroring your changes, one branch in azure-sdk and one per language repository receiving that sync. You can use these branches to run tests in those repos. The pipeline also queues test runs for template pipelines for each repo. These help you test the changes in the **Tools PR**. All of this is done in the `Create Sync` stage of the corresponding pipeline, specifically through `template: ./templates/steps/sync-directory.yml`.
 4. If you make additional changes to your **Tools PR** repeat steps 1 - 3 until you have completed the necessary testing of your changes. This includes full releases of the template package, if necessary.
 5. Once you reviewed all the test runs and did any of additional ad-hoc tests from the created branches in language repositories, you must manually approve in your pipeline execution instance the next stage - creation of PRs.
-6. Once approved, the pipeline proceeds to the next stage, named `CreateSyncPRs` in the [sync-.github.yml file][yml]. This stage creates one pull request for each language repository, merging changes from the branch created in step 3 into the default (usually `main`) branch. We call these PRs here **Sync PRs**. A link to each of the **Sync PRs** will show up in the **Tools PR** for you to click and review.
+6. Once approved, the pipeline proceeds to the next stage, named `CreateSyncPRs` in the corresponding pipeline YAML. This stage creates one pull request for each language repository, merging changes from the branch created in step 3 into the default (usually `main`) branch. We call these PRs here **Sync PRs**. A link to each of the **Sync PRs** will show up in the **Tools PR** for you to click and review.
 7. Review and approve each of your **Sync PRs** and resolve any open review conversations. For some repos (C and C++) you might need to frequently use the `Update Branch` button to get the checks green.
     - You can mass approve and mark AI-generated PR reviews as resolved with [this script](https://github.com/Azure/azure-sdk-tools/blob/main/eng/scripts/Approve-Sync-PRs.ps1): `<repo root>/eng/scripts/Approve-Sync-PRs.ps1 <tools sync PR>`
     - This script will also approve the next stage in the sync pipeline (`CreateSyncPRs` or `VerifyAndMerge`) so it can proceed.
-8. Sign Off on the [`VerifyAndMerge` stage][yml]. This will merge any remaining open **Sync PR** and also append `auto-merge` to the **Tools PR**.
+8. Sign off on the `VerifyAndMerge` stage in each triggered sync pipeline. This will merge any remaining open **Sync PR** and also append `auto-merge` to the **Tools PR**.
    - If a **Sync PR** has any failing checks, it will need to be manually merged, even if `/check-enforcer override` has been run ([azure-sdk-tools#1147](https://github.com/Azure/azure-sdk-tools/issues/1147)).
 
-### The pipeline link needs to be updated once the pipeline is created
-
-[pipeline]: https://dev.azure.com/azure-sdk/internal/_build?definitionId=1372&_a=summary
-[yml]: https://github.com/Azure/azure-sdk-tools/blob/main/eng/pipelines/sync-.github.yml
+[workflow-yml]: https://github.com/Azure/azure-sdk-tools/blob/main/eng/pipelines/sync-.github.yml
+[skills-yml]: https://github.com/Azure/azure-sdk-tools/blob/main/eng/pipelines/sync-.github-skills.yml

--- a/eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
+++ b/eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
@@ -21,15 +21,18 @@ steps:
         }
         if ((!"$(System.PullRequest.SourceBranch)".StartsWith("sync-.github")) -and "$(System.PullRequest.TargetBranch)" -match "^(refs/heads/)?$(DefaultBranch)$")
         {
-          # This list needs to be kept in sync with the FilePatterns listed in eng/pipelines/sync-.github.yml
-          $filePatterns = @(".github/workflows/*event*", ".github/workflows/post-apiview.yml", ".github/skills/azsdk-common-*/**")
+          # These lists need to be kept in sync with eng/pipelines/sync-.github.yml and
+          # eng/pipelines/sync-.github-skills.yml.
+          $workflowFilePatterns = @(".github/workflows/*event*", ".github/workflows/post-apiview.yml", ".github/workflows/protected-files.yml")
+          $skillsFilePatterns = @(".github/skills/azsdk-common-*/**")
+          $filePatterns = @($workflowFilePatterns + $skillsFilePatterns)
           $filesInCommonDir = @()
           foreach ($filePattern in $filePatterns) {
             $filesInCommonDir += & "eng/common/scripts/get-changedfiles.ps1" -DiffPath $filePattern -DiffFilterType ""
           }
           if ($filesInCommonDir.Count -gt 0)
           {
-            Write-Host "##vso[task.LogIssue type=error;]Changes to selected files under '.github/' directory should not be made in this Repo`n${filesInCommonDir}"
+            Write-Host "##vso[task.LogIssue type=error;]Changes to selected workflow and shared skill files under '.github/' should not be made in this Repo`n${filesInCommonDir}"
             Write-Host "##vso[task.LogIssue type=error;]Follow the workflow at https://github.com/Azure/azure-sdk-tools/blob/main/doc/engsys_workflows_and_skills.md"
             exit 1
           }

--- a/eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
+++ b/eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
@@ -9,7 +9,7 @@ steps:
         # Find the default branch of the repo. The variable value sets in build step.
         Write-Host "Default Branch: $(DefaultBranch)"
 
-        if ((!"$(System.PullRequest.SourceBranch)".StartsWith("sync-eng/common")) -and "$(System.PullRequest.TargetBranch)" -match "^(refs/heads/)?$(DefaultBranch)$")
+        if ((!"$(System.PullRequest.SourceBranch)".StartsWith("sync-eng-common")) -and "$(System.PullRequest.TargetBranch)" -match "^(refs/heads/)?$(DefaultBranch)$")
         {
           $filesInCommonDir = & "eng/common/scripts/get-changedfiles.ps1" -DiffPath 'eng/common/*' -DiffFilterType ""
           if ($filesInCommonDir.Count -gt 0)

--- a/eng/common/scripts/Delete-RemoteBranches.ps1
+++ b/eng/common/scripts/Delete-RemoteBranches.ps1
@@ -6,7 +6,8 @@ param(
   $CentralRepoId,
   # We start from the sync PRs, use the branch name to get the PR number of central repo. E.g. sync-eng/common-(<branchName>)-(<PrNumber>). Have group name on PR number.
   # For sync-eng/common work, we use regex as "^sync-eng/common.*-(?<PrNumber>\d+).*$".
-  # For sync-.github work, we use regex as "^sync-.github.*-(?<PrNumber>\d+).*$".
+  # For sync-.github and sync-.github-skills work, we use regex as
+  # "^sync-\.github.*-(?<PrNumber>\d+).*$".
   $BranchRegex,
   # When set, directly delete this exact branch name without querying all branches.
   # This is a fast path that avoids the expensive GraphQL branch listing and rate limit

--- a/eng/pipelines/branch-cleanup.yml
+++ b/eng/pipelines/branch-cleanup.yml
@@ -97,7 +97,7 @@ jobs:
               -WhatIf:$${{parameters.WhatIfPreference}}
 
         - task: PowerShell@2
-          displayName: ${{ repo }} sync workflow branch clean-up
+          displayName: ${{ repo }} sync .github branch clean-up
           condition: succeededOrFailed()
           continueOnError: true
           inputs:

--- a/eng/pipelines/sync-.github-skills.yml
+++ b/eng/pipelines/sync-.github-skills.yml
@@ -1,19 +1,20 @@
-# Mirror selected workflow files in the .github directory to all subscribed repos
+# Mirror shared skills in the .github/skills directory to all subscribed repos
 #
 # For more information on this file, please see:
 # doc/engsys_workflows_and_skills.md
 parameters:
 - name: DirectoryToSync
   type: string
-  default: .github/workflows
+  default: .github/skills
   # Remember to update the path includes below as well as the eng-common-workflow-enforcer.yml
   # and .github/workflows/protected-files.yml files if you update this list.
 - name: FilePatterns
   type: object
   default:
-    - '*event*'
-    - 'post-apiview.yml'
-    - 'protected-files.yml'
+    # Shared skills use an azsdk-common- directory prefix and live in .github/skills/
+    # in azure-sdk-tools. Only azsdk-common-* directories are synced to target repos.
+    # Repo-specific skills in .github/skills/<name>/ are not affected by this sync.
+    - 'azsdk-common-*'
 - name: Repos
   type: object
   default:
@@ -21,15 +22,14 @@ parameters:
     - azure-sdk-for-android
     - azure-sdk-for-c
     - azure-sdk-for-cpp
-    - azure-sdk-for-go
     - azure-sdk-for-ios
     - azure-sdk-for-java
     - azure-sdk-for-js
     - azure-sdk-for-net
     - azure-sdk-for-python
-    - azure-sdk-for-rust
-    # TODO: Re-enable syncing to specs repo after we standardize on workflow linting/naming
-    # - azure-rest-api-specs
+    # TODO: Onboard rust and go repos
+    # - azure-sdk-for-go
+    # - azure-sdk-for-rust
 
 trigger: none
 
@@ -39,10 +39,7 @@ pr:
       - main
   paths:
     include:
-      # Workflows
-      - .github/workflows/*event*
-      - .github/workflows/post-apiview.yml
-      - .github/workflows/protected-files.yml
+      - .github/skills/azsdk-common-*/**
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-repo-sync.yml

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-repo-sync.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-repo-sync.yml
@@ -71,7 +71,7 @@ stages:
                 CommitMessage: "Sync ${{ parameters.DirectoryToSync }} directory with azure-sdk-tools repository for Tools PR $(System.PullRequest.PullRequestNumber)"
                 DirectoryToSync: ${{ parameters.DirectoryToSync }}
                 FilePatterns: ${{ parameters.FilePatterns }}
-                UpstreamBranchName: "sync-${{ parameters.DirectoryToSync }}-$(System.PullRequest.SourceBranch)-$(System.PullRequest.PullRequestNumber)"
+                UpstreamBranchName: "sync-${{ replace(parameters.DirectoryToSync, '/', '-') }}-$(System.PullRequest.SourceBranch)-$(System.PullRequest.PullRequestNumber)"
                 BaseBranchName: $(system.pullRequest.targetBranch)
                 SkipCheckingForChanges: true
                 Repos: ${{ parameters.Repos }}
@@ -126,7 +126,7 @@ stages:
                           -RepoName "${{ repo }}"
                           -BaseBranch $(system.pullRequest.targetBranch)
                           -PROwner "Azure"
-                          -PRBranch "sync-${{ parameters.DirectoryToSync }}-$(System.PullRequest.SourceBranch)-$(System.PullRequest.PullRequestNumber)"
+                          -PRBranch "sync-${{ replace(parameters.DirectoryToSync, '/', '-') }}-$(System.PullRequest.SourceBranch)-$(System.PullRequest.PullRequestNumber)"
                           -AuthToken "$(GH_TOKEN)"
                           -PRTitle "Sync ${{ parameters.DirectoryToSync }} directory with azure-sdk-tools for PR $(System.PullRequest.PullRequestNumber)"
                           -PRLabels "Central-EngSys,EngSys"
@@ -193,7 +193,7 @@ stages:
                         filePath: $(System.DefaultWorkingDirectory)/eng/common/scripts/Delete-RemoteBranches.ps1
                         arguments: >
                           -RepoId "Azure/${{ repo }}"
-                          -TargetBranch "sync-${{ parameters.DirectoryToSync }}-$(System.PullRequest.SourceBranch)-$(System.PullRequest.PullRequestNumber)"
+                          -TargetBranch "sync-${{ replace(parameters.DirectoryToSync, '/', '-') }}-$(System.PullRequest.SourceBranch)-$(System.PullRequest.PullRequestNumber)"
                           -AuthToken $(GH_TOKEN)
 
   - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
@@ -214,6 +214,6 @@ stages:
                 CommitMessage: Sync ${{ parameters.DirectoryToSync }} directory with azure-sdk-tools repository
                 DirectoryToSync: ${{ parameters.DirectoryToSync }}
                 FilePatterns: ${{ parameters.FilePatterns }}
-                UpstreamBranchName: "sync-${{ parameters.DirectoryToSync }}"
+                UpstreamBranchName: "sync-${{ replace(parameters.DirectoryToSync, '/', '-') }}"
                 BaseBranchName: ${{ parameters.BaseBranchName }}
                 Repos: ${{ parameters.Repos }}

--- a/tools/azsdk-cli/docs/skills-guidelines.md
+++ b/tools/azsdk-cli/docs/skills-guidelines.md
@@ -110,9 +110,9 @@ The `azsdk-common-` prefix ensures shared skills sort together in a distinct blo
 
 ### How to sync skills across azure sdk repositories
 
-The `tools - sync-.github` pipeline syncs shared skills from `.github/skills/` in `azure-sdk-tools` to `.github/skills/` in all subscribed Azure SDK repositories. It uses `FilePatterns` to sync only `azsdk-common-*` directories, leaving repo-specific skills untouched. This works the same way as the `tools - sync-eng-common` pipeline.
+The `tools - sync-.github-skills` pipeline syncs shared skills from `.github/skills/` in `azure-sdk-tools` to `.github/skills/` in all subscribed Azure SDK repositories. It uses `FilePatterns` to sync only `azsdk-common-*` directories, leaving repo-specific skills untouched. This works the same way as the `tools - sync-eng-common` pipeline.
 
-The pipeline definition is at [`eng/pipelines/sync-.github.yml`](../../eng/pipelines/sync-.github.yml).
+The pipeline definition is at [`eng/pipelines/sync-.github-skills.yml`](../../eng/pipelines/sync-.github-skills.yml).
 
 To distribute skills from azure-sdk-tools to individual Azure SDK repositories:
 
@@ -135,7 +135,7 @@ To distribute skills from azure-sdk-tools to individual Azure SDK repositories:
 
     <Skill instructions and sub-sections here>
     ```
-3. Submit a PR — the sync pipeline triggers automatically when files under `.github/skills/azsdk-common-*` change.
+3. Submit a PR — the `tools - sync-.github-skills` pipeline triggers automatically when files under `.github/skills/azsdk-common-*` change.
 4. The pipeline creates sync PRs in all subscribed repos following the standard sync workflow (see [common_engsys.md](../../doc/common/common_engsys.md) for details on the sync process).
 
 **Important:** Do **NOT** modify `azsdk-common-*` skill directories in individual language repos — they will be overwritten on the next sync.


### PR DESCRIPTION
Split github workflow and github skills sync into two pipelines

I will follow up with a help text change to `.github/workflows/protected-files.yml` but some things are a bit borked so going to get in the current version first so I can fix the workflow file sync state across repos.