### PR TITLE
Add guardrails against manual fallback in azure-typespec-author skill

### DIFF
--- a/.github/skills/azure-typespec-author/SKILL.md
+++ b/.github/skills/azure-typespec-author/SKILL.md
@@ -36,6 +36,7 @@ The `azure-typespec-author` skill **must** be invoked immediately in all modes (
 - **Always validate** — run every steps in [validation](references/validation.md) after every edit.
 - **Always cite references** — provide links that justify the approach.
 - **Follow the authoring plan exactly** — code changes in Step 4 MUST follow the authoring plan generated in Step 3. Do not deviate by referring to existing code patterns in the TypeSpec project; the authoring plan is the single source of truth for what to change.
+- **NEVER proceed with manual edits if an MCP tool call fails.** If `azsdk_typespec_generate_authoring_plan` or `azsdk_run_typespec_validation` fails (due to authentication errors, timeouts, or other issues), **stop and report the error to the user**. Do not attempt to author or validate TypeSpec changes without the tool — the authoring plan provides grounded guidance that cannot be reliably replicated manually.
 
 ## Workflow
 
@@ -88,3 +89,8 @@ Output all referenced document URLs from Step 3. This gives the user direct link
 - "Add a new preview API version 2026-01-01-preview for widget resource manager"
 - "Add an ARM resource named Asset with CRUD operations"
 - "Add a new property to the Widget model"
+
+## Troubleshooting
+
+- If `azsdk_typespec_generate_authoring_plan` fails with an authentication error, stop and ask the user to authenticate. Do not proceed with manual TypeSpec edits.
+- If a tool call times out, report the error and suggest retrying. Do not attempt to replicate the tool's behavior manually.

--- a/plugins/azure-sdk-tools/skills/azure-typespec-author/SKILL.md
+++ b/plugins/azure-sdk-tools/skills/azure-typespec-author/SKILL.md
@@ -26,6 +26,7 @@ compatibility: "azure-sdk-mcp server with azsdk_typespec_generate_authoring_plan
 - **Always validate** — run every steps in [validation](references/validation.md) after every edit.
 - **Always cite references** — provide links that justify the approach.
 - **Follow the authoring plan exactly** — code changes in Step 4 MUST follow the authoring plan generated in Step 3. Do not deviate by referring to existing code patterns in the TypeSpec project; the authoring plan is the single source of truth for what to change.
+- **NEVER proceed with manual edits if an MCP tool call fails.** If `azsdk_typespec_generate_authoring_plan` or `azsdk_run_typespec_validation` fails (due to authentication errors, timeouts, or other issues), **stop and report the error to the user**. Do not attempt to author or validate TypeSpec changes without the tool — the authoring plan provides grounded guidance that cannot be reliably replicated manually.
 
 ---
 
@@ -120,3 +121,5 @@ See [validation guide](references/validation.md) for sub-steps. You must run Typ
 
 - **TypeSpec validation fails** — display all errors, provide fix suggestions, re-run validation.
 - **API Version Evolution** — use the versioning guide URLs in the [version evolution reference](references/api-version-evolution.md); do not call the authoring plan tool.
+- If `azsdk_typespec_generate_authoring_plan` fails with an authentication error, stop and ask the user to authenticate. Do not proceed with manual TypeSpec edits.
+- If a tool call times out, report the error and suggest retrying. Do not attempt to replicate the tool's behavior manually.


### PR DESCRIPTION
## What
Add guardrails to the `azure-typespec-author` skill to prevent the agent from making manual TypeSpec edits when MCP tool calls fail.

## Why
Fixes #15458 — when `azsdk_typespec_generate_authoring_plan` fails (e.g. due to authentication errors), the agent proceeds to author TypeSpec changes manually instead of stopping and asking the user to fix the auth issue. This leads to incorrect changes without grounded guidance.

## Changes
- Added constraint: NEVER proceed with manual edits if an MCP tool call fails — stop and report the error
- Added troubleshooting lines for auth failures and timeouts
- Applied to both `.github/skills/` and `plugins/` copies