### PR TITLE
spec-gen-sdk: accept both breakingChangeLabel and breakingChangesLabel

### DIFF
--- a/tools/spec-gen-sdk/src/automation/reportStatus.ts
+++ b/tools/spec-gen-sdk/src/automation/reportStatus.ts
@@ -7,7 +7,7 @@ import { vsoAddAttachment, vsoLogError, vsoLogWarning } from './logging';
 import { ExecutionReport, PackageReport } from '../types/ExecutionReport';
 import { deleteTmpJsonFile, readTmpJsonFile, writeTmpJsonFile } from '../utils/fsUtils';
 import { marked } from "marked";
-import { toolError, toolWarning } from '../utils/messageUtils';
+import { toolError, toolWarning, configWarning } from '../utils/messageUtils';
 import { FailureType, WorkflowContext } from '../types/Workflow';
 import { setFailureType } from '../utils/workflowUtils';
 import { commentDetailView, renderHandlebarTemplate } from '../utils/reportStatusUtils';
@@ -31,6 +31,17 @@ export const generateReport = (context: WorkflowContext) => {
   if (context.specConfigPath && context.specConfigPath.endsWith('tspconfig.yaml')) {
     generateFromTypeSpec = true;
   }
+
+  const packageOptions = context.swaggerToSdkConfig.packageOptions;
+  const breakingChangeLabelValue = packageOptions.breakingChangesLabel ?? packageOptions.breakingChangeLabel;
+  if (packageOptions.breakingChangesLabel === undefined && packageOptions.breakingChangeLabel !== undefined) {
+    context.logger.warn(
+      configWarning(
+        "'breakingChangeLabel' in swagger_to_sdk config is deprecated. Rename it to 'breakingChangesLabel'.",
+      ),
+    );
+  }
+
   for (const pkg of context.handledPackages) {
     setSdkAutoStatus(context, pkg.status);
     hasSuppressions = Boolean(pkg.presentSuppressionLines.length > 0);
@@ -52,7 +63,7 @@ export const generateReport = (context: WorkflowContext) => {
       apiViewArtifact: pkg.apiViewArtifactPath,
       language: pkg.language,
       hasBreakingChange: pkg.hasBreakingChange,
-      breakingChangeLabel: context.swaggerToSdkConfig.packageOptions.breakingChangesLabel,
+      breakingChangeLabel: breakingChangeLabelValue,
       shouldLabelBreakingChange,
       areBreakingChangeSuppressed,
       presentBreakingChangeSuppressions: pkg.presentSuppressionLines,

--- a/tools/spec-gen-sdk/src/types/SwaggerToSdkConfig.ts
+++ b/tools/spec-gen-sdk/src/types/SwaggerToSdkConfig.ts
@@ -52,8 +52,9 @@ export type SwaggerToSdkConfig = {
     changelogScript?: RunOptions & {
       breakingChangeDetect?: RunLogFilterOptions;
     };
-    breakingChangeLabel?: string;
     breakingChangesLabel?: string;
+    /** @deprecated Use breakingChangesLabel. Read for backward compatibility with existing language repo configs. */
+    breakingChangeLabel?: string;
   };
   artifactOptions: {
     artifactPathFromFileSearch?:

--- a/tools/spec-gen-sdk/src/types/SwaggerToSdkConfigSchema.json
+++ b/tools/spec-gen-sdk/src/types/SwaggerToSdkConfigSchema.json
@@ -165,9 +165,16 @@
           // Update version and release data.
           "$ref": "#/definitions/RunOptions"
         },
-        "breakingChangeLabel": {
+        "breakingChangesLabel": {
           // Label to be added in spec PR if breaking change is found
           "type": "string"
+        },
+        "breakingChangeLabel": {
+          // Deprecated alias of breakingChangesLabel. Kept for backward
+          // compatibility with existing language repo configs; new configs
+          // should use breakingChangesLabel.
+          "type": "string",
+          "deprecated": true
         }
       },
       "default": {}


### PR DESCRIPTION
## Summary

- The `SwaggerToSdkConfigSchema.json` schema documents `breakingChangeLabel` (singular) on `packageOptions`, but `reportStatus.ts` was reading `breakingChangesLabel` (plural). Any language repo `swagger_to_sdk.json` that followed the schema was silently ignored — the label never made it into `execution-report.json` and the spec PR never got tagged.
- This change accepts both names on input, prefers the plural (which matches today's runtime behavior), and emits a `CONFIG-WARN` line when only the deprecated singular is set so language repos still on the old key have a visible signal to migrate.
- The schema now declares both keys; the singular is marked `"deprecated": true`. The TS type keeps both fields with the singular tagged `@deprecated`. The output `PackageReport.breakingChangeLabel` shape is unchanged — downstream pipeline consumers see no contract change.

## Test plan

- [x] `npx vitest run reportStatus workflowPackage reportStatusUtils` → 73/73 pass
- [x] Full `npx vitest run` → 305/306 pass (the one failure in `entrypoint.test.ts` reproduces on clean `main` and is unrelated to this change)
- [x] `npx tsc --noEmit` clean
- [ ] After this lands, sweep `azure-sdk-for-<lang>` repos to rename `breakingChangeLabel` → `breakingChangesLabel` in each `swagger_to_sdk.json`, then remove the deprecated branch in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)