### PR TITLE
Fix breaking-change label config alias handling and align report schemas

### DIFF
--- a/tools/spec-gen-sdk/src/automation/reportStatus.ts
+++ b/tools/spec-gen-sdk/src/automation/reportStatus.ts
@@ -31,6 +31,10 @@ export const generateReport = (context: WorkflowContext) => {
   if (context.specConfigPath && context.specConfigPath.endsWith('tspconfig.yaml')) {
     generateFromTypeSpec = true;
   }
+  const breakingChangeLabel =
+    context.swaggerToSdkConfig.packageOptions.breakingChangesLabel ??
+    context.swaggerToSdkConfig.packageOptions.breakingChangeLabel;
+
   for (const pkg of context.handledPackages) {
     setSdkAutoStatus(context, pkg.status);
     hasSuppressions = Boolean(pkg.presentSuppressionLines.length > 0);
@@ -52,7 +56,7 @@ export const generateReport = (context: WorkflowContext) => {
       apiViewArtifact: pkg.apiViewArtifactPath,
       language: pkg.language,
       hasBreakingChange: pkg.hasBreakingChange,
-      breakingChangeLabel: context.swaggerToSdkConfig.packageOptions.breakingChangesLabel,
+      breakingChangeLabel,
       shouldLabelBreakingChange,
       areBreakingChangeSuppressed,
       presentBreakingChangeSuppressions: pkg.presentSuppressionLines,

--- a/tools/spec-gen-sdk/src/types/ExecutionReportSchema.json
+++ b/tools/spec-gen-sdk/src/types/ExecutionReportSchema.json
@@ -78,6 +78,7 @@
             "type": "string"
           },
           "shouldLabelBreakingChange": {
+            // Whether this package should receive the breaking-change label based on generated report results.
             "type": "boolean"
           },
           "areBreakingChangeSuppressed": {

--- a/tools/spec-gen-sdk/src/types/ExecutionReportSchema.json
+++ b/tools/spec-gen-sdk/src/types/ExecutionReportSchema.json
@@ -77,6 +77,9 @@
           "breakingChangeLabel": {
             "type": "string"
           },
+          "shouldLabelBreakingChange": {
+            "type": "boolean"
+          },
           "areBreakingChangeSuppressed": {
             "type": "boolean"
           },
@@ -101,4 +104,3 @@
       }
     }
   }
-  

--- a/tools/spec-gen-sdk/src/types/SwaggerToSdkConfigSchema.json
+++ b/tools/spec-gen-sdk/src/types/SwaggerToSdkConfigSchema.json
@@ -165,8 +165,12 @@
           // Update version and release data.
           "$ref": "#/definitions/RunOptions"
         },
+        "breakingChangesLabel": {
+          // Canonical label to be added in spec PR if breaking change is found
+          "type": "string"
+        },
         "breakingChangeLabel": {
-          // Label to be added in spec PR if breaking change is found
+          // Backward-compatible alias for breakingChangesLabel
           "type": "string"
         }
       },

--- a/tools/spec-gen-sdk/src/types/SwaggerToSdkConfigSchema.json
+++ b/tools/spec-gen-sdk/src/types/SwaggerToSdkConfigSchema.json
@@ -166,11 +166,13 @@
           "$ref": "#/definitions/RunOptions"
         },
         "breakingChangesLabel": {
-          // Canonical label to be added in spec PR if breaking change is found
+          // Canonical single label string to be added in spec PR if breaking change is found.
+          // Takes precedence over breakingChangeLabel when both are present.
           "type": "string"
         },
         "breakingChangeLabel": {
-          // Backward-compatible alias for breakingChangesLabel
+          // Backward-compatible alias for breakingChangesLabel.
+          // Ignored when breakingChangesLabel is also present.
           "type": "string"
         }
       },

--- a/tools/spec-gen-sdk/test/automation/reportStatus.test.ts
+++ b/tools/spec-gen-sdk/test/automation/reportStatus.test.ts
@@ -170,10 +170,26 @@ describe('reportStatus', () => {
     };
 
     const getWrittenExecutionReport = () => {
-      const call = vi.mocked(writeTmpJsonFile).mock.calls.find(([, fileName]) => fileName === 'execution-report.json');
+      const matchingCalls = vi.mocked(writeTmpJsonFile).mock.calls.filter(([, fileName]) => fileName === 'execution-report.json');
+      const call = matchingCalls.at(-1);
       expect(call).toBeDefined();
       return call![2] as WrittenExecutionReport;
     };
+
+    const createWorkflowContextWithPackageOptions = (
+      packageOptions: {
+        breakingChangeLabel?: string;
+        breakingChangesLabel?: string;
+      }
+    ) => ({
+      ...mockWorkflowContext,
+      swaggerToSdkConfig: {
+        ...mockWorkflowContext.swaggerToSdkConfig,
+        packageOptions: {
+          ...packageOptions,
+        },
+      },
+    } as WorkflowContext);
 
     it('should generate report successfully with valid context', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
@@ -191,7 +207,9 @@ describe('reportStatus', () => {
     });
 
     it('should use breakingChangesLabel when only plural config key is provided', () => {
-      generateReport(mockWorkflowContext);
+      const workflowContext = createWorkflowContextWithPackageOptions({ breakingChangesLabel: 'breaking-change' });
+
+      generateReport(workflowContext);
 
       expect(getWrittenExecutionReport().packages[0]).toEqual(expect.objectContaining({
         breakingChangeLabel: 'breaking-change',
@@ -199,10 +217,9 @@ describe('reportStatus', () => {
     });
 
     it('should fall back to breakingChangeLabel when plural config key is not provided', () => {
-      mockWorkflowContext.swaggerToSdkConfig.packageOptions.breakingChangesLabel = undefined;
-      mockWorkflowContext.swaggerToSdkConfig.packageOptions.breakingChangeLabel = 'legacy-breaking-change';
+      const workflowContext = createWorkflowContextWithPackageOptions({ breakingChangeLabel: 'legacy-breaking-change' });
 
-      generateReport(mockWorkflowContext);
+      generateReport(workflowContext);
 
       expect(getWrittenExecutionReport().packages[0]).toEqual(expect.objectContaining({
         breakingChangeLabel: 'legacy-breaking-change',
@@ -210,10 +227,12 @@ describe('reportStatus', () => {
     });
 
     it('should prefer breakingChangesLabel when both config keys are provided', () => {
-      mockWorkflowContext.swaggerToSdkConfig.packageOptions.breakingChangesLabel = 'canonical-breaking-change';
-      mockWorkflowContext.swaggerToSdkConfig.packageOptions.breakingChangeLabel = 'legacy-breaking-change';
+      const workflowContext = createWorkflowContextWithPackageOptions({
+        breakingChangeLabel: 'legacy-breaking-change',
+        breakingChangesLabel: 'canonical-breaking-change',
+      });
 
-      generateReport(mockWorkflowContext);
+      generateReport(workflowContext);
 
       expect(getWrittenExecutionReport().packages[0]).toEqual(expect.objectContaining({
         breakingChangeLabel: 'canonical-breaking-change',

--- a/tools/spec-gen-sdk/test/automation/reportStatus.test.ts
+++ b/tools/spec-gen-sdk/test/automation/reportStatus.test.ts
@@ -162,6 +162,19 @@ describe('reportStatus', () => {
   });
 
   describe('generateReport', () => {
+    type WrittenExecutionReport = {
+      packages: Array<{
+        breakingChangeLabel?: string;
+        shouldLabelBreakingChange?: boolean;
+      }>;
+    };
+
+    const getWrittenExecutionReport = () => {
+      const call = vi.mocked(writeTmpJsonFile).mock.calls.find(([, fileName]) => fileName === 'execution-report.json');
+      expect(call).toBeDefined();
+      return call![2] as WrittenExecutionReport;
+    };
+
     it('should generate report successfully with valid context', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
@@ -175,6 +188,44 @@ describe('reportStatus', () => {
       expect(setSdkAutoStatus).toHaveBeenCalledWith(mockWorkflowContext, 'succeeded');
       expect(deleteTmpJsonFile).toHaveBeenCalledWith(mockWorkflowContext, 'execution-report.json');
       expect(writeTmpJsonFileMock.mock.calls[0][2]).toMatchSnapshot();
+    });
+
+    it('should use breakingChangesLabel when only plural config key is provided', () => {
+      generateReport(mockWorkflowContext);
+
+      expect(getWrittenExecutionReport().packages[0]).toEqual(expect.objectContaining({
+        breakingChangeLabel: 'breaking-change',
+      }));
+    });
+
+    it('should fall back to breakingChangeLabel when plural config key is not provided', () => {
+      mockWorkflowContext.swaggerToSdkConfig.packageOptions.breakingChangesLabel = undefined;
+      mockWorkflowContext.swaggerToSdkConfig.packageOptions.breakingChangeLabel = 'legacy-breaking-change';
+
+      generateReport(mockWorkflowContext);
+
+      expect(getWrittenExecutionReport().packages[0]).toEqual(expect.objectContaining({
+        breakingChangeLabel: 'legacy-breaking-change',
+      }));
+    });
+
+    it('should prefer breakingChangesLabel when both config keys are provided', () => {
+      mockWorkflowContext.swaggerToSdkConfig.packageOptions.breakingChangesLabel = 'canonical-breaking-change';
+      mockWorkflowContext.swaggerToSdkConfig.packageOptions.breakingChangeLabel = 'legacy-breaking-change';
+
+      generateReport(mockWorkflowContext);
+
+      expect(getWrittenExecutionReport().packages[0]).toEqual(expect.objectContaining({
+        breakingChangeLabel: 'canonical-breaking-change',
+      }));
+    });
+
+    it('should include shouldLabelBreakingChange in generated execution report', () => {
+      generateReport(mockWorkflowContext);
+
+      expect(getWrittenExecutionReport().packages[0]).toEqual(expect.objectContaining({
+        shouldLabelBreakingChange: false,
+      }));
     });
 
     it('should handle breaking changes correctly', () => {


### PR DESCRIPTION
Fixes #15888

## Summary

This PR resolves several inconsistencies in the breaking-change label configuration and execution report schema within `spec-gen-sdk`.

During review of the issue, I found that runtime behavior, configuration schemas, and execution report schemas had drifted out of sync.

## Changes

### 1. Backward-compatible breaking-change label handling

Updated `reportStatus.ts` to support both configuration keys:

* `breakingChangesLabel` (canonical runtime key)
* `breakingChangeLabel` (backward-compatible alias)

Behavior:

* If only `breakingChangesLabel` is present, it is used.
* If only `breakingChangeLabel` is present, it is used.
* If both keys are present, `breakingChangesLabel` takes precedence.

### 2. Configuration schema alignment

Updated `SwaggerToSdkConfigSchema.json` to document both:

* `breakingChangesLabel`
* `breakingChangeLabel`

This aligns the documented configuration contract with the runtime implementation.

### 3. Execution report schema alignment

Updated `ExecutionReportSchema.json` to include:

```text
shouldLabelBreakingChange
```

This property is emitted by report generation and already exists in the TypeScript report model, but was missing from the JSON schema.

### 4. Test coverage

Added/updated tests covering:

* plural-only configuration
* singular-only configuration fallback
* precedence when both keys are present
* emitted `shouldLabelBreakingChange` in generated reports

## Validation

Executed the report status test suite locally:

```bash
npm test -- test/automation/reportStatus.test.ts
```

Result:

```text
Test Files: 1 passed
Tests: 25 passed
```

## Compatibility

This change is fully backward-compatible:

* No existing configuration keys were removed.
* No public interfaces were renamed.
* Existing consumers using either configuration key continue to work.
* Runtime behavior remains unchanged for configurations already using `breakingChangesLabel`.
