### PR TITLE
Create release plan tool changes to support private preview release plan

### DIFF
--- a/.github/skills/azsdk-common-prepare-release-plan/SKILL.md
+++ b/.github/skills/azsdk-common-prepare-release-plan/SKILL.md
@@ -19,26 +19,35 @@ compatibility: "azure-sdk-mcp server, API spec PR, or TypeSpec project path"
 | `azure-sdk-mcp:azsdk_create_release_plan` | Create plan |
 | `azure-sdk-mcp:azsdk_get_release_plan` | Get details |
 | `azure-sdk-mcp:azsdk_get_release_plan_for_spec_pr` | Find by spec PR |
+| `azure-sdk-mcp:azsdk_update_release_plan` | Update plan fields |
 | `azure-sdk-mcp:azsdk_update_sdk_details_in_release_plan` | Update SDK info |
 | `azure-sdk-mcp:azsdk_link_sdk_pull_request_to_release_plan` | Link SDK PR |
 | `azure-sdk-mcp:azsdk_link_namespace_approval_issue` | Link namespace |
+| `azure-sdk-mcp:azsdk_update_api_spec_pull_request_in_release_plan` | Update spec PR |
 
 ## Steps
 
 1. **Prerequisites** — Check for API spec PR link or a TypeSpec project path; prompt if unavailable.
 2. **Check Existing** — Query by release plan number or spec PR link (do not query by work item ID).
-3. **Gather Info** — Collect Service Tree IDs, timeline. See [details](references/release-plan-details.md).
-4. **Create** — Run `azure-sdk-mcp:azsdk_create_release_plan`.
-5. **Namespace** — For mgmt plane first releases, link approval issue.
-6. **Link PRs** — Link SDK PRs to plan.
+3. **Gather Info** — Collect Service Tree IDs, timeline, and API release type. See [details](references/release-plan-details.md).
+4. **API Release Type** — Ask user for API release type: "Private Preview", "Public Preview", or "GA". This is required.
+5. **Validate Spec PR** — If spec PR is provided, validate it matches the API release type:
+   - Private Preview → must be in `azure-rest-api-specs-pr`
+   - Public Preview / GA → must be in `azure-rest-api-specs`
+6. **Create** — Run `azure-sdk-mcp:azsdk_create_release_plan` with `apiReleaseType` parameter. SDK release type defaults automatically (beta for preview, stable for GA).
+7. **Namespace** — For mgmt plane first releases, link approval issue.
+8. **Link PRs** — Link SDK PRs to plan.
 
 ## Examples
 
 - "Create a release plan for my spec PR"
 - "Create a release plan for my TypeSpec project"
+- "Create a private preview release plan"
+- "Create a GA release plan for my spec PR"
 - "Link my SDK PR to release plan"
 
 ## Troubleshooting
 
 - Requires `azure-sdk-mcp` server; no CLI fallback.
 - If creation fails, verify Service Tree IDs and the provided spec PR URL or TypeSpec project path.
+- If spec PR validation fails, check that the spec PR repo matches the API release type (private repo for Private Preview, public repo for Public Preview/GA).

--- a/.github/skills/azsdk-common-prepare-release-plan/references/release-plan-details.md
+++ b/.github/skills/azsdk-common-prepare-release-plan/references/release-plan-details.md
@@ -9,7 +9,17 @@ Collect these details (do not use temporary values):
 - **Service Tree ID**: GUID format - confirm with user
 - **Product Service Tree ID**: GUID format - confirm with user
 - **Expected Release Timeline**: "Month YYYY" format
-- **SDK Release Type**: "beta" (preview) or "stable" (GA)
+- **API Release Type** (required): One of "Private Preview", "Public Preview", or "GA"
+- **SDK Release Type** (optional): "beta" or "stable". Defaults to "beta" for Private Preview and Public Preview, "stable" for GA.
+
+## API Release Type and Spec PR Validation
+
+When creating or updating a release plan with a spec PR:
+
+- **Private Preview**: Spec PR must be in `azure-rest-api-specs-pr` (private repo). A public spec PR in `azure-rest-api-specs` is NOT allowed.
+- **Public Preview** or **GA**: Spec PR must be in `azure-rest-api-specs` (public repo). A private spec PR in `azure-rest-api-specs-pr` is NOT allowed.
+
+If user provides an invalid combination, inform them of the correct pairing.
 
 ## SDK Details Update
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
@@ -90,7 +90,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
                 {
                     { "System.Title", releasePlan.Title },
                     { "System.Description", releasePlan.Description },
-                    { "System.State", "New" }
+                    { "System.State", "New" },
+                    { "Custom.ReleasePlanId", 100 }
                 }
             };
             return Task.FromResult(workItem);
@@ -126,7 +127,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
             return Task.FromResult(releasePlan);
         }
 
-        Task<List<ReleasePlanWorkItem>> IDevOpsService.GetReleasePlansForProductAsync(string productTreeId, string sdkReleaseType, bool isTestReleasePlan, CancellationToken ct)
+        Task<List<ReleasePlanWorkItem>> IDevOpsService.GetReleasePlansForProductAsync(string productTreeId, string sdkReleaseType, bool isTestReleasePlan, string apiReleaseType, CancellationToken ct)
         {
             var releasePlans = new List<ReleasePlanWorkItem>();
             return Task.FromResult(releasePlans);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
@@ -70,7 +70,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         public async Task Test_Create_releasePlan_for_existing_product()
         {
             var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
-            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "beta", specPullRequestUrl: "https://github.com/Azure/azure-rest-api-specs/pull/35446", isTestReleasePlan: true);
+            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "GA", specPullRequestUrl: "https://github.com/Azure/azure-rest-api-specs/pull/35446", isTestReleasePlan: true);
             Assert.IsNotNull(releaseplan);
 
             //Verify service ID and product ID in response. It should have values from previous release plans.
@@ -82,17 +82,27 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         public async Task Test_Create_releasePlan_with_invalid_SDK_type()
         {
             var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
-            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "invalid-sdk-type", specPullRequestUrl: "https://github.com/Azure/azure-rest-api-specs/pull/35446", isTestReleasePlan: true);
+            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "GA", sdkReleaseType: "invalid-sdk-type", specPullRequestUrl: "https://github.com/Azure/azure-rest-api-specs/pull/35446", isTestReleasePlan: true);
             Assert.IsNotNull(releaseplan);
             Assert.IsNotNull(releaseplan.ResponseError);
             Assert.True(releaseplan.ResponseError.Contains("Invalid SDK release type"));
         }
 
         [Test]
