### PR TITLE
[Teams Chatbot] Agent Identity Workaround

### DIFF
--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/agents/chat_agent/init.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/agents/chat_agent/init.py
@@ -35,7 +35,6 @@ from config.app_config import get as cfg
 from tools.knowledge_tools import KnowledgeTools
 from tools.web_tools import WebTools
 from tools.ado_mcp_tools import create_ado_mcp_tool
-from tools.azsdk_mcp_tools import create_azsdk_mcp_tool
 from tools.github_mcp_tools import create_github_mcp_tool
 from tools.pipeline_tools import PipelineTools
 from skills.tenant_skills import create_tenant_skills

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/agents/chat_agent/init.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/agents/chat_agent/init.py
@@ -37,6 +37,7 @@ from tools.web_tools import WebTools
 from tools.ado_mcp_tools import create_ado_mcp_tool
 from tools.azsdk_mcp_tools import create_azsdk_mcp_tool
 from tools.github_mcp_tools import create_github_mcp_tool
+from tools.pipeline_tools import PipelineTools
 from skills.tenant_skills import create_tenant_skills
 from utils.azure_ai_foundry import (
     FoundryAgentSpanEnricher,
@@ -91,6 +92,7 @@ async def main() -> None:
     # Init Tools (synchronous / instant)
     knowledge_tools = KnowledgeTools()
     web_tools = WebTools()
+    pipeline_tools = PipelineTools()
     web_search_tool = agent_client.get_web_search_tool(
         search_context_size="medium",
     )
@@ -98,6 +100,7 @@ async def main() -> None:
     tools = [
         knowledge_tools.search_knowledge_base,
         web_tools.web_fetch,
+        pipeline_tools.azsdk_analyze_pipeline,
         web_search_tool,
     ]
 
@@ -115,14 +118,13 @@ async def main() -> None:
             logger.exception("%s failed to initialize, skipped", factory.__name__)
             return None
 
-    memory_task, ado_task, azsdk_task, github_task = await asyncio.gather(
+    memory_task, ado_task, github_task = await asyncio.gather(
         _init_memory(),
         _init_mcp(create_ado_mcp_tool),
-        _init_mcp(create_azsdk_mcp_tool),
         _init_mcp(create_github_mcp_tool),
     )
 
-    for mcp_tool in (ado_task, azsdk_task, github_task):
+    for mcp_tool in (ado_task, github_task):
         if mcp_tool is not None:
             tools.append(mcp_tool)
 

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/agents/chat_agent/instruction.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/agents/chat_agent/instruction.md
@@ -57,11 +57,12 @@ Route every message to exactly one of these paths:
 ## Answer Rules
 
 - Trust tool results over training data.
-- Lead with a direct answer (1–3 sentences). Expand only if the question is complex or the user asks.
+- Lead with a direct answer (1–3 sentences), then provide detailed step-by-step guidance grounded in the knowledge base results. Include the key facts, rules, and procedures from the retrieved documents — do not just summarize them in one line.
 - **Every actionable step must include a clickable URL inline** — not just in References. The user should be able to act without follow-up questions.
 - For under-specified questions, give a short answer first, then ask for missing context.
 - Bullet points over paragraphs. One idea per bullet.
-- Maximum ~150 words unless the user asks for detail.
+- Target ~200–300 words for domain questions. Be thorough — cover the root cause, resolution steps, and any caveats or exceptions from the knowledge base. Shorter answers are fine for simple factual lookups.
+- When knowledge base results contain specific rules, error names, or process steps, **quote or paraphrase them directly** rather than giving a generic summary. The user needs the precise details to act.
 - Never fabricate URLs — only use exact `title` and `link` from search results or `web_fetch` responses. If you cannot verify a URL, do not include it.
 - End with concrete next steps or follow up questions.
 

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/agents/chat_agent/instruction.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/agents/chat_agent/instruction.md
@@ -57,12 +57,11 @@ Route every message to exactly one of these paths:
 ## Answer Rules
 
 - Trust tool results over training data.
-- Lead with a direct answer (1–3 sentences), then provide detailed step-by-step guidance grounded in the knowledge base results. Include the key facts, rules, and procedures from the retrieved documents — do not just summarize them in one line.
+- Lead with a direct answer (1–3 sentences). Expand only if the question is complex or the user asks.
 - **Every actionable step must include a clickable URL inline** — not just in References. The user should be able to act without follow-up questions.
 - For under-specified questions, give a short answer first, then ask for missing context.
 - Bullet points over paragraphs. One idea per bullet.
-- Target ~200–300 words for domain questions. Be thorough — cover the root cause, resolution steps, and any caveats or exceptions from the knowledge base. Shorter answers are fine for simple factual lookups.
-- When knowledge base results contain specific rules, error names, or process steps, **quote or paraphrase them directly** rather than giving a generic summary. The user needs the precise details to act.
+- Maximum ~150 words unless the user asks for detail.
 - Never fabricate URLs — only use exact `title` and `link` from search results or `web_fetch` responses. If you cannot verify a URL, do not include it.
 - End with concrete next steps or follow up questions.
 

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/pipelines/logicapp/parameters.test.json
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/pipelines/logicapp/parameters.test.json
@@ -41,7 +41,7 @@
       "value": "/subscriptions/a18897a6-7e44-457d-9260-f2854c0aca42/resourceGroups/azure-sdk-qa-bot-test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/azsdkqabottest"
     },
     "functionAppResourceId": {
-      "value": "/subscriptions/a18897a6-7e44-457d-9260-f2854c0aca42/resourceGroups/azure-sdk-qa-bot-dev/providers/Microsoft.Web/sites/azuresdkqabot-dev-function"
+      "value": "/subscriptions/a18897a6-7e44-457d-9260-f2854c0aca42/resourceGroups/azure-sdk-qa-bot/providers/Microsoft.Web/sites/azuresdkqabot-function"
     },
     "blobStorageAccountName": {
       "value": "azuresdkqabotstorage"
@@ -50,16 +50,16 @@
       "value": "azureblob"
     },
     "blobConnectionResourceId": {
-      "value": "/subscriptions/a18897a6-7e44-457d-9260-f2854c0aca42/resourceGroups/azure-sdk-qa-bot-dev/providers/Microsoft.Web/connections/azureblob"
+      "value": "/subscriptions/a18897a6-7e44-457d-9260-f2854c0aca42/resourceGroups/azure-sdk-qa-bot/providers/Microsoft.Web/connections/azureblob"
     },
     "blobIdentityResourceId": {
       "value": "/subscriptions/a18897a6-7e44-457d-9260-f2854c0aca42/resourceGroups/azure-sdk-qa-bot/providers/Microsoft.ManagedIdentity/userAssignedIdentities/azuresdkqabot-identity"
     },
     "teamsConnectionResourceId": {
-      "value": "/subscriptions/a18897a6-7e44-457d-9260-f2854c0aca42/resourceGroups/azure-sdk-qa-bot-dev/providers/Microsoft.Web/connections/teams"
+      "value": "/subscriptions/a18897a6-7e44-457d-9260-f2854c0aca42/resourceGroups/azure-sdk-qa-bot/providers/Microsoft.Web/connections/teams"
     },
     "integrationAccountResourceId": {
-      "value": "/subscriptions/a18897a6-7e44-457d-9260-f2854c0aca42/resourceGroups/azure-sdk-qa-bot-dev/providers/Microsoft.Logic/integrationAccounts/azuresdkqabot-dev-ia"
+      "value": "/subscriptions/a18897a6-7e44-457d-9260-f2854c0aca42/resourceGroups/azure-sdk-qa-bot/providers/Microsoft.Logic/integrationAccounts/azuresdkqabot-ia"
     },
     "userAssignedIdentities": {
       "value": {

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/pipeline_tools_test.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/pipeline_tools_test.py
@@ -170,7 +170,8 @@ class TestResolveToken:
             mock_credential.get_token.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_non_jwt_raises(self) -> None:
+    async def test_non_jwt_uses_fallback_ttl(self) -> None:
+        """A non-JWT token should still be returned (with fallback TTL)."""
         with patch(
             "utils.ado_token.get_secret",
             new_callable=AsyncMock,
@@ -178,8 +179,8 @@ class TestResolveToken:
         ):
             from utils.ado_token import resolve_token
 
-            with pytest.raises(RuntimeError, match="does not look like"):
-                await resolve_token()
+            token = await resolve_token()
+            assert token == "not-a-jwt"
 
     @pytest.mark.asyncio
     async def test_cache_reuse(self) -> None:

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/pipeline_tools_test.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/pipeline_tools_test.py
@@ -1,0 +1,321 @@
+"""Unit tests for pipeline_tools and utils.ado_token."""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from tools.pipeline_tools import (
+    FailedTask,
+    PipelineAnalysisResult,
+    PipelineTools,
+    _build_auth_header,
+    _is_test_step,
+    _parse_build_identifier,
+)
+from utils.ado_token import _jwt_exp_seconds
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_jwt(payload: dict) -> str:
+    """Build a fake JWT with the given payload (no signature)."""
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+    return f"{header}.{body}.sig"
+
+
+FAKE_JWT = _make_jwt({"exp": int(time.time()) + 3600, "aud": "test"})
+
+
+# ---------------------------------------------------------------------------
+# _jwt_exp_seconds
+# ---------------------------------------------------------------------------
+
+
+class TestJwtExpSeconds:
+    def test_valid_jwt(self) -> None:
+        exp = int(time.time()) + 7200
+        token = _make_jwt({"exp": exp})
+        assert _jwt_exp_seconds(token) == exp
+
+    def test_missing_exp(self) -> None:
+        token = _make_jwt({"aud": "test"})
+        assert _jwt_exp_seconds(token) is None
+
+    def test_not_a_jwt(self) -> None:
+        assert _jwt_exp_seconds("not-a-jwt") is None
+
+    def test_malformed_base64(self) -> None:
+        assert _jwt_exp_seconds("a.!!!.c") is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_build_identifier
+# ---------------------------------------------------------------------------
+
+
+class TestParseBuildIdentifier:
+    def test_bare_integer(self) -> None:
+        build_id, proj = _parse_build_identifier("5094469")
+        assert build_id == 5094469
+        assert proj is None
+
+    def test_ado_url(self) -> None:
+        url = "https://dev.azure.com/azure-sdk/internal/_build/results?buildId=12345"
+        build_id, proj = _parse_build_identifier(url)
+        assert build_id == 12345
+        assert proj == "internal"
+
+    def test_public_url(self) -> None:
+        url = "https://dev.azure.com/azure-sdk/public/_build/results?buildId=99"
+        build_id, proj = _parse_build_identifier(url)
+        assert build_id == 99
+        assert proj == "public"
+
+    def test_empty_raises(self) -> None:
+        with pytest.raises(ValueError, match="Empty"):
+            _parse_build_identifier("")
+
+    def test_no_build_id_in_url_raises(self) -> None:
+        with pytest.raises(ValueError, match="Could not extract buildId"):
+            _parse_build_identifier("https://dev.azure.com/azure-sdk/internal/_build")
+
+    def test_invalid_string_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid"):
+            _parse_build_identifier("not-a-number-or-url")
+
+
+# ---------------------------------------------------------------------------
+# _build_auth_header
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAuthHeader:
+    def test_bearer_format(self) -> None:
+        header = _build_auth_header("my-token")
+        assert header == {"Authorization": "Bearer my-token"}
+
+
+# ---------------------------------------------------------------------------
+# _is_test_step
+# ---------------------------------------------------------------------------
+
+
+class TestIsTestStep:
+    def test_test_in_name(self) -> None:
+        assert _is_test_step("Run tests") is True
+
+    def test_deploy_test_resources_excluded(self) -> None:
+        assert _is_test_step("Deploy Test Resources") is False
+
+    def test_none(self) -> None:
+        assert _is_test_step(None) is False
+
+    def test_no_test(self) -> None:
+        assert _is_test_step("Build SDK") is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_token
+# ---------------------------------------------------------------------------
+
+
+class TestResolveToken:
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self) -> None:
+        """Reset the module-level token cache between tests."""
+        import utils.ado_token as mod
+
+        mod._token_cache = None
+
+    @pytest.mark.asyncio
+    async def test_kv_token_used(self) -> None:
+        with patch(
+            "utils.ado_token.get_secret", new_callable=AsyncMock, return_value=FAKE_JWT
+        ):
+            from utils.ado_token import resolve_token
+
+            token = await resolve_token()
+            assert token == FAKE_JWT
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_credential(self) -> None:
+        mock_credential = AsyncMock()
+        mock_credential.get_token.return_value = AsyncMock(token=FAKE_JWT)
+
+        with (
+            patch(
+                "utils.ado_token.get_secret", new_callable=AsyncMock, return_value=None
+            ),
+            patch("utils.ado_token.get_credential", return_value=mock_credential),
+        ):
+            from utils.ado_token import resolve_token
+
+            token = await resolve_token()
+            assert token == FAKE_JWT
+            mock_credential.get_token.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_non_jwt_raises(self) -> None:
+        with patch(
+            "utils.ado_token.get_secret",
+            new_callable=AsyncMock,
+            return_value="not-a-jwt",
+        ):
+            from utils.ado_token import resolve_token
+
+            with pytest.raises(RuntimeError, match="does not look like"):
+                await resolve_token()
+
+    @pytest.mark.asyncio
+    async def test_cache_reuse(self) -> None:
+        secret_mock = AsyncMock(return_value=FAKE_JWT)
+        with patch("utils.ado_token.get_secret", secret_mock):
+            from utils.ado_token import resolve_token
+
+            t1 = await resolve_token()
+            t2 = await resolve_token()
+            assert t1 == t2
+            # get_secret should only be called once due to caching.
+            assert secret_mock.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# PipelineTools.azsdk_analyze_pipeline (integration-style with mocked HTTP)
+# ---------------------------------------------------------------------------
+
+
+def _mock_transport(responses: dict[str, httpx.Response]) -> httpx.MockTransport:
+    """Build a MockTransport that routes by URL substring."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        for pattern, resp in responses.items():
+            if pattern in url:
+                return resp
+        return httpx.Response(404, json={"error": "not found"})
+
+    return httpx.MockTransport(handler)
+
+
+class TestAnalyzePipeline:
+    @pytest.fixture(autouse=True)
+    def _clear_token_cache(self) -> None:
+        import utils.ado_token as mod
+
+        mod._token_cache = None
+
+    @pytest.mark.asyncio
+    async def test_invalid_identifier(self) -> None:
+        tools = PipelineTools()
+        result = await tools.azsdk_analyze_pipeline(pipeline="", project="")
+        assert result.success is False
+        assert "Empty" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_token_failure(self) -> None:
+        with patch(
+            "tools.pipeline_tools.resolve_token",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("no token"),
+        ):
+            tools = PipelineTools()
+            result = await tools.azsdk_analyze_pipeline(
+                pipeline="123", project="public"
+            )
+            assert result.success is False
+            assert "no token" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_successful_analysis(self) -> None:
+        build_json = {
+            "id": 100,
+            "status": "completed",
+            "result": "failed",
+            "project": {"name": "public"},
+        }
+        timeline_json = {
+            "records": [
+                {
+                    "type": "Task",
+                    "result": "failed",
+                    "name": "Build",
+                    "log": {"id": 1},
+                },
+                {
+                    "type": "Task",
+                    "result": "failed",
+                    "name": "Run tests",
+                    "log": {"id": 2},
+                },
+            ]
+        }
+        log_text = "error CS1234: something went wrong"
+
+        transport = _mock_transport(
+            {
+                "/builds/100?": httpx.Response(200, json=build_json),
+                "/timeline": httpx.Response(200, json=timeline_json),
+                "/logs/1": httpx.Response(200, text=log_text),
+            }
+        )
+
+        with patch(
+            "tools.pipeline_tools.resolve_token",
+            new_callable=AsyncMock,
+            return_value="fake",
+        ):
+            with patch(
+                "httpx.AsyncClient", return_value=httpx.AsyncClient(transport=transport)
+            ):
+                tools = PipelineTools()
+                result = await tools.azsdk_analyze_pipeline(
+                    pipeline="100", project="public"
+                )
+
+        assert result.success is True
+        assert result.build_id == 100
+        assert result.status == "completed"
+        assert result.result == "failed"
+        # "Run tests" should be filtered out; only "Build" kept.
+        assert len(result.failed_tasks) == 1
+        assert result.failed_tasks[0].name == "Build"
+        assert "CS1234" in result.failed_tasks[0].log_excerpt
+
+    @pytest.mark.asyncio
+    async def test_permission_error_on_resolve_project(self) -> None:
+        transport = _mock_transport(
+            {
+                "/builds/999?": httpx.Response(203, text="<html>sign in</html>"),
+            }
+        )
+
+        with patch(
+            "tools.pipeline_tools.resolve_token",
+            new_callable=AsyncMock,
+            return_value="fake",
+        ):
+            with patch(
+                "httpx.AsyncClient", return_value=httpx.AsyncClient(transport=transport)
+            ):
+                tools = PipelineTools()
+                result = await tools.azsdk_analyze_pipeline(
+                    pipeline="999", project="public"
+                )
+
+        assert result.success is False
+        assert result.error is not None

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tools/ado_mcp_tools.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tools/ado_mcp_tools.py
@@ -4,9 +4,12 @@ Provides an MCP-based tool that connects to the Azure DevOps MCP server
 via stdio (``npx @azure-devops/mcp``).  Exposes pipeline definition
 lookup so the agent can help users find release / CI pipeline links.
 
-Authentication: acquires a bearer token for Azure DevOps via the shared
-Azure credential chain and injects it as ``ADO_MCP_AUTH_TOKEN`` so the
-MCP server (launched with ``-a env``) can authenticate API calls.
+Authentication: Azure DevOps does not accept Foundry agent identities
+as organization members, so the hosted agent cannot mint an ADO token
+directly. An out-of-band job (a UAMI that IS an org member) refreshes
+a usable ADO credential into Key Vault, and this module reads it from
+there and injects it as ``ADO_MCP_AUTH_TOKEN`` so the MCP server
+(launched with ``-a env``) can authenticate API calls.
 """
 
 from __future__ import annotations
@@ -14,26 +17,23 @@ from __future__ import annotations
 import logging
 import os
 
-from azure.core.credentials_async import AsyncTokenCredential
 from agent_framework import MCPStdioTool
 
 from config.app_config import get as cfg
 from tools import truncating_mcp_parser
 from utils.azure_credential import get_credential
+from utils.azure_keyvault import get_secret
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_ADO_ORG = "azure-sdk"
 # Environment variable read by the ADO MCP server in ``-a env`` auth mode.
 _ADO_TOKEN_ENV = "ADO_MCP_AUTH_TOKEN"
-# Azure DevOps resource ID used as the OAuth2 scope for token acquisition.
-_ADO_SCOPE = "499b84ac-1321-427f-aa17-267ca6975798/.default"
-
-
-async def _get_ado_bearer_token(credential: AsyncTokenCredential) -> str:
-    """Acquire a bearer token for Azure DevOps using the shared credential."""
-    token = await credential.get_token(_ADO_SCOPE)
-    return token.token
+# Key Vault secret holding the ADO bearer token (shared with pipeline_tools.py).
+_TOKEN_SECRET_NAME = "ado-token"
+# AAD resource ID for Azure DevOps; used to mint a token via the agent
+# identity as a fallback when no KV secret is present.
+_ADO_RESOURCE_SCOPE = "499b84ac-1321-427f-aa17-267ca6975798/.default"
 
 
 async def create_ado_mcp_tool() -> MCPStdioTool:
@@ -44,18 +44,45 @@ async def create_ado_mcp_tool() -> MCPStdioTool:
     org = cfg("ADO_ORG", _DEFAULT_ADO_ORG) or _DEFAULT_ADO_ORG
     env = {**os.environ}
 
-    # Acquire a bearer token and inject it for the MCP server's envvar auth mode.
-    if _ADO_TOKEN_ENV not in env:
+    # Pull the ADO credential from Key Vault and inject it for the MCP
+    # server's envvar auth mode. If the secret is absent, fall back to
+    # the agent identity (works once ADO accepts it as an org member —
+    # simply delete the KV secret to switch over).
+    token: str | None = None
+    source: str = ""
+    try:
+        kv_value = await get_secret(_TOKEN_SECRET_NAME)
+        if kv_value and kv_value.strip():
+            token = kv_value.strip()
+    except Exception:
+        logger.warning(
+            "Failed to read KV secret '%s'; will try agent identity",
+            _TOKEN_SECRET_NAME,
+            exc_info=True,
+        )
+
+    if token is None:
         try:
             credential = get_credential()
-            env[_ADO_TOKEN_ENV] = await _get_ado_bearer_token(credential)
-            logger.info("ADO bearer token acquired via Azure credential chain")
+            access_token = await credential.get_token(_ADO_RESOURCE_SCOPE)
+            token = access_token.token
         except Exception:
             logger.warning(
-                "Failed to acquire ADO bearer token via Azure credential; "
-                "the MCP server will start without ADO_MCP_AUTH_TOKEN",
+                "Failed to mint ADO token via agent identity; ADO MCP server "
+                "will start without %s",
+                _ADO_TOKEN_ENV,
                 exc_info=True,
             )
+
+    if token:
+        env[_ADO_TOKEN_ENV] = token
+    else:
+        logger.warning(
+            "No ADO token available (KV secret '%s' empty and identity "
+            "fallback failed); ADO MCP server will start without %s",
+            _TOKEN_SECRET_NAME,
+            _ADO_TOKEN_ENV,
+        )
 
     logger.info("ADO MCP tool configured (org=%s)", org)
 

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tools/ado_mcp_tools.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tools/ado_mcp_tools.py
@@ -9,7 +9,7 @@ as organization members, so the hosted agent cannot mint an ADO token
 directly. An out-of-band job (a UAMI that IS an org member) refreshes
 a usable ADO credential into Key Vault, and this module reads it from
 there and injects it as ``ADO_MCP_AUTH_TOKEN`` so the MCP server
-(launched with ``-a env``) can authenticate API calls.
+(launched with ``-a envvar``) can authenticate API calls.
 """
 
 from __future__ import annotations
@@ -21,19 +21,13 @@ from agent_framework import MCPStdioTool
 
 from config.app_config import get as cfg
 from tools import truncating_mcp_parser
-from utils.azure_credential import get_credential
-from utils.azure_keyvault import get_secret
+from utils.ado_token import resolve_token
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_ADO_ORG = "azure-sdk"
-# Environment variable read by the ADO MCP server in ``-a env`` auth mode.
+# Environment variable read by the ADO MCP server in ``-a envvar`` auth mode.
 _ADO_TOKEN_ENV = "ADO_MCP_AUTH_TOKEN"
-# Key Vault secret holding the ADO bearer token (shared with pipeline_tools.py).
-_TOKEN_SECRET_NAME = "ado-token"
-# AAD resource ID for Azure DevOps; used to mint a token via the agent
-# identity as a fallback when no KV secret is present.
-_ADO_RESOURCE_SCOPE = "499b84ac-1321-427f-aa17-267ca6975798/.default"
 
 
 async def create_ado_mcp_tool() -> MCPStdioTool:
@@ -44,44 +38,16 @@ async def create_ado_mcp_tool() -> MCPStdioTool:
     org = cfg("ADO_ORG", _DEFAULT_ADO_ORG) or _DEFAULT_ADO_ORG
     env = {**os.environ}
 
-    # Pull the ADO credential from Key Vault and inject it for the MCP
-    # server's envvar auth mode. If the secret is absent, fall back to
-    # the agent identity (works once ADO accepts it as an org member —
-    # simply delete the KV secret to switch over).
-    token: str | None = None
-    source: str = ""
+    # Pull the ADO credential via the shared resolver (KV-first, with
+    # JIT caching) and inject it for the MCP server's envvar auth mode.
     try:
-        kv_value = await get_secret(_TOKEN_SECRET_NAME)
-        if kv_value and kv_value.strip():
-            token = kv_value.strip()
+        token = await resolve_token()
+        env[_ADO_TOKEN_ENV] = token
     except Exception:
         logger.warning(
-            "Failed to read KV secret '%s'; will try agent identity",
-            _TOKEN_SECRET_NAME,
-            exc_info=True,
-        )
-
-    if token is None:
-        try:
-            credential = get_credential()
-            access_token = await credential.get_token(_ADO_RESOURCE_SCOPE)
-            token = access_token.token
-        except Exception:
-            logger.warning(
-                "Failed to mint ADO token via agent identity; ADO MCP server "
-                "will start without %s",
-                _ADO_TOKEN_ENV,
-                exc_info=True,
-            )
-
-    if token:
-        env[_ADO_TOKEN_ENV] = token
-    else:
-        logger.warning(
-            "No ADO token available (KV secret '%s' empty and identity "
-            "fallback failed); ADO MCP server will start without %s",
-            _TOKEN_SECRET_NAME,
+            "Failed to resolve ADO token; ADO MCP server will start " "without %s",
             _ADO_TOKEN_ENV,
+            exc_info=True,
         )
 
     logger.info("ADO MCP tool configured (org=%s)", org)
@@ -89,7 +55,16 @@ async def create_ado_mcp_tool() -> MCPStdioTool:
     return MCPStdioTool(
         name="ado-mcp-tools",
         command="npx",
-        args=["-y", "@azure-devops/mcp", org, "-d", "core", "pipelines", "-a", "env"],
+        args=[
+            "-y",
+            "@azure-devops/mcp",
+            org,
+            "-d",
+            "core",
+            "pipelines",
+            "-a",
+            "envvar",
+        ],
         env=env,
         load_prompts=False,
         parse_tool_results=truncating_mcp_parser,

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tools/pipeline_tools.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tools/pipeline_tools.py
@@ -1,0 +1,442 @@
+"""Azure Pipelines failure-log tool (direct ADO REST, no MCP server).
+
+Replaces the previous azsdk-cli MCP stdio approach.
+
+Why a Key Vault hop instead of calling ADO with the agent identity:
+Azure DevOps does not accept Foundry agent identities (Entra service
+principals) as organization members, so the hosted agent cannot mint
+an ADO token directly. An out-of-band job (a UAMI that IS an org
+member) refreshes a usable AAD bearer token into Key Vault, and this
+tool reads it from there at request time.
+
+Credential source (refreshed JIT before expiry, mirroring the GitHub
+MCP token-manager pattern):
+  Key Vault secret named ``ado-token`` in the vault configured via
+  ``KEYVAULT_ENDPOINT`` (App Configuration). The secret value must be
+  an AAD bearer token (JWT) for the ADO resource
+  ``499b84ac-1321-427f-aa17-267ca6975798``; PATs are not supported.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+import json
+import logging
+import time
+from typing import Annotated
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+from pydantic import BaseModel
+
+from tools import tool
+from utils.azure_credential import get_credential
+from utils.azure_keyvault import get_secret
+
+logger = logging.getLogger(__name__)
+
+_ADO_BASE_URL = "https://dev.azure.com/azure-sdk"
+_PUBLIC_PROJECT = "public"
+_INTERNAL_PROJECT = "internal"
+_TOKEN_SECRET_NAME = "ado-token"
+# AAD resource ID for Azure DevOps; used when minting a token via the
+# agent identity as a fallback when no KV secret is present.
+_ADO_RESOURCE_SCOPE = "499b84ac-1321-427f-aa17-267ca6975798/.default"
+# Refresh the token this many seconds before its JWT ``exp`` claim.
+_TOKEN_REFRESH_BUFFER_SECS = 5 * 60
+# Fallback cache TTL when the token has no parseable ``exp`` claim.
+_TOKEN_FALLBACK_TTL_SECS = 5 * 60
+_API_VERSION = "7.1"
+
+_HTTP_TIMEOUT_SECONDS = 30.0
+_MAX_LOG_TAIL_CHARS = 4000
+_MAX_TOTAL_LOG_CHARS = 32000
+
+# Cached (token, refresh_after_monotonic).
+_token_cache: tuple[str, float] | None = None
+_token_cache_lock = asyncio.Lock()
+
+
+class FailedTask(BaseModel):
+    """A single failed pipeline task with the tail of its log."""
+
+    name: str
+    log_id: int
+    log_excerpt: str
+
+
+class PipelineAnalysisResult(BaseModel):
+    """Result for ``azsdk_analyze_pipeline``."""
+
+    success: bool
+    build_id: int
+    project: str
+    pipeline_url: str = ""
+    status: str = ""
+    result: str = ""
+    failed_tasks: list[FailedTask] = []
+    error: str | None = None
+    notes: str = ""
+
+
+def _jwt_exp_seconds(token: str) -> int | None:
+    """Return the ``exp`` claim (Unix seconds) from a JWT, or ``None``."""
+    parts = token.split(".")
+    if len(parts) < 2:
+        return None
+    payload_b64 = parts[1]
+    # base64url decode with padding tolerance.
+    padding = "=" * (-len(payload_b64) % 4)
+    try:
+        payload_bytes = base64.urlsafe_b64decode(payload_b64 + padding)
+        payload = json.loads(payload_bytes)
+    except (binascii.Error, ValueError, UnicodeDecodeError):
+        return None
+    exp = payload.get("exp")
+    return int(exp) if isinstance(exp, (int, float)) else None
+
+
+async def _resolve_token() -> str:
+    """Return an ADO AAD bearer token, refreshed JIT.
+
+    Resolution order:
+      1. Key Vault secret ``ado-token`` (populated by an out-of-band
+         job, used while the Foundry agent identity is not an ADO org
+         member).
+      2. The agent identity itself via :func:`get_credential` — taken
+         when the KV secret is absent or empty. Switch to this path by
+         simply deleting the secret once ADO accepts the agent identity.
+
+    The cached token is reused until ``exp - _TOKEN_REFRESH_BUFFER_SECS``
+    (mirroring the GitHub MCP token-manager pattern). When the JWT has
+    no parseable ``exp``, falls back to a short fixed TTL so we still
+    pick up rotations.
+    """
+    global _token_cache
+    now = time.monotonic()
+    if _token_cache is not None and _token_cache[1] > now:
+        return _token_cache[0]
+
+    async with _token_cache_lock:
+        # Double-checked: another coroutine may have just refreshed.
+        if _token_cache is not None and _token_cache[1] > now:
+            return _token_cache[0]
+
+        value = await get_secret(_TOKEN_SECRET_NAME)
+        token = (value or "").strip()
+        source: str
+        if token:
+            if not token.startswith("eyJ"):
+                raise RuntimeError(
+                    f"ADO token secret '{_TOKEN_SECRET_NAME}' does not look like "
+                    "an AAD bearer token (JWT). PATs are not supported by this tool."
+                )
+            source = f"KV '{_TOKEN_SECRET_NAME}'"
+        else:
+            # Fall back to the agent identity. Works once ADO accepts the
+            # Foundry agent identity as an org member; otherwise the call
+            # below succeeds but ADO API requests will return 203/401.
+            logger.info(
+                "KV secret '%s' is empty; minting ADO token via agent identity",
+                _TOKEN_SECRET_NAME,
+            )
+            credential = get_credential()
+            access_token = await credential.get_token(_ADO_RESOURCE_SCOPE)
+            token = access_token.token
+            source = "agent identity"
+
+        # Compute the refresh deadline from the JWT exp claim.
+        exp_unix = _jwt_exp_seconds(token)
+        if exp_unix is not None:
+            seconds_until_exp = exp_unix - int(time.time())
+            ttl = max(seconds_until_exp - _TOKEN_REFRESH_BUFFER_SECS, 0)
+            logger.debug(
+                "ADO token loaded from %s, exp in %ds, refresh in %ds",
+                source,
+                seconds_until_exp,
+                ttl,
+            )
+        else:
+            ttl = _TOKEN_FALLBACK_TTL_SECS
+            logger.debug(
+                "ADO token loaded from %s; no parseable exp, using %ds TTL",
+                source,
+                ttl,
+            )
+
+        _token_cache = (token, now + ttl)
+        return token
+
+
+def _build_auth_header(token: str) -> dict[str, str]:
+    """Build the Authorization header for an AAD bearer token."""
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _parse_build_identifier(identifier: str) -> tuple[int, str | None]:
+    """Extract ``(build_id, project_hint)`` from a raw id or ADO URL.
+
+    Accepts either a bare integer (e.g. ``"5094469"``) or a results URL
+    (e.g. ``https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5094469``).
+    """
+    s = (identifier or "").strip()
+    if not s:
+        raise ValueError("Empty pipeline identifier.")
+    if s.isdigit():
+        return int(s), None
+
+    parsed = urlparse(s)
+    if not parsed.scheme or not parsed.netloc:
+        raise ValueError(f"Invalid pipeline identifier: {identifier}")
+
+    segments = [seg for seg in parsed.path.split("/") if seg]
+    # /<org>/<project>/_build/...
+    project = segments[1] if len(segments) >= 2 else None
+
+    qs = parse_qs(parsed.query)
+    build_id_str = (qs.get("buildId") or [None])[0]
+    if not build_id_str or not build_id_str.isdigit():
+        raise ValueError(f"Could not extract buildId from: {identifier}")
+    return int(build_id_str), project
+
+
+def _is_test_step(name: str | None) -> bool:
+    """Match the C# heuristic: 'test' in name, except 'deploy test resources'."""
+    if not name:
+        return False
+    lower = name.lower()
+    if "deploy test resources" in lower:
+        return False
+    return "test" in lower
+
+
+async def _get_json(client: httpx.AsyncClient, url: str) -> dict | None:
+    response = await client.get(url)
+    # ADO returns 203 with a sign-in HTML page when the request is unauthorized.
+    if response.status_code == 203:
+        raise PermissionError(f"Not authorized: {url}")
+    if response.status_code == 404:
+        return None
+    response.raise_for_status()
+    return response.json()
+
+
+async def _resolve_project(
+    client: httpx.AsyncClient, build_id: int, hint: str | None
+) -> str:
+    """Locate which ADO project a build belongs to."""
+    candidates = [hint] if hint else [_PUBLIC_PROJECT, _INTERNAL_PROJECT]
+    last_error: Exception | None = None
+    for proj in candidates:
+        url = (
+            f"{_ADO_BASE_URL}/{proj}/_apis/build/builds/{build_id}"
+            f"?api-version={_API_VERSION}"
+        )
+        try:
+            data = await _get_json(client, url)
+        except (PermissionError, httpx.HTTPStatusError) as e:
+            last_error = e
+            continue
+        if data:
+            return data.get("project", {}).get("name") or proj
+    raise RuntimeError(
+        f"Could not locate build {build_id} in projects {candidates}"
+        + (f" (last error: {last_error})" if last_error else "")
+    )
+
+
+async def _get_failed_log_ids(
+    client: httpx.AsyncClient, project: str, build_id: int
+) -> list[tuple[str, int]]:
+    """Return ``(task_name, log_id)`` for each failed non-test Task."""
+    url = (
+        f"{_ADO_BASE_URL}/{project}/_apis/build/builds/{build_id}/timeline"
+        f"?api-version={_API_VERSION}"
+    )
+    data = await _get_json(client, url)
+    if not data:
+        return []
+
+    seen: set[int] = set()
+    out: list[tuple[str, int]] = []
+    for rec in data.get("records") or []:
+        if rec.get("result") != "failed" or rec.get("type") != "Task":
+            continue
+        name = rec.get("name")
+        if _is_test_step(name):
+            continue
+        log = rec.get("log") or {}
+        log_id = log.get("id")
+        if not isinstance(log_id, int) or log_id <= 0 or log_id in seen:
+            continue
+        seen.add(log_id)
+        out.append((name or f"task-{log_id}", log_id))
+    return out
+
+
+async def _get_log_tail(
+    client: httpx.AsyncClient, project: str, build_id: int, log_id: int
+) -> str:
+    """Fetch a task log and return its tail (errors are usually at the end)."""
+    url = (
+        f"{_ADO_BASE_URL}/{project}/_apis/build/builds/{build_id}/logs/{log_id}"
+        f"?api-version={_API_VERSION}"
+    )
+    response = await client.get(url)
+    if response.status_code == 203:
+        raise PermissionError(f"Not authorized: {url}")
+    response.raise_for_status()
+    text = response.text or ""
+    if len(text) > _MAX_LOG_TAIL_CHARS:
+        return "... [head truncated]\n" + text[-_MAX_LOG_TAIL_CHARS:]
+    return text
+
+
+class PipelineTools:
+    """Tools for analyzing Azure DevOps pipeline runs in the azure-sdk org."""
+
+    @tool
+    async def azsdk_analyze_pipeline(
+        self,
+        *,
+        pipeline: Annotated[
+            str,
+            (
+                "Azure Pipelines build link "
+                "(e.g. https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5094469) "
+                "or just the numeric build ID."
+            ),
+        ],
+        project: Annotated[
+            str,
+            (
+                "Optional ADO project name override ('public' or 'internal'). "
+                "If empty, auto-detected from the link or by probing both projects."
+            ),
+        ] = "",
+    ) -> PipelineAnalysisResult:
+        """Fetch failure logs for an Azure SDK pipeline run.
+
+        Returns the build status plus the tail of each failed
+        non-test task's log so the agent can diagnose the failure.
+        """
+        try:
+            build_id, project_from_link = _parse_build_identifier(pipeline)
+        except ValueError as e:
+            return PipelineAnalysisResult(
+                success=False, build_id=0, project="", error=str(e)
+            )
+
+        hint = (project or project_from_link or "").strip() or None
+        try:
+            token = await _resolve_token()
+        except RuntimeError as e:
+            return PipelineAnalysisResult(
+                success=False, build_id=build_id, project=hint or "", error=str(e)
+            )
+        auth = _build_auth_header(token)
+
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(_HTTP_TIMEOUT_SECONDS),
+            headers={"Accept": "application/json", **auth},
+            follow_redirects=False,
+        ) as client:
+            try:
+                resolved_project = await _resolve_project(client, build_id, hint)
+            except (PermissionError, RuntimeError) as e:
+                return PipelineAnalysisResult(
+                    success=False,
+                    build_id=build_id,
+                    project=hint or "",
+                    error=str(e),
+                )
+            except httpx.HTTPError as e:
+                return PipelineAnalysisResult(
+                    success=False,
+                    build_id=build_id,
+                    project=hint or "",
+                    error=f"HTTP error resolving project: {e}",
+                )
+
+            pipeline_url = (
+                f"{_ADO_BASE_URL}/{resolved_project}"
+                f"/_build/results?buildId={build_id}&view=results"
+            )
+
+            status, result = "", ""
+            try:
+                build = await _get_json(
+                    client,
+                    f"{_ADO_BASE_URL}/{resolved_project}/_apis/build/builds/"
+                    f"{build_id}?api-version={_API_VERSION}",
+                )
+                if build:
+                    status = build.get("status") or ""
+                    result = build.get("result") or ""
+            except Exception:
+                logger.debug("build summary fetch failed", exc_info=True)
+
+            try:
+                failed = await _get_failed_log_ids(client, resolved_project, build_id)
+            except PermissionError as e:
+                return PipelineAnalysisResult(
+                    success=False,
+                    build_id=build_id,
+                    project=resolved_project,
+                    pipeline_url=pipeline_url,
+                    status=status,
+                    result=result,
+                    error=str(e),
+                )
+            except httpx.HTTPError as e:
+                return PipelineAnalysisResult(
+                    success=False,
+                    build_id=build_id,
+                    project=resolved_project,
+                    pipeline_url=pipeline_url,
+                    status=status,
+                    result=result,
+                    error=f"HTTP error fetching timeline: {e}",
+                )
+
+            failed_tasks: list[FailedTask] = []
+            total_chars = 0
+            truncated = False
+            for name, log_id in failed:
+                remaining = _MAX_TOTAL_LOG_CHARS - total_chars
+                if remaining <= 0:
+                    truncated = True
+                    break
+                try:
+                    excerpt = await _get_log_tail(
+                        client, resolved_project, build_id, log_id
+                    )
+                except Exception as e:
+                    excerpt = f"[failed to fetch log: {e}]"
+                if len(excerpt) > remaining:
+                    excerpt = excerpt[-remaining:]
+                    truncated = True
+                total_chars += len(excerpt)
+                failed_tasks.append(
+                    FailedTask(name=name, log_id=log_id, log_excerpt=excerpt)
+                )
+
+            notes = ""
+            if truncated:
+                notes = (
+                    f"Output truncated to ~{_MAX_TOTAL_LOG_CHARS} chars across "
+                    f"{len(failed_tasks)} failed task log(s)."
+                )
+
+            return PipelineAnalysisResult(
+                success=True,
+                build_id=build_id,
+                project=resolved_project,
+                pipeline_url=pipeline_url,
+                status=status,
+                result=result,
+                failed_tasks=failed_tasks,
+                notes=notes,
+            )

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tools/pipeline_tools.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tools/pipeline_tools.py
@@ -24,7 +24,7 @@ from typing import Annotated
 from urllib.parse import parse_qs, urlparse
 
 import httpx
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from tools import tool
 from utils.ado_token import resolve_token
@@ -58,7 +58,7 @@ class PipelineAnalysisResult(BaseModel):
     pipeline_url: str = ""
     status: str = ""
     result: str = ""
-    failed_tasks: list[FailedTask] = []
+    failed_tasks: list[FailedTask] = Field(default_factory=list)
     error: str | None = None
     notes: str = ""
 
@@ -225,7 +225,7 @@ class PipelineTools:
         hint = (project or project_from_link or "").strip() or None
         try:
             token = await resolve_token()
-        except RuntimeError as e:
+        except Exception as e:
             return PipelineAnalysisResult(
                 success=False, build_id=build_id, project=hint or "", error=str(e)
             )

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tools/pipeline_tools.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tools/pipeline_tools.py
@@ -19,12 +19,7 @@ MCP token-manager pattern):
 
 from __future__ import annotations
 
