### PR TITLE
Run npm ci before running TypeSpec emitter to parse package names

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/TypeSpecHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/TypeSpecHelperTests.cs
@@ -21,7 +21,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Helpers
             gitHubService = new Mock<IGitHubService>();
             var gitCommandHelper = new GitCommandHelper(NullLogger<GitCommandHelper>.Instance, Mock.Of<IRawOutputHelper>());
             gitHelper = new GitHelper(gitHubService.Object, gitCommandHelper, logger);
-            typeSpecHelper = new TypeSpecHelper(gitHelper);
+            var processHelper = new ProcessHelper(new TestLogger<ProcessHelper>(), Mock.Of<IRawOutputHelper>());
+            typeSpecHelper = new TypeSpecHelper(gitHelper, processHelper);
         }
 
         [Test]
@@ -127,7 +128,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Helpers
         public async Task Test_IsRepoPathForSpecRepo(Uri repo)
         {
             var gitHelper = CreateGitHelper(repo);
-            var helper = new TypeSpecHelper(gitHelper);
+            var processHelper = new ProcessHelper(new TestLogger<ProcessHelper>(), Mock.Of<IRawOutputHelper>());
+            var helper = new TypeSpecHelper(gitHelper, processHelper);
             Assert.That(await helper.IsRepoPathForSpecRepoAsync("unused because of mock"), "is a specs repo (public or private)");
         }
 
@@ -139,7 +141,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Helpers
         [Test]
         public async Task Test_IsRepoPathForPublicSpecRepo(Uri repo)
         {
-            var helper = new TypeSpecHelper(CreateGitHelper(repo));
+            var processHelper = new ProcessHelper(new TestLogger<ProcessHelper>(), Mock.Of<IRawOutputHelper>());
+            var helper = new TypeSpecHelper(CreateGitHelper(repo), processHelper);
             Assert.That(!await helper.IsRepoPathForPublicSpecRepoAsync("unused because of the mock"), "not the public specs repo");
         }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/FeedbackClassifierServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/FeedbackClassifierServiceTests.cs
@@ -100,7 +100,10 @@ public class FeedbackClassifierServiceTests
     private static FeedbackItem CreateTestItem(string text, string? id = null)
     {
         var item = new FeedbackItem { Text = text };
-        if (id != null) item.Id = id;
+        if (id != null)
+        {
+            item.Id = id;
+        }
         return item;
     }
 
