### PR TITLE
Sync skill content from .github/skills to plugins

### DIFF
--- a/plugins/azure-sdk-tools/skills/apiview-feedback-resolution/SKILL.md
+++ b/plugins/azure-sdk-tools/skills/apiview-feedback-resolution/SKILL.md
@@ -5,8 +5,7 @@ metadata:
   version: "1.0.0"
   distribution: shared
 description: "Analyze and resolve APIView review feedback on Azure SDK PRs. **UTILITY SKILL**. USE FOR: APIView comments, API review feedback, SDK API surface changes. DO NOT USE FOR: general code review, non-APIView feedback. INVOKES: azure-sdk-mcp:azsdk_apiview_get_comments, azure-sdk-mcp:azsdk_typespec_customized_code_update."
-compatibility:
-  requires: "azure-sdk-mcp server, SDK pull request with APIView review link"
+compatibility: "azure-sdk-mcp server, SDK pull request with APIView review link"
 ---
 
 # APIView Feedback Resolution

--- a/plugins/azure-sdk-tools/skills/azure-typespec-author/SKILL.md
+++ b/plugins/azure-sdk-tools/skills/azure-typespec-author/SKILL.md
@@ -4,8 +4,7 @@ license: MIT
 metadata:
   version: "1.0.0"
 description: "Authors and modifies Azure TypeSpec (.tsp) API specifications. USE FOR: any TypeSpec/tsp change — api versions (add, bump, preview, stable, promote), resources, operations, models, properties, decorators, visibility, constraints, breaking changes, LRO, suppressions, operationId, spread model. Covers ARM resource-manager and data-plane services. DO NOT USE FOR: SDK generation, releasing SDK packages, or single MCP tool calls. INVOKES: azure-sdk-mcp:azsdk_typespec_generate_authoring_plan, azure-sdk-mcp:azsdk_run_typespec_validation."
-compatibility:
-  requires: "azure-sdk-mcp server with azsdk_typespec_generate_authoring_plan and azsdk_run_typespec_validation tools"
+compatibility: "azure-sdk-mcp server with azsdk_typespec_generate_authoring_plan and azsdk_run_typespec_validation tools"
 ---
 
 # Azure TypeSpec Author

--- a/plugins/azure-sdk-tools/skills/generate-sdk-locally/SKILL.md
+++ b/plugins/azure-sdk-tools/skills/generate-sdk-locally/SKILL.md
@@ -5,8 +5,7 @@ metadata:
   version: "1.1.0"
   distribution: shared
 description: "Generate, build, and test Azure SDKs locally from TypeSpec with automatic customization. WHEN: \"generate SDK locally\", \"build SDK\", \"run SDK tests\", \"update changelog\", \"fix SDK build errors\", \"fix breaking changes\", \"resolve SDK generation errors\", \"customize TypeSpec\", \"rename SDK client\", \"rename SDK model\", \"hide operation from SDK\", \"fix analyzer errors\", \"resolve customization drift\", \"create subclient\", \"update metadata\", \"update version\". DO NOT USE FOR: publishing to package registries, CI pipeline configuration, API design review. INVOKES: azsdk_verify_setup, azsdk_package_generate_code, azsdk_package_build_code, azsdk_package_run_check, azsdk_package_run_tests, azsdk_customized_code_update, azsdk_package_update_changelog_content, azsdk_package_update_metadata, azsdk_package_update_version."
-compatibility:
-  requires: "azure-sdk-mcp server, local azure-sdk-for-{language} clone, language build tools"
+compatibility: "azure-sdk-mcp server, local azure-sdk-for-{language} clone, language build tools"
 ---
 
 # Generate SDK Locally

--- a/plugins/azure-sdk-tools/skills/live-and-recorded-tests/SKILL.md
+++ b/plugins/azure-sdk-tools/skills/live-and-recorded-tests/SKILL.md
@@ -5,8 +5,7 @@ metadata:
   version: "0.1.0"
   distribution: shared
 description: "Deploy test resources and run Azure SDK tests in live, record, or playback mode. WHEN: \"run live tests\", \"run recorded tests\", \"deploy test resources\", \"record tests\", \"run tests in record mode\", \"clean up test resources\", \"run tests against live resources\". DO NOT USE FOR: writing new tests, authoring Bicep templates, playback-only test runs without resource deployment. INVOKES: azure-sdk-mcp:azsdk_package_run_tests."