-import asyncio
-import base64
-import binascii
-import json
 import logging
-import time
 from typing import Annotated
 from urllib.parse import parse_qs, urlparse
 
@@ -32,31 +27,18 @@ import httpx
 from pydantic import BaseModel
 
 from tools import tool
-from utils.azure_credential import get_credential
-from utils.azure_keyvault import get_secret
+from utils.ado_token import resolve_token
 
 logger = logging.getLogger(__name__)
 
 _ADO_BASE_URL = "https://dev.azure.com/azure-sdk"
 _PUBLIC_PROJECT = "public"
 _INTERNAL_PROJECT = "internal"
-_TOKEN_SECRET_NAME = "ado-token"
-# AAD resource ID for Azure DevOps; used when minting a token via the
-# agent identity as a fallback when no KV secret is present.
-_ADO_RESOURCE_SCOPE = "499b84ac-1321-427f-aa17-267ca6975798/.default"
-# Refresh the token this many seconds before its JWT ``exp`` claim.
-_TOKEN_REFRESH_BUFFER_SECS = 5 * 60
-# Fallback cache TTL when the token has no parseable ``exp`` claim.
-_TOKEN_FALLBACK_TTL_SECS = 5 * 60
 _API_VERSION = "7.1"
 
 _HTTP_TIMEOUT_SECONDS = 30.0
 _MAX_LOG_TAIL_CHARS = 4000
 _MAX_TOTAL_LOG_CHARS = 32000