+        public async Task Test_Create_releasePlan_with_invalid_api_release_type()
+        {
+            var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
+            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "invalid-type", specPullRequestUrl: "https://github.com/Azure/azure-rest-api-specs/pull/35446", isTestReleasePlan: true);
+            Assert.IsNotNull(releaseplan);
+            Assert.IsNotNull(releaseplan.ResponseError);
+            Assert.True(releaseplan.ResponseError.Contains("Invalid API release type"));
+        }
+
+        [Test]
         public async Task Test_Create_releasePlan_with_invalid_service_tree_id()
         {
             var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
-            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "beta", specPullRequestUrl: "https://github.com/Azure/azure-rest-api-specs/pull/35446", serviceTreeId: "InvalidServiceTreeId", isTestReleasePlan: true);
+            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "GA", specPullRequestUrl: "https://github.com/Azure/azure-rest-api-specs/pull/35446", serviceTreeId: "InvalidServiceTreeId", isTestReleasePlan: true);
             Assert.IsNotNull(releaseplan);
             Assert.IsNotNull(releaseplan.ResponseError);
             Assert.True(releaseplan.ResponseError.Contains("Service tree ID 'InvalidServiceTreeId' is not a valid GUID"));
@@ -102,7 +112,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         public async Task Test_Create_releasePlan_with_invalid_product_tree_id()
         {
             var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
-            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "beta", specPullRequestUrl: "https://github.com/Azure/azure-rest-api-specs/pull/35446", productTreeId: "InvalidProductTreeId", isTestReleasePlan: true);
+            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "GA", specPullRequestUrl: "https://github.com/Azure/azure-rest-api-specs/pull/35446", productTreeId: "InvalidProductTreeId", isTestReleasePlan: true);
             Assert.IsNotNull(releaseplan);
             Assert.IsNotNull(releaseplan.ResponseError);
             Assert.True(releaseplan.ResponseError.Contains("Product tree ID 'InvalidProductTreeId' is not a valid GUID"));
@@ -112,24 +122,23 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         public async Task Test_Create_releasePlan_with_invalid_pull_request_url()
         {
             var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
-            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "beta", specPullRequestUrl: "https://github.com/Azure/invalid-repo/pull/35446", isTestReleasePlan: true);
+            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "GA", specPullRequestUrl: "https://github.com/Azure/invalid-repo/pull/35446", isTestReleasePlan: true);
             Assert.IsNotNull(releaseplan);
             Assert.IsNotNull(releaseplan.ResponseError);
             Assert.True(releaseplan.ResponseError.Contains("Invalid spec pull request URL"));
         }
 
-        [TestCase("TypeSpecTestData/specification/testcontoso/Contoso.Management", "July 2025", "https://github.com/Azure/azure-rest-api-specs/pull/35446", "beta", "", "")]
-        [TestCase("TypeSpecTestData/specification/testcontoso/Contoso.Management", "July 2025", "https://github.com/Azure/azure-rest-api-specs/pull/35447", "stable", "", "")]
-        [TestCase("TypeSpecTestData/specification/testcontoso/Contoso.Management", "July 2025", "https://github.com/Azure/azure-rest-api-specs/pull/35448", "Preview", "", "")]
-        [TestCase("TypeSpecTestData/specification/testcontoso/Contoso.Management", "July 2025", "https://github.com/Azure/azure-rest-api-specs/pull/35449", "GA", "", "")]
-        [TestCase("https://github.com/Azure/azure-rest-api-specs/blob/main/specification/dell/Dell.Storage.Management", "January 2026", "https://github.com/Azure/azure-rest-api-specs/pull/39310", "stable", "12345678-1234-5678-9012-123456789012", "87654321-4321-8765-1234-210987654321")]
+        [TestCase("TypeSpecTestData/specification/testcontoso/Contoso.Management", "July 2025", "https://github.com/Azure/azure-rest-api-specs/pull/35446", "GA", "", "")]
+        [TestCase("TypeSpecTestData/specification/testcontoso/Contoso.Management", "July 2025", "https://github.com/Azure/azure-rest-api-specs/pull/35447", "Public Preview", "", "")]
+        [TestCase("TypeSpecTestData/specification/testcontoso/Contoso.Management", "July 2025", "https://github.com/Azure/azure-rest-api-specs-pr/pull/35448", "Private Preview", "", "")]
+        [TestCase("https://github.com/Azure/azure-rest-api-specs/blob/main/specification/dell/Dell.Storage.Management", "January 2026", "https://github.com/Azure/azure-rest-api-specs/pull/39310", "GA", "12345678-1234-5678-9012-123456789012", "87654321-4321-8765-1234-210987654321")]
         [Test]
-        public async Task Test_Create_releasePlan_with_valid_inputs(string typeSpecPath, string targetMonth, string prUrl, string sdkType, string serviceId, string productId)
+        public async Task Test_Create_releasePlan_with_valid_inputs(string typeSpecPath, string targetMonth, string prUrl, string apiType, string serviceId, string productId)
         {
             var result = await releasePlanTool.CreateReleasePlan(
                 typeSpecPath, 
                 targetMonth,
-                sdkType,
+                apiType,
                 specPullRequestUrl: prUrl,
                 serviceTreeId: serviceId,
                 productTreeId: productId,
@@ -167,7 +176,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             var releaseplan = await testReleasePlanTool.CreateReleasePlan(
                 testCodeFilePath,
                 "July 2025",
-                "beta",
+                "GA",
                 specPullRequestUrl: "https://github.com/Azure/azure-rest-api-specs/pull/35446",
                 isTestReleasePlan: false); // This should be overridden to true by environment variable
 
@@ -207,7 +216,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             var releaseplan = await testReleasePlanTool.CreateReleasePlan(
                 testCodeFilePath,
                 "July 2025",
-                "beta",
+                "GA",
                 specPullRequestUrl: "https://github.com/Azure/azure-rest-api-specs/pull/35446",
                 isTestReleasePlan: false);
 
@@ -242,14 +251,77 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         }
 
         [Test]
-        public async Task Test_Create_releasePlan_rejects_azure_rest_api_specs_pr_repo()
+        public async Task Test_Create_releasePlan_private_preview_accepts_azure_rest_api_specs_pr_repo()
         {
             var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
-            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "beta", specPullRequestUrl: "https://github.com/Azure/azure-rest-api-specs-pr/pull/35446", isTestReleasePlan: true);
+            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "Private Preview", specPullRequestUrl: "https://github.com/Azure/azure-rest-api-specs-pr/pull/35446", isTestReleasePlan: true);
+            Assert.IsNotNull(releaseplan);
+            Assert.IsNull(releaseplan.ResponseError, $"Unexpected error: {releaseplan.ResponseError}");
+            Assert.IsNotNull(releaseplan.ReleasePlanDetails);
+        }
+
+        [Test]
+        public async Task Test_Create_releasePlan_private_preview_rejects_public_spec_pr()
+        {
+            var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
+            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "Private Preview", specPullRequestUrl: "https://github.com/Azure/azure-rest-api-specs/pull/35446", isTestReleasePlan: true);
             Assert.IsNotNull(releaseplan);
             Assert.IsNotNull(releaseplan.ResponseError);
