### PR TITLE
chore: upgrade Vally CLI to 0.5.0 in skill eval workflow

### DIFF
--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: '22'
 
       - name: Install Vally CLI
-        run: npm install -g @microsoft/vally-cli@0.4.0
+        run: npm install -g @microsoft/vally-cli@0.5.0
 
       - name: Lint skills
         run: vally lint .


### PR DESCRIPTION
## Summary
- bump `.github/workflows/skill-eval.yml` from `@microsoft/vally-cli@0.4.0` to `@microsoft/vally-cli@0.5.0`

## Why
- align CI with the currently published latest Vally CLI package on npm
- keep skill lint/eval behavior consistent with local usage

## Validation
- searched `.github/**`, `doc/**`, and `tools/**` for pinned `@microsoft/vally-cli@...` references
- confirmed only `skill-eval.yml` had a Vally pin to update
