### PR TITLE
Added a pre-generate step to build plugin projects for .NET

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/SdkGenerationToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/SdkGenerationToolTests.cs
@@ -3,6 +3,7 @@
 using Moq;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models.Responses.TypeSpec;
+using Azure.Sdk.Tools.Cli.Services.Languages;
 using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 using Azure.Sdk.Tools.Cli.Tools.Package;
 
@@ -58,7 +59,8 @@ public class SdkGenerationToolTests
             _mockGitHelper.Object,
             _logger,
             _mockTspClientHelper.Object,
-            Mock.Of<IRawOutputHelper>()
+            Mock.Of<IRawOutputHelper>(),
+            Array.Empty<LanguageService>()
         );
     }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added pre-build step for the .NET plugin during SDK generation
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/DotnetLanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/DotnetLanguageService.cs
@@ -49,6 +49,49 @@ public sealed partial class DotnetLanguageService: LanguageService
     public override SdkLanguage Language { get; } = SdkLanguage.DotNet;
     public override bool IsCustomizedCodeUpdateSupported => true;
 
+    private const string PluginRelativePath = "eng/packages/plugins/client/Client.Plugin";
+    private static readonly TimeSpan PluginBuildTimeout = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Pre-builds the .NET emitter plugin so that pre-compiled DLLs are available in dist/
+    /// before tsp-client runs. This prevents GeneratorHandler from attempting to build the
+    /// plugin .csproj from a copied location where relative paths are broken.
+    /// </summary>
+    public override async Task PreGenerateAsync(string repoRoot, CancellationToken ct)
+    {
+        var pluginDir = Path.Combine(repoRoot, PluginRelativePath);
+        if (!Directory.Exists(pluginDir))
+        {
+            logger.LogWarning("Plugin directory not found at {PluginDir}, skipping pre-build", pluginDir);
+            return;
+        }
+
+        logger.LogInformation("Pre-building .NET plugin at {PluginDir}", pluginDir);
+        var options = new ProcessOptions(
+            DotNetCommand, ["build"],
+            workingDirectory: pluginDir,
+            timeout: PluginBuildTimeout);
+
+        try
+        {
+            var result = await processHelper.Run(options, ct);
+            if (result.ExitCode != 0)
+            {
+                logger.LogWarning(
+                    "Plugin pre-build failed (exit code {ExitCode}). Continuing — GeneratorHandler may attempt its own build.\n{Output}",
+                    result.ExitCode, result.Output);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Plugin pre-build failed. Continuing — GeneratorHandler may attempt its own build.");
+        }
+    }
+
     // .NET packages have their main csproj in a src/ subdirectory
     protected override string[] PackageManifestPatterns => ["*.csproj"];
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/LanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/LanguageService.cs
@@ -399,6 +399,20 @@ namespace Azure.Sdk.Tools.Cli.Services.Languages
         }
 
         /// <summary>
+        /// Performs language-specific pre-generation steps (e.g., pre-building plugins).
+        /// Called before tools run code generation.
+        /// The default implementation is a no-op. Override in language-specific subclasses as needed.
+        /// As of now, only the .NET language service overrides this to pre-build its generator plugin.
+        /// Implementations should warn and continue on failure rather than throwing.
+        /// </summary>
+        /// <param name="repoRoot">Absolute path to the SDK repository root.</param>
+        /// <param name="ct">Cancellation token.</param>
+        public virtual Task PreGenerateAsync(string repoRoot, CancellationToken ct)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
         /// Performs language-specific validation (build, compile, tests, lint, type-check, etc.).
         /// </summary>
         /// <param name="packagePath">Path to the package directory containing generated code.</param>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkGenerationTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkGenerationTool.cs
@@ -8,6 +8,7 @@ using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Models.Responses.Package;
 using Azure.Sdk.Tools.Cli.Models.Responses.TypeSpec;
+using Azure.Sdk.Tools.Cli.Services.Languages;
 using Azure.Sdk.Tools.Cli.Tools.Core;
 
 namespace Azure.Sdk.Tools.Cli.Tools.Package
@@ -17,8 +18,9 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
         IGitHelper gitHelper,
         ILogger<SdkGenerationTool> logger,
         ITspClientHelper tspClientHelper,
