### PR TITLE
Update fetching of installation ID

### DIFF
--- a/eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+++ b/eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
@@ -15,7 +15,7 @@ steps:
   - template: /eng/common/pipelines/templates/steps/login-to-github.yml
     parameters:
       TokenOwners:
-        - ${{ split(parameters.RepoId, '/')[0] }}
+        - ${{ parameters.RepoId }}
       ScriptDirectory: ${{ parameters.ScriptDirectory }}
 
 - task: PowerShell@2

--- a/eng/common/scripts/login-to-github.ps1
+++ b/eng/common/scripts/login-to-github.ps1
@@ -131,7 +131,7 @@ function Get-GitHubInstallationId {
     $resp | Foreach-Object { Write-Host "  $($_.id): $($_.account.login) [$($_.target_type)]" }
 
     $resp = $resp | Where-Object { $_.account.login -ieq $InstallationTokenOwner }
-    if (!$resp.id) { throw "No installations found for this App." }
+    if ($null -eq $resp -or !$resp.id) { throw "No installation found for '$InstallationTokenOwner' in this App. Verify the App is installed on that org/user." }
     return $resp.id
 }
 
@@ -154,8 +154,10 @@ $jwt = New-GitHubAppJwt -VaultName $KeyVaultName -KeyName $KeyName -AppId $GitHu
 
 foreach ($InstallationTokenOwner in $InstallationTokenOwners) 
 {
-  Write-Host "Fetching installation ID for $InstallationTokenOwner ..."
-  $installationId = Get-GitHubInstallationId -Jwt $jwt -ApiBase $GitHubApiBaseUrl -ApiVersion $GitHubApiVersion -InstallationTokenOwner $InstallationTokenOwner
+  # Token owners can be provided as either "owner" or "owner/repo". Normalize to owner.
+  $normalizedOwner = ($InstallationTokenOwner -split '/')[0]
+  Write-Host "Fetching installation ID for $InstallationTokenOwner (normalized owner: $normalizedOwner) ..."
+  $installationId = Get-GitHubInstallationId -Jwt $jwt -ApiBase $GitHubApiBaseUrl -ApiVersion $GitHubApiVersion -InstallationTokenOwner $normalizedOwner
 
   Write-Host "Installation ID resolved: $installationId"
 
@@ -165,7 +167,7 @@ foreach ($InstallationTokenOwner in $InstallationTokenOwners)
   $variableName = $VariableNamePrefix
   if ($InstallationTokenOwners.Count -gt 1)
   {
-    $variableName = $VariableNamePrefix + "_" + $InstallationTokenOwner
+    $variableName = $VariableNamePrefix + "_" + $normalizedOwner
   }
 
   Set-Item -Path Env:$variableName -Value $installationToken


### PR DESCRIPTION
This pull request updates the GitHub authentication and token handling logic in the pipeline and related scripts to improve reliability and correctness, especially when dealing with repository identifiers that include both owner and repo names. The changes ensure that the correct owner is used when fetching installation IDs, and improve error messaging for easier troubleshooting.

**Improvements to GitHub authentication and token handling:**

* In `login-to-github.ps1`, token owners are now normalized to just the owner part (splitting off any `/repo` suffix) before resolving installation IDs, ensuring compatibility with GitHub App installations.
* The environment variable name for each token is now constructed using the normalized owner rather than the potentially more specific `owner/repo` form, preventing issues with variable naming.

**Error handling and messaging:**

* The error message when no installation is found for a given owner is now more informative, specifying the owner and suggesting verification of the App installation.

**Pipeline parameter passing:**

* In `create-tags-and-git-release.yml`, the `TokenOwners` parameter now passes the full `RepoId` string, allowing downstream logic to handle normalization, which centralizes and simplifies token owner processing.