### PR TITLE
Use work item ID as release plan Id when release plan number is not set

### DIFF
--- a/tools/release-plan-dashboard/lib/devops-api.js
+++ b/tools/release-plan-dashboard/lib/devops-api.js
@@ -263,7 +263,7 @@ function mapReleasePlan(workItem, apiSpecMap) {
     createdBy: stripEmail(createdByName),
     releaseMonth: fields["Custom.SDKReleasemonth"] || "",
     releaseType: fields["Custom.SDKtypetobereleased"] || "",
-    releasePlanId: fields["Custom.ReleasePlanID"] || "",
+    releasePlanId: fields["Custom.ReleasePlanID"] || String(id),
     releasePlanLink: fields["Custom.ReleasePlanLink"] || "",
     submittedBy: submittedByName || createdByName,
     ownerPM: stripEmail(fields["Custom.PrimaryPM"] || ""),

--- a/tools/release-plan-dashboard/public/app.js
+++ b/tools/release-plan-dashboard/public/app.js
@@ -106,20 +106,20 @@
     <h3>Step 2: Collect the following details</h3>
     <ol class="guide-list">
       <li><strong>Relative path</strong> to your TypeSpec project<br><em>e.g. <code>specification/contosowidgetmanager/Contoso.Management</code></em></li>
-      <li><strong>SDK release type:</strong> beta or stable</li>
+      <li><strong>API release type:</strong> Private Preview, Public Preview, or GA</li>
       <li><strong>API spec pull request</strong> (optional)</li>
-      <li><strong>Service Tree ID</strong> for your service <em>(optional*)</em></li>
-      <li><strong>Service Tree ID</strong> for your product <em>(optional*)</em></li>
+      <li><strong>Product's ID in Service Tree</strong> <em>(optional*)</em></li>
+      <li><strong>Service ID</strong> for the service linked to your product <em>(optional*)</em></li>
     </ol>
     <p style="font-size:.82rem;color:#605e5c;">* Service Tree IDs are only required if this is the first time creating a release plan for your TypeSpec project path. For subsequent plans, they will be auto-populated.</p>
     <h3>Step 3: Use this prompt</h3>
     <p>Copy and paste the following prompt into Copilot CLI or VS Code Copilot chat, filling in your details:</p>
     <pre class="guide-prompt"><code>Create a release plan for TypeSpec project with following details:
 - TypeSpec project path: &lt;specification/your-service/Your.Management&gt;
-- SDK release type: &lt;beta or stable&gt;
+- API release type: &lt;Private Preview, Public Preview, or GA&gt;
 - API spec PR: &lt;optional PR link&gt;
-- Service Tree ID (Service): &lt;optional, your-service-tree-id&gt;
-- Service Tree ID (Product): &lt;optional, your-product-tree-id&gt;</code></pre>
+- Product ID: &lt;optional, your-product-tree-id&gt;
+- Service ID: &lt;optional, your-service-tree-id&gt;</code></pre>
     <p style="font-size:.82rem;color:#605e5c;margin-top:12px;">📘 For more details, visit <a href="https://aka.ms/azsdk/agent" target="_blank" rel="noopener">Azure SDK Tools Agent documentation</a>.</p>`;
 
   // Set default modal content in store once Alpine is ready

--- a/tools/release-plan-dashboard/routes/api.js
+++ b/tools/release-plan-dashboard/routes/api.js
@@ -303,10 +303,15 @@ router.get("/api/release-plans", async (req, res) => {
           .status(400)
           .json({ error: "Invalid release plan ID format." });
       }
+      // Match by Custom.ReleasePlanID or by work item ID (numeric fallback)
+      const isNumeric = /^\d+$/.test(filterPlanId);
+      const condition = isNumeric
+        ? `AND ([Custom.ReleasePlanID] = '${filterPlanId}' OR [System.Id] = ${filterPlanId})`
+        : `AND [Custom.ReleasePlanID] = '${filterPlanId}'`;
       const wiqlQuery = `SELECT [System.Id] FROM WorkItems
         WHERE [System.TeamProject] = 'Release'
           AND [System.WorkItemType] = 'Release Plan'
-          AND [Custom.ReleasePlanID] = '${filterPlanId}'`;
+          ${condition}`;
       const ids = await runWiql(wiqlQuery);
       if (!ids.length)
         return res.json({


### PR DESCRIPTION
Release plan number is set by PowerApps and if a product Id lookup in PowerApps backend fails then release plan will not have any release plan ID. We will also be shutting down PowerApps backend soon so release plan dashboard should use work item ID as the fallback ID in case if release plan ID is missing in ADO.