### PR TITLE
[Teams Chatbot] Rebuild Foundry conversation when response status is failed

### DIFF
--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/services/chat_service.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/services/chat_service.py
@@ -385,44 +385,36 @@ class ChatService:
         broken_conversation_id: str,
         current_turn_items: list[ResponseInputItemParam],
     ) -> tuple[str, list[ResponseInputItemParam]]:
-        """Discard the corrupted Foundry conversation and reseed from its own
-        item history, dropping tool-call items so the new conversation starts
-        in a consistent state.
+        """Abandon the corrupted Foundry conversation and reseed a fresh one
+        from its own item history, dropping tool-call items so the new
+        conversation starts in a consistent state.
+
+        The broken conversation is intentionally NOT deleted — it is kept on
+        the server for tracing/debugging. We just stop pointing at it: the
+        Cosmos mapping is overwritten so future turns use the new id, and the
+        orphaned conversation can be cleaned up out-of-band later.
 
         Strategy:
-        1. List items from the broken Foundry conversation BEFORE deleting it,
-           and keep only ``message`` items (user/assistant text and any
-           multimodal content). Tool-related items (``function_call``,
-           ``function_call_output``, ``mcp_call``, ``code_interpreter_call``,
-           etc.) are dropped — they are what caused the corruption and are
-           safe to omit because the assistant's final text already summarizes
-           their effect for the user.
-        2. Delete the broken conversation (best effort).
-        3. Create a fresh Foundry conversation and update the Cosmos mapping.
-        4. Compose the next-turn input as: system anchors from the current
+        1. List items from the broken Foundry conversation and keep only
+           ``message`` items (user/assistant text and any multimodal content).
+           Tool-related items (``function_call``, ``function_call_output``,
+           ``mcp_call``, ``code_interpreter_call``, etc.) are dropped — they
+           are what caused the corruption and are safe to omit because the
+           assistant's final text already summarizes their effect.
+        2. Create a fresh Foundry conversation and update the Cosmos mapping
+           so future turns use the new id.
+        3. Compose the next-turn input as: system anchors from the current
            turn + the filtered Foundry history + the current turn's live
            inputs.
         """
-        # 1. Pull surviving message items from the broken conversation first.
+        # 1. Pull surviving message items from the broken conversation.
         replay_items = await self._list_message_items(
             openai_client, broken_conversation_id
         )
 
-        # 2. Delete the broken conversation (best effort).
-        try:
-            await openai_client.conversations.delete(broken_conversation_id)
-            logger.info(
-                "Deleted broken Foundry conversation: %s", broken_conversation_id
-            )
-        except Exception:
-            logger.warning(
-                "Failed to delete broken Foundry conversation %s; continuing.",
-                broken_conversation_id,
-                exc_info=True,
-            )
-
-        # 3. Create a new conversation and update the Cosmos mapping so future
-        #    turns use the new id
+        # 2. Create a new conversation and update the Cosmos mapping (upsert
+        #    replaces the prior mapping). The broken conversation is left in
+        #    place for tracing.
         new_conversation = await openai_client.conversations.create()
         new_conversation_id = new_conversation.id
         await self._conversation_service.save_agent_conversation_mapping(
@@ -431,12 +423,13 @@ class ChatService:
             agent_conversation_id=new_conversation_id,
         )
         logger.info(
-            "Created replacement Foundry conversation: %s (replaces %s)",
+            "Created replacement Foundry conversation: %s (replaces %s, "
+            "broken conversation preserved for tracing)",
             new_conversation_id,
             broken_conversation_id,
         )
 
-        # 4. Split current_turn_items into system anchors vs. live user
+        # 3. Split current_turn_items into system anchors vs. live user
         #    inputs. System messages (tenant context, memory scope) were
         #    rebuilt this turn and are not part of the historical replay.
         system_anchors: list[ResponseInputItemParam] = []

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/services/chat_service.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/services/chat_service.py
@@ -41,6 +41,7 @@ from openai.types.responses import (
     ResponseOutputMessage,
 )
 from openai.types.responses.response_input_item_param import ResponseInputItemParam
+from openai.types.responses.response_status import ResponseStatus
 from config.tenant_config import TenantID
 from typing import Any, cast
 from utils.background_tasks import BackgroundTaskTracker
@@ -134,27 +135,46 @@ class ChatService:
         # Streaming is broken for hosted agents — text is lost entirely.
         # See https://github.com/Azure/azure-sdk-for-python/issues/45282
         # and https://github.com/Azure/azure-sdk-for-python/issues/46015
-        raw_response = await openai_client.responses.with_raw_response.create(
-            input=conversation_items,
-            conversation=agent_conversation_id,
-            store=True,
-            stream=False,
-            extra_body={
-                "agent_reference": agent_ref,
-            },
+        response, trace_id = await self._invoke_agent(
+            openai_client,
+            conversation_items=conversation_items,
+            agent_conversation_id=agent_conversation_id,
+            agent_ref=agent_ref,
         )
-        response: OpenAIResponse = raw_response.parse()
 
-        # Extract AI Foundry trace ID from x-request-id header.
-        # The header may contain duplicated values separated by comma.
-        x_request_id = raw_response.headers.get("x-request-id", "")
-        trace_id = x_request_id.split(",")[0].strip() if x_request_id else None
-        logger.info(
-            "Agent trace: trace_id=%s, response_id=%s, conversation=%s",
-            trace_id,
-            response.id,
-            agent_conversation_id,
-        )
+        # Known upstream issue — Foundry server-managed conversation can end
+        # up in a broken state (e.g. orphan function_call item with no paired
+        # function_call_output) that surfaces as response.status == "failed"
+        # on a later turn. Any failed status is treated as conversation
+        # corruption: discard the broken conversation, reseed a fresh one from
+        # Cosmos plain-text history, and retry once.
+        # Tracking:
+        #   - https://github.com/Azure/azure-sdk-for-python/issues/46092
+        #   - https://github.com/microsoft/agent-framework/issues/5041
+        #   - https://github.com/microsoft/agent-framework/issues/5023
+        failed_status: ResponseStatus = "failed"
+        if response.status == failed_status:
+            logger.warning(
+                "Foundry conversation %s returned status=failed; rebuilding "
+                "from Cosmos plain-text history. response_id=%s error=%s",
+                agent_conversation_id,
+                response.id,
+                response.error,
+            )
+            agent_conversation_id, conversation_items = (
+                await self._rebuild_conversation_after_failure(
+                    openai_client,
+                    req,
+                    broken_conversation_id=agent_conversation_id,
+                    current_turn_items=conversation_items,
+                )
+            )
+            response, trace_id = await self._invoke_agent(
+                openai_client,
+                conversation_items=conversation_items,
+                agent_conversation_id=agent_conversation_id,
+                agent_ref=agent_ref,
+            )
 
         # Poll if response completed with empty text (Foundry persistence delay).
         if response.status == "completed" and not response.output_text:
@@ -324,6 +344,173 @@ class ChatService:
 
         logger.info("Created new AI Foundry conversation: %s", new_id)
         return new_id, True
+
+    async def _invoke_agent(
+        self,
+        openai_client: AsyncOpenAI,
+        *,
+        conversation_items: list[ResponseInputItemParam],
+        agent_conversation_id: str,
+        agent_ref: dict,
+    ) -> tuple[OpenAIResponse, str | None]:
+        """Call the hosted agent and return (parsed response, trace id)."""
+        raw_response = await openai_client.responses.with_raw_response.create(
+            input=conversation_items,
+            conversation=agent_conversation_id,
+            store=True,
+            stream=False,
+            extra_body={
+                "agent_reference": agent_ref,
+            },
+        )
+        response: OpenAIResponse = raw_response.parse()
+
+        # Extract AI Foundry trace ID from x-request-id header.
+        # The header may contain duplicated values separated by comma.
+        x_request_id = raw_response.headers.get("x-request-id", "")
+        trace_id = x_request_id.split(",")[0].strip() if x_request_id else None
+        logger.info(
+            "Agent trace: trace_id=%s, response_id=%s, conversation=%s, status=%s",
+            trace_id,
+            response.id,
+            agent_conversation_id,
+            response.status,
+        )
+        return response, trace_id
+
+    async def _rebuild_conversation_after_failure(
+        self,
+        openai_client: AsyncOpenAI,
+        req: ChatRequest,
+        *,
+        broken_conversation_id: str,
+        current_turn_items: list[ResponseInputItemParam],
+    ) -> tuple[str, list[ResponseInputItemParam]]:
+        """Discard the corrupted Foundry conversation and reseed from Cosmos.
+
+        Strategy:
+        1. Best-effort delete the broken Foundry conversation.
+        2. Create a fresh Foundry conversation and update the Cosmos mapping.
+        3. Rebuild input items: tenant + memory-scope system messages from the
+           current turn, then plain-text user/assistant turns from Cosmos
+           (excluding the in-flight user message), then the current turn's
+           user message and any image items.
+
+        Tool-call/result items are NOT replayed because Cosmos only stores
+        plain text. Semantic context is preserved; intermediate tool results
+        are not. This is an acceptable trade-off because the alternative is
+        a failed turn.
+        """
+        # 1. Delete the broken conversation (best effort).
+        try:
+            await openai_client.conversations.delete(broken_conversation_id)
+            logger.info(
+                "Deleted broken Foundry conversation: %s", broken_conversation_id
+            )
+        except Exception:
+            logger.warning(
+                "Failed to delete broken Foundry conversation %s; continuing.",
+                broken_conversation_id,
+                exc_info=True,
+            )
+
+        # 2. Create a new conversation and update the Cosmos mapping so future
+        #    turns use the new id.
+        new_conversation = await openai_client.conversations.create()
+        new_conversation_id = new_conversation.id
+        await self._conversation_service.save_agent_conversation_mapping(
+            req.conversation_id,
+            req.conversation_type,
+            agent_conversation_id=new_conversation_id,
+        )
+        logger.info(
+            "Created replacement Foundry conversation: %s (replaces %s)",
+            new_conversation_id,
+            broken_conversation_id,
+        )
+
+        # 3. Split current_turn_items into system anchors vs. the live user
+        #    message + image inputs. System messages were built fresh this
+        #    turn (tenant context, memory scope) and must be re-applied to the
+        #    new conversation. The trailing user/image items are this turn's
+        #    actual input.
+        system_anchors: list[ResponseInputItemParam] = []
+        live_inputs: list[ResponseInputItemParam] = []
+        for item in current_turn_items:
+            if isinstance(item, dict) and item.get("role") == "system":
+                system_anchors.append(item)
+            else:
+                live_inputs.append(item)
+
+        # Load past conversation as plain text from Cosmos.
+        replay_items = await self._build_replay_items_from_cosmos(req)
+
+        rebuilt = [*system_anchors, *replay_items, *live_inputs]
+        logger.info(
+            "Reseeded conversation %s: %d system anchors, %d replay messages, "
+            "%d live inputs",
+            new_conversation_id,
+            len(system_anchors),
+            len(replay_items),
+            len(live_inputs),
+        )
+        return new_conversation_id, rebuilt
+
+    async def _build_replay_items_from_cosmos(
+        self, req: ChatRequest
+    ) -> list[ResponseInputItemParam]:
+        """Load past user/bot turns from Cosmos and convert to Responses input.
+
+        Returns an empty list when the request lacks conversation identifiers
+        or the conversation has no stored messages. The in-flight user
+        message (matched by ``req.message.id`` when available) is excluded
+        so it isn't duplicated alongside ``live_inputs``.
+        """
+        if not req.conversation_id or not req.conversation_type:
+            return []
+
+        try:
+            messages = await self._conversation_service.get_messages_by_conversation(
+                req.conversation_id,
+                req.conversation_type,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to load Cosmos history for conversation=%s; "
+                "reseeding without replay.",
+                req.conversation_id,
+                exc_info=True,
+            )
+            return []
+
+        current_message_id = getattr(req.message, "id", None)
+        replay: list[ResponseInputItemParam] = []
+        for msg in messages:
+            if current_message_id and msg.id == current_message_id:
+                continue
+            content = (msg.content or "").strip()
+            if not content:
+                continue
+            # Bot answers are persisted with sender_role=Role.System
+            # (see _save_bot_answer_to_conversation). Map them back to
+            # assistant turns; everything else is treated as a user turn.
+            role = (
+                Role.Assistant
+                if msg.sender_role in (Role.System, Role.Assistant)
+                else Role.User
+            )
+            replay.append(
+                cast(
+                    ResponseInputItemParam,
+                    ConversationItem(
+                        role=role,
+                        content=content,
+                        user_id=getattr(msg, "sender_id", None),
+                        user_name=getattr(msg, "sender_name", None),
+                    ).model_dump(mode="json", exclude_none=True),
+                )
+            )
+        return replay
 
     @staticmethod
     async def _build_image_items(

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/services/chat_service.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/services/chat_service.py
@@ -34,6 +34,7 @@ from utils.azure_memory_store import sanitize_scope
 from azure.ai.projects.aio import AIProjectClient
 from azure.ai.projects.models import AgentVersionDetails
 from openai import AsyncOpenAI, NotFoundError
+from openai.types.conversations import Message as ConversationsMessage
 from openai.types.responses import Response as OpenAIResponse
 from openai.types.responses import (
     ResponseFunctionToolCall,
@@ -41,7 +42,6 @@ from openai.types.responses import (
     ResponseOutputMessage,
 )
 from openai.types.responses.response_input_item_param import ResponseInputItemParam
-from openai.types.responses.response_status import ResponseStatus
 from config.tenant_config import TenantID
 from typing import Any, cast
 from utils.background_tasks import BackgroundTaskTracker
@@ -152,8 +152,7 @@ class ChatService:
         #   - https://github.com/Azure/azure-sdk-for-python/issues/46092
         #   - https://github.com/microsoft/agent-framework/issues/5041
         #   - https://github.com/microsoft/agent-framework/issues/5023
-        failed_status: ResponseStatus = "failed"
-        if response.status == failed_status:
+        if response.status == "failed":
             logger.warning(
                 "Foundry conversation %s returned status=failed; rebuilding "
                 "from Cosmos plain-text history. response_id=%s error=%s",
@@ -386,22 +385,30 @@ class ChatService:
         broken_conversation_id: str,
         current_turn_items: list[ResponseInputItemParam],
     ) -> tuple[str, list[ResponseInputItemParam]]:
-        """Discard the corrupted Foundry conversation and reseed from Cosmos.
+        """Discard the corrupted Foundry conversation and reseed from its own
+        item history, dropping tool-call items so the new conversation starts
+        in a consistent state.
 
         Strategy:
-        1. Best-effort delete the broken Foundry conversation.
-        2. Create a fresh Foundry conversation and update the Cosmos mapping.
-        3. Rebuild input items: tenant + memory-scope system messages from the
-           current turn, then plain-text user/assistant turns from Cosmos
-           (excluding the in-flight user message), then the current turn's
-           user message and any image items.
-
-        Tool-call/result items are NOT replayed because Cosmos only stores
-        plain text. Semantic context is preserved; intermediate tool results
-        are not. This is an acceptable trade-off because the alternative is
-        a failed turn.
+        1. List items from the broken Foundry conversation BEFORE deleting it,
+           and keep only ``message`` items (user/assistant text and any
+           multimodal content). Tool-related items (``function_call``,
+           ``function_call_output``, ``mcp_call``, ``code_interpreter_call``,
+           etc.) are dropped — they are what caused the corruption and are
+           safe to omit because the assistant's final text already summarizes
+           their effect for the user.
+        2. Delete the broken conversation (best effort).
+        3. Create a fresh Foundry conversation and update the Cosmos mapping.
+        4. Compose the next-turn input as: system anchors from the current
+           turn + the filtered Foundry history + the current turn's live
+           inputs.
         """
