### PR TITLE
[APIView] Switch sandboxing pipelines to use POST endpoint - PART 2

### DIFF
--- a/eng/pipelines/apiview-review-gen-typespec.yml
+++ b/eng/pipelines/apiview-review-gen-typespec.yml
@@ -59,13 +59,16 @@ jobs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
       artifactName: 'apiview'
 
-  - task: Powershell@2
+  - task: AzurePowerShell@5
     displayName: 'Send Request to APIView to Update Token files'
     condition: succeededOrFailed()
     inputs:
-      pwsh: true
-      filePath: $(Build.SourcesDirectory)/eng/scripts/Apiview-Update-Generated-Review.ps1
-      arguments: >
+      azureSubscription: 'APIView prod deployment'
+      ScriptType: 'FilePath'
+      ScriptPath: $(Build.SourcesDirectory)/eng/scripts/Apiview-Update-Generated-Review.ps1
+      ScriptArguments: >
         -BuildId $(Build.BuildId)
         -MetadataFileName "typespec-metadata.json"
         -ApiviewUpdateUrl "$(APIViewURL)/review/UpdateApiReview"
+      azurePowerShellVersion: latestVersion
+      pwsh: true

--- a/eng/pipelines/templates/steps/apiview-review-gen.yml
+++ b/eng/pipelines/templates/steps/apiview-review-gen.yml
@@ -39,11 +39,14 @@ steps:
     pathtoPublish: '$(Build.ArtifactStagingDirectory)/'
     artifactName: 'apiview'
 
-- task: Powershell@2
+- task: AzurePowerShell@5
   displayName: 'Send Request to APIView to Update Token files'
   inputs:
-    pwsh: true
-    filePath: $(Build.SourcesDirectory)/eng/scripts/Apiview-Update-Generated-Review.ps1
-    arguments: >
+    azureSubscription: 'APIView prod deployment'
+    ScriptType: 'FilePath'
+    ScriptPath: $(Build.SourcesDirectory)/eng/scripts/Apiview-Update-Generated-Review.ps1
+    ScriptArguments: >
       -BuildId $(Build.BuildId)
       -ApiviewUpdateUrl "${{ parameters.APIViewURL}}/review/UpdateApiReview"
+    azurePowerShellVersion: latestVersion
+    pwsh: true

--- a/eng/scripts/Apiview-Update-Generated-Review.ps1
+++ b/eng/scripts/Apiview-Update-Generated-Review.ps1
@@ -11,29 +11,58 @@ param (
 ####################################################################################################################
 
 # This script is called by tools - generate-<Language>-apireview pipelines to send a request to APIView server to
-# to notify that generated code file is ready and published. APIView server pulls this code file from artifact and 
+# to notify that generated code file is ready and published. APIView server pulls this code file from artifact and
 # uploads into APIView. This offline step abstracts and protects APIView server resources so caller doesn't have to
 # know about APIView server. Pipline will publish an artifact 'apiview' before this script is called
 
-# Script will send a request to APIView with build ID, artifact name and repo name as params.
-# Sample request is as follows:
-# https://apistaging.test.dev/review/UpdateApiReview?repoName=azure/azure-sdk-tools&buildId=1742433&artifact=apiview
+# Script will send an authenticated POST request to APIView with build ID, artifact name and repo name.
+# Requires an AzurePowerShell@5 context with a service connection authorized for APIView so that
+# `Get-AzAccessToken -ResourceUrl api://apiview` can mint a bearer token.
+# Sample request:
+# POST https://apiview.dev/review/UpdateApiReview
+# Body: { "repoName": "azure/azure-sdk-tools", "buildId": "1742433", "artifactName": "apiview" }
 
 ####################################################################################################################
 
-$uri = $ApiviewUpdateUrl + "?artifact=" + $ArtifactName + "&buildId=" + $BuildId + "&repoName=" + $repoName
-if ($MetadataFileName) {
-    $encodedMetadataFileName = [Uri]::EscapeDataString($MetadataFileName)
-    $uri = $uri + "&metadataFile=" + $encodedMetadataFileName
+# Acquire Entra ID bearer token for APIView (resource = api://apiview)
+try {
+    $tokenResponse = Get-AzAccessToken -ResourceUrl "api://apiview" -ErrorAction Stop
 }
-Write-Host "Request URI: $($uri)"
+catch {
+    Write-Error "Failed to acquire access token for APIView (resource: api://apiview): $($_.Exception.Message)"
+    exit 1
+}
+$token = $tokenResponse.Token
+if (-not $token) {
+    Write-Error "Failed to acquire access token for APIView (resource: api://apiview)"
+    exit 1
+}
+
+$body = @{
+    repoName     = $RepoName
+    artifactName = $ArtifactName
+    buildId      = $BuildId
+    project      = "internal"
+}
+if ($MetadataFileName) {
+    $body.metadataFile = $MetadataFileName
+}
+
+$headers = @{
+    Authorization  = "Bearer $token"
+    "Content-Type" = "application/json"
+}
+
+$jsonBody = $body | ConvertTo-Json -Compress
+Write-Host "Request URL: $ApiviewUpdateUrl"
+Write-Host "Request body: $jsonBody"
 try
 {
-    $Response = Invoke-WebRequest -Method 'GET' $uri -MaximumRetryCount 3
+    $Response = Invoke-WebRequest -Method 'POST' -Uri $ApiviewUpdateUrl -Headers $headers -Body $jsonBody -MaximumRetryCount 3
     Write-Host "Response status : $($Response.StatusCode)"
 }
 catch
 {
-    Write-Host "Error $StatusCode - Exception details: $($_.Exception.Response)"
+    Write-Host "Error - Exception details: $($_.Exception.Response)"
     exit 1
 }


### PR DESCRIPTION
Follow-up to:
https://github.com/Azure/azure-sdk-tools/pull/15684

This switches the sandboxing pipelines to use the authenticated update endpoint. 