@@ -124,7 +127,8 @@ public class FeedbackClassifierServiceTests
     {
         var rawOutputHelper = Mock.Of<IRawOutputHelper>();
         var gitHelper = CreateRealGitHelper();
-        var typeSpecHelper = new TypeSpecHelper(gitHelper);
+        var processHelper = new ProcessHelper(new TestLogger<ProcessHelper>(), rawOutputHelper);
+        var typeSpecHelper = new TypeSpecHelper(gitHelper, processHelper);
 
         var copilotClient = new CopilotClient(new CopilotClientOptions
         {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/TypeSpec/TypeSpecCustomizationServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/TypeSpec/TypeSpecCustomizationServiceTests.cs
@@ -74,7 +74,8 @@ internal class TypeSpecCustomizationServiceTests
             rawOutputHelper);
         var tokenUsageHelper = new TokenUsageHelper(rawOutputHelper);
         var gitHelper = CreateRealGitHelper();
-        var typeSpecHelper = new TypeSpecHelper(gitHelper);
+        var processHelper = new ProcessHelper(new TestLogger<ProcessHelper>(), rawOutputHelper);
+        var typeSpecHelper = new TypeSpecHelper(gitHelper, processHelper);
 
         // Create real CopilotClient - this will use GitHub credentials
         var copilotClient = new CopilotClient(new CopilotClientOptions
@@ -132,7 +133,8 @@ internal class TypeSpecCustomizationServiceTests
         var copilotAgentRunner = Mock.Of<ICopilotAgentRunner>();
         var npxHelper = Mock.Of<INpxHelper>();
         var tokenUsageHelper = new TokenUsageHelper(Mock.Of<IRawOutputHelper>());
-        var typeSpecHelper = new TypeSpecHelper(Mock.Of<IGitHelper>());
+        var processHelper = new ProcessHelper(new TestLogger<ProcessHelper>(), Mock.Of<IRawOutputHelper>());
+        var typeSpecHelper = new TypeSpecHelper(Mock.Of<IGitHelper>(), processHelper);
         var gitHelper = Mock.Of<IGitHelper>();
 
         var service = new TypeSpecCustomizationService(
@@ -159,7 +161,8 @@ internal class TypeSpecCustomizationServiceTests
         var npxHelper = Mock.Of<INpxHelper>();
         var tokenUsageHelper = new TokenUsageHelper(Mock.Of<IRawOutputHelper>());
         var gitHelper = CreateRealGitHelper();
-        var typeSpecHelper = new TypeSpecHelper(gitHelper);
+        var processHelper = new ProcessHelper(new TestLogger<ProcessHelper>(), Mock.Of<IRawOutputHelper>());
+        var typeSpecHelper = new TypeSpecHelper(gitHelper, processHelper);
 
         var service = new TypeSpecCustomizationService(
             logger,

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
@@ -51,7 +51,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync((string path, CancellationToken _) => path.Contains("specification") ? path.Substring(0, path.IndexOf("specification")) : path);
             gitHelper = gitHelperMock.Object;
 
-            typeSpecHelper = new TypeSpecHelper(gitHelper);
+            var processHelper = new ProcessHelper(new TestLogger<ProcessHelper>(), Mock.Of<IRawOutputHelper>());
+            typeSpecHelper = new TypeSpecHelper(gitHelper, processHelper);
 
             releasePlanTool = new ReleasePlanTool(
                 devOpsService,

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
@@ -853,7 +853,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         public async Task Test_FindProduct_with_valid_typespec_path()
         {
             // Arrange
-            var typeSpecProjectPath = "specification/testcontoso/Contoso.Management";
+            var typeSpecProjectPath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
 
             // Act
             var result = await releasePlanTool.GetProductByTypeSpecPath(typeSpecProjectPath);
@@ -882,8 +882,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             // Assert
             Assert.IsNotNull(result);
             Assert.IsNull(result.ProductInfo);
-            Assert.IsNull(result.ResponseError);
-            Assert.That(result.Message, Does.Contain("No release plan found"));
+            Assert.That(result.ResponseError, Does.Contain("Invalid TypeSpec project path. tspconfig.yaml is not found in the path specification/nonexistent/Service."));
         }
 
         [Test]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 0.6.16 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 0.6.16 (2026-06-01)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fixed issues in the MCP tool to lookup service details using TypeSpec project path.
 
 ## 0.6.15 (2026-05-29)
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TypeSpecHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TypeSpecHelper.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Models.AzureDevOps;
@@ -72,11 +73,13 @@ namespace Azure.Sdk.Tools.Cli.Helpers
         [GeneratedRegex(@"^https://github\.com/[^/]+/azure-rest-api-specs/(blob|tree)/[^/]+/specification/.+$", RegexOptions.IgnoreCase)]
         private static partial Regex GitHubSpecUrlRegex();
 
-        private IGitHelper _gitHelper;
+        private readonly IGitHelper _gitHelper;
+        private readonly IProcessHelper _processHelper;
 
-        public TypeSpecHelper(IGitHelper gitHelper)
+        public TypeSpecHelper(IGitHelper gitHelper, IProcessHelper processHelper)
         {
             _gitHelper = gitHelper;
+            _processHelper = processHelper;
         }
 
         public bool IsUrl(string path)
@@ -96,6 +99,12 @@ namespace Azure.Sdk.Tools.Cli.Helpers
             return typeSpecObject?.IsManagementPlane ?? false;
         }
 
+        private bool IsTypeParserExecutablePresent(string repoRoot)
+        {
+            var tspExecutable = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "tsp.cmd" : "tsp";
+            return File.Exists(Path.Combine(repoRoot, "node_modules", ".bin", tspExecutable));
+        }
+
         /// <inheritdoc/>
         public async Task<TypeSpecProject?> ParseTypeSpecProjectAsync(string typeSpecProjectPath, INpxHelper npxHelper, ILogger logger, CancellationToken ct)
         {
@@ -111,6 +120,21 @@ namespace Azure.Sdk.Tools.Cli.Helpers
                 {
                     logger.LogWarning("Invalid TypeSpec project path: {typeSpecProjectPath}. Skipping metadata emitter.", typeSpecProjectPath);
                     return null;
+                }
+
+                var repoRoot = GetSpecRepoRootPath(typeSpecProjectPath);
+                if (string.IsNullOrEmpty(repoRoot))
+                {
+                    logger.LogWarning("Could not determine repo root for path: {typeSpecProjectPath}. Skipping metadata emitter.", typeSpecProjectPath);
+                    return null;
+                }
+
+                if (!IsTypeParserExecutablePresent(repoRoot))
+                {
+                    logger.LogInformation("TypeSpec compiler not found in {typeSpecProjectPath}. Installing dependencies...", typeSpecProjectPath);
+                    var processOptions = new ProcessOptions("npm", ["ci"], workingDirectory: repoRoot);
+                    await _processHelper.Run(processOptions, ct);
+                    logger.LogInformation("npm ci completed.");
                 }
 
                 var project = TypeSpecProject.ParseTypeSpecConfig(typeSpecProjectPath);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TypeSpecHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TypeSpecHelper.cs
@@ -132,7 +132,7 @@ namespace Azure.Sdk.Tools.Cli.Helpers
                     var packageLockPath = Path.Combine(repoRoot, "package-lock.json");
                     if (!File.Exists(packageLockPath))
                     {
-                        logger.LogWarning("TypeSpec compiler not found and {packageLockPath} does not exist. Skipping npm ci.", packageLockPath);
+                        logger.LogWarning("TypeSpec compiler not found in node-modules and {packageLockPath} does not exist. Skipping npm ci.", packageLockPath);
                     }
                     else
                     {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TypeSpecHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TypeSpecHelper.cs
@@ -125,16 +125,27 @@ namespace Azure.Sdk.Tools.Cli.Helpers
                 var repoRoot = GetSpecRepoRootPath(typeSpecProjectPath);
                 if (string.IsNullOrEmpty(repoRoot))
                 {
-                    logger.LogWarning("Could not determine repo root for path: {typeSpecProjectPath}. Skipping metadata emitter.", typeSpecProjectPath);
-                    return null;
+                    logger.LogWarning("Could not determine repo root for path: {typeSpecProjectPath}. Continuing without automatic dependency install.", typeSpecProjectPath);
                 }
-
-                if (!IsTypeParserExecutablePresent(repoRoot))
+                else if (!IsTypeParserExecutablePresent(repoRoot))
                 {
-                    logger.LogInformation("TypeSpec compiler not found in {typeSpecProjectPath}. Installing dependencies...", typeSpecProjectPath);
-                    var processOptions = new ProcessOptions("npm", ["ci"], workingDirectory: repoRoot);
-                    await _processHelper.Run(processOptions, ct);
-                    logger.LogInformation("npm ci completed.");
+                    var packageLockPath = Path.Combine(repoRoot, "package-lock.json");
+                    if (!File.Exists(packageLockPath))
+                    {
+                        logger.LogWarning("TypeSpec compiler not found and {packageLockPath} does not exist. Skipping npm ci.", packageLockPath);
+                    }
+                    else
+                    {
+                        logger.LogInformation("TypeSpec compiler not found in {repoRoot}. Installing dependencies...", repoRoot);
+                        var processOptions = new ProcessOptions("npm", ["ci"], workingDirectory: repoRoot, timeout: TimeSpan.FromMinutes(15));
+                        var npmResult = await _processHelper.Run(processOptions, ct);
+                        if (npmResult.ExitCode != 0)
+                        {
+                            logger.LogWarning("npm ci failed with exit code {ExitCode}. Output: {Output}", npmResult.ExitCode, npmResult.Output);
+                            return null;
+                        }
+                        logger.LogInformation("npm ci completed.");
+                    }
                 }
 
                 var project = TypeSpecProject.ParseTypeSpecConfig(typeSpecProjectPath);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -1710,15 +1710,25 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     };
                 }
 
+                var isValidTypeSpec = typeSpecHelper.IsValidTypeSpecProjectPath(typeSpecProjectPath);
+                if (!isValidTypeSpec)
+                {
+                    return new ProductInfoResponse
+                    {
+                        ResponseError = $"Invalid TypeSpec project path. tspconfig.yaml is not found in the path {typeSpecProjectPath}.",
+                        TypeSpecProject = typeSpecProjectPath
+                    };
+                }
+                var specRelativePath = typeSpecHelper.GetTypeSpecProjectRelativePath(typeSpecProjectPath);
                 // Get product info from DevOps service
-                var productInfo = await devOpsService.GetProductInfoByTypeSpecProjectPathAsync(typeSpecProjectPath, ct);
+                var productInfo = await devOpsService.GetProductInfoByTypeSpecProjectPathAsync(specRelativePath, ct);
 
                 if (productInfo == null)
                 {
                     return new ProductInfoResponse
                     {
-                        Message = $"No release plan found for TypeSpec project path: {typeSpecProjectPath}",
-                        TypeSpecProject = typeSpecProjectPath
+                        Message = $"No release plan found for TypeSpec project path: {specRelativePath}",
+                        TypeSpecProject = specRelativePath
                     };
                 }
 
@@ -1726,7 +1736,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 {
                     ProductInfo = productInfo,
                     Message = "Successfully retrieved product information.",
-                    TypeSpecProject = typeSpecProjectPath
+                    TypeSpecProject = specRelativePath
                 };
             }
             catch (Exception ex)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -1011,6 +1011,12 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
 
                 var requiredLanguages = releasePlan.IsManagementPlane ? languagesforMgmtplane : languagesforDataplane;
 
+                // Validate SDK language name
+                if (SdkInfos.Any(sdk => !requiredLanguages.Contains(sdk.Language, StringComparer.OrdinalIgnoreCase)))
+                {
+                    return new DefaultCommandResponse { ResponseError = $"Unsupported SDK language found. Supported languages are: {string.Join(", ", requiredLanguages)}" };
+                }
+
                 // Validate SDK Package names
                 var languagePrefixMap = new Dictionary<string, string>
                 (StringComparer.OrdinalIgnoreCase)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -1009,12 +1009,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     return new DefaultCommandResponse { ResponseError = $"No release plan found with work item ID {releasePlanWorkItemId}" };
                 }
 
-                var supportedLanguages = releasePlan.IsManagementPlane ? languagesforMgmtplane : languagesforDataplane;
-                // Validate SDK language name
-                if (SdkInfos.Any(sdk => !supportedLanguages.Contains(sdk.Language, StringComparer.OrdinalIgnoreCase)))
-                {
-                    return $"Unsupported SDK language found. Supported languages are: {string.Join(", ", supportedLanguages)}";
-                }
+                var requiredLanguages = releasePlan.IsManagementPlane ? languagesforMgmtplane : languagesforDataplane;
 
                 // Validate SDK Package names
                 var languagePrefixMap = new Dictionary<string, string>
@@ -1053,11 +1048,11 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 }
 
                 // Check if any language is excluded
-                var excludedLanguages = supportedLanguages.Except(SdkInfos.Select(sdk => sdk.Language), StringComparer.OrdinalIgnoreCase);
+                var excludedLanguages = requiredLanguages.Except(SdkInfos.Select(sdk => sdk.Language), StringComparer.OrdinalIgnoreCase);
                 if (excludedLanguages.Any())
                 {
                     logger.LogDebug("Languages excluded in release plan. Work Item: {releasePlanWorkItemId}, languages: {excludedLanguages}", releasePlanWorkItemId, string.Join(", ", excludedLanguages));
-                    sb.AppendLine($"Important: The following languages were excluded in the release plan. SDK must be released for all languages. [{string.Join(", ", supportedLanguages)}]");
+                    sb.AppendLine($"Important: The following languages were excluded in the release plan. SDK must be released for all languages. [{string.Join(", ", requiredLanguages)}]");
                     sb.AppendLine("Explanation is required for any language exclusion. Please provide a justification for each excluded language.");
 
                     // Mark excluded language as 'Requested' in the release plan work item.


### PR DESCRIPTION
TypeSpec config parser requires tsp and TypeSpec emitter packages and these are installed by npm ci. Add a step in TypeSpec parsing to check if tsp is present and run npm ci when tsp is not present.

Impact: This issue is causing a lot of back and forth when update release plan or update sdk details MCP tool fails. Change in this PR will simplify user experience by automatically handling missing TypeSpec packages when parsing the project to get package names.