-        # 1. Delete the broken conversation (best effort).
+        # 1. Pull surviving message items from the broken conversation first.
+        replay_items = await self._list_message_items(
+            openai_client, broken_conversation_id
+        )
+
+        # 2. Delete the broken conversation (best effort).
         try:
             await openai_client.conversations.delete(broken_conversation_id)
             logger.info(
@@ -414,8 +421,8 @@ class ChatService:
                 exc_info=True,
             )
 
-        # 2. Create a new conversation and update the Cosmos mapping so future
-        #    turns use the new id.
+        # 3. Create a new conversation and update the Cosmos mapping so future
+        #    turns use the new id
         new_conversation = await openai_client.conversations.create()
         new_conversation_id = new_conversation.id
         await self._conversation_service.save_agent_conversation_mapping(
@@ -429,11 +436,9 @@ class ChatService:
             broken_conversation_id,
         )
 
-        # 3. Split current_turn_items into system anchors vs. the live user
-        #    message + image inputs. System messages were built fresh this
-        #    turn (tenant context, memory scope) and must be re-applied to the
-        #    new conversation. The trailing user/image items are this turn's
-        #    actual input.
+        # 4. Split current_turn_items into system anchors vs. live user
+        #    inputs. System messages (tenant context, memory scope) were
+        #    rebuilt this turn and are not part of the historical replay.
         system_anchors: list[ResponseInputItemParam] = []
         live_inputs: list[ResponseInputItemParam] = []
         for item in current_turn_items:
@@ -441,9 +446,6 @@ class ChatService:
                 system_anchors.append(item)
             else:
                 live_inputs.append(item)
-
-        # Load past conversation as plain text from Cosmos.
-        replay_items = await self._build_replay_items_from_cosmos(req)
 
         rebuilt = [*system_anchors, *replay_items, *live_inputs]
         logger.info(
@@ -456,60 +458,39 @@ class ChatService:
         )
         return new_conversation_id, rebuilt
 
-    async def _build_replay_items_from_cosmos(
-        self, req: ChatRequest
+    @staticmethod
+    async def _list_message_items(
+        openai_client: AsyncOpenAI,
+        conversation_id: str,
     ) -> list[ResponseInputItemParam]:
-        """Load past user/bot turns from Cosmos and convert to Responses input.
-
-        Returns an empty list when the request lacks conversation identifiers
-        or the conversation has no stored messages. The in-flight user
-        message (matched by ``req.message.id`` when available) is excluded
-        so it isn't duplicated alongside ``live_inputs``.
+        """List items from a Foundry conversation, keeping only ``message``
+        entries. Returns an empty list if the API call fails — the new
+        conversation will simply start with no replayed history.
         """
-        if not req.conversation_id or not req.conversation_type:
-            return []
-
+        replay: list[ResponseInputItemParam] = []
         try:
-            messages = await self._conversation_service.get_messages_by_conversation(
-                req.conversation_id,
-                req.conversation_type,
-            )
+            # AsyncCursorPage is async-iterable and transparently pages.
+            async for item in openai_client.conversations.items.list(conversation_id):
+                # Keep only user/assistant messages; drop every tool-related
+                # variant of ConversationItem (ResponseFunctionToolCallItem,
+                # ResponseFunctionToolCallOutputItem, McpCall, LocalShellCall,
+                # ResponseCodeInterpreterToolCall, etc.).
+                if not isinstance(item, ConversationsMessage):
+                    continue
+                payload = item.model_dump(mode="json", exclude_none=True)
+                # The Responses input schema doesn't accept server-assigned
+                # fields like ``id`` / ``status`` on replayed items.
+                payload.pop("id", None)
+                payload.pop("status", None)
+                replay.append(cast(ResponseInputItemParam, payload))
         except Exception:
             logger.warning(
-                "Failed to load Cosmos history for conversation=%s; "
-                "reseeding without replay.",
-                req.conversation_id,
+                "Failed to list items from broken Foundry conversation %s; "
+                "reseeding with no replayed history.",
+                conversation_id,
                 exc_info=True,
             )
             return []
-
-        current_message_id = getattr(req.message, "id", None)
-        replay: list[ResponseInputItemParam] = []
-        for msg in messages:
-            if current_message_id and msg.id == current_message_id:
-                continue
-            content = (msg.content or "").strip()
-            if not content:
-                continue
-            # Bot answers are persisted with sender_role=Role.System
-            # (see _save_bot_answer_to_conversation). Map them back to
-            # assistant turns; everything else is treated as a user turn.
-            role = (
-                Role.Assistant
-                if msg.sender_role in (Role.System, Role.Assistant)
-                else Role.User
-            )
-            replay.append(
-                cast(
-                    ResponseInputItemParam,
-                    ConversationItem(
-                        role=role,
-                        content=content,
-                        user_id=getattr(msg, "sender_id", None),
-                        user_name=getattr(msg, "sender_name", None),
-                    ).model_dump(mode="json", exclude_none=True),
-                )
-            )
         return replay
 
     @staticmethod


### PR DESCRIPTION
### Problem

> Real case: https://teams.microsoft.com/l/message/19:0351f5f9404446e4b4fd4eaf2c27448d@thread.skype/1780523957385?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1780523957385&teamName=Azure%20SDK&channelName=API%20Spec%20Review&createdTime=1780523957385

After many chat rounds, the Azure AI Foundry hosted agent occasionally returns a Response with `status == "failed"` (e.g. BadRequestError: 'No tool output found for function call ...'). Once the server-managed conversation enters this corrupted state, every subsequent turn fails until the conversation is abandoned. Users experience a permanently broken chat thread.

Related upstream issues:

- Azure/azure-sdk-for-python#46092
- microsoft/agent-framework#5041
- microsoft/agent-framework#5023

### Fix

When `response.status == "failed"`, delete the broken Foundry conversation, create a new one, replayed the conversation with the current message and history messages saved in Cosmos DB, and retry once.

### Test

I've reproduced `status == "failed"` locally, the next turn succeeds against the freshly created conversation.
I also test it in testing channel, the bot could support very long conversation now: [test case](https://teams.microsoft.com/l/message/19:26a1bcfaf04440b98c43acb74792d645@thread.tacv2/1780555689318?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=39910aef-85da-4e30-b5e3-35f04ef38648&parentMessageId=1780555689318&teamName=Azure%20SDK%20Q%26A%20Bot%20Testing&channelName=Azure%20SDK%20QA%20bot%20for%20API%20Spec%20Review%20Testing&createdTime=1780555689318)