-        IRawOutputHelper outputHelper
-    ) : MCPTool
+        IRawOutputHelper outputHelper,
+        IEnumerable<LanguageService> languageServices
+    ) : LanguageMcpTool(languageServices, gitHelper, logger)
     {
         public override CommandGroup[] CommandHierarchy { get; set; } = [SharedCommandGroups.Package];
 
@@ -111,6 +113,14 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
                     logger.LogInformation("TypeSpec Project Path from tsp-location.yaml: {TypeSpecProjectPath}", typeSpecProjectPath);
 
                     reporter.NextStep($"Discovered SDK repo '{sdkRepoName}', starting code re-generation");
+
+                    // Pre-build language-specific plugins before generation
+                    var languageService = await GetLanguageServiceAsync(tspLocationPath, ct);
+                    if (languageService != null)
+                    {
+                        var sdkRepoRoot = await gitHelper.DiscoverRepoRootAsync(tspLocationPath, ct);
+                        await languageService.PreGenerateAsync(sdkRepoRoot, ct);
+                    }
 
                     // Run tsp-client update using the existing tsp-location.yaml
                     TspToolResponse tspResult;
@@ -205,6 +215,13 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
             {
                 additionalArgs.Add("--emitter-options");
                 additionalArgs.Add(emitterOptions);
+            }
+
+            // Pre-build language-specific plugins before generation
+            var languageService = GetLanguageService(SdkLanguageHelpers.GetLanguageForRepo(sdkRepoName));
+            if (languageService != null)
+            {
+                await languageService.PreGenerateAsync(sdkRepoRoot, ct);
             }
 
             // Use the helper to initialize generation

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkGenerationTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkGenerationTool.cs
@@ -16,11 +16,11 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
     [McpServerToolType, Description("This type contains the tools to generate SDK code locally.")]
     public class SdkGenerationTool(
         IGitHelper gitHelper,
-        ILogger<SdkGenerationTool> logger,
+        ILogger<SdkGenerationTool> sdkGenLogger,
         ITspClientHelper tspClientHelper,
         IRawOutputHelper outputHelper,
         IEnumerable<LanguageService> languageServices
-    ) : LanguageMcpTool(languageServices, gitHelper, logger)
+    ) : LanguageMcpTool(languageServices, gitHelper, sdkGenLogger)
     {
         public override CommandGroup[] CommandHierarchy { get; set; } = [SharedCommandGroups.Package];
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/CustomizedCodeUpdateTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/CustomizedCodeUpdateTool.cs
@@ -348,6 +348,8 @@ public class CustomizedCodeUpdateTool : LanguageMcpTool
         if (tspFixSucceeded > 0)
         {
             logger.LogDebug("Regenerating {packagePath}", packagePath);
+            var repoRoot = await gitHelper.DiscoverRepoRootAsync(packagePath, ct);
+            await languageService.PreGenerateAsync(repoRoot, ct);
             var regenResult = await tspClientHelper.UpdateGenerationAsync(packagePath, localSpecRepoPath: tspProjectPath, isCli: false, ct: ct);
             if (!regenResult.IsSuccessful)
             {


### PR DESCRIPTION
Resolved https://github.com/Azure/azure-sdk-tools/issues/15443

This pull request adds support for language-specific pre-generation steps in the SDK generation workflow, with an initial implementation for .NET that pre-builds its emitter plugin before code generation. The changes ensure that any required language-specific setup (such as building plugins) is performed automatically before running code generation tools, improving reliability and reducing manual intervention.

**Language pre-generation support:**

* Introduced a new virtual method `PreGenerateAsync` in `LanguageService` for performing language-specific pre-generation steps before code generation; the default implementation is a no-op, and only .NET overrides it for now.
* Updated `SdkGenerationTool` and related workflows to invoke `PreGenerateAsync` for the appropriate language service before running code generation, both when generating from a TypeSpec location and from a TypeSpec config. 

**.NET plugin pre-build implementation:**

* Implemented `PreGenerateAsync` in `DotnetLanguageService` to pre-build the .NET emitter plugin (`Client.Plugin`) before code generation, preventing issues with relative paths and build failures during code generation. The method logs warnings and continues on failure to avoid blocking the workflow.
