### PR TITLE
Run `npm exec -- eslint <paths> --fix --fix-type [problem,suggestion]` instead of `npm run lint:fix`

### DIFF
--- a/tools/js-sdk-release-tools/src/common/devToolUtils.ts
+++ b/tools/js-sdk-release-tools/src/common/devToolUtils.ts
@@ -47,7 +47,14 @@ export async function lintFix(packageDirectory: string) {
 
       // Ensure @azure/eslint-plugin-azure-sdk is built first; pnpm install only symlinks it.
       logger.info(`Building @azure/eslint-plugin-azure-sdk to ensure its dist files are available.`);
-      await runCommand('pnpm', ['build', '--filter', '@azure/eslint-plugin-azure-sdk'], runCommandOptions, true, 300, true);
+      await runCommand(
+        'pnpm',
+        ['build', '--filter', '@azure/eslint-plugin-azure-sdk'],
+        runCommandOptions,
+        true,
+        300,
+        true
+      );
       logger.info(`@azure/eslint-plugin-azure-sdk build step completed.`);
 
       // Lint only TypeScript source directories; exclude JSON files to avoid a crash in the

--- a/tools/js-sdk-release-tools/src/common/devToolUtils.ts
+++ b/tools/js-sdk-release-tools/src/common/devToolUtils.ts
@@ -49,6 +49,11 @@ export async function lintFix(packageDirectory: string) {
       await runCommand('pnpm', ['install', '--no-frozen-lockfile'], options, true, 300, true);
     }
 
+    // Ensure workspace packages used by the eslint config (e.g. @azure/eslint-plugin-azure-sdk)
+    // are built before invoking eslint, since pnpm install does not build workspace packages.
+    // Run from the process cwd (monorepo root) so pnpm can resolve the workspace filter.
+    await runCommand('pnpm', ['build', '--filter', '@azure/eslint-plugin-azure-sdk'], runCommandOptions, true, 300, true);
+
     // Build the list of paths to lint; conditionally include test and samples-dev if they exist.
     const lintPaths = ['package.json', 'api-extractor.json', 'src'];
     if (fs.existsSync(path.join(packageDirectory, 'test'))) {

--- a/tools/js-sdk-release-tools/src/common/devToolUtils.ts
+++ b/tools/js-sdk-release-tools/src/common/devToolUtils.ts
@@ -36,53 +36,45 @@ export async function lintFix(packageDirectory: string) {
   const options = { ...runCommandOptions, cwd };
 
   try {
-    // Ensure eslint is a dev dependency so `npm exec -- eslint` resolves it from local node_modules.
-    // Mgmt packages set lint/lint:fix to "echo skipped", so we run eslint directly instead of
-    // going through `npm run lint:fix` (which would be a no-op for those packages).
     const packageJsonPath = path.join(packageDirectory, 'package.json');
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf-8' }));
-    if (!packageJson.devDependencies?.eslint) {
-      logger.info(`eslint not found in devDependencies, adding it.`);
-      packageJson.devDependencies = packageJson.devDependencies ?? {};
-      packageJson.devDependencies['eslint'] = '^8.0.0';
-      fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, '  '), { encoding: 'utf-8' });
-      logger.info(`Re-running pnpm install to install newly added eslint devDependency.`);
-      await runCommand('pnpm', ['install', '--no-frozen-lockfile'], options, true, 300, true);
-      logger.info(`pnpm install completed after adding eslint.`);
+    const lintFixScript: string = packageJson.scripts?.['lint:fix'] ?? '';
+
+    if (lintFixScript.trimStart().startsWith('echo')) {
+      // lint:fix is a no-op for this package (e.g. mgmt packages set it to "echo skipped").
+      // Run eslint directly via `pnpm exec` so that pnpm resolves the binary from the
+      // workspace-hoisted node_modules/.bin without mutating package.json.
+
+      // Ensure @azure/eslint-plugin-azure-sdk is built first; pnpm install only symlinks it.
+      logger.info(`Building @azure/eslint-plugin-azure-sdk to ensure its dist files are available.`);
+      await runCommand('pnpm', ['build', '--filter', '@azure/eslint-plugin-azure-sdk'], runCommandOptions, true, 300, true);
+      logger.info(`@azure/eslint-plugin-azure-sdk build step completed.`);
+
+      // Lint only TypeScript source directories; exclude JSON files to avoid a crash in the
+      // ts-package-json-repo rule of @azure/eslint-plugin-azure-sdk under ESLint 9.
+      const lintPaths = ['src'];
+      if (fs.existsSync(path.join(packageDirectory, 'test'))) {
+        lintPaths.push('test');
+        logger.info(`'test' directory found, including in lint paths.`);
+      }
+      if (fs.existsSync(path.join(packageDirectory, 'samples-dev'))) {
+        lintPaths.push('samples-dev');
+        logger.info(`'samples-dev' directory found, including in lint paths.`);
+      }
+      logger.info(`Lint paths: ${lintPaths.join(', ')}`);
+
+      await runCommand(
+        'pnpm',
+        ['exec', 'eslint', ...lintPaths, '--fix', '--fix-type', '[problem,suggestion]'],
+        options,
+        true,
+        3600,
+        true
+      );
     } else {
-      logger.info(`eslint found in devDependencies: ${packageJson.devDependencies.eslint}`);
+      logger.info(`lint:fix script found ('${lintFixScript}'), running 'npm run lint:fix'.`);
+      await runCommand('npm', ['run', 'lint:fix'], options, true, 300, true);
     }
-
-    // Ensure workspace packages used by the eslint config (e.g. @azure/eslint-plugin-azure-sdk)
-    // are built before invoking eslint, since pnpm install does not build workspace packages.
-    // Run from the process cwd (monorepo root) so pnpm can resolve the workspace filter.
-    logger.info(`Building @azure/eslint-plugin-azure-sdk to ensure its dist files are available.`);
-    await runCommand('pnpm', ['build', '--filter', '@azure/eslint-plugin-azure-sdk'], runCommandOptions, true, 300, true);
-    logger.info(`@azure/eslint-plugin-azure-sdk build step completed.`);
-
-    // Build the list of paths to lint; conditionally include test and samples-dev if they exist.
-    // Note: we lint only TypeScript source directories (not package.json/api-extractor.json) to
-    // avoid compatibility issues between ESLint 9 and certain @azure/eslint-plugin-azure-sdk rules
-    // (e.g. ts-package-json-repo) that crash when processing JSON files.
-    const lintPaths = ['src'];
-    if (fs.existsSync(path.join(packageDirectory, 'test'))) {
-      lintPaths.push('test');
-      logger.info(`'test' directory found, including in lint paths.`);
-    }
-    if (fs.existsSync(path.join(packageDirectory, 'samples-dev'))) {
-      lintPaths.push('samples-dev');
-      logger.info(`'samples-dev' directory found, including in lint paths.`);
-    }
-    logger.info(`Lint paths: ${lintPaths.join(', ')}`);
-
-    await runCommand(
-      'npm',
-      ['exec', '--', 'eslint', ...lintPaths, '--fix', '--fix-type', '[problem,suggestion]'],
-      options,
-      true,
-      3600,
-      true
-    );
     logger.info(`Fix the automatically repairable lint errors successfully.`);
   } catch (error) {
     logger.warn(`Failed to fix lint errors due to: ${(error as Error)?.stack ?? error}`);

--- a/tools/js-sdk-release-tools/src/common/devToolUtils.ts
+++ b/tools/js-sdk-release-tools/src/common/devToolUtils.ts
@@ -1,5 +1,7 @@
 import { logger } from '../utils/logger.js';
 import { runCommand, runCommandOptions } from './utils.js';
+import fs from 'fs';
+import path from 'path';
 
 export async function formatSdk(packageDirectory: string) {
   logger.info(`Start to format code in '${packageDirectory}'.`);
@@ -34,7 +36,36 @@ export async function lintFix(packageDirectory: string) {
   const options = { ...runCommandOptions, cwd };
 
   try {
-    await runCommand(`npm`, ['run', 'lint:fix'], options, true, 3600, true);
+    // Ensure eslint is a dev dependency so `npm exec -- eslint` resolves it from local node_modules.
+    // Mgmt packages set lint/lint:fix to "echo skipped", so we run eslint directly instead of
+    // going through `npm run lint:fix` (which would be a no-op for those packages).
+    const packageJsonPath = path.join(packageDirectory, 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf-8' }));
+    if (!packageJson.devDependencies?.eslint) {
+      logger.info(`eslint not found in devDependencies, adding it.`);
+      packageJson.devDependencies = packageJson.devDependencies ?? {};
+      packageJson.devDependencies['eslint'] = '^8.0.0';
+      fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, '  '), { encoding: 'utf-8' });
+      await runCommand('pnpm', ['install', '--no-frozen-lockfile'], options, true, 300, true);
+    }
+
+    // Build the list of paths to lint; conditionally include test and samples-dev if they exist.
+    const lintPaths = ['package.json', 'api-extractor.json', 'src'];
+    if (fs.existsSync(path.join(packageDirectory, 'test'))) {
+      lintPaths.push('test');
+    }
+    if (fs.existsSync(path.join(packageDirectory, 'samples-dev'))) {
+      lintPaths.push('samples-dev');
+    }
+
+    await runCommand(
+      'npm',
+      ['exec', '--', 'eslint', ...lintPaths, '--fix', '--fix-type', '[problem,suggestion]'],
+      options,
+      true,
+      3600,
+      true
+    );
     logger.info(`Fix the automatically repairable lint errors successfully.`);
   } catch (error) {
     logger.warn(`Failed to fix lint errors due to: ${(error as Error)?.stack ?? error}`);

--- a/tools/js-sdk-release-tools/src/common/devToolUtils.ts
+++ b/tools/js-sdk-release-tools/src/common/devToolUtils.ts
@@ -61,7 +61,10 @@ export async function lintFix(packageDirectory: string) {
     logger.info(`@azure/eslint-plugin-azure-sdk build step completed.`);
 
     // Build the list of paths to lint; conditionally include test and samples-dev if they exist.
-    const lintPaths = ['package.json', 'api-extractor.json', 'src'];
+    // Note: we lint only TypeScript source directories (not package.json/api-extractor.json) to
+    // avoid compatibility issues between ESLint 9 and certain @azure/eslint-plugin-azure-sdk rules
+    // (e.g. ts-package-json-repo) that crash when processing JSON files.
+    const lintPaths = ['src'];
     if (fs.existsSync(path.join(packageDirectory, 'test'))) {
       lintPaths.push('test');
       logger.info(`'test' directory found, including in lint paths.`);

--- a/tools/js-sdk-release-tools/src/common/devToolUtils.ts
+++ b/tools/js-sdk-release-tools/src/common/devToolUtils.ts
@@ -46,22 +46,31 @@ export async function lintFix(packageDirectory: string) {
       packageJson.devDependencies = packageJson.devDependencies ?? {};
       packageJson.devDependencies['eslint'] = '^8.0.0';
       fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, '  '), { encoding: 'utf-8' });
+      logger.info(`Re-running pnpm install to install newly added eslint devDependency.`);
       await runCommand('pnpm', ['install', '--no-frozen-lockfile'], options, true, 300, true);
+      logger.info(`pnpm install completed after adding eslint.`);
+    } else {
+      logger.info(`eslint found in devDependencies: ${packageJson.devDependencies.eslint}`);
     }
 
     // Ensure workspace packages used by the eslint config (e.g. @azure/eslint-plugin-azure-sdk)
     // are built before invoking eslint, since pnpm install does not build workspace packages.
     // Run from the process cwd (monorepo root) so pnpm can resolve the workspace filter.
+    logger.info(`Building @azure/eslint-plugin-azure-sdk to ensure its dist files are available.`);
     await runCommand('pnpm', ['build', '--filter', '@azure/eslint-plugin-azure-sdk'], runCommandOptions, true, 300, true);
+    logger.info(`@azure/eslint-plugin-azure-sdk build step completed.`);
 
     // Build the list of paths to lint; conditionally include test and samples-dev if they exist.
     const lintPaths = ['package.json', 'api-extractor.json', 'src'];
     if (fs.existsSync(path.join(packageDirectory, 'test'))) {
       lintPaths.push('test');
+      logger.info(`'test' directory found, including in lint paths.`);
     }
     if (fs.existsSync(path.join(packageDirectory, 'samples-dev'))) {
       lintPaths.push('samples-dev');
+      logger.info(`'samples-dev' directory found, including in lint paths.`);
     }
+    logger.info(`Lint paths: ${lintPaths.join(', ')}`);
 
     await runCommand(
       'npm',


### PR DESCRIPTION
fixes https://github.com/Azure/azure-sdk-tools/issues/15754
### Problem
Mgmt-plane packages set lint:fix to echo skipped, so `lintFix` (which called `npm run lint:fix`) was a no-op. Generated code was left with bare type imports that should be import type.

### Fix
Run ESLint directly via `npm exec -- eslint src [test] [samples-dev] --fix --fix-type [problem,suggestion]` instead of `npm run lint:fix`
Build @azure/eslint-plugin-azure-sdk before linting (pnpm install symlinks workspace packages but doesn't build them)
Exclude JSON files from lint paths — ESLint 9 crashes in the ts-package-json-repo rule when processing `package.json`
Treat ESLint exit code 1 as non-fatal — fixes are written to disk even when unfixable errors remain

### Test AutoPR:
https://github.com/Azure/azure-sdk-for-js/pull/38694
https://github.com/Azure/azure-sdk-for-js/pull/38695