### PR TITLE
spec-gen-sdk: accept breakingChangesLabel (plural) in SwaggerToSdkConfig schema

### DIFF
--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## Unreleased
+
+- Added `breakingChangesLabel` (plural) to the `SwaggerToSdkConfig` JSON schema and kept `breakingChangeLabel` (singular) as a deprecated fallback. `reportStatus` now prefers the plural value and falls back to the singular when only the legacy key is set.
+
 ## 2026-04-07 - 0.9.7
 
 - Made 'sdk-release-type' parameter optional, same as 'api-version'

--- a/tools/spec-gen-sdk/src/automation/reportStatus.ts
+++ b/tools/spec-gen-sdk/src/automation/reportStatus.ts
@@ -52,7 +52,9 @@ export const generateReport = (context: WorkflowContext) => {
       apiViewArtifact: pkg.apiViewArtifactPath,
       language: pkg.language,
       hasBreakingChange: pkg.hasBreakingChange,
-      breakingChangeLabel: context.swaggerToSdkConfig.packageOptions.breakingChangesLabel,
+      breakingChangeLabel:
+        context.swaggerToSdkConfig.packageOptions.breakingChangesLabel
+          ?? context.swaggerToSdkConfig.packageOptions.breakingChangeLabel,
       shouldLabelBreakingChange,
       areBreakingChangeSuppressed,
       presentBreakingChangeSuppressions: pkg.presentSuppressionLines,

--- a/tools/spec-gen-sdk/src/types/SwaggerToSdkConfigSchema.json
+++ b/tools/spec-gen-sdk/src/types/SwaggerToSdkConfigSchema.json
@@ -166,6 +166,11 @@
           "$ref": "#/definitions/RunOptions"
         },
         "breakingChangeLabel": {
+          // Deprecated: use 'breakingChangesLabel' instead. Retained for
+          // backward compatibility and read as a fallback by spec-gen-sdk.
+          "type": "string"
+        },
+        "breakingChangesLabel": {
           // Label to be added in spec PR if breaking change is found
           "type": "string"
         }

--- a/tools/spec-gen-sdk/test/automation/reportStatus.test.ts
+++ b/tools/spec-gen-sdk/test/automation/reportStatus.test.ts
@@ -233,6 +233,47 @@ describe('reportStatus', () => {
       );
     });
 
+    it('should prefer breakingChangesLabel (plural) when both keys are set', () => {
+      mockWorkflowContext.swaggerToSdkConfig.packageOptions = {
+        breakingChangesLabel: 'BreakingChange-Plural',
+        breakingChangeLabel: 'BreakingChange-Singular',
+      } as any;
+
+      generateReport(mockWorkflowContext);
+
+      expect(writeTmpJsonFile).toHaveBeenCalledWith(
+        mockWorkflowContext,
+        'execution-report.json',
+        expect.objectContaining({
+          packages: expect.arrayContaining([
+            expect.objectContaining({
+              breakingChangeLabel: 'BreakingChange-Plural',
+            }),
+          ]),
+        })
+      );
+    });
+
+    it('should fall back to legacy breakingChangeLabel (singular) when plural is absent', () => {
+      mockWorkflowContext.swaggerToSdkConfig.packageOptions = {
+        breakingChangeLabel: 'BreakingChange-Singular',
+      } as any;
+
+      generateReport(mockWorkflowContext);
+
+      expect(writeTmpJsonFile).toHaveBeenCalledWith(
+        mockWorkflowContext,
+        'execution-report.json',
+        expect.objectContaining({
+          packages: expect.arrayContaining([
+            expect.objectContaining({
+              breakingChangeLabel: 'BreakingChange-Singular',
+            }),
+          ]),
+        })
+      );
+    });
+
     it('should write markdown file when pullNumber is provided', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
 


### PR DESCRIPTION
## Summary

The `SwaggerToSdkConfig` JSON schema only declared `breakingChangeLabel` (singular), while
`reportStatus.ts` actually reads `breakingChangesLabel` (plural) when populating
`ExecutionReport.packages[].breakingChangeLabel`. Any SDK repo that set only the
schema-documented (singular) key would silently end up with an `undefined` label in the
execution report.

## Changes

- **`src/types/SwaggerToSdkConfigSchema.json`** — add `breakingChangesLabel` (plural) as the canonical property; keep `breakingChangeLabel` (singular) with a `Deprecated:` comment for backward compatibility.
- **`src/automation/reportStatus.ts`** — reader now prefers `breakingChangesLabel` and falls back to `breakingChangeLabel` when only the legacy key is set.
- **`test/automation/reportStatus.test.ts`** — added two tests: (a) plural wins when both are set; (b) singular is used as a fallback.
- **`CHANGELOG.md`** — added an `Unreleased` entry.

No change was needed in `SwaggerToSdkConfig.ts` (the TS type already declared both fields).

## Compatibility

Fully backward-compatible:
- Existing repos using `breakingChangesLabel` (plural) — behavior unchanged.
- Existing repos using only `breakingChangeLabel` (singular) — now actually honored (was previously silently dropped).
- New repos should adopt `breakingChangesLabel`.

## Validation

- `npm test` → 23/23 `reportStatus` tests pass (305/306 overall; the one failure is a pre-existing Windows path-separator issue in `entrypoint.test.ts` unrelated to this change).
- `npm run lint` → clean.