-            Assert.True(releaseplan.ResponseError.Contains("Invalid spec pull request URL"));
-            Assert.True(releaseplan.ResponseError.Contains("azure-rest-api-specs repo"));
+            Assert.True(releaseplan.ResponseError.Contains("cannot be linked to a Private Preview release plan"));
+        }
+
+        [Test]
+        public async Task Test_Create_releasePlan_public_preview_rejects_private_spec_pr()
+        {
+            var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
+            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "Public Preview", specPullRequestUrl: "https://github.com/Azure/azure-rest-api-specs-pr/pull/35446", isTestReleasePlan: true);
+            Assert.IsNotNull(releaseplan);
+            Assert.IsNotNull(releaseplan.ResponseError);
+            Assert.True(releaseplan.ResponseError.Contains("cannot be linked to a Public Preview or GA release plan"));
+        }
+
+        [Test]
+        public async Task Test_Create_releasePlan_ga_rejects_private_spec_pr()
+        {
+            var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
+            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "GA", specPullRequestUrl: "https://github.com/Azure/azure-rest-api-specs-pr/pull/35446", isTestReleasePlan: true);
+            Assert.IsNotNull(releaseplan);
+            Assert.IsNotNull(releaseplan.ResponseError);
+            Assert.True(releaseplan.ResponseError.Contains("cannot be linked to a Public Preview or GA release plan"));
+        }
+
+        [Test]
+        public async Task Test_Create_releasePlan_spec_pr_validation_is_case_insensitive()
+        {
+            var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
+            // Use uppercase URL - should still work
+            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "Private Preview", specPullRequestUrl: "https://github.com/Azure/Azure-Rest-Api-Specs-PR/pull/35446", isTestReleasePlan: true);
+            Assert.IsNotNull(releaseplan);
+            Assert.IsNull(releaseplan.ResponseError, $"Unexpected error: {releaseplan.ResponseError}");
+        }
+
+        [Test]
+        public async Task Test_Create_releasePlan_defaults_sdk_type_to_beta_for_preview()
+        {
+            var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
+            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "Public Preview", specPullRequestUrl: "https://github.com/Azure/azure-rest-api-specs/pull/35446", isTestReleasePlan: true);
+            Assert.IsNotNull(releaseplan);
+            Assert.IsNull(releaseplan.ResponseError, $"Unexpected error: {releaseplan.ResponseError}");
+            var details = releaseplan.ReleasePlanDetails as ReleasePlanWorkItem;
+            Assert.IsNotNull(details);
+            Assert.That(details.SDKReleaseType, Is.EqualTo("beta"));
+        }
+
+        [Test]
+        public async Task Test_Create_releasePlan_defaults_sdk_type_to_stable_for_ga()
+        {
+            var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
+            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "GA", specPullRequestUrl: "https://github.com/Azure/azure-rest-api-specs/pull/35446", isTestReleasePlan: true);
+            Assert.IsNotNull(releaseplan);
+            Assert.IsNull(releaseplan.ResponseError, $"Unexpected error: {releaseplan.ResponseError}");
+            var details = releaseplan.ReleasePlanDetails as ReleasePlanWorkItem;
+            Assert.IsNotNull(details);
+            Assert.That(details.SDKReleaseType, Is.EqualTo("stable"));
         }
 
         [Test]
@@ -259,7 +331,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             var releaseplan = await releasePlanTool.CreateReleasePlan(
                 testCodeFilePath,
                 "July 2025",
-                "beta",
+                "GA",
                 serviceTreeId: "87654321-4321-8765-1234-210987654321",
                 productTreeId: "12345678-1234-5678-9012-123456789012",
                 isTestReleasePlan: true);
@@ -277,7 +349,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             var releaseplan = await releasePlanTool.CreateReleasePlan(
                 testCodeFilePath,
                 "July 2025",
-                "beta",
+                "GA",
                 isTestReleasePlan: true);
             Assert.IsNotNull(releaseplan);
             Assert.IsNotNull(releaseplan.ResponseError);
@@ -291,7 +363,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             var releaseplan = await releasePlanTool.CreateReleasePlan(
                 testCodeFilePath,
                 "July 2025",
-                "beta",
+                "GA",
                 serviceTreeId: "87654321-4321-8765-1234-210987654321",
                 productTreeId: "12345678-1234-5678-9012-123456789012",
                 isTestReleasePlan: true);
@@ -303,13 +375,13 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         }
 
         [Test]
-        public async Task Test_Get_Release_Plan_For_Pull_Request_rejects_azure_rest_api_specs_pr_repo()
+        public async Task Test_Get_Release_Plan_For_Pull_Request_accepts_azure_rest_api_specs_pr_repo()
         {
             var releaseplan = await releasePlanTool.GetReleasePlanForPullRequest("https://github.com/Azure/azure-rest-api-specs-pr/pull/35446");
             Assert.IsNotNull(releaseplan);
-            Assert.IsNotNull(releaseplan.ResponseError);
-            Assert.True(releaseplan.ResponseError.Contains("Failed to get release plan details"));
-            Assert.True(releaseplan.ResponseError.Contains("Invalid spec pull request URL"));
+            // The PR URL is now valid; the mock returns a release plan with WorkItemId=0 for any PR URL
+            // so GetReleasePlanForPullRequest should still succeed without error
+            Assert.IsNull(releaseplan.ResponseError);
         }
 
         [Test]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -5,8 +5,16 @@
 ### Features Added
 
 - Added pre-build step for the .NET plugin during SDK generation
+- Added `apiReleaseType` required parameter to `CreateReleasePlan` (options: Private Preview, Public Preview, GA) to set `Custom.ReleasePlanType` in ADO work items.
+- Spec PR validation against release type: Private Preview requires `azure-rest-api-specs-pr`; Public Preview/GA requires `azure-rest-api-specs`.
+- SDK release type now defaults automatically (beta for preview, stable for GA) when not provided.
+- Duplicate release plan check now considers API release type, allowing separate plans for different release stages.
+- Release plan title format updated to include release type (e.g., "Private Preview release plan for Contoso.Management").
 
 ### Breaking Changes
+
+- Removed `userEmail` parameter from `CreateReleasePlan`; email is resolved automatically.
+- `sdkReleaseType` parameter in `CreateReleasePlan` is now optional (was required).
 
 ### Bugs Fixed
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -16,10 +16,6 @@
 - Removed `userEmail` parameter from `CreateReleasePlan`; email is resolved automatically.
 - `sdkReleaseType` parameter in `CreateReleasePlan` is now optional (was required).
 
