### PR TITLE
Add skill-eval-authoring skill and harden release-plan eval exemplar

### DIFF
--- a/.github/skills/.vally.yaml
+++ b/.github/skills/.vally.yaml
@@ -1,6 +1,7 @@
 paths:
   evals:
     - skill-authoring/evals/
+    - skill-eval-authoring/evals/
     - azsdk-common-pipeline-troubleshooting/evals/
     - markdown-token-optimizer/evals/
     - sensei/evals/

--- a/.github/skills/azsdk-common-prepare-release-plan/evals/eval.yaml
+++ b/.github/skills/azsdk-common-prepare-release-plan/evals/eval.yaml
@@ -1,5 +1,13 @@
 name: azsdk-common-prepare-release-plan-eval
-description: Evaluation suite for the azsdk-common-prepare-release-plan skill
+description: |
+  Capability tests for the prepare-release-plan skill.
+
+  This file is the canonical four-layer-pattern exemplar referenced by the
+  skill-eval-authoring skill. Every capability stimulus asserts BOTH that the
+  right skill was loaded (skill-invocation) AND that the right MCP tool was
+  called (tool-calls). Substring graders are only used as cheap output-shape
+  sanity checks, never as the sole assertion.
+
 type: capability
 
 environment: azsdk-mcp-mock
@@ -7,6 +15,7 @@ environment: azsdk-mcp-mock
 tags:
   area: azsdk-common-prepare-release-plan
   type: ci-gate
+  tier: integration
 
 config:
   runs: 1
@@ -18,51 +27,90 @@ scoring:
   threshold: 0.8
 
 stimuli:
-  - name: release-plan-basic-001
-    prompt: "I need to create a release plan for my API spec PR https://github.com/Azure/azure-rest-api-specs/pull/12345. The API version is 2024-06-01 and it's a stable release."
+  # ----- HAPPY PATH: create release plan from spec PR -----
+  - name: create-from-spec-pr
+    prompt: |
+      Create a release plan for spec PR
+      https://github.com/Azure/azure-rest-api-specs/pull/38387.
+      API version 2024-06-01-preview, public preview, beta SDK,
+      target December 2026, TypeSpec project
+      specification/contosowidgetmanager/Contoso.WidgetManager.
     graders:
-      - type: output-contains
+      - type: skill-invocation
         config:
-          substring: "release plan"
+          required: ["azsdk-common-prepare-release-plan"]
+      - type: tool-calls
+        config:
+          required:
+            - name: azsdk_create_release_plan
+          disallowed:
+            - name: azsdk_release_sdk
+      - type: output-matches
+        config:
+          pattern: "(release plan|work item).*(created|link|id|succeeded)"
 
-  - name: release-plan-edge-001
-    prompt: "Update the release plan with these SDK details: JavaScript package '@azure/arm-compute' and Go package 'sdk/armcompute'."
+  # ----- HAPPY PATH: update SDK details on existing release plan -----
+  - name: update-sdk-details
+    prompt: |
+      Update release plan 67890 with these SDK packages:
+      JavaScript @azure/arm-compute v3.0.0 and Go sdk/armcompute v2.0.0.
     graders:
-      - type: output-contains
+      - type: skill-invocation
         config:
-          substring: "release plan"
+          required: ["azsdk-common-prepare-release-plan"]
+      - type: tool-calls
+        config:
+          required:
+            - name: azsdk_update_sdk_details_in_release_plan
 
-  - name: release-plan-link-001
-    prompt: "I have release plan 67890 and SDK PRs for Python (PR #100) and .NET (PR #200) in the azure-sdk repos. Link them to the release plan."
+  # ----- HAPPY PATH: link SDK pull requests -----
+  - name: link-sdk-prs
+    prompt: |
+      I have release plan 67890 and SDK PRs:
+      Python Azure/azure-sdk-for-python#100 and .NET Azure/azure-sdk-for-net#200.
+      Link them to the release plan.
     graders:
-      - type: output-contains
+      - type: skill-invocation
         config:
-          substring: "release plan"
+          required: ["azsdk-common-prepare-release-plan"]
+      - type: tool-calls
+        config:
+          required:
+            - name: azsdk_link_sdk_pull_request_to_release_plan
 
-  - name: release-plan-negative-001
+  # ----- HAPPY PATH: get release plan status -----
+  - name: get-release-plan-status
+    prompt: "What's the status of release plan 67890?"
+    graders:
+      - type: skill-invocation
+        config:
+          required: ["azsdk-common-prepare-release-plan"]
+      - type: tool-calls
+        config:
+          required:
+            - name: azsdk_get_release_plan
+
+  # ----- NEGATIVE: wrong tool family (package release, not release plan) -----
+  - name: refuses-package-release
     prompt: "Release the azure-mgmt-compute Python package to PyPI now."
     graders:
+      - type: skill-invocation
+        config:
+          disallowed: ["azsdk-common-prepare-release-plan"]
       - type: tool-calls
         config:
           disallowed:
-            - name: azure-sdk-mcp-azsdk_create_release_plan
-      - type: output-not-contains
-        config:
-          substring: "Service Tree ID"
+            - name: azsdk_create_release_plan
+            - name: azsdk_release_sdk
 
-  - name: basic-trigger
-    prompt: "I need to prepare a release plan for the new Azure SDK package version"
-    graders:
-      - type: output-contains
-        config:
-          substring: "release"
-
-  - name: anti-trigger
+  # ----- NEGATIVE: completely off-topic -----
+  - name: refuses-logging-question
     prompt: "How do I configure logging in my Azure Function?"
     graders:
-      - type: output-not-contains
+      - type: skill-invocation
         config:
-          substring: "release plan"
-      - type: output-not-contains
+          disallowed: ["azsdk-common-prepare-release-plan"]
+      - type: tool-calls
         config:
-          substring: "changelog"
+          disallowed:
+            - name: azsdk_create_release_plan

