### PR TITLE
Add GitHub Copilot CLI as a prerequisite in azsdk_verify_setup

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/SetupRequirements/VerifySetupServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/SetupRequirements/VerifySetupServiceTests.cs
@@ -85,6 +85,7 @@ internal class VerifySetupServiceTests
                     { "tsp", "1.0.1" },
                     { "pwsh", "PowerShell 7.2.0" },
                     { "gh", "gh version 2.30.0" },
+                    { "copilot", "0.1.26" },
                     { "python", "Python 3.9.0" },
                     { "pip", "pip 24.0" },
                     { "java", "java 17.0.1" },
@@ -571,5 +572,18 @@ internal class VerifySetupServiceTests
 
         Assert.That(result.IsFixable, Is.False);
         Assert.That(result.HasBlockingFailures, Is.False);
+    }
+
+    [Test]
+    public async Task VerifySetup_Fails_WhenCopilotCliNotFound()
+    {
+        SetupFailedProcessMock("copilot", 1, "copilot: command not found");
+        RecreateService();
+
+        var result = await verifySetupService.VerifySetup(new HashSet<SdkLanguage> { SdkLanguage.Python }, "/test/path/python");
+
+        Assert.That(result.Results, Is.Not.Null.And.Not.Empty);
+        Assert.That(result.Results!.Any(r => r.Requirement.Contains("Copilot")), Is.True);
+        Assert.That(result.ResponseError, Is.Null);
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/SetupRequirements/CoreRequirements.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/SetupRequirements/CoreRequirements.cs
@@ -17,6 +17,7 @@ public static class CoreRequirements
         new TspRequirement(),
         new PowerShellRequirement(),
         new GitHubCliRequirement(),
+        new CopilotCliRequirement(),
         new LongPathsRequirement(),
         new PythonRequirement(),
         new PipRequirement()
@@ -145,6 +146,24 @@ public static class CoreRequirements
         public override IReadOnlyList<string> GetInstructions(RequirementContext ctx)
         {
             return ["Download and install from https://cli.github.com/"];
+        }
+    }
+
+    public class CopilotCliRequirement : Requirement
+    {
+        public override string Name => "GitHub Copilot CLI";
+        public override string[] CheckCommand => ["copilot", "--version"];
+        public override string? NotAutoInstallableReason => NotInstallableReasons.SystemTool;
+
+        public override string? Reason =>
+            "Required for SDK code customization, sample generation, and README generation workflows.";
+
+        public override IReadOnlyList<string> GetInstructions(RequirementContext ctx)
+        {
+            return [
+                "Install the GitHub Copilot CLI: https://docs.github.com/en/copilot/how-tos/copilot-cli/install-copilot-cli",
+                "Or set the AZSDK_COPILOT_CLI_PATH environment variable to the path of an existing Copilot CLI executable."
+            ];
         }
     }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/SetupRequirements/CoreRequirements.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/SetupRequirements/CoreRequirements.cs
@@ -161,8 +161,7 @@ public static class CoreRequirements
         public override IReadOnlyList<string> GetInstructions(RequirementContext ctx)
         {
             return [
-                "Install the GitHub Copilot CLI: https://docs.github.com/en/copilot/how-tos/copilot-cli/install-copilot-cli",
-                "Or set the AZSDK_COPILOT_CLI_PATH environment variable to the path of an existing Copilot CLI executable."
+                "Install the GitHub Copilot CLI: https://docs.github.com/en/copilot/how-tos/copilot-cli/install-copilot-cli"
             ];
         }
     }


### PR DESCRIPTION
Add the GitHub Copilot CLI as a core prerequisite check in azsdk_verify_setup.
Fixes #15483.

azsdk_verify_setup currently passes even when the Copilot CLI is missing, but azsdk_customized_code_update then fails at runtime. This catches the missing dependency early.

## Changes
- Added CopilotCliRequirement to CoreRequirements — checks copilot --version with installation instructions
- Added test for Copilot CLI not found scenario