### PR TITLE
[apiview] Update Python Semver handling in VersionNormalization

### DIFF
--- a/src/dotnet/APIView/APIViewUnitTests/APIRevisionsManagerTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/APIRevisionsManagerTests.cs
@@ -107,7 +107,7 @@ public class APIRevisionsManagerTests
         _mockProjectsManager = new Mock<IProjectsManager>();
         _mockApiVersionsManager = new Mock<IAPIVersionsManager>();
         _mockApiVersionsManager
-            .Setup(m => m.GetOrCreateVersionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
+            .Setup(m => m.GetOrCreateVersionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
             .ReturnsAsync(new APIVersionModel { Id = "default-version-id" });
 
         TelemetryConfiguration telemetryConfiguration = new();
@@ -407,7 +407,7 @@ public class APIRevisionsManagerTests
         };
 
         _mockApiVersionsManager
-            .Setup(m => m.GetOrCreateVersionAsync(reviewId, "1.0.0", It.IsAny<int?>(), It.IsAny<string>()))
+            .Setup(m => m.GetOrCreateVersionAsync(reviewId, "1.0.0", It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
             .ReturnsAsync(new APIVersionModel { Id = expectedVersionId });
 
         _mockCodeFileManager

--- a/src/dotnet/APIView/APIViewUnitTests/AutoReviewServiceTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/AutoReviewServiceTests.cs
@@ -677,7 +677,7 @@ namespace APIViewUnitTests
                 .ReturnsAsync(review);
             _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
                 .ReturnsAsync(new List<APIRevisionListItemModel> { previousBuild });
-            _mockApiVersionsManager.Setup(m => m.GetOrCreateVersionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
+            _mockApiVersionsManager.Setup(m => m.GetOrCreateVersionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
                 .ReturnsAsync(versionModel);
             _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
                 .ReturnsAsync(new List<CommentItemModel>());
@@ -729,7 +729,7 @@ namespace APIViewUnitTests
                 .ReturnsAsync(review);
             _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
                 .ReturnsAsync(new List<APIRevisionListItemModel> { previousBuild });
-            _mockApiVersionsManager.Setup(m => m.GetOrCreateVersionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
+            _mockApiVersionsManager.Setup(m => m.GetOrCreateVersionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
                 .ReturnsAsync(versionModel);
             _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
                 .ReturnsAsync(new List<CommentItemModel>());
@@ -798,7 +798,7 @@ namespace APIViewUnitTests
                 .ReturnsAsync(review);
             _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
                 .ReturnsAsync(new List<APIRevisionListItemModel> { existingRevision });
-            _mockApiVersionsManager.Setup(m => m.GetOrCreateVersionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
+            _mockApiVersionsManager.Setup(m => m.GetOrCreateVersionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
                 .ReturnsAsync(versionModel);
             _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
                 .ReturnsAsync(new List<CommentItemModel>());
@@ -866,7 +866,7 @@ namespace APIViewUnitTests
                 .ReturnsAsync(review);
             _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
                 .ReturnsAsync(new List<APIRevisionListItemModel> { revisionV1, revisionV2 });
-            _mockApiVersionsManager.Setup(m => m.GetOrCreateVersionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
+            _mockApiVersionsManager.Setup(m => m.GetOrCreateVersionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
                 .ReturnsAsync(versionV1);
             _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
                 .ReturnsAsync(new List<CommentItemModel>());
@@ -945,7 +945,7 @@ namespace APIViewUnitTests
                 .ReturnsAsync(review);
             _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
                 .ReturnsAsync(new List<APIRevisionListItemModel> { b3V2, b2V1, b1V1 });
-            _mockApiVersionsManager.Setup(m => m.GetOrCreateVersionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
+            _mockApiVersionsManager.Setup(m => m.GetOrCreateVersionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
                 .ReturnsAsync(v2BetaVersionModel);
             _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>(), It.IsAny<bool>()))
                 .ReturnsAsync(new List<CommentItemModel>());

--- a/src/dotnet/APIView/APIViewUnitTests/VersionNormalizationTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/VersionNormalizationTests.cs
@@ -81,6 +81,16 @@ public class VersionNormalizationTests
         Assert.Equal(expectedKind, kind);
     }
 
+    [Theory]
+    [InlineData("1.0.0.post1", "1.0.0", VersionKind.Stable)]
+    [InlineData("2.5.0.post2", "2.5.0", VersionKind.Stable)]
+    public void NormalizeVersion_PythonPostRelease_IsStable(string input, string expectedId, VersionKind expectedKind)
+    {
+        var (id, kind) = VersionNormalizationHelper.NormalizeVersion(input, language: "Python");
+        Assert.Equal(expectedId, id);
+        Assert.Equal(expectedKind, kind);
+    }
+
     [Fact]
     public void NormalizeVersion_UppercaseLabel_IsLowercased()
     {

--- a/src/dotnet/APIView/APIViewWeb/Helpers/VersionNormalizationHelper.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/VersionNormalizationHelper.cs
@@ -22,7 +22,7 @@ public static class VersionNormalizationHelper
         var semVer = new AzureEngSemanticVersion(versionIdentifier, language);
 
         // Non-semver version strings are handled by language/shape:
-        //   • Python: PEP 440 qualifiers (.dev, .post) are unparseable by the semver regex → Preview.
+        //   • Python: PEP 440 qualifiers (e.g. .dev) that are unparseable by the regex → Preview.
         //   • Any language: bare positive integers (e.g. Azure Key Vault "6", "7") → Stable.
         //   • Everything else falls back to Preview.
         if (!semVer.IsSemVerFormat)

--- a/src/dotnet/APIView/APIViewWeb/Helpers/VersionNormalizationHelper.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/VersionNormalizationHelper.cs
@@ -22,7 +22,7 @@ public static class VersionNormalizationHelper
         var semVer = new AzureEngSemanticVersion(versionIdentifier, language);
 
         // Non-semver version strings are handled by language/shape:
-        //   • Python: PEP 440 qualifiers (e.g. .dev) that are unparseable by the regex → Preview.
+        //   • Python: PEP 440 qualifiers (e.g. .dev) that are unparseable by the semver regex → Preview.
         //   • Any language: bare positive integers (e.g. Azure Key Vault "6", "7") → Stable.
         //   • Everything else falls back to Preview.
         if (!semVer.IsSemVerFormat)

--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -235,7 +235,7 @@ namespace APIViewWeb.Managers
 
             if (!string.IsNullOrEmpty(packageVersion) && !string.IsNullOrEmpty(reviewId))
             {
-                APIVersionModel versionModel = await _apiVersionsManager.GetOrCreateVersionAsync(reviewId, packageVersion, prNumber, sourceBranch);
+                APIVersionModel versionModel = await _apiVersionsManager.GetOrCreateVersionAsync(reviewId, packageVersion, language, prNumber, sourceBranch);
                 apiRevision.APIVersionId = versionModel.Id;
             }
 

--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -235,7 +235,12 @@ namespace APIViewWeb.Managers
 
             if (!string.IsNullOrEmpty(packageVersion) && !string.IsNullOrEmpty(reviewId))
             {
-                APIVersionModel versionModel = await _apiVersionsManager.GetOrCreateVersionAsync(reviewId, packageVersion, language, prNumber, sourceBranch);
+                APIVersionModel versionModel = await _apiVersionsManager.GetOrCreateVersionAsync(
+                    reviewId,
+                    packageVersion,
+                    language: language,
+                    pullRequestNo: prNumber,
+                    sourceBranch: sourceBranch);
                 apiRevision.APIVersionId = versionModel.Id;
             }
 

--- a/src/dotnet/APIView/APIViewWeb/Managers/APIVersionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIVersionsManager.cs
@@ -18,7 +18,7 @@ public class APIVersionsManager : IAPIVersionsManager
         _versionsRepository = versionsRepository;
     }
 
-    public async Task<APIVersionModel> GetOrCreateVersionAsync(string reviewId, string packageVersion, int? pullRequestNo = null, string sourceBranch = null)
+    public async Task<APIVersionModel> GetOrCreateVersionAsync(string reviewId, string packageVersion, string language = null, int? pullRequestNo = null, string sourceBranch = null)
     {
         string versionIdentifier;
         VersionKind kind;
@@ -30,7 +30,7 @@ public class APIVersionsManager : IAPIVersionsManager
         }
         else
         {
-            (versionIdentifier, kind) = VersionNormalizationHelper.NormalizeVersion(packageVersion);
+            (versionIdentifier, kind) = VersionNormalizationHelper.NormalizeVersion(packageVersion, language);
         }
 
         APIVersionModel existing = await _versionsRepository.GetVersionByIdentifierAsync(reviewId, versionIdentifier, kind);

--- a/src/dotnet/APIView/APIViewWeb/Managers/AutoReviewService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/AutoReviewService.cs
@@ -71,7 +71,7 @@ public class AutoReviewService : IAutoReviewService
                 APIVersionModel incomingVersionModel = null;
                 if (!string.IsNullOrEmpty(codeFile.PackageVersion))
                 {
-                    incomingVersionModel = await _apiVersionsManager.GetOrCreateVersionAsync(review.Id, codeFile.PackageVersion);
+                    incomingVersionModel = await _apiVersionsManager.GetOrCreateVersionAsync(review.Id, codeFile.PackageVersion, codeFile.Language);
                 }
 
                 // Scope to automatic revisions for the same logical version as the incoming upload.

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIVersionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIVersionsManager.cs
@@ -7,7 +7,7 @@ namespace APIViewWeb.Managers.Interfaces;
 
 public interface IAPIVersionsManager
 {
-    Task<APIVersionModel> GetOrCreateVersionAsync(string reviewId, string packageVersion, int? pullRequestNo = null, string sourceBranch = null);
+    Task<APIVersionModel> GetOrCreateVersionAsync(string reviewId, string packageVersion, string language = null, int? pullRequestNo = null, string sourceBranch = null);
     Task<IEnumerable<APIVersionModel>> GetVersionsForReviewAsync(string reviewId);
     Task<APIVersionModel> GetVersionByIdAsync(string reviewId, string versionId);
     Task<APIVersionModel> GetVersionByIdentifierAsync(string reviewId, string versionIdentifier, VersionKind? kind = null);


### PR DESCRIPTION
followup from https://github.com/Azure/azure-sdk-tools/pull/14495 which enables pep440 python post-release formats (e.g. `1.0.0.post1` )

this PR updates a previously missed usage of semver within APIView - passes in language to `VersionNormalizationHelper.NormalizeVersion` so that semver can be parsed correctly in case of Python postreleases