--- a/.github/skills/skill-eval-authoring/SKILL.md
+++ b/.github/skills/skill-eval-authoring/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: skill-eval-authoring
+description: |
+  Author and harden Vally eval suites for Azure SDK skills (.github/skills/*/evals/).
+  WHEN: "write an eval", "add a capability test", "skill is missing tests",
+  "fix vacuous output-contains", "review my eval.yaml", "apply the four-layer pattern",
+  "add trigger and anti-trigger tests", "lint skill evals".
+  DO NOT USE FOR: running the Vally CLI directly (use the Vally primer), debugging
+  failing test trajectories, MCP tool implementation, SKILL.md authoring itself.
+  INVOKES: file_search, read_file, create_file, replace_string_in_file, run_in_terminal
+  (for `vally lint` and `vally eval --tag area=<skill>`).
+---
+
+# Skill: Eval authoring for `.github/skills`
+
+## What this skill is for
+
+Skill evals in this repo are not pass/fail vibes &mdash; they are the **contract** a
+skill makes with the agent runtime. This skill teaches the agent (and you) how to
+write evals that actually pin that contract down, so a silent regression cannot
+sneak through CI.
+
+Use this skill when:
+
+- You created a new skill under `.github/skills/<name>/` and the `evals/` folder
+  is empty or stubby.
+- An existing capability test is graded only by `output-contains "<single word>"`
+  and you want to harden it.
+- A reviewer asked you to add trigger / anti-trigger coverage.
+- You need to lint the whole `.github/skills` tree before opening a PR.
+
+## The four-layer pattern (memorize this)
+
+Every capability stimulus should assert as many of these layers as apply. **At
+minimum**, layer 1 + layer 2.
+
+| Layer | Grader | Asserts |
+|-------|--------|---------|
+| 1. Routing | `skill-invocation` | The right skill was loaded for this prompt |
+| 2. Tool-use | `tool-calls` | The right MCP tool was invoked (and wrong ones were not) |
+| 3. Output shape | `output-matches` or `output-contains` | The reply structurally addresses the request |
+| 4. Judgment | `prompt` (LLM) | Anything the first three cannot express; use sparingly |
+
+Negative stimuli flip layers 1 and 2 to `disallowed:`.
+
+## Folder layout to produce
+
+```
+.github/skills/<skill-name>/
+├── SKILL.md
+├── references/                       # optional, for long docs the skill points to
+└── evals/
+    ├── eval.yaml                     # capability tests
+    └── trigger.eval.yaml             # routing tests (positive + anti-trigger)
+```
+
+## Hard rules (the linter will enforce these)
+
+1. Every `eval.yaml` and `trigger.eval.yaml` MUST set `scoring.threshold`
+   (recommended: `0.8`). Vally treats missing threshold as 0 &mdash; everything
+   passes.
+2. No capability stimulus may have only `output-contains` as its grader, unless
+   the substring is &ge; 20 chars AND not a prefix of the prompt itself.
+3. Every capability stimulus MUST have at least one `tool-calls` OR
+   `skill-invocation` grader.
+4. Tool names in `tool-calls.required` / `disallowed` should be the **bare**
+   form (`azsdk_create_release_plan`), not the MCP-prefixed form, for
+   portability across environments. (Both match, the bare form is just clearer.)
+5. Negative stimuli MUST assert tool absence with `tool-calls.disallowed`, not
+   only `output-not-contains`. Output silence is cheap; tool absence is the
+   actual contract.
+
+## Canonical exemplar
+
+When in doubt, copy the shape of
+[.github/skills/azsdk-common-prepare-release-plan/evals/eval.yaml](../azsdk-common-prepare-release-plan/evals/eval.yaml).
+It is intentionally the gold-standard reference for this skill.
+
+## Workflow the agent should follow
+
+1. **Read the target skill's `SKILL.md`.** Pull the `INVOKES:` tool list and
+   the `WHEN:` / `DO NOT USE FOR:` phrases.
+2. **Inventory the evals folder.** Note any existing stimuli; new work should be
+   additive unless explicitly asked to rewrite.
+3. **Generate one capability stimulus per `INVOKES:` tool.** Use the four-layer
+   pattern. Pick prompts that are concrete (real-ish URLs, version numbers,
+   project paths) so the model has to call the tool, not just paraphrase.
+4. **Generate trigger / anti-trigger entries** from the `WHEN:` and
+   `DO NOT USE FOR:` phrases. Each phrase becomes one stimulus with a single
+   `skill-invocation` grader.
+5. **Set `scoring.threshold: 0.8`** and add tags:
+   `area: <skill-name>`, `type: ci-gate`, `tier: integration` (or `unit` if the
+   tests are prompt-only refusals).
+6. **Run the lint script and a focused eval:**
+   ```powershell
+   cd .github/skills
+   vally lint .
+   vally eval --tag area=<skill-name> --output-dir ./results
+   ```
+7. **Open a PR** with: the new YAML files, a one-paragraph summary of what is
+   covered (per tool) and what is not yet covered (with a follow-up note).
+
+## Anti-patterns to call out in review
+
+| Smell | Why it's bad | Fix |
+|-------|--------------|-----|
+| `output-contains: "release plan"` as the only grader | Passes on refusals, paraphrases, wrong-tool calls | Add `tool-calls.required` + `skill-invocation.required` |
+| Stimulus prompt and substring are the same phrase | Model parrots the prompt &rarr; trivially passes | Use `output-matches` with a structural regex (e.g. `"(created|link|id).*(work item|plan)"`) |
+| Negative test uses only `output-not-contains` | Model can call a forbidden tool then politely not mention it | Add `tool-calls.disallowed` |
+| No `trigger.eval.yaml` at all | Routing regressions undetected | Add minimum 3 trigger + 3 anti-trigger stimuli |
+| `scoring.weights` set but no `threshold` | Weights are parsed but not applied; threshold defaults to 0 | Set `threshold: 0.8`; drop weights unless you've verified the runtime applies them |
+| Tool name with a typo (`azsdk_creat_release_plan`) | Regex match silently fails &rarr; test "passes" tool-disallowed checks | Cross-check against the actual `toolName` strings in a recent `results.jsonl` |
+
+## References
+
+- `references/four-layer-pattern.md` &mdash; deep dive with copy-paste templates.
+- `references/grader-catalog.md` &mdash; what each grader does, when to reach for it.
+- `references/anti-patterns.md` &mdash; the full list of smells and fixes.
+- Notebook design doc:
+  [Skill evals &mdash; status, redesign, adoption](file:///C:/Users/gaoh/notebooks/azsdk-evals/design-vally-eval-framework.html).
+- Vally Skills &amp; Tests primer:
+  [primer-vally-skills-tests.html](file:///C:/Users/gaoh/notebooks/azsdk-evals/primer-vally-skills-tests.html).

--- a/.github/skills/skill-eval-authoring/evals/eval.yaml
+++ b/.github/skills/skill-eval-authoring/evals/eval.yaml
@@ -1,0 +1,60 @@
+name: skill-eval-authoring-eval
+description: |
+  Capability tests for the skill-eval-authoring skill (the meta-skill that
+  teaches the agent to write evals). Verifies that when given a skill with no
+  eval coverage, the agent produces a four-layer-pattern eval.yaml plus a
+  trigger.eval.yaml in the right shape.
+type: capability
+
+environment: azsdk-mcp-mock
+
+tags:
+  area: skill-eval-authoring
+  type: ci-gate
+  tier: unit
+
+config:
+  runs: 1
+  timeout: "120s"
+  model: claude-opus-4.6
+  executor: copilot-sdk
+
+scoring:
+  threshold: 0.8
+
+stimuli:
+  - name: produces-four-layer-eval-when-asked
+    prompt: |
+      I have a new skill called `azsdk-example-foo` whose SKILL.md says it
+      invokes the MCP tools `azsdk_example_foo_create` and
+      `azsdk_example_foo_list`. The evals folder is empty. Write me a
+      capability eval that follows the four-layer pattern.
+    graders:
+      - type: skill-invocation
+        config:
+          required: ["skill-eval-authoring"]
+      - type: output-matches
+        config:
+          pattern: "skill-invocation[\\s\\S]+tool-calls"
+      - type: output-contains
+        config:
+          substring: "azsdk_example_foo_create"
+
+  - name: catches-vacuous-output-contains
+    prompt: |
+      Review this eval and tell me what's wrong:
+
+      ```yaml
+      - name: foo-001
+        prompt: "create a foo"
+        graders:
+          - type: output-contains
+            config: { substring: "foo" }
+      ```
+    graders:
+      - type: skill-invocation
+        config:
+          required: ["skill-eval-authoring"]
+      - type: output-matches
+        config:
+          pattern: "(vacuous|tautolog|parrot|too generic|same word|tool-calls|skill-invocation)"

--- a/.github/skills/skill-eval-authoring/evals/trigger.eval.yaml
+++ b/.github/skills/skill-eval-authoring/evals/trigger.eval.yaml
@@ -1,0 +1,85 @@
+name: skill-eval-authoring-trigger-eval
+description: Trigger and anti-trigger tests for the skill-eval-authoring skill
+type: capability
+
+environment: azsdk-mcp-mock
+
+tags:
+  area: skill-eval-authoring
+  type: ci-gate
+  tier: unit
+
+config:
+  runs: 1
+  timeout: "60s"
+  model: claude-opus-4.6
+  executor: copilot-sdk
+
+scoring:
+  threshold: 0.8
+
+stimuli:
+  # ----- POSITIVE TRIGGERS -----
+  - name: trigger-write-an-eval
+    prompt: "write an eval for my new skill"
+    graders:
+      - type: skill-invocation
+        config:
+          required: ["skill-eval-authoring"]
+
+  - name: trigger-add-capability-test
+    prompt: "add a capability test to my skill's evals folder"
+    graders:
+      - type: skill-invocation
+        config:
+          required: ["skill-eval-authoring"]
+
+  - name: trigger-fix-vacuous-output-contains
+    prompt: "my eval only uses output-contains, can you harden it"
+    graders:
+      - type: skill-invocation
+        config:
+          required: ["skill-eval-authoring"]
+
+  - name: trigger-add-trigger-tests
+    prompt: "add trigger and anti-trigger tests for my skill"
+    graders:
+      - type: skill-invocation
+        config:
+          required: ["skill-eval-authoring"]
+
+  - name: trigger-review-eval-yaml
+    prompt: "review my eval.yaml and tell me what's missing"
+    graders:
+      - type: skill-invocation
+        config:
+          required: ["skill-eval-authoring"]
+
+  # ----- ANTI-TRIGGERS -----
+  - name: anti-trigger-run-vally-cli
+    prompt: "run vally eval against my changes"
+    graders:
+      - type: skill-invocation
+        config:
+          disallowed: ["skill-eval-authoring"]
+
+  - name: anti-trigger-write-skill-md
+    prompt: "write a SKILL.md for my new skill"
+    graders:
+      - type: skill-invocation
+        config:
+          disallowed: ["skill-eval-authoring"]
+
+  - name: anti-trigger-debug-failing-trajectory
+    prompt: "debug why this eval trajectory failed at turn 3"
+    graders:
+      - type: skill-invocation
+        config:
+          disallowed: ["skill-eval-authoring"]
+
+  - name: anti-trigger-release-package
+    prompt: "release the azure-mgmt-compute Python package"
+    graders:
+      - type: skill-invocation
+        config:
+          disallowed: ["skill-eval-authoring"]

--- a/.github/skills/skill-eval-authoring/references/anti-patterns.md
+++ b/.github/skills/skill-eval-authoring/references/anti-patterns.md
@@ -1,0 +1,128 @@
+# Anti-patterns in skill evals (and their fixes)
+
+Found in the wild across `.github/skills/*/evals/`. Listed by impact.
+
+## A1. Single vacuous `output-contains` as the only grader
+
+**Smell**
+```yaml
+- name: release-plan-basic-001
+  prompt: "Create a release plan for spec PR ..."
+  graders:
+    - type: output-contains
+      config:
+        substring: "release plan"
+```
+
+**Why it's bad.** Passes on every outcome except a flat refusal that doesn't
+echo the prompt: correct tool call, wrong tool call, paraphrase of the prompt,
+polite "I'll help you with that release plan" with no action. CI is green by
+construction.
+
+**Fix.** Apply the four-layer pattern. Minimum: add `skill-invocation.required`
+and `tool-calls.required`. Optionally tighten the substring to a structural
+`output-matches` regex.
+
+---
+
+## A2. Negative test grades only output, not tool absence
+
+**Smell**
+```yaml
+- name: anti-trigger
+  prompt: "How do I configure logging in my Azure Function?"
+  graders:
+    - type: output-not-contains
+      config:
+        substring: "release plan"
+```
+
+**Why it's bad.** The model can still invoke `azsdk_create_release_plan` and
+just not mention it in its reply. The contract being tested is "do not call
+the tool"; the assertion is "do not say the word".
+
+**Fix.** Add `tool-calls.disallowed` for every tool the skill could wrongly
+invoke. Keep the substring check as a secondary sanity grader.
+
+---
+
+## A3. Stimulus prompt is the same string as the grader substring
+
+**Smell**
+```yaml
+- name: basic-trigger
+  prompt: "I need to prepare a release plan for the new Azure SDK package version"
+  graders:
+    - type: output-contains
+      config:
+        substring: "release"
+```
+
+**Why it's bad.** Any minimally cooperative reply will parrot a word from the
+prompt. This is a tautology, not a test.
+
+**Fix.** Use `output-matches` with a regex describing the *response shape*
+(e.g., `(work item|link|id).*\d`), or replace with `skill-invocation` /
+`tool-calls`.
+
+---
+
+## A4. Missing `scoring.threshold`
+
+**Smell**
+```yaml
+scoring:
+  weights:
+    output-contains: 1.0
+```
+
+**Why it's bad.** Vally defaults `threshold` to 0 when unset, so every
+stimulus passes regardless of any grader's score. `weights` is parsed but not
+applied as partial credit.
+
+**Fix.** Always set `scoring.threshold: 0.8` (or higher for anti-trigger
+files where any miss is a hard regression).
+
+---
+
+## A5. Missing `trigger.eval.yaml`
+
+**Smell.** A skill has `eval.yaml` only, with the trigger phrases tucked into
+capability stimuli that also test behavior.
+
+**Why it's bad.** Routing regressions ("my skill stopped activating for the
+obvious prompt") are silent — the capability test passes on a different skill
+doing roughly the right thing.
+
+**Fix.** Add `trigger.eval.yaml` with at least 3 positive and 3 anti-trigger
+entries, each graded only by `skill-invocation`.
+
+---
+
+## A6. Tool name typo in `disallowed` (or `required`)
+
+**Smell**
+```yaml
+- type: tool-calls
+  config:
+    disallowed:
+      - name: azsdk_creat_release_plan   # missing "e"
+```
+
+**Why it's bad.** Regex compiles, never matches anything, "passes" silently.
+
+**Fix.** Cross-check tool names against a real trajectory
+(`vally-results/.../results.jsonl` has every `toolName` string used in a run).
+
+---
+
+## A7. One environment for everything
+
+**Smell.** Every eval uses `azsdk-mcp-mock`, including scenarios that need
+real DevOps/GitHub to verify end-to-end.
+
+**Why it's bad.** Mock cannot catch contract drift between the MCP tool and
+the real backend (e.g., DevOps API renamed a field).
+
+**Fix.** Reserve a small e2e tier with `environment: azsdk-mcp` and
+`tags.tier: e2e`; run it nightly, not on every PR.

--- a/.github/skills/skill-eval-authoring/references/four-layer-pattern.md
+++ b/.github/skills/skill-eval-authoring/references/four-layer-pattern.md
@@ -1,0 +1,75 @@
+# Four-layer pattern — deep dive
+
+Every capability stimulus in a skill eval has a *contract* it's verifying. The
+four layers below are the dimensions of that contract. Each layer answers one
+question; together they pin down what "the skill works" actually means.
+
+## Layer 1 — Routing (`skill-invocation`)
+
+> Did the right skill get loaded for this prompt?
+
+```yaml
+- type: skill-invocation
+  config:
+    required: ["azsdk-common-prepare-release-plan"]
+```
+
+Use `disallowed:` for negative tests where the skill must NOT activate.
+
+## Layer 2 — Tool-use (`tool-calls`)
+
+> Did the agent call the right MCP tool with the right args?
+
+```yaml
+- type: tool-calls
+  config:
+    required:
+      - name: azsdk_create_release_plan
+    disallowed:
+      - name: azsdk_release_sdk
+```
+
+`name` is compiled as a regex. The bare form (`azsdk_create_release_plan`) is
+preferred because it's portable across MCP server prefixes. You can also
+constrain `command` and `path` argument values with their own regex.
+
+## Layer 3 — Output shape (`output-matches`)
+
+> Did the agent's reply structurally address the request?
+
+```yaml
+- type: output-matches
+  config:
+    pattern: "(release plan|work item).*(created|link|id)"
+```
+
+Prefer `output-matches` over `output-contains` for capability tests. A regex
+that requires two related concepts in proximity is much harder to game than a
+single keyword.
+
+## Layer 4 — Judgment (`prompt`)
+
+> Anything the first three cannot express. Use sparingly.
+
+```yaml
+- type: prompt
+  config:
+    prompt: |
+      Did the assistant confirm creation AND surface the link/id back to
+      the user? Score 1 for yes, 0 for no.
+```
+
+LLM judges are expensive and non-deterministic. Reach for them only when a
+regex would be brittle or a tool-call check is insufficient (e.g., verifying
+the agent *explained* a failure correctly to the user).
+
+## Composition cheat-sheet
+
+| Stimulus kind | Required layers |
+|---------------|-----------------|
+| Capability — happy path | 1 + 2, optional 3 |
+| Capability — multi-tool flow | 1 + 2 with multiple required entries |
+| Negative — wrong topic | 1 disallowed + 2 disallowed |
+| Trigger | 1 required only |
+| Anti-trigger | 1 disallowed only |
+| Performance | 2 + `metric-threshold` |

--- a/.github/skills/skill-eval-authoring/references/grader-catalog.md
+++ b/.github/skills/skill-eval-authoring/references/grader-catalog.md
@@ -1,0 +1,59 @@
+# Grader catalog (Vally 0.5.0)
+
+Verified against `eng/skill-eval/node_modules/@microsoft/vally/dist/graders/`.
+Both static graders (deterministic, code-based) and the LLM judge are listed.
+Aliases are explicit.
+
+## Static graders
+
+| Grader | Purpose | Typical use |
+|--------|---------|-------------|
+| `skill-invocation` | `required` / `disallowed` skills loaded during the run | Trigger and anti-trigger tests |
+| `tool-calls` | `required` / `disallowed` tool calls; `name` is regex; `command` / `path` arg regex supported | Every capability test |
+| `output-contains` | Substring search on assistant output; supports `negate: true` | Cheap sanity, never sole grader |
+| `output-not-contains` | Alias of `output-contains` with `negate: true` | Negative sanity |
+| `output-matches` | Regex search on assistant output | Preferred capability output-shape grader |
+| `file-exists` | A file exists in the workspace after the run | Skills that scaffold files |
+| `file-contains` | Substring search in a workspace file | Skills that edit files |
+| `file-matches` | Regex search in a workspace file | Skills that edit files |
+| `completed` | Trajectory finished without unhandled error | Liveness baseline |
+| `run-command` | Exec a shell command; non-zero exit = fail | Build/lint verification |
+| `program` | Exec a script with stdin/stdout JSON contract | Custom verifiers |
+| `metric-threshold` (aliases: `token-budget`, `tool-call-count`, `turn-count`, `error-count`, `wall-time`) | Cap a metric collected during the run | Nightly performance tier |
+
+## LLM graders
+
+| Grader | Purpose | Cost | Notes |
+|--------|---------|------|-------|
+| `prompt` | Free-form LLM judge with a custom rubric | High | Use only when regex/tool-calls cannot express the assertion |
+| `pairwise` | A/B comparison of two trajectories | High | Only valid in `vally compare`, not `vally eval` |
+
+## Picking a grader
+
+```
+Need to check routing?            → skill-invocation
+Need to check the right tool?     → tool-calls
+Need to check the wrong tool didn't fire? → tool-calls (disallowed)
+Need to check the answer mentions X? → output-contains
+Need to check the answer is structurally correct? → output-matches
+Need to check a file was created?  → file-exists / file-matches
+Need to check the build still passes after a code edit? → run-command
+Need to check performance?         → metric-threshold
+Anything else?                     → prompt (LLM, last resort)
+```
+
+## Hidden behaviors worth knowing
+
+- **`scoring.weights`** is parsed but not currently applied per-grader by the
+  runtime. Set `scoring.threshold` for a pass/fail bar; do not rely on weights
+  for partial credit.
+- **`scoring.threshold` defaults to 0** if unset → every stimulus passes. Lint
+  fails missing thresholds for that reason.
+- **`tool-calls.name`** is a regex. An empty pattern would match every tool;
+  the grader explicitly rejects this to avoid silent passes.
+- **`tool-calls`** receives the tool name as recorded by the executor. The
+  copilot-sdk executor prefixes MCP tools with the server alias
+  (`azure-sdk-mcp-azsdk_create_release_plan`). Bare names work because regex
+  matches a substring; prefer bare for portability.
+- **`environment.git.source`** does NOT expand env vars; use a literal URL or
+  set up the fixture in `workDir` instead.


### PR DESCRIPTION
## Summary

Adds a new meta-skill, **`skill-eval-authoring`**, that teaches the agent (and contributors) how to write robust evals for skills under `.github/skills/`. Rewrites the release-plan capability suite as the canonical exemplar the new skill points to.

## Motivation

Audit of all 9 skill eval suites surfaced that **~25 capability stimuli are graded only by a single `output-contains "<keyword>"`**. These tests pass on:

- correct tool call ✅
- polite refusal ❌
- wrong-tool call that mentions the keyword ❌
- prompt parroting ❌

CI is green by construction. The fix is structural, not a one-line lint: contributors need a pattern and a worked example.

## What's in this PR

### New: `.github/skills/skill-eval-authoring/`

| File | Purpose |
|------|---------|
| `SKILL.md` | Meta-skill with WHEN / DO NOT USE FOR / INVOKES frontmatter. Hard rules + workflow. |
| `references/four-layer-pattern.md` | Deep dive on the routing → tool-use → output shape → judgment layering. |
| `references/grader-catalog.md` | All Vally 0.5.0 graders, verified against `dist/graders/`. Documents hidden behaviors (`scoring.weights` not applied, `scoring.threshold` defaults to 0, regex semantics of `tool-calls.name`, prefixed tool names work). |
| `references/anti-patterns.md` | 7 smells (A1–A7) with examples and fixes. |
| `evals/eval.yaml` + `evals/trigger.eval.yaml` | Eats its own dog food: 2 capability + 9 trigger/anti-trigger stimuli. |

### Rewritten: `.github/skills/azsdk-common-prepare-release-plan/evals/eval.yaml`

Replaced the previous 6 stimuli (most of which were graded only by `output-contains "release plan"`) with 6 four-layer-pattern stimuli covering: create-from-spec-pr, update-sdk-details, link-sdk-prs, get-release-plan-status, and two negatives. The file's `description:` declares it the canonical exemplar.

### Registered: `.github/skills/.vally.yaml`

Adds `skill-eval-authoring/evals/` to `paths.evals`.

## Out of scope (deliberate)

- **Lint script** that fails CI on single-substring capability tests — proposed as P2 in the design doc.
- **Sweep of the other 8 skill eval suites** to apply the four-layer pattern — proposed as P1 follow-ups, one PR per skill, owned by skill author.
- **Tiered environments** (`unit` / `integration` / `e2e`) — proposed as P2.

## Open questions for the group (also captured in the design doc)

1. Where do live-MCP e2e tests run? Owner? Cost?
2. Multi-model matrix (opus + gpt-5.4) for skill evals, or pin one?
3. Threshold per tier — 0.8 for capability, 1.0 for anti-trigger?
4. Extend `tool-calls` arg matching to arbitrary keys (today only `command` / `path`)?
5. Should we record a known-good trajectory per skill and diff-grade against it?
6. Who *owns* the eval suite per skill — author, language team, or engsys?
7. Add a failure-attribution LLM pass to classify each red stimulus (skill / model / MCP tool)?

## Verification

- Manually verified grader registration against `eng/skill-eval/node_modules/@microsoft/vally/dist/pipeline/grading.js` and `dist/graders/static/`.
- Confirmed prefixed tool names emit through copilot-sdk adapter by inspecting a real trajectory in `vally-results/.../results.jsonl`.
- New skill folder lints clean (frontmatter parses; references resolve).

Draft until reviewers weigh in on the open questions above.