-compatibility:
-  requires: "azure-sdk-mcp server, Azure PowerShell (Az module), local azure-sdk-for-{language} clone"
+compatibility: "azure-sdk-mcp server, Azure PowerShell (Az module), local azure-sdk-for-{language} clone"
 ---
 
 # Live and Recorded Tests

--- a/plugins/azure-sdk-tools/skills/markdown-token-optimizer/SKILL.md
+++ b/plugins/azure-sdk-tools/skills/markdown-token-optimizer/SKILL.md
@@ -5,8 +5,7 @@ license: MIT
 metadata:
   author: Microsoft
   version: "1.0.0"
-compatibility:
-  platforms: "copilot-chat"
+compatibility: "copilot-chat"
 ---
 
 # Markdown Token Optimizer

--- a/plugins/azure-sdk-tools/skills/pipeline-troubleshooting/SKILL.md
+++ b/plugins/azure-sdk-tools/skills/pipeline-troubleshooting/SKILL.md
@@ -5,8 +5,7 @@ metadata:
   version: "1.0.0"
   distribution: shared
 description: "Diagnose and resolve failures in Azure SDK CI and generation pipelines. **UTILITY SKILL**. USE FOR: \"pipeline failed\", \"build failure\", \"CI check failing\", \"SDK generation error\", \"reproduce pipeline locally\", \"debug SDK pipeline\". DO NOT USE FOR: local build issues without pipeline context, API design review, SDK publishing. INVOKES: azure-sdk-mcp:azsdk_analyze_pipeline, azure-sdk-mcp:azsdk_package_build_code, azure-sdk-mcp:azsdk_package_run_check."
-compatibility:
-  requires: "azure-sdk-mcp server, Azure DevOps pipeline build ID"
+compatibility: "azure-sdk-mcp server, Azure DevOps pipeline build ID"
 ---
 
 # Pipeline Troubleshooting

--- a/plugins/azure-sdk-tools/skills/prepare-release-plan/SKILL.md
+++ b/plugins/azure-sdk-tools/skills/prepare-release-plan/SKILL.md
@@ -5,8 +5,7 @@ metadata:
   version: "1.0.0"
   distribution: shared
 description: "Create and manage release plan work items for Azure SDK releases across languages. **UTILITY SKILL**. USE FOR: \"create release plan\", \"update release plan\", \"link SDK PR to plan\", \"namespace approval\", \"check release plan status\". DO NOT USE FOR: SDK code generation, pipeline troubleshooting, API review feedback. INVOKES: azure-sdk-mcp:azsdk_create_release_plan, azure-sdk-mcp:azsdk_get_release_plan, azure-sdk-mcp:azsdk_link_sdk_pull_request_to_release_plan."
-compatibility:
-  requires: "azure-sdk-mcp server, API spec PR, or TypeSpec project path"
+compatibility: "azure-sdk-mcp server, API spec PR, or TypeSpec project path"
 ---
 
 # Prepare Release Plan

--- a/plugins/azure-sdk-tools/skills/sdk-release/SKILL.md
+++ b/plugins/azure-sdk-tools/skills/sdk-release/SKILL.md
@@ -5,9 +5,7 @@ metadata:
   version: "1.0.0"
   distribution: shared
 description: "Check release readiness and trigger the release pipeline for Azure SDK packages. **UTILITY SKILL**. USE FOR: \"release SDK\", \"trigger release\", \"check release readiness\", \"release pipeline\", \"publish package\", \"ship SDK\". DO NOT USE FOR: SDK development, code generation, pipeline debugging, release plan creation. INVOKES: azure-sdk-mcp:azsdk_release_sdk."
-compatibility:
-  requires: "azure-sdk-mcp server, SDK package merged on release branch"
-  supports: ".NET, Java, JavaScript, Python, Go"
+compatibility: "azure-sdk-mcp server, SDK package merged on release branch. Supports .NET, Java, JavaScript, Python, Go"
 ---
 
 # SDK Release

--- a/plugins/azure-sdk-tools/skills/skill-authoring/SKILL.md
+++ b/plugins/azure-sdk-tools/skills/skill-authoring/SKILL.md
@@ -5,8 +5,7 @@ license: MIT
 metadata:
   author: Microsoft
   version: "1.0.0"
-compatibility:
-  platforms: "copilot-chat"
+compatibility: "copilot-chat"
 ---
 
 # Skill Authoring Guide


### PR DESCRIPTION
Copy SKILL.md and references/ from .github/skills to plugins/azure-sdk-tools/skills/ for 8 matching skills. Skipped azure-typespec-author due to large divergence.

Resolves #15685 