### PR TITLE
Support test release plan dashboard using ADO items with test tag

### DIFF
--- a/tools/release-plan-dashboard/package-lock.json
+++ b/tools/release-plan-dashboard/package-lock.json
@@ -1617,18 +1617,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.19.0"
-      }
-    },
     "node_modules/@typespec/ts-http-runtime": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
@@ -4416,15 +4404,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",

--- a/tools/release-plan-dashboard/routes/api.js
+++ b/tools/release-plan-dashboard/routes/api.js
@@ -66,10 +66,16 @@ function hasGitHubToken() {
 
 /** Fetches all active release plans from Azure DevOps, enriches with GitHub data. */
 async function fetchAllReleasePlans() {
+  const environment = (process.env.ENVIRONMENT || "production").toLowerCase();
+  const tagCondition =
+    environment === "test"
+      ? "AND [System.Tags] CONTAINS 'Release Planner App Test'"
+      : "AND [System.Tags] NOT CONTAINS 'Release Planner App Test'";
+
   const wiqlQuery = `SELECT [System.Id] FROM WorkItems
     WHERE [System.TeamProject] = 'Release'
       AND [System.WorkItemType] = 'Release Plan'
-      AND [System.Tags] NOT CONTAINS 'Release Planner App Test'
+      ${tagCondition}
       AND (
         [System.State] IN ('In Progress','Not Started','New')
         OR ([System.State] = 'Finished' AND [System.ChangedDate] >= @Today - 60)


### PR DESCRIPTION
Support a test release plan dashboard to show all test release plans with `Release Planner App Test` tag in ADO. 