### PR TITLE
Add Release Plan ID in get release plan fields

### DIFF
--- a/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
+++ b/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
@@ -1205,6 +1205,7 @@ function Get-ReleasePlan-Link($releasePlanWorkItemId)
   $fields += "System.Title"
   $fields += "Custom.ReleasePlanLink"
   $fields += "Custom.ReleasePlanSubmittedby"
+  $fields += "Custom.ReleasePlanID"
 
   $fieldList = ($fields | ForEach-Object { "[$_]"}) -join ", "
   $query = "SELECT ${fieldList} FROM WorkItems WHERE [System.Id] = $releasePlanWorkItemId"


### PR DESCRIPTION
Fixes the first change mentioned in https://github.com/Azure/azure-sdk-tools/issues/15629.