### PR TITLE
Use DevOps feed for sync_knowledge.yml

### DIFF
--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/sync_knowledge.yml
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/sync_knowledge.yml
@@ -69,6 +69,8 @@ extends:
               - template: /eng/pipelines/templates/variables/globals.yml@self
               - name: workingDirectory
                 value: '$(System.DefaultWorkingDirectory)/knowledge_sources'
+              - name: npmrcPath
+                value: '$(Agent.BuildDirectory)/azure-sdk-qa-bot-knowledge-sync/.npmrc'
 
             pool:
               name: $(LINUXPOOL)
@@ -107,15 +109,23 @@ extends:
                 inputs:
                   versionSpec: '20.x'
 
+              - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml@self
+                parameters:
+                  npmrcPath: $(npmrcPath)
+
               - script: |
                   npm ci
                 displayName: 'Install dependencies'
                 workingDirectory: $(Agent.BuildDirectory)/s/azure-sdk-tools/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync
+                env:
+                  npm_config_userconfig: $(npmrcPath)
 
               - script: |
                   npm run build
                 displayName: 'Build TypeScript project'
                 workingDirectory: $(Agent.BuildDirectory)/s/azure-sdk-tools/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync
+                env:
+                  npm_config_userconfig: $(npmrcPath)
 
               - script: |
                   npm run start


### PR DESCRIPTION
This pull request updates the CI pipeline configuration for the `azure-sdk-qa-bot-knowledge-sync` tool to ensure that packages are resolved from the DevOps feed. The main focus is to ensure that a custom `.npmrc` file is created and used for authenticated npm operations to the feed.