-### Bugs Fixed
-
-### Other Changes
-
 ## 0.6.13 (2026-05-18)
 
 ### Features Added

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.6.14 (Unreleased)
+## 0.6.14 (2026-05-27)
 
 ### Features Added
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ApiReleaseType.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ApiReleaseType.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Sdk.Tools.Cli.Models;
+
+public enum ApiReleaseType
+{
+    Unknown,
+    PrivatePreview,
+    PublicPreview,
+    GA
+}
+
+public static class ApiReleaseTypeExtensions
+{
+    private const string AdoPrivatePreview = "APEX Private Preview";
+    private const string AdoPublicPreview = "APEX Public Preview";
+    private const string AdoGA = "GA";
+
+    /// <summary>
+    /// Converts a user-supplied string to an ApiReleaseType enum value (case-insensitive).
+    /// </summary>
+    public static bool TryParseFromUserInput(string? input, out ApiReleaseType result)
+    {
+        result = ApiReleaseType.Unknown;
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return false;
+        }
+
+        var trimmed = input.Trim();
+        if (trimmed.Equals("Private Preview", StringComparison.OrdinalIgnoreCase))
+        {
+            result = ApiReleaseType.PrivatePreview;
+        }
+        if (trimmed.Equals("Public Preview", StringComparison.OrdinalIgnoreCase))
+        {
+            result = ApiReleaseType.PublicPreview;
+        }
+        if (trimmed.Equals("GA", StringComparison.OrdinalIgnoreCase))
+        {
+            result = ApiReleaseType.GA;
+        }
+        return result != ApiReleaseType.Unknown;
+    }
+
+    /// <summary>
+    /// Converts an ADO work item field value to an ApiReleaseType enum value.
+    /// </summary>
+    public static ApiReleaseType FromAdoFieldValue(string? adoValue)
+    {
+        if (string.IsNullOrWhiteSpace(adoValue))
+        {
+            return ApiReleaseType.Unknown;
+        }
+
+        if (adoValue.Equals(AdoPrivatePreview, StringComparison.OrdinalIgnoreCase))
+        {
+            return ApiReleaseType.PrivatePreview;
+        }
+
+        if (adoValue.Equals(AdoPublicPreview, StringComparison.OrdinalIgnoreCase))
+        {
+            return ApiReleaseType.PublicPreview;
+        }
+
+        if (adoValue.Equals(AdoGA, StringComparison.OrdinalIgnoreCase))
+        {
+            return ApiReleaseType.GA;
+        }
+
+        return ApiReleaseType.Unknown;
+    }
+
+    /// <summary>
+    /// Returns the ADO work item field value for this release type.
+    /// </summary>
+    public static string ToAdoFieldValue(this ApiReleaseType releaseType) => releaseType switch
+    {
+        ApiReleaseType.PrivatePreview => AdoPrivatePreview,
+        ApiReleaseType.PublicPreview => AdoPublicPreview,
+        ApiReleaseType.GA => AdoGA,
+        _ => string.Empty
+    };
+
+    /// <summary>
+    /// Returns a display-friendly label (used in titles, user messages).
+    /// </summary>
+    public static string ToDisplayLabel(this ApiReleaseType releaseType) => releaseType switch
+    {
+        ApiReleaseType.PrivatePreview => "Private Preview",
+        ApiReleaseType.PublicPreview => "Public Preview",
+        ApiReleaseType.GA => "GA",
+        _ => string.Empty
+    };
+
+    /// <summary>
+    /// Returns the default SDK release type for the given API release type.
+    /// </summary>
+    public static string GetDefaultSdkReleaseType(this ApiReleaseType releaseType) =>
+        releaseType == ApiReleaseType.GA ? "stable" : "beta";
+
+    /// <summary>
+    /// Validates whether a spec PR URL is compatible with this release type.
+    /// Returns null if valid, or an error message if invalid.
+    /// </summary>
+    public static string? ValidateSpecPullRequest(this ApiReleaseType releaseType, string specPullRequestUrl)
+    {
+        if (string.IsNullOrEmpty(specPullRequestUrl) || releaseType == ApiReleaseType.Unknown)
+        {
+            return null;
+        }
+
+        var isPrivateSpec = specPullRequestUrl.Contains("azure-rest-api-specs-pr", StringComparison.OrdinalIgnoreCase);
+
+        if (releaseType == ApiReleaseType.PrivatePreview && !isPrivateSpec)
+        {
+            return "A spec pull request in azure-rest-api-specs (public) cannot be linked to a Private Preview release plan. " +
+                   "Use a spec PR from azure-rest-api-specs-pr for Private Preview, or choose Public Preview or GA release type for a public spec PR.";
+        }
+
+        if ((releaseType == ApiReleaseType.PublicPreview || releaseType == ApiReleaseType.GA) && isPrivateSpec)
+        {
+            return "A spec pull request in azure-rest-api-specs-pr (private) cannot be linked to a Public Preview or GA release plan. " +
+                   "Use a spec PR from azure-rest-api-specs for Public Preview or GA, or choose Private Preview release type for a private spec PR.";
+        }
+
+        return null;
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ApiReleaseType.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ApiReleaseType.cs
@@ -33,11 +33,11 @@ public static class ApiReleaseTypeExtensions
         {
             result = ApiReleaseType.PrivatePreview;
         }
-        if (trimmed.Equals("Public Preview", StringComparison.OrdinalIgnoreCase))
+        else if (trimmed.Equals("Public Preview", StringComparison.OrdinalIgnoreCase))
         {
             result = ApiReleaseType.PublicPreview;
         }
-        if (trimmed.Equals("GA", StringComparison.OrdinalIgnoreCase))
+        else if (trimmed.Equals("GA", StringComparison.OrdinalIgnoreCase))
         {
             result = ApiReleaseType.GA;
         }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AzureDevOps/ReleasePlanWorkItem.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AzureDevOps/ReleasePlanWorkItem.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using Azure.Sdk.Tools.Cli.Attributes;
+using Azure.Sdk.Tools.Cli.Models;
 using Microsoft.VisualStudio.Services.WebApi.Patch.Json;
 
 namespace Azure.Sdk.Tools.Cli.Models.AzureDevOps
@@ -74,6 +75,12 @@ namespace Azure.Sdk.Tools.Cli.Models.AzureDevOps
 
         [FieldName("Custom.ReleasePlanType")]
         public string ReleasePlanType { get; set; } = string.Empty;
+
+        public ApiReleaseType ApiReleaseType
+        {
+            get => ApiReleaseTypeExtensions.FromAdoFieldValue(ReleasePlanType);
+            set => ReleasePlanType = value.ToAdoFieldValue();
+        }
 
         public override Microsoft.VisualStudio.Services.WebApi.Patch.Json.JsonPatchDocument GetPatchDocument()
         {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AzureDevOps/ReleasePlanWorkItem.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AzureDevOps/ReleasePlanWorkItem.cs
@@ -72,6 +72,9 @@ namespace Azure.Sdk.Tools.Cli.Models.AzureDevOps
         [FieldName("Custom.ProductLifecycle")]
         public string ProductLifecycle { get; set; } = string.Empty;
 
+        [FieldName("Custom.ReleasePlanType")]
+        public string ReleasePlanType { get; set; } = string.Empty;
+
         public override Microsoft.VisualStudio.Services.WebApi.Patch.Json.JsonPatchDocument GetPatchDocument()
         {
             var jsonDocument = base.GetPatchDocument();

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -92,7 +92,7 @@ namespace Azure.Sdk.Tools.Cli.Services
         public Task<ReleasePlanWorkItem> GetReleasePlanAsync(int releasePlanId, CancellationToken ct);
         public Task<ReleasePlanWorkItem> GetReleasePlanForWorkItemAsync(int workItemId, CancellationToken ct);
         public Task<ReleasePlanWorkItem> GetReleasePlanAsync(string pullRequestUrl, CancellationToken ct);
-        public Task<List<ReleasePlanWorkItem>> GetReleasePlansForProductAsync(string productTreeId, string sdkReleaseType, bool isTestReleasePlan = false, CancellationToken ct = default);
+        public Task<List<ReleasePlanWorkItem>> GetReleasePlansForProductAsync(string productTreeId, string sdkReleaseType, bool isTestReleasePlan = false, string apiReleaseType = "", CancellationToken ct = default);
         public Task<List<ReleasePlanWorkItem>> GetReleasePlansForPackageAsync(string packageName, string language, bool isTestReleasePlan = false, CancellationToken ct = default);
         public Task<List<ReleasePlanWorkItem>> GetReleasePlansByProductAndLifecycleAsync(string productTreeId, string productLifecycle, bool isTestReleasePlan = false, CancellationToken ct = default);
         public Task<WorkItem> CreateReleasePlanWorkItemAsync(ReleasePlanWorkItem releasePlan, CancellationToken ct);
@@ -198,7 +198,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             return await MapWorkItemToReleasePlanAsync(releasePlanWorkItems[0], ct);
         }
 
-        public async Task<List<ReleasePlanWorkItem>> GetReleasePlansForProductAsync(string productTreeId, string sdkReleaseType, bool isTestReleasePlan = false, CancellationToken ct = default)
+        public async Task<List<ReleasePlanWorkItem>> GetReleasePlansForProductAsync(string productTreeId, string sdkReleaseType, bool isTestReleasePlan = false, string apiReleaseType = "", CancellationToken ct = default)
         {
             try
             {
@@ -206,6 +206,10 @@ namespace Azure.Sdk.Tools.Cli.Services
                 query += $" AND [System.Tags] {(isTestReleasePlan ? "CONTAINS" : "NOT CONTAINS")} '{RELEASE_PLANNER_APP_TEST}'";
                 query += $" AND [Custom.ProductServiceTreeID] = '{productTreeId}'";
                 query += $" AND [Custom.SDKtypetobereleased] = '{sdkReleaseType}'";
+                if (!string.IsNullOrEmpty(apiReleaseType))
+                {
+                    query += $" AND [Custom.ReleasePlanType] = '{apiReleaseType}'";
+                }
                 query += " AND [System.WorkItemType] = 'Release Plan'";
                 query += " AND [System.State] IN ('New','Not Started','In Progress')";
                 var releasePlanWorkItems = await FetchWorkItemsAsync(query, ct);
@@ -464,7 +468,15 @@ namespace Azure.Sdk.Tools.Cli.Services
             try
             {
                 // Create release plan work item
-                var releasePlanTitle = $"Release plan for {releasePlan.ProductName ?? releasePlan.ProductTreeId}";
+                var titleLabel = releasePlan.ReleasePlanType switch
+                {
+                    "APEX Private Preview" => "Private Preview",
+                    "APEX Public Preview" => "Public Preview",
+                    "GA" => "GA",
+                    _ => ""
+                };
+                var releasePlanTypeLabel = string.IsNullOrEmpty(titleLabel) ? "" : $"{titleLabel} ";
+                var releasePlanTitle = $"{releasePlanTypeLabel}release plan for {releasePlan.ProductName ?? releasePlan.ProductTreeId}";
                 logger.LogInformation("Creating release plan with title: {releasePlanTitle}", releasePlanTitle);
                 var releasePlanWorkItem = await CreateWorkItemAsync(releasePlan, "Release Plan", releasePlanTitle, ct: ct);
                 releasePlanWorkItemId = releasePlanWorkItem?.Id ?? 0;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -331,6 +331,7 @@ namespace Azure.Sdk.Tools.Cli.Services
                 APISpecProjectPath = workItem.Fields.TryGetValue("Custom.ApiSpecProjectPath", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 AttestationStatus = workItem.Fields.TryGetValue("Custom.AttestationStatus", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 ProductLifecycle = workItem.Fields.TryGetValue("Custom.ProductLifecycle", out value) ? value?.ToString() ?? string.Empty : string.Empty,
+                ReleasePlanType = workItem.Fields.TryGetValue("Custom.ReleasePlanType", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 Owner = workItem.Fields.TryGetValue("Custom.PrimaryPM", out value) ? value?.ToString() ?? string.Empty : string.Empty,
             };
 
@@ -468,13 +469,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             try
             {
                 // Create release plan work item
-                var titleLabel = releasePlan.ReleasePlanType switch
-                {
-                    "APEX Private Preview" => "Private Preview",
-                    "APEX Public Preview" => "Public Preview",
-                    "GA" => "GA",
-                    _ => ""
-                };
+                var titleLabel = releasePlan.ApiReleaseType.ToDisplayLabel();
                 var releasePlanTypeLabel = string.IsNullOrEmpty(titleLabel) ? "" : $"{titleLabel} ";
                 var releasePlanTitle = $"{releasePlanTypeLabel}release plan for {releasePlan.ProductName ?? releasePlan.ProductTreeId}";
                 logger.LogInformation("Creating release plan with title: {releasePlanTitle}", releasePlanTitle);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -231,7 +231,6 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             DefaultValueFactory = _ => false,
         };
 
-        private const string sdkBotEmail = "azuresdk@microsoft.com";
         private const string sdkApexEmail = "azsdkapex@microsoft.com";
         private static readonly string DEFAULT_BRANCH = "main";
         private static readonly string PUBLIC_SPECS_REPO = "azure-rest-api-specs";
@@ -619,10 +618,9 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 logger.LogInformation("Found release plan work item {WorkItemId} to update", releasePlan.WorkItemId);
 
                 // Validate spec PR against release type if both are available
-                var releasePlanType = releasePlan.ReleasePlanType;
-                if (!string.IsNullOrEmpty(specPullRequestUrl) && !string.IsNullOrEmpty(releasePlanType))
+                if (!string.IsNullOrEmpty(specPullRequestUrl) && releasePlan.ApiReleaseType != ApiReleaseType.Unknown)
                 {
-                    ValidateSpecPullRequestForReleaseType(specPullRequestUrl, releasePlanType);
+                    ValidateSpecPullRequestForReleaseType(specPullRequestUrl, releasePlan.ApiReleaseType);
                 }
 
                 // Update release plan fields
@@ -714,39 +712,16 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             }
         }
 
-        private static bool IsPrivateSpecPullRequest(string specPullRequestUrl)
+        private static void ValidateSpecPullRequestForReleaseType(string specPullRequestUrl, ApiReleaseType apiReleaseType)
         {
-            return specPullRequestUrl.Contains("azure-rest-api-specs-pr", StringComparison.OrdinalIgnoreCase);
-        }
-
-        private static void ValidateSpecPullRequestForReleaseType(string specPullRequestUrl, string apiReleaseType)
-        {
-            if (string.IsNullOrEmpty(specPullRequestUrl) || string.IsNullOrEmpty(apiReleaseType))
+            var error = apiReleaseType.ValidateSpecPullRequest(specPullRequestUrl);
+            if (error != null)
             {
-                return;
-            }
-
-            var isPrivateSpec = IsPrivateSpecPullRequest(specPullRequestUrl);
-
-            if (apiReleaseType == "APEX Private Preview" && !isPrivateSpec)
-            {
-                throw new Exception("A spec pull request in azure-rest-api-specs (public) cannot be linked to a Private Preview release plan. Use a spec PR from azure-rest-api-specs-pr for Private Preview, or choose Public Preview or GA release type for a public spec PR.");
-            }
-
-            if ((apiReleaseType == "APEX Public Preview" || apiReleaseType == "GA") && isPrivateSpec)
-            {
-                throw new Exception("A spec pull request in azure-rest-api-specs-pr (private) cannot be linked to a Public Preview or GA release plan. Use a spec PR from azure-rest-api-specs for Public Preview or GA, or choose Private Preview release type for a private spec PR.");
+                throw new Exception(error);
             }
         }
 
-        private static readonly Dictionary<string, string> ApiReleaseTypeMappings = new(StringComparer.OrdinalIgnoreCase)
-        {
-            { "private preview", "APEX Private Preview" },
-            { "public preview", "APEX Public Preview" },
-            { "ga", "GA" }
-        };
-
-        private async Task ValidateCreateReleasePlanInputAsync(string typeSpecProjectPath, string serviceTreeId, string productTreeId, string specPullRequestUrl, string sdkReleaseType, CancellationToken ct)
+        private async Task ValidateCreateReleasePlanInputAsync(string typeSpecProjectPath, string serviceTreeId, string productTreeId, string specPullRequestUrl, string sdkReleaseType, ApiReleaseType apiReleaseType, CancellationToken ct)
         {
             if (!string.IsNullOrEmpty(specPullRequestUrl))
             {
@@ -765,7 +740,8 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             }
 
             // Skip filesystem validation for URLs since GetSpecRepoRootPath expects local paths
-            if (!typeSpecHelper.IsUrl(typeSpecProjectPath))
+            // For Private Preview, allow private spec repos
+            if (!typeSpecHelper.IsUrl(typeSpecProjectPath) && apiReleaseType != ApiReleaseType.PrivatePreview)
             {
                 var repoRoot = typeSpecHelper.GetSpecRepoRootPath(typeSpecProjectPath);
 
@@ -776,6 +752,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                         SDK generation and release require the API specs pull request to be in the public azure-rest-api-specs repository.
                         Please create a pull request in the public Azure/azure-rest-api-specs repository to move your specs changes to public.
                         A release plan cannot be created for SDK generation using a pull request in a private repository.
+                        Use Private Preview API release type if you are working with a private spec repository.
                         """);
                 }
             }
@@ -797,7 +774,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             try
             {
                 // Validate and map API release type
-                if (!ApiReleaseTypeMappings.TryGetValue(apiReleaseType?.Trim() ?? "", out var mappedApiReleaseType))
+                if (!ApiReleaseTypeExtensions.TryParseFromUserInput(apiReleaseType, out var parsedApiReleaseType))
                 {
                     return new ReleasePlanResponse { ResponseError = $"Invalid API release type '{apiReleaseType}'. Supported values are: Private Preview, Public Preview, GA" };
                 }
@@ -805,7 +782,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 // Default SDK release type based on API release type if not provided
                 if (string.IsNullOrEmpty(sdkReleaseType))
                 {
-                    sdkReleaseType = mappedApiReleaseType == "GA" ? "stable" : "beta";
+                    sdkReleaseType = parsedApiReleaseType.GetDefaultSdkReleaseType();
                 }
                 else
                 {
@@ -821,10 +798,10 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     }
                 }
 
-                await ValidateCreateReleasePlanInputAsync(typeSpecProjectPath, serviceTreeId, productTreeId, specPullRequestUrl, sdkReleaseType, ct);
+                await ValidateCreateReleasePlanInputAsync(typeSpecProjectPath, serviceTreeId, productTreeId, specPullRequestUrl, sdkReleaseType, parsedApiReleaseType, ct);
 
                 // Validate spec PR against release type
-                ValidateSpecPullRequestForReleaseType(specPullRequestUrl, mappedApiReleaseType);
+                ValidateSpecPullRequestForReleaseType(specPullRequestUrl, parsedApiReleaseType);
 
                 // Handle both URLs and local paths for TypeSpec projects
                 bool isValidTypeSpec;
@@ -898,8 +875,8 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                         }
                     }
 
-                    logger.LogInformation("Checking for existing release plans for product: {productTreeId} with API release type: {apiReleaseType}", productTreeId, mappedApiReleaseType);
-                    var existingReleasePlans = await devOpsService.GetReleasePlansForProductAsync(productTreeId, sdkReleaseType, isTestReleasePlan, mappedApiReleaseType, ct);
+                    logger.LogInformation("Checking for existing release plans for product: {productTreeId} with API release type: {apiReleaseType}", productTreeId, parsedApiReleaseType.ToDisplayLabel());
+                    var existingReleasePlans = await devOpsService.GetReleasePlansForProductAsync(productTreeId, sdkReleaseType, isTestReleasePlan, parsedApiReleaseType.ToAdoFieldValue(), ct);
                     if (existingReleasePlans.Any())
                     {
                         return new ReleasePlanResponse
@@ -916,11 +893,6 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 logger.LogInformation("Attempting to retrieve current user email.");
 
                 var userEmail = await userHelper.GetUserEmail(ct);
-                if (userEmail == sdkBotEmail)
-                {
-                    throw new InvalidOperationException("Cannot create release plan using SDK bot email. Please provide a valid user email address.");
-                }
-
                 logger.LogInformation("User email for release plan submission: {userEmail}", userEmail);
 
                 var productDisplayName = Path.GetFileName(specProject);
@@ -939,7 +911,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     ReleasePlanSubmittedByEmail = userEmail,
                     APISpecProjectPath = specProject,
                     ProductName = productDisplayName,
-                    ReleasePlanType = mappedApiReleaseType
+                    ApiReleaseType = parsedApiReleaseType
                 };
                 var workItem = await devOpsService.CreateReleasePlanWorkItemAsync(releasePlan, ct);
                 if (workItem == null)
@@ -1633,9 +1605,9 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 }
 
                 // Validate spec PR against release type
-                if (releasePlan != null && !string.IsNullOrEmpty(releasePlan.ReleasePlanType))
+                if (releasePlan != null && releasePlan.ApiReleaseType != ApiReleaseType.Unknown)
                 {
-                    ValidateSpecPullRequestForReleaseType(specPullRequestUrl, releasePlan.ReleasePlanType);
+                    ValidateSpecPullRequestForReleaseType(specPullRequestUrl, releasePlan.ApiReleaseType);
                 }
 
                 // Update the spec pull request in the release plan

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -117,6 +117,12 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
         private readonly Option<string> sdkReleaseTypeOpt = new("--sdk-type")
         {
             Description = "SDK release type: beta or stable",
+            Required = false,
+        };
+
+        private readonly Option<string> apiReleaseTypeOpt = new("--api-release-type")
+        {
+            Description = "API release type: Private Preview, Public Preview, or GA",
             Required = true,
         };
 
@@ -125,12 +131,6 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             Description = "Create release plan in test environment",
             Required = false,
             DefaultValueFactory = _ => false,
-        };
-
-        private readonly Option<string> userEmailOpt = new("--user-email")
-        {
-            Description = "User email for release plan creation",
-            Required = false,
         };
 
         private readonly Option<string> namespaceApprovalIssueOpt = new("--namespace-approval-issue")
@@ -259,7 +259,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
         [GeneratedRegex("https:\\/\\/github.com\\/Azure\\/azure-sdk\\/issues\\/([0-9]+)")]
         private static partial Regex NameSpaceIssueUrlRegex();
 
-        [GeneratedRegex("https:\\/\\/github.com\\/Azure\\/azure-rest-api-specs\\/pull\\/[0-9]+\\/?")]
+        [GeneratedRegex("https:\\/\\/github.com\\/Azure\\/azure-rest-api-specs(-pr)?\\/pull\\/[0-9]+\\/?", RegexOptions.IgnoreCase)]
         private static partial Regex PullRequestUrlRegex();
 
         [GeneratedRegex(@"^\d{4}-\d{2}-\d{2}(-preview)?$")]
@@ -272,11 +272,11 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             {
                 typeSpecProjectPathOpt,
                 targetReleaseOpt,
+                apiReleaseTypeOpt,
                 serviceTreeIdOpt,
                 productTreeIdOpt,
                 optionalPullRequestOpt,
                 sdkReleaseTypeOpt,
-                userEmailOpt,
                 isTestReleasePlanOpt,
                 forceCreateReleasePlanOpt,
             },
@@ -319,17 +319,17 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     var productTreeId = commandParser.GetValue(productTreeIdOpt);
                     var specPullRequestUrl = commandParser.GetValue(optionalPullRequestOpt);
                     var sdkReleaseType = commandParser.GetValue(sdkReleaseTypeOpt);
+                    var apiReleaseType = commandParser.GetValue(apiReleaseTypeOpt);
                     var isTestReleasePlan = commandParser.GetValue(isTestReleasePlanOpt);
-                    var userEmail = commandParser.GetValue(userEmailOpt);
                     var forceCreateReleasePlan = commandParser.GetValue(forceCreateReleasePlanOpt);
                     return await CreateReleasePlan(
                         typeSpecProjectPath,
                         targetReleaseMonthYear,
-                        sdkReleaseType,
+                        apiReleaseType,
+                        sdkReleaseType: sdkReleaseType,
                         specPullRequestUrl: specPullRequestUrl,
                         serviceTreeId: serviceTreeId,
                         productTreeId: productTreeId,
-                        userEmail: userEmail,
                         isTestReleasePlan: isTestReleasePlan,
                         forceCreateReleasePlan: forceCreateReleasePlan,
                         ct: ct
@@ -618,6 +618,13 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
 
                 logger.LogInformation("Found release plan work item {WorkItemId} to update", releasePlan.WorkItemId);
 
+                // Validate spec PR against release type if both are available
+                var releasePlanType = releasePlan.ReleasePlanType;
+                if (!string.IsNullOrEmpty(specPullRequestUrl) && !string.IsNullOrEmpty(releasePlanType))
+                {
+                    ValidateSpecPullRequestForReleaseType(specPullRequestUrl, releasePlanType);
+                }
+
                 // Update release plan fields
                 var fieldsToUpdate = new Dictionary<string, string>
                 {
@@ -703,9 +710,41 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
 
             if (!match.Success)
             {
-                throw new Exception($"Invalid spec pull request URL '{specPullRequestUrl}'. It should be a valid GitHub pull request to azure-rest-api-specs repo.");
+                throw new Exception($"Invalid spec pull request URL '{specPullRequestUrl}'. It should be a valid GitHub pull request to azure-rest-api-specs or azure-rest-api-specs-pr repo.");
             }
         }
+
+        private static bool IsPrivateSpecPullRequest(string specPullRequestUrl)
+        {
+            return specPullRequestUrl.Contains("azure-rest-api-specs-pr", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static void ValidateSpecPullRequestForReleaseType(string specPullRequestUrl, string apiReleaseType)
+        {
+            if (string.IsNullOrEmpty(specPullRequestUrl) || string.IsNullOrEmpty(apiReleaseType))
+            {
+                return;
+            }
+
+            var isPrivateSpec = IsPrivateSpecPullRequest(specPullRequestUrl);
+
+            if (apiReleaseType == "APEX Private Preview" && !isPrivateSpec)
+            {
+                throw new Exception("A spec pull request in azure-rest-api-specs (public) cannot be linked to a Private Preview release plan. Use a spec PR from azure-rest-api-specs-pr for Private Preview, or choose Public Preview or GA release type for a public spec PR.");
+            }
+
+            if ((apiReleaseType == "APEX Public Preview" || apiReleaseType == "GA") && isPrivateSpec)
+            {
+                throw new Exception("A spec pull request in azure-rest-api-specs-pr (private) cannot be linked to a Public Preview or GA release plan. Use a spec PR from azure-rest-api-specs for Public Preview or GA, or choose Private Preview release type for a private spec PR.");
+            }
+        }
+
+        private static readonly Dictionary<string, string> ApiReleaseTypeMappings = new(StringComparer.OrdinalIgnoreCase)
+        {
+            { "private preview", "APEX Private Preview" },
+            { "public preview", "APEX Public Preview" },
+            { "ga", "GA" }
+        };
 
         private async Task ValidateCreateReleasePlanInputAsync(string typeSpecProjectPath, string serviceTreeId, string productTreeId, string specPullRequestUrl, string sdkReleaseType, CancellationToken ct)
         {
@@ -753,22 +792,39 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
         }
 
         [McpServerTool(Name = CreateReleasePlanToolName), Description("Create Release Plan for a TypeSpec project, service, product. Service ID and product Id are required if a previous release plan is not found for the TypeSpec project.")]
-        public async Task<ReleasePlanResponse> CreateReleasePlan(string typeSpecProjectPath, string targetReleaseMonthYear, string sdkReleaseType, string specPullRequestUrl = "", string serviceTreeId = "", string productTreeId = "", string userEmail = "", bool isTestReleasePlan = false, bool forceCreateReleasePlan = false, CancellationToken ct = default)
+        public async Task<ReleasePlanResponse> CreateReleasePlan(string typeSpecProjectPath, string targetReleaseMonthYear, string apiReleaseType, string sdkReleaseType = "", string specPullRequestUrl = "", string serviceTreeId = "", string productTreeId = "", bool isTestReleasePlan = false, bool forceCreateReleasePlan = false, CancellationToken ct = default)
         {
             try
             {
-                sdkReleaseType = sdkReleaseType?.ToLower() ?? "";
-                var sdkReleaseTypeMappings = new Dictionary<string, string>
+                // Validate and map API release type
+                if (!ApiReleaseTypeMappings.TryGetValue(apiReleaseType?.Trim() ?? "", out var mappedApiReleaseType))
                 {
-                    { "ga", "stable" },
-                    { "preview", "beta" }
-                };
-                if (sdkReleaseTypeMappings.TryGetValue(sdkReleaseType, out var mappedType))
+                    return new ReleasePlanResponse { ResponseError = $"Invalid API release type '{apiReleaseType}'. Supported values are: Private Preview, Public Preview, GA" };
+                }
+
+                // Default SDK release type based on API release type if not provided
+                if (string.IsNullOrEmpty(sdkReleaseType))
                 {
-                    sdkReleaseType = mappedType;
+                    sdkReleaseType = mappedApiReleaseType == "GA" ? "stable" : "beta";
+                }
+                else
+                {
+                    sdkReleaseType = sdkReleaseType.ToLower();
+                    var sdkReleaseTypeMappings = new Dictionary<string, string>
+                    {
+                        { "ga", "stable" },
+                        { "preview", "beta" }
+                    };
+                    if (sdkReleaseTypeMappings.TryGetValue(sdkReleaseType, out var mappedType))
+                    {
+                        sdkReleaseType = mappedType;
+                    }
                 }
 
                 await ValidateCreateReleasePlanInputAsync(typeSpecProjectPath, serviceTreeId, productTreeId, specPullRequestUrl, sdkReleaseType, ct);
+
+                // Validate spec PR against release type
+                ValidateSpecPullRequestForReleaseType(specPullRequestUrl, mappedApiReleaseType);
 
                 // Handle both URLs and local paths for TypeSpec projects
                 bool isValidTypeSpec;
@@ -842,8 +898,8 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                         }
                     }
 
-                    logger.LogInformation("Checking for existing release plans for product: {productTreeId}", productTreeId);
-                    var existingReleasePlans = await devOpsService.GetReleasePlansForProductAsync(productTreeId, sdkReleaseType, isTestReleasePlan, ct);
+                    logger.LogInformation("Checking for existing release plans for product: {productTreeId} with API release type: {apiReleaseType}", productTreeId, mappedApiReleaseType);
+                    var existingReleasePlans = await devOpsService.GetReleasePlansForProductAsync(productTreeId, sdkReleaseType, isTestReleasePlan, mappedApiReleaseType, ct);
                     if (existingReleasePlans.Any())
                     {
                         return new ReleasePlanResponse
@@ -859,19 +915,15 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 var specType = isValidTypeSpec ? "TypeSpec" : "OpenAPI";
                 logger.LogInformation("Attempting to retrieve current user email.");
 
-                var email = await userHelper.GetUserEmail(ct);
-                if (email != sdkBotEmail)
-                {
-                    userEmail = email;
-                    logger.LogInformation("Using current user email to submit release plan: {userEmail}", userEmail);
-                }
-                else if (string.IsNullOrEmpty(userEmail))
+                var userEmail = await userHelper.GetUserEmail(ct);
+                if (userEmail == sdkBotEmail)
                 {
                     throw new InvalidOperationException("Cannot create release plan using SDK bot email. Please provide a valid user email address.");
                 }
 
                 logger.LogInformation("User email for release plan submission: {userEmail}", userEmail);
 
+                var productDisplayName = Path.GetFileName(specProject);
                 var releasePlan = new ReleasePlanWorkItem
                 {
                     SDKReleaseMonth = targetReleaseMonthYear,
@@ -886,7 +938,8 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     IsCreatedByAgent = true,
                     ReleasePlanSubmittedByEmail = userEmail,
                     APISpecProjectPath = specProject,
-                    ProductName = Path.GetFileName(specProject)
+                    ProductName = productDisplayName,
+                    ReleasePlanType = mappedApiReleaseType
                 };
                 var workItem = await devOpsService.CreateReleasePlanWorkItemAsync(releasePlan, ct);
                 if (workItem == null)
@@ -1560,10 +1613,11 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 }
                 ValidatePullRequestUrl(specPullRequestUrl);
 
-                // Get work item ID from release plan ID if needed
-                if (workItemId == 0)
+                // Get the release plan to check its type
+                ReleasePlanWorkItem? releasePlan = null;
+                if (releasePlanId > 0)
                 {
-                    var releasePlan = await devOpsService.GetReleasePlanAsync(releasePlanId, ct);
+                    releasePlan = await devOpsService.GetReleasePlanAsync(releasePlanId, ct);
                     if (releasePlan == null)
                     {
                         return new ReleaseWorkflowResponse
@@ -1572,6 +1626,16 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                         };
                     }
                     workItemId = releasePlan.WorkItemId;
+                }
+                else
+                {
+                    releasePlan = await devOpsService.GetReleasePlanForWorkItemAsync(workItemId, ct);
+                }
+
+                // Validate spec PR against release type
+                if (releasePlan != null && !string.IsNullOrEmpty(releasePlan.ReleasePlanType))
+                {
+                    ValidateSpecPullRequestForReleaseType(specPullRequestUrl, releasePlan.ReleasePlanType);
                 }
 
                 // Update the spec pull request in the release plan


### PR DESCRIPTION
Create release plan tool takes API spec release type to support private preview release plan for those services still in private preview life cycle.