### PR TITLE
Update create release plan tool to include release plan dashboard link

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 0.6.18 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 0.6.18 (2026-06-08)
 
 ### Other Changes
+
+- Updated the release plan response to include the link to release plan dashboard.
+- Added release plan type check in SDK generation and inform the agent that SDK generation is not required for private preview. 
 
 ## 0.6.17 (2026-06-02)
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AzureDevOps/ReleasePlanWorkItem.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AzureDevOps/ReleasePlanWorkItem.cs
@@ -9,6 +9,7 @@ namespace Azure.Sdk.Tools.Cli.Models.AzureDevOps
     public class ReleasePlanWorkItem : WorkItemBase
     {
         public const string DashboardBaseUrl = "https://azsdk-releaseplan-dashboard-hveph5aqhhcfhtgu.westus-01.azurewebsites.net/?releaseplan=";
+        public const string DashboardBaseUrlTest = "https://releaseplan-dashboard-test.azurewebsites.net/?releaseplan=";
 
         [FieldName("Custom.ServiceTreeID")]
         public string ServiceTreeId { get; set; } = string.Empty;
@@ -36,8 +37,8 @@ namespace Azure.Sdk.Tools.Cli.Models.AzureDevOps
         public string SpecType {  get; set; } = string.Empty;
 
         public string ReleasePlanLink => ReleasePlanId > 0
-            ? $"{DashboardBaseUrl}{ReleasePlanId}"
-            : string.Empty;
+            ? (IsTestReleasePlan ? $"{DashboardBaseUrlTest}{ReleasePlanId}" : $"{DashboardBaseUrl}{ReleasePlanId}")
+            : (WorkItemId > 0 ? (IsTestReleasePlan ? $"{DashboardBaseUrlTest}{WorkItemId}" : $"{DashboardBaseUrl}{WorkItemId}") : string.Empty);
 
         public bool IsTestReleasePlan { get; set; } = false;
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ReleasePlan/ReleasePlanResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ReleasePlan/ReleasePlanResponse.cs
@@ -14,6 +14,7 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses.ReleasePlan
         public ReleasePlanWorkItem? ReleasePlanDetails { get; set; }
         [JsonPropertyName("message")]
         public string Message { get; set; } = string.Empty;
+        public string ReleasePlanLink => ReleasePlanDetails != null ? ReleasePlanDetails.ReleasePlanLink : string.Empty;
         protected override string Format()
         {
             var result = new StringBuilder();
@@ -24,6 +25,7 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses.ReleasePlan
                 result.AppendLine($"Status: {ReleasePlanDetails.Status}");
                 result.AppendLine($"Owner: {ReleasePlanDetails.Owner}");
                 result.AppendLine($"SDK Release Month: {ReleasePlanDetails.SDKReleaseMonth}");
+                result.AppendLine($"Release Plan Link: {ReleasePlanLink}");
             }
             else
             {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ReleasePlan/ReleasePlanResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ReleasePlan/ReleasePlanResponse.cs
@@ -14,6 +14,7 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses.ReleasePlan
         public ReleasePlanWorkItem? ReleasePlanDetails { get; set; }
         [JsonPropertyName("message")]
         public string Message { get; set; } = string.Empty;
+        [JsonPropertyName("release_plan_link")]
         public string ReleasePlanLink => ReleasePlanDetails != null ? ReleasePlanDetails.ReleasePlanLink : string.Empty;
         protected override string Format()
         {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -333,6 +333,7 @@ namespace Azure.Sdk.Tools.Cli.Services
                 ProductLifecycle = workItem.Fields.TryGetValue("Custom.ProductLifecycle", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 ReleasePlanType = workItem.Fields.TryGetValue("Custom.ReleasePlanType", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 Owner = workItem.Fields.TryGetValue("Custom.PrimaryPM", out value) ? value?.ToString() ?? string.Empty : string.Empty,
+                IsTestReleasePlan = workItem.Fields.TryGetValue("System.Tags", out value) && value is String tags && tags.Contains(RELEASE_PLANNER_APP_TEST)
             };
 
             foreach (var lang in SUPPORTED_SDK_LANGUAGES)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -784,7 +784,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             }
         }
 
-        [McpServerTool(Name = CreateReleasePlanToolName), Description("Create Release Plan for a TypeSpec project, service, product. Service ID and product Id are required if a previous release plan is not found for the TypeSpec project.")]
+        [McpServerTool(Name = CreateReleasePlanToolName), Description("Create Release Plan for a TypeSpec project and API release type. API release types support Private Preview, Public Preview, and GA. Service ID and product Id are required if a previous release plan is not found for the TypeSpec project.")]
         public async Task<ReleasePlanResponse> CreateReleasePlan(string typeSpecProjectPath, string targetReleaseMonthYear, string apiReleaseType, string sdkReleaseType = "", string specPullRequestUrl = "", string serviceTreeId = "", string productTreeId = "", bool isTestReleasePlan = false, bool forceCreateReleasePlan = false, CancellationToken ct = default)
         {
             try

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/SpecWorkFlowTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/SpecWorkFlowTool.cs
@@ -206,7 +206,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
 
                 if (releasePlan.ApiReleaseType == ApiReleaseType.PrivatePreview)
                 {
-                    response.ResponseErrors.Add($"Release plan with work item ID {workItemId} is in Private Preview stage. Important: SDK cannot be generated and released for private preview release plans and private preview release plan only requires to merge API spec PR. If required for validation purposes, you can generate the SDK locally only and only for SDK validation.");
+                    response.Details.Add($"Release plan with work item ID {workItemId} is in Private Preview stage. Important: SDK cannot be generated and released for private preview release plans and private preview release plan only requires to merge API spec PR. If required for validation purposes, you can generate the SDK locally only and only for SDK validation.");
                     response.Status = "Success";
                     return response;
                 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/SpecWorkFlowTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/SpecWorkFlowTool.cs
@@ -193,9 +193,24 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 {
                     response.ResponseErrors.Add("Release plan work item ID is required to run SDK generation.");
                     response.Status = "Failed";
-                    response.NextSteps = ["Create a release plan if you don't have one or get existing release plan  and re-run SDK generation."];
+                    response.NextSteps = ["Create a release plan if you don't have one or get existing release plan and re-run SDK generation."];
                     return response;
                 }
+                var releasePlan = await devopsService.GetReleasePlanForWorkItemAsync(workItemId, ct);
+                if (releasePlan == null)
+                {
+                    response.ResponseErrors.Add($"No release plan found for work item ID {workItemId}. Please check the work item ID and try again.");
+                    response.Status = "Failed";
+                    return response;
+                }
+
+                if (releasePlan.ApiReleaseType == ApiReleaseType.PrivatePreview)
+                {
+                    response.ResponseErrors.Add($"Release plan with work item ID {workItemId} is in Private Preview stage. Important: SDK cannot be generated and released for private preview release plans and private preview release plan only requires to merge API spec PR. If required for validation purposes, you can generate the SDK locally only and only for SDK validation.");
+                    response.Status = "Success";
+                    return response;
+                }
+
                 language = inputSanitizer.SanitizeLanguage(language);
                 logger.LogInformation(
                     "Generating SDK for TypeSpec project: {TypespecProjectRoot}, API Version: {ApiVersion}, SDK Release Type: {SdkReleaseType}, Language: {Language}, Pull Request Number: {PullRequestNumber}, Work Item ID: {WorkItemId}",
@@ -261,8 +276,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     apiSpecBranchRef = (pullRequest?.Merged ?? false) ? pullRequest.Base.Ref : $"refs/pull/{pullRequestNumber}/merge";
                 }
 
-                string sdkRepoBranch = "";
-                var releasePlan = workItemId != 0 ? await devopsService.GetReleasePlanForWorkItemAsync(workItemId, ct) : null;
+                string sdkRepoBranch = "";                
                 var sdkPullRequestUrl = releasePlan?.SDKInfo.FirstOrDefault(s => s.Language == language)?.SdkPullRequestUrl;
                 if (!string.IsNullOrEmpty(sdkPullRequestUrl))
                 {


### PR DESCRIPTION
This PR has the changes to resolve the feedback form agent testing.
- Include a link to release plan dashboard when a release plan is created.
- Update SDK generation tool to include a message when release plan is private preview.