### PR TITLE
Ignore eval result files in the typespec authoring dir

### DIFF
--- a/.github/skills/.gitignore
+++ b/.github/skills/.gitignore
@@ -2,3 +2,5 @@ results/
 .waza-cache/
 coverage.txt
 *.exe
+eval-results.md
+results.jsonl


### PR DESCRIPTION
ignore these files in case the results are in a directory outside of results/