-
-# Cached (token, refresh_after_monotonic).
-_token_cache: tuple[str, float] | None = None
-_token_cache_lock = asyncio.Lock()
 
 
 class FailedTask(BaseModel):
@@ -79,95 +61,6 @@ class PipelineAnalysisResult(BaseModel):
     failed_tasks: list[FailedTask] = []
     error: str | None = None
     notes: str = ""
-
-
-def _jwt_exp_seconds(token: str) -> int | None:
-    """Return the ``exp`` claim (Unix seconds) from a JWT, or ``None``."""
-    parts = token.split(".")
-    if len(parts) < 2:
-        return None
-    payload_b64 = parts[1]
-    # base64url decode with padding tolerance.
-    padding = "=" * (-len(payload_b64) % 4)
-    try:
-        payload_bytes = base64.urlsafe_b64decode(payload_b64 + padding)
-        payload = json.loads(payload_bytes)
-    except (binascii.Error, ValueError, UnicodeDecodeError):
-        return None
-    exp = payload.get("exp")
-    return int(exp) if isinstance(exp, (int, float)) else None
-
-
-async def _resolve_token() -> str:
-    """Return an ADO AAD bearer token, refreshed JIT.
-
-    Resolution order:
-      1. Key Vault secret ``ado-token`` (populated by an out-of-band
-         job, used while the Foundry agent identity is not an ADO org
-         member).
-      2. The agent identity itself via :func:`get_credential` — taken
-         when the KV secret is absent or empty. Switch to this path by
-         simply deleting the secret once ADO accepts the agent identity.
-
-    The cached token is reused until ``exp - _TOKEN_REFRESH_BUFFER_SECS``
-    (mirroring the GitHub MCP token-manager pattern). When the JWT has
-    no parseable ``exp``, falls back to a short fixed TTL so we still
-    pick up rotations.
-    """
-    global _token_cache
-    now = time.monotonic()
-    if _token_cache is not None and _token_cache[1] > now:
-        return _token_cache[0]
-
-    async with _token_cache_lock:
-        # Double-checked: another coroutine may have just refreshed.
-        if _token_cache is not None and _token_cache[1] > now:
-            return _token_cache[0]
-
-        value = await get_secret(_TOKEN_SECRET_NAME)
-        token = (value or "").strip()
-        source: str
-        if token:
-            if not token.startswith("eyJ"):
-                raise RuntimeError(
-                    f"ADO token secret '{_TOKEN_SECRET_NAME}' does not look like "
-                    "an AAD bearer token (JWT). PATs are not supported by this tool."
-                )
-            source = f"KV '{_TOKEN_SECRET_NAME}'"
-        else:
-            # Fall back to the agent identity. Works once ADO accepts the
-            # Foundry agent identity as an org member; otherwise the call
-            # below succeeds but ADO API requests will return 203/401.
-            logger.info(
-                "KV secret '%s' is empty; minting ADO token via agent identity",
-                _TOKEN_SECRET_NAME,
-            )
-            credential = get_credential()
-            access_token = await credential.get_token(_ADO_RESOURCE_SCOPE)
-            token = access_token.token
-            source = "agent identity"
-
-        # Compute the refresh deadline from the JWT exp claim.
-        exp_unix = _jwt_exp_seconds(token)
-        if exp_unix is not None:
-            seconds_until_exp = exp_unix - int(time.time())
-            ttl = max(seconds_until_exp - _TOKEN_REFRESH_BUFFER_SECS, 0)
-            logger.debug(
-                "ADO token loaded from %s, exp in %ds, refresh in %ds",
-                source,
-                seconds_until_exp,
-                ttl,
-            )
-        else:
-            ttl = _TOKEN_FALLBACK_TTL_SECS
-            logger.debug(
-                "ADO token loaded from %s; no parseable exp, using %ds TTL",
-                source,
-                ttl,
-            )
-
-        _token_cache = (token, now + ttl)
-        return token
 
 
 def _build_auth_header(token: str) -> dict[str, str]:
@@ -331,7 +224,7 @@ class PipelineTools:
 
         hint = (project or project_from_link or "").strip() or None
         try:
-            token = await _resolve_token()
+            token = await resolve_token()
         except RuntimeError as e:
             return PipelineAnalysisResult(
                 success=False, build_id=build_id, project=hint or "", error=str(e)

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/utils/ado_token.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/utils/ado_token.py
@@ -19,6 +19,7 @@ import json
 import logging
 import time
 
+from config.app_config import get as cfg
 from utils.azure_credential import get_credential
 from utils.azure_keyvault import get_secret
 
@@ -26,8 +27,6 @@ logger = logging.getLogger(__name__)
 
 # Key Vault secret holding the ADO bearer token.
 TOKEN_SECRET_NAME = "ado-token"
-# AAD resource ID for Azure DevOps.
-ADO_RESOURCE_SCOPE = "499b84ac-1321-427f-aa17-267ca6975798/.default"
 # Refresh the token this many seconds before its JWT ``exp`` claim.
 _TOKEN_REFRESH_BUFFER_SECS = 5 * 60
 # Fallback cache TTL when the token has no parseable ``exp`` claim.
@@ -85,7 +84,8 @@ async def resolve_token() -> str:
                 TOKEN_SECRET_NAME,
             )
             credential = get_credential()
-            access_token = await credential.get_token(ADO_RESOURCE_SCOPE)
+            scope = cfg("ADO_RESOURCE_SCOPE")
+            access_token = await credential.get_token(scope)
             token = access_token.token
 
         # Compute the refresh deadline from the JWT exp claim.

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/utils/ado_token.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/utils/ado_token.py
@@ -85,6 +85,11 @@ async def resolve_token() -> str:
             )
             credential = get_credential()
             scope = cfg("ADO_RESOURCE_SCOPE")
+            if not scope:
+                raise RuntimeError(
+                    "ADO_RESOURCE_SCOPE is not configured. "
+                    "Set it in Azure App Configuration."
+                )
             access_token = await credential.get_token(scope)
             token = access_token.token
 

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/utils/ado_token.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/utils/ado_token.py
@@ -77,14 +77,8 @@ async def resolve_token() -> str:
 
         value = await get_secret(TOKEN_SECRET_NAME)
         token = (value or "").strip()
-        source: str
         if token:
-            if not token.startswith("eyJ"):
-                raise RuntimeError(
-                    f"ADO token secret '{TOKEN_SECRET_NAME}' does not look like "
-                    "an AAD bearer token (JWT). PATs are not supported."
-                )
-            source = f"KV '{TOKEN_SECRET_NAME}'"
+            pass
         else:
             logger.info(
                 "KV secret '%s' is empty; minting ADO token via agent identity",
@@ -93,7 +87,6 @@ async def resolve_token() -> str:
             credential = get_credential()
             access_token = await credential.get_token(ADO_RESOURCE_SCOPE)
             token = access_token.token
-            source = "agent identity"
 
         # Compute the refresh deadline from the JWT exp claim.
         exp_unix = _jwt_exp_seconds(token)
@@ -101,16 +94,14 @@ async def resolve_token() -> str:
             seconds_until_exp = exp_unix - int(time.time())
             ttl = max(seconds_until_exp - _TOKEN_REFRESH_BUFFER_SECS, 0)
             logger.debug(
-                "ADO token loaded from %s, exp in %ds, refresh in %ds",
-                source,
+                "ADO token loaded, exp in %ds, refresh in %ds",
                 seconds_until_exp,
                 ttl,
             )
         else:
             ttl = _TOKEN_FALLBACK_TTL_SECS
             logger.debug(
-                "ADO token loaded from %s; no parseable exp, using %ds TTL",
-                source,
+                "ADO token loaded; no parseable exp, using %ds TTL",
                 ttl,
             )
 

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/utils/ado_token.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/utils/ado_token.py
@@ -1,0 +1,118 @@
+"""Shared ADO bearer-token resolver with JIT refresh.
+
+Centralises the KV-first → managed-identity-fallback logic used by both
+``tools.ado_mcp_tools`` (MCPStdioTool env injection) and
+``tools.pipeline_tools`` (direct REST calls).
+
+The cached token is reused until ``exp - _TOKEN_REFRESH_BUFFER_SECS``
+(mirroring the GitHub MCP token-manager pattern).  When the JWT has no
+parseable ``exp``, falls back to a short fixed TTL so we still pick up
+rotations.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+import json
+import logging
+import time
+
+from utils.azure_credential import get_credential
+from utils.azure_keyvault import get_secret
+
+logger = logging.getLogger(__name__)
+
+# Key Vault secret holding the ADO bearer token.
+TOKEN_SECRET_NAME = "ado-token"
+# AAD resource ID for Azure DevOps.
+ADO_RESOURCE_SCOPE = "499b84ac-1321-427f-aa17-267ca6975798/.default"
+# Refresh the token this many seconds before its JWT ``exp`` claim.
+_TOKEN_REFRESH_BUFFER_SECS = 5 * 60
+# Fallback cache TTL when the token has no parseable ``exp`` claim.
+_TOKEN_FALLBACK_TTL_SECS = 5 * 60
+
+# Cached (token, refresh_after_monotonic).
+_token_cache: tuple[str, float] | None = None
+_token_cache_lock = asyncio.Lock()
+
+
+def _jwt_exp_seconds(token: str) -> int | None:
+    """Return the ``exp`` claim (Unix seconds) from a JWT, or ``None``."""
+    parts = token.split(".")
+    if len(parts) < 2:
+        return None
+    payload_b64 = parts[1]
+    padding = "=" * (-len(payload_b64) % 4)
+    try:
+        payload_bytes = base64.urlsafe_b64decode(payload_b64 + padding)
+        payload = json.loads(payload_bytes)
+    except (binascii.Error, ValueError, UnicodeDecodeError):
+        return None
+    exp = payload.get("exp")
+    return int(exp) if isinstance(exp, (int, float)) else None
+
+
+async def resolve_token() -> str:
+    """Return an ADO AAD bearer token, refreshed JIT.
+
+    Resolution order:
+      1. Key Vault secret ``ado-token`` (populated by an out-of-band
+         job, used while the Foundry agent identity is not an ADO org
+         member).
+      2. The agent identity itself via :func:`get_credential` — taken
+         when the KV secret is absent or empty.  Switch to this path by
+         simply deleting the secret once ADO accepts the agent identity.
+    """
+    global _token_cache
+    now = time.monotonic()
+    if _token_cache is not None and _token_cache[1] > now:
+        return _token_cache[0]
+
+    async with _token_cache_lock:
+        # Double-checked: another coroutine may have just refreshed.
+        if _token_cache is not None and _token_cache[1] > now:
+            return _token_cache[0]
+
+        value = await get_secret(TOKEN_SECRET_NAME)
+        token = (value or "").strip()
+        source: str
+        if token:
+            if not token.startswith("eyJ"):
+                raise RuntimeError(
+                    f"ADO token secret '{TOKEN_SECRET_NAME}' does not look like "
+                    "an AAD bearer token (JWT). PATs are not supported."
+                )
+            source = f"KV '{TOKEN_SECRET_NAME}'"
+        else:
+            logger.info(
+                "KV secret '%s' is empty; minting ADO token via agent identity",
+                TOKEN_SECRET_NAME,
+            )
+            credential = get_credential()
+            access_token = await credential.get_token(ADO_RESOURCE_SCOPE)
+            token = access_token.token
+            source = "agent identity"
+
+        # Compute the refresh deadline from the JWT exp claim.
+        exp_unix = _jwt_exp_seconds(token)
+        if exp_unix is not None:
+            seconds_until_exp = exp_unix - int(time.time())
+            ttl = max(seconds_until_exp - _TOKEN_REFRESH_BUFFER_SECS, 0)
+            logger.debug(
+                "ADO token loaded from %s, exp in %ds, refresh in %ds",
+                source,
+                seconds_until_exp,
+                ttl,
+            )
+        else:
+            ttl = _TOKEN_FALLBACK_TTL_SECS
+            logger.debug(
+                "ADO token loaded from %s; no parseable exp, using %ds TTL",
+                source,
+                ttl,
+            )
+
+        _token_cache = (token, now + ttl)
+        return token

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-function/package-lock.json
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-function/package-lock.json
@@ -12,6 +12,7 @@
         "@azure/data-tables": "^13.3.1",
         "@azure/functions": "^4.0.0",
         "@azure/identity": "^4.5.0",
+        "@azure/keyvault-secrets": "^4.11.2",
         "@azure/openai": "^1.0.0-beta.12",
         "@azure/search-documents": "^12.1.0",
         "@azure/storage-blob": "^12.21.0",
@@ -275,6 +276,81 @@
         "@azure/msal-node": "^3.5.0",
         "open": "^10.1.0",
         "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/keyvault-common": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-common/-/keyvault-common-2.1.0.tgz",
+      "integrity": "sha512-aCDidWuKY06LWQ4x7/8TIXK6iRqTaRWRL3t7T+LC+j1b07HtoIsOxP/tU90G4jCSBn5TAyUTCtA4MS/y5Hudaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure-rest/core-client": "^2.3.3",
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.8.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.10.0",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/keyvault-common/node_modules/@azure-rest/core-client": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-2.6.0.tgz",
+      "integrity": "sha512-iuFKDm8XPzNxPfRjhyU5/xKZmcRDzSuEghXDHHk4MjBV/wFL34GmYVBZnn9wmuoLBeS1qAw9ceMdaeJBPcB1QQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/keyvault-secrets": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-secrets/-/keyvault-secrets-4.11.2.tgz",
+      "integrity": "sha512-ECj/kwZbZlQXj2kfWivSICbKwj6W3chmFhv8qUdauqYnjvZ0hWZBFSsZWux7W2nX3MP49PLUCusXk+hAg3pipg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure-rest/core-client": "^2.3.3",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-lro": "^2.7.2",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.0",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/keyvault-common": "^2.1.0",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/keyvault-secrets/node_modules/@azure-rest/core-client": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-2.6.0.tgz",
+      "integrity": "sha512-iuFKDm8XPzNxPfRjhyU5/xKZmcRDzSuEghXDHHk4MjBV/wFL34GmYVBZnn9wmuoLBeS1qAw9ceMdaeJBPcB1QQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-function/package.json
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-function/package.json
@@ -15,6 +15,7 @@
     "@azure/data-tables": "^13.3.1",
     "@azure/functions": "^4.0.0",
     "@azure/identity": "^4.5.0",
+    "@azure/keyvault-secrets": "^4.11.2",
     "@azure/openai": "^1.0.0-beta.12",
     "@azure/search-documents": "^12.1.0",
     "@azure/storage-blob": "^12.21.0",

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-function/src/functions/AdoTokenRefresh.ts
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-function/src/functions/AdoTokenRefresh.ts
@@ -43,8 +43,8 @@ async function refreshAdoToken(_timer: Timer, context: InvocationContext): Promi
     context.log("Secret '%s' updated in Key Vault", SECRET_NAME);
 }
 
-// Run every 40 minutes so the token (~1 hour validity) stays fresh.
+// Run every 6 hours so the token (~24 hour validity) stays fresh.
 app.timer("adoTokenRefresh", {
-    schedule: "0 */40 * * * *",
+    schedule: "0 0 */6 * * *",
     handler: refreshAdoToken,
 });

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-function/src/functions/AdoTokenRefresh.ts
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-function/src/functions/AdoTokenRefresh.ts
@@ -2,7 +2,6 @@ import { app, InvocationContext, Timer } from "@azure/functions";
 import { DefaultAzureCredential, ManagedIdentityCredential } from "@azure/identity";
 import { SecretClient } from "@azure/keyvault-secrets";
 
-const ADO_RESOURCE_SCOPE = "499b84ac-1321-427f-aa17-267ca6975798/.default";
 const SECRET_NAME = "ado-token";
 
 /**
@@ -31,7 +30,7 @@ async function refreshAdoToken(_timer: Timer, context: InvocationContext): Promi
         : new DefaultAzureCredential();
 
     context.log("Requesting ADO token via managed identity...");
-    const tokenResponse = await credential.getToken(ADO_RESOURCE_SCOPE);
+    const tokenResponse = await credential.getToken(process.env.ADO_RESOURCE_SCOPE);
     if (!tokenResponse?.token) {
         context.error("Failed to obtain ADO token — empty response");
         throw new Error("ADO token acquisition returned no token");

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-function/src/functions/AdoTokenRefresh.ts
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-function/src/functions/AdoTokenRefresh.ts
@@ -1,0 +1,50 @@
+import { app, InvocationContext, Timer } from "@azure/functions";
+import { DefaultAzureCredential, ManagedIdentityCredential } from "@azure/identity";
+import { SecretClient } from "@azure/keyvault-secrets";
+
+const ADO_RESOURCE_SCOPE = "499b84ac-1321-427f-aa17-267ca6975798/.default";
+const SECRET_NAME = "ado-token";
+
+/**
+ * Timer-triggered function that refreshes the Azure DevOps bearer token
+ * in Key Vault.
+ *
+ * The Foundry-hosted QA Bot Agent cannot mint an ADO token directly
+ * (ADO doesn't accept its identity as an org member). This function
+ * runs under a UAMI that IS an org member, mints a token, and writes
+ * it to Key Vault for the agent to consume.
+ *
+ * Environment variables:
+ *   - KEY_VAULT_URL  : e.g. https://xxxx-kv.vault.azure.net
+ *   - AZURE_CLIENT_ID: client ID of the user-assigned managed identity
+ */
+async function refreshAdoToken(_timer: Timer, context: InvocationContext): Promise<void> {
+    const kvUrl = process.env.KEY_VAULT_URL;
+    if (!kvUrl) {
+        context.error("KEY_VAULT_URL is not configured");
+        throw new Error("KEY_VAULT_URL environment variable is required");
+    }
+
+    const clientId = process.env.AZURE_CLIENT_ID;
+    const credential = clientId
+        ? new ManagedIdentityCredential({ clientId })
+        : new DefaultAzureCredential();
+
+    context.log("Requesting ADO token via managed identity...");
+    const tokenResponse = await credential.getToken(ADO_RESOURCE_SCOPE);
+    if (!tokenResponse?.token) {
+        context.error("Failed to obtain ADO token — empty response");
+        throw new Error("ADO token acquisition returned no token");
+    }
+    context.log("ADO token acquired, expires at %s", new Date(tokenResponse.expiresOnTimestamp).toISOString());
+
+    const secretClient = new SecretClient(kvUrl, credential);
+    await secretClient.setSecret(SECRET_NAME, tokenResponse.token);
+    context.log("Secret '%s' updated in Key Vault", SECRET_NAME);
+}
+
+// Run every 40 minutes so the token (~1 hour validity) stays fresh.
+app.timer("adoTokenRefresh", {
+    schedule: "0 */40 * * * *",
+    handler: refreshAdoToken,
+});

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-function/src/index.ts
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-function/src/index.ts
@@ -3,6 +3,7 @@ import { app } from '@azure/functions';
 // Import function registrations
 import './functions/BotAnalytics';
 import './functions/ActivityConverter';
+import './functions/AdoTokenRefresh';
 
 app.setup({
     enableHttpStream: true,

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-function/tsconfig.json
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-function/tsconfig.json
@@ -9,5 +9,6 @@
     "strict": false,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true
-  }
+  },
+  "exclude": ["scripts"]
 }


### PR DESCRIPTION
Currently we've merged the framework migration PR: https://github.com/Azure/azure-sdk-tools/pull/15089. But we still encountered some issues that need to solve:

**1. Unable to add Agent identity to Azure DevOps Project**
- Impact: Our agent cannot access to ADO pipeline logs
- ICM: https://portal.microsofticm.com/imp/v5/incidents/details/797495593/summary
- Workaround: Add a new function to Azure function app, Use UMI to refresh the ADO token in the Key Vault at regular intervals. Since azsdk mcp doesn't support token auth, we need to implement a pipeline analyze tool.

**2. Can not assign CosmosDB data-plane RBAC Role to Agent identity**
- Impact: Our agent cannot use tenant-scope memory, since the tenant-scope memory is saved in CosmosDB
- ICM: https://portal.microsofticm.com/imp/v5/incidents/details/793196131/summary
- Workaround: Use key-based auth to CosmosDB

### Test
https://teams.microsoft.com/l/message/19:8551c70d67864a04b843151a256e109a@thread.tacv2/1779687695933?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=39910aef-85da-4e30-b5e3-35f04ef38648&parentMessageId=1779687695933&teamName=Azure%20SDK%20Q%26A%20Bot%20Testing&channelName=Azure%20SDK%20QA%20bot%20for%20Python%20Testing%20%20%F0%9F%90%8D&createdTime=1779687695933