### PR TITLE
[AZSDK CLI] Add command to get ADO Package Work Item

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/TestData/TestPrompts.json
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/TestData/TestPrompts.json
@@ -49,6 +49,9 @@
 
     { "toolName": "azsdk_package_build_code", "prompt": "Build my SDK package", "category": "all" },
     { "toolName": "azsdk_package_build_code", "prompt": "Compile the code for my package", "category": "all" },
+    { "toolName": "azsdk_package_find_work_item", "prompt": "Find the Azure DevOps package work item for azure-storage-blob version 12.30 in Python", "category": "all" },
+    { "toolName": "azsdk_package_find_work_item", "prompt": "Get the ADO package work item link for Azure.Storage.Blobs 12.30.0 in .NET", "category": "all" },
+    { "toolName": "azsdk_package_find_work_item", "prompt": "Look up the package work item for the Java storage blob package", "category": "all" },
     { "toolName": "azsdk_package_generate_code", "prompt": "Generate SDK code from my TypeSpec", "category": "all" },
     { "toolName": "azsdk_package_generate_code", "prompt": "Run code generation for my package", "category": "all" },
     { "toolName": "azsdk_package_run_check", "prompt": "Run the azsdk package check command to validate my SDK", "category": "all" },

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/TestData/TestPrompts.json
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/TestData/TestPrompts.json
@@ -49,9 +49,6 @@
 
     { "toolName": "azsdk_package_build_code", "prompt": "Build my SDK package", "category": "all" },
     { "toolName": "azsdk_package_build_code", "prompt": "Compile the code for my package", "category": "all" },
-    { "toolName": "azsdk_package_find_work_item", "prompt": "Find the Azure DevOps package work item for azure-storage-blob version 12.30 in Python", "category": "all" },
-    { "toolName": "azsdk_package_find_work_item", "prompt": "Get the ADO package work item link for Azure.Storage.Blobs 12.30.0 in .NET", "category": "all" },
-    { "toolName": "azsdk_package_find_work_item", "prompt": "Look up the package work item for the Java storage blob package", "category": "all" },
     { "toolName": "azsdk_package_generate_code", "prompt": "Generate SDK code from my TypeSpec", "category": "all" },
     { "toolName": "azsdk_package_generate_code", "prompt": "Run code generation for my package", "category": "all" },
     { "toolName": "azsdk_package_run_check", "prompt": "Run the azsdk package check command to validate my SDK", "category": "all" },

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
@@ -21,6 +21,21 @@ namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
             throw new NotImplementedException();
         }
 
+        public Task<List<PackageWorkitemResponse>> FindPackageWorkItemsAsync(string packageName, string language, string packageVersionMajorMinor, CancellationToken ct = default)
+        {
+            return Task.FromResult(new List<PackageWorkitemResponse>
+            {
+                new()
+                {
+                    PackageName = packageName,
+                    Language = SdkLanguageHelpers.GetSdkLanguage(language),
+                    Version = packageVersionMajorMinor,
+                    WorkItemId = 12345,
+                    WorkItemUrl = "https://dev.azure.com/fake-org/fake-project/_workitems/edit/12345"
+                }
+            });
+        }
+
         Task<List<ReleasePlanWorkItem>> IDevOpsService.ListOverdueReleasePlansAsync(CancellationToken ct)
         {
             return Task.FromResult(new List<ReleasePlanWorkItem>());

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
@@ -21,21 +21,6 @@ namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
             throw new NotImplementedException();
         }
 
-        public Task<List<PackageWorkitemResponse>> FindPackageWorkItemsAsync(string packageName, string language, string packageVersionMajorMinor, CancellationToken ct = default)
-        {
-            return Task.FromResult(new List<PackageWorkitemResponse>
-            {
-                new()
-                {
-                    PackageName = packageName,
-                    Language = SdkLanguageHelpers.GetSdkLanguage(language),
-                    Version = packageVersionMajorMinor,
-                    WorkItemId = 12345,
-                    WorkItemUrl = "https://dev.azure.com/fake-org/fake-project/_workitems/edit/12345"
-                }
-            });
-        }
-
         public Task<List<int>> FindPackageWorkItemIdsAsync(string packageName, string language, string packageVersionMajorMinor, CancellationToken ct = default)
         {
             return Task.FromResult(new List<int> { 12345 });

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
@@ -36,6 +36,11 @@ namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
             });
         }
 
+        public Task<List<int>> FindPackageWorkItemIdsAsync(string packageName, string language, string packageVersionMajorMinor, CancellationToken ct = default)
+        {
+            return Task.FromResult(new List<int> { 12345 });
+        }
+
         Task<List<ReleasePlanWorkItem>> IDevOpsService.ListOverdueReleasePlansAsync(CancellationToken ct)
         {
             return Task.FromResult(new List<ReleasePlanWorkItem>());

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackageWorkItemLookupToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackageWorkItemLookupToolTests.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.CommandLine;
+using Azure.Sdk.Tools.Cli.Models.Responses.Package;
+using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
+using Azure.Sdk.Tools.Cli.Tools.Package;
+using Moq;
+
+namespace Azure.Sdk.Tools.Cli.Tests.Tools.Package;
+
+public class PackageWorkItemLookupToolTests
+{
+    private Mock<IDevOpsService> devOpsService;
+    private PackageWorkItemLookupTool tool;
+
+    [SetUp]
+    public void Setup()
+    {
+        devOpsService = new Mock<IDevOpsService>();
+        tool = new PackageWorkItemLookupTool(devOpsService.Object, new TestLogger<PackageWorkItemLookupTool>());
+    }
+
+    [Test]
+    public async Task FindPackageWorkItemReturnsBrowserLinkForSingularMatch()
+    {
+        devOpsService.Setup(service => service.FindPackageWorkItemsAsync("azure-storage-blob", "Python", "12.30", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new PackageWorkitemResponse
+                {
+                    PackageName = "azure-storage-blob",
+                    WorkItemId = 31370,
+                    WorkItemUrl = "https://dev.azure.com/azure-sdk/Release/_apis/wit/workItems/31370"
+                }
+            ]);
+
+        var result = await tool.FindPackageWorkItem("azure-storage-blob", "12.30", "Python", CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(0));
+            Assert.That(result.WorkItemId, Is.EqualTo(31370));
+            Assert.That(result.WorkItemUrl, Is.EqualTo("https://dev.azure.com/azure-sdk/release/_workitems/edit/31370"));
+        });
+    }
+
+    [Test]
+    public async Task FindPackageWorkItemReturnsErrorWhenNoMatchExists()
+    {
+        devOpsService.Setup(service => service.FindPackageWorkItemsAsync("azure-storage-blob", "Python", "12.30", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var result = await tool.FindPackageWorkItem("azure-storage-blob", "12.30", "Python", CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(1));
+            Assert.That(result.ResponseError, Does.Contain("No package work item found"));
+        });
+    }
+
+    [Test]
+    public async Task FindPackageWorkItemReturnsErrorWhenMultipleMatchesExist()
+    {
+        devOpsService.Setup(service => service.FindPackageWorkItemsAsync("azure-storage-blob", "Python", "12.30", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new PackageWorkitemResponse { WorkItemId = 1 },
+                new PackageWorkitemResponse { WorkItemId = 2 }
+            ]);
+
+        var result = await tool.FindPackageWorkItem("azure-storage-blob", "12.30", "Python", CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(1));
+            Assert.That(result.ResponseError, Does.Contain("Expected one package work item"));
+            Assert.That(result.NextSteps, Has.Count.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void CommandParsesPackageWorkItemLookupOptions()
+    {
+        var command = tool.GetCommandInstances().First();
+        var parseConfig = new CommandLineConfiguration(command)
+        {
+            ResponseFileTokenReplacer = null
+        };
+
+        var parseResult = command.Parse("--package-name azure-storage-blob --package-version 12.30 --language Python", parseConfig);
+        Assert.That(parseResult.Errors, Is.Empty);
+
+        parseResult = command.Parse("--package-name azure-storage-blob --package-version-major-minor 12.30 --language Python", parseConfig);
+        Assert.That(parseResult.Errors, Is.Empty);
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackageWorkItemLookupToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackageWorkItemLookupToolTests.cs
@@ -79,6 +79,43 @@ public class PackageWorkItemLookupToolTests
     }
 
     [Test]
+    [TestCase("12.30.0", "12.30")]
+    [TestCase("12.30.0-beta.1", "12.30")]
+    [TestCase("12", "12.0")]
+    public async Task FindPackageWorkItemNormalizesPackageVersionBeforeLookup(string packageVersion, string expectedPackageVersionMajorMinor)
+    {
+        devOpsService.Setup(service => service.FindPackageWorkItemsAsync("azure-storage-blob", "Python", expectedPackageVersionMajorMinor, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new PackageWorkitemResponse
+                {
+                    PackageName = "azure-storage-blob",
+                    WorkItemId = 31370,
+                    WorkItemUrl = "https://dev.azure.com/azure-sdk/Release/_apis/wit/workItems/31370"
+                }
+            ]);
+
+        var result = await tool.FindPackageWorkItem("azure-storage-blob", packageVersion, "Python", CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(0));
+            Assert.That(result.PackageVersionMajorMinor, Is.EqualTo(expectedPackageVersionMajorMinor));
+        });
+    }
+
+    [Test]
+    public async Task FindPackageWorkItemReturnsErrorForInvalidPackageVersion()
+    {
+        var result = await tool.FindPackageWorkItem("azure-storage-blob", "12.x", "Python", CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(1));
+            Assert.That(result.ResponseError, Does.Contain("Package version must be a major version, major.minor version, or full SemVer version"));
+        });
+    }
+
+    [Test]
     public void CommandParsesPackageWorkItemLookupOptions()
     {
         var command = tool.GetCommandInstances().First();

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackageWorkItemLookupToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackageWorkItemLookupToolTests.cs
@@ -22,17 +22,10 @@ public class PackageWorkItemLookupToolTests
     }
 
     [Test]
-    public async Task FindPackageWorkItemReturnsBrowserLinkForSingularMatch()
+    public async Task FindPackageWorkItemReturnsIdForSingularMatch()
     {
-        devOpsService.Setup(service => service.FindPackageWorkItemsAsync("azure-storage-blob", "Python", "12.30", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
-                new PackageWorkitemResponse
-                {
-                    PackageName = "azure-storage-blob",
-                    WorkItemId = 31370,
-                    WorkItemUrl = "https://dev.azure.com/azure-sdk/Release/_apis/wit/workItems/31370"
-                }
-            ]);
+        devOpsService.Setup(service => service.FindPackageWorkItemIdsAsync("azure-storage-blob", "Python", "12.30", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([31370]);
 
         var result = await tool.FindPackageWorkItem("azure-storage-blob", "12.30", "Python", CancellationToken.None);
 
@@ -40,14 +33,13 @@ public class PackageWorkItemLookupToolTests
         {
             Assert.That(result.ExitCode, Is.EqualTo(0));
             Assert.That(result.WorkItemId, Is.EqualTo(31370));
-            Assert.That(result.WorkItemUrl, Is.EqualTo("https://dev.azure.com/azure-sdk/release/_workitems/edit/31370"));
         });
     }
 
     [Test]
     public async Task FindPackageWorkItemReturnsErrorWhenNoMatchExists()
     {
-        devOpsService.Setup(service => service.FindPackageWorkItemsAsync("azure-storage-blob", "Python", "12.30", It.IsAny<CancellationToken>()))
+        devOpsService.Setup(service => service.FindPackageWorkItemIdsAsync("azure-storage-blob", "Python", "12.30", It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
 
         var result = await tool.FindPackageWorkItem("azure-storage-blob", "12.30", "Python", CancellationToken.None);
@@ -62,11 +54,8 @@ public class PackageWorkItemLookupToolTests
     [Test]
     public async Task FindPackageWorkItemReturnsErrorWhenMultipleMatchesExist()
     {
-        devOpsService.Setup(service => service.FindPackageWorkItemsAsync("azure-storage-blob", "Python", "12.30", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
-                new PackageWorkitemResponse { WorkItemId = 1 },
-                new PackageWorkitemResponse { WorkItemId = 2 }
-            ]);
+        devOpsService.Setup(service => service.FindPackageWorkItemIdsAsync("azure-storage-blob", "Python", "12.30", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([1, 2]);
 
         var result = await tool.FindPackageWorkItem("azure-storage-blob", "12.30", "Python", CancellationToken.None);
 
@@ -74,7 +63,8 @@ public class PackageWorkItemLookupToolTests
         {
             Assert.That(result.ExitCode, Is.EqualTo(1));
             Assert.That(result.ResponseError, Does.Contain("Expected one package work item"));
-            Assert.That(result.NextSteps, Has.Count.EqualTo(2));
+            Assert.That(result.ResponseError, Does.Contain("1, 2"));
+            Assert.That(result.NextSteps, Is.Null);
         });
     }
 
@@ -84,15 +74,8 @@ public class PackageWorkItemLookupToolTests
     [TestCase("12", "12.0")]
     public async Task FindPackageWorkItemNormalizesPackageVersionBeforeLookup(string packageVersion, string expectedPackageVersionMajorMinor)
     {
-        devOpsService.Setup(service => service.FindPackageWorkItemsAsync("azure-storage-blob", "Python", expectedPackageVersionMajorMinor, It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
-                new PackageWorkitemResponse
-                {
-                    PackageName = "azure-storage-blob",
-                    WorkItemId = 31370,
-                    WorkItemUrl = "https://dev.azure.com/azure-sdk/Release/_apis/wit/workItems/31370"
-                }
-            ]);
+        devOpsService.Setup(service => service.FindPackageWorkItemIdsAsync("azure-storage-blob", "Python", expectedPackageVersionMajorMinor, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([31370]);
 
         var result = await tool.FindPackageWorkItem("azure-storage-blob", packageVersion, "Python", CancellationToken.None);
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added the `package find-work-item` CLI command to find Azure DevOps package work item IDs by package name, package version, and language.
+
 ### Breaking Changes
 
 ### Bugs Fixed
@@ -11,10 +13,6 @@
 ### Other Changes
 
 ## 0.6.18 (2026-06-08)
-
-### Features Added
-
-- Added the `package find-work-item` CLI command to find Azure DevOps package work item IDs by package name, package version, and language.
 
 ### Other Changes
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## 0.6.18 (2026-06-08)
 
+### Features Added
+
+- Added the `azsdk_package_find_work_item` MCP tool and `package find-work-item` CLI command to find Azure DevOps package work item links by package name, package version, and language.
+
 ### Other Changes
 
 - Updated the release plan response to include the link to release plan dashboard.

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Features Added
 
-- Added the `azsdk_package_find_work_item` MCP tool and `package find-work-item` CLI command to find Azure DevOps package work item links by package name, package version, and language.
+- Added the `package find-work-item` CLI command to find Azure DevOps package work item IDs by package name, package version, and language.
 
 ### Other Changes
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedOptions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedOptions.cs
@@ -26,6 +26,7 @@ namespace Azure.Sdk.Tools.Cli.Commands
             typeof(TelemetryIngestionTool),
             typeof(PackageInfoTool),
             typeof(PackageCheckTool),
+            typeof(PackageWorkItemLookupTool),
             typeof(PipelineTestsTool),
             typeof(QuokkaTool),
             typeof(ReadMeGeneratorTool),

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageWorkItemLookupResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageWorkItemLookupResponse.cs
@@ -2,16 +2,25 @@
 // Licensed under the MIT License.
 using System.Text;
 using System.Text.Json.Serialization;
+using Azure.Sdk.Tools.Cli.Configuration;
 
 namespace Azure.Sdk.Tools.Cli.Models.Responses.Package;
 
 public class PackageWorkItemLookupResponse : CommandResponse
 {
+    private string workItemUrl = string.Empty;
+
     [JsonPropertyName("work_item_id")]
     public int WorkItemId { get; set; }
 
     [JsonPropertyName("work_item_url")]
-    public string WorkItemUrl { get; set; } = string.Empty;
+    public string WorkItemUrl
+    {
+        get => WorkItemId > 0
+            ? $"{Constants.AZURE_SDK_DEVOPS_BASE_URL}/{Constants.AZURE_SDK_DEVOPS_RELEASE_PROJECT}/_workitems/edit/{WorkItemId}"
+            : workItemUrl.Replace("_apis/wit/workItems", "_workitems/edit");
+        set => workItemUrl = value;
+    }
 
     [JsonPropertyName("package_name")]
     public string PackageName { get; set; } = string.Empty;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageWorkItemLookupResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageWorkItemLookupResponse.cs
@@ -2,25 +2,13 @@
 // Licensed under the MIT License.
 using System.Text;
 using System.Text.Json.Serialization;
-using Azure.Sdk.Tools.Cli.Configuration;
 
 namespace Azure.Sdk.Tools.Cli.Models.Responses.Package;
 
 public class PackageWorkItemLookupResponse : CommandResponse
 {
-    private string workItemUrl = string.Empty;
-
     [JsonPropertyName("work_item_id")]
     public int WorkItemId { get; set; }
-
-    [JsonPropertyName("work_item_url")]
-    public string WorkItemUrl
-    {
-        get => WorkItemId > 0
-            ? $"{Constants.AZURE_SDK_DEVOPS_BASE_URL}/{Constants.AZURE_SDK_DEVOPS_RELEASE_PROJECT}/_workitems/edit/{WorkItemId}"
-            : workItemUrl.Replace("_apis/wit/workItems", "_workitems/edit");
-        set => workItemUrl = value;
-    }
 
     [JsonPropertyName("package_name")]
     public string PackageName { get; set; } = string.Empty;
@@ -34,11 +22,7 @@ public class PackageWorkItemLookupResponse : CommandResponse
     protected override string Format()
     {
         var output = new StringBuilder();
-        output.AppendLine(WorkItemUrl);
         output.AppendLine($"Work Item ID: {WorkItemId}");
-        output.AppendLine($"Package: {PackageName}");
-        output.AppendLine($"Version: {PackageVersionMajorMinor}");
-        output.AppendLine($"Language: {Language}");
         return output.ToString();
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageWorkItemLookupResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageWorkItemLookupResponse.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace Azure.Sdk.Tools.Cli.Models.Responses.Package;
+
+public class PackageWorkItemLookupResponse : CommandResponse
+{
+    [JsonPropertyName("work_item_id")]
+    public int WorkItemId { get; set; }
+
+    [JsonPropertyName("work_item_url")]
+    public string WorkItemUrl { get; set; } = string.Empty;
+
+    [JsonPropertyName("package_name")]
+    public string PackageName { get; set; } = string.Empty;
+
+    [JsonPropertyName("package_version_major_minor")]
+    public string PackageVersionMajorMinor { get; set; } = string.Empty;
+
+    [JsonPropertyName("language")]
+    public string Language { get; set; } = string.Empty;
+
+    protected override string Format()
+    {
+        var output = new StringBuilder();
+        output.AppendLine(WorkItemUrl);
+        output.AppendLine($"Work Item ID: {WorkItemId}");
+        output.AppendLine($"Package: {PackageName}");
+        output.AppendLine($"Version: {PackageVersionMajorMinor}");
+        output.AppendLine($"Language: {Language}");
+        return output.ToString();
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -107,7 +107,6 @@ namespace Azure.Sdk.Tools.Cli.Services
         public Task<bool> LinkNamespaceApprovalIssueAsync(int releasePlanWorkItemId, string url, CancellationToken ct);
         public Task<PackageWorkitemResponse> GetPackageWorkItemAsync(string packageName, string language, string packageVersion = "", CancellationToken ct = default);
         public Task<List<int>> FindPackageWorkItemIdsAsync(string packageName, string language, string packageVersionMajorMinor, CancellationToken ct = default);
-        public Task<List<PackageWorkitemResponse>> FindPackageWorkItemsAsync(string packageName, string language, string packageVersionMajorMinor, CancellationToken ct = default);
         public Task<List<PackageWorkitemResponse>> ListPartialPackageWorkItemAsync(string packageName, string language, CancellationToken ct);
         public Task<Build> RunPipelineAsync(int pipelineDefinitionId, Dictionary<string, string> templateParams, string apiSpecBranchRef = "main", CancellationToken ct = default);
         public Task<Dictionary<string, List<string>>> GetPipelineLlmArtifacts(string project, int buildId, CancellationToken ct);
@@ -1326,21 +1325,6 @@ namespace Azure.Sdk.Tools.Cli.Services
                 return null;
             }
             return MapPackageWorkItemToModel(packageWorkItems[0]); // Return the first package work item
-        }
-
-        public async Task<List<PackageWorkitemResponse>> FindPackageWorkItemsAsync(string packageName, string language, string packageVersionMajorMinor, CancellationToken ct = default)
-        {
-            language = MapLanguageIdToName(language);
-            if (packageName.Contains(' ') || packageName.Contains('\'') || packageName.Contains('"') || language.Contains(' ') || language.Contains('\'') || language.Contains('"') || packageVersionMajorMinor.Contains(' ') || packageVersionMajorMinor.Contains('\'') || packageVersionMajorMinor.Contains('"'))
-            {
-                throw new ArgumentException("Invalid data in one of the parameters.");
-            }
-
-            var query = $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{Constants.AZURE_SDK_DEVOPS_RELEASE_PROJECT}' AND [System.WorkItemType] = 'Package' AND [Custom.Package] = '{packageName}' AND [Custom.PackageVersionMajorMinor] = '{packageVersionMajorMinor}' AND [Custom.Language] = '{language}' AND [System.State] NOT IN ('Closed','Duplicate','Abandoned') AND [System.Tags] NOT CONTAINS '{RELEASE_PLANNER_APP_TEST}'";
-            logger.LogDebug("Executing package work item lookup query: {query}", query);
-
-            var packageWorkItems = await FetchWorkItemsAsync(query, ct);
-            return packageWorkItems.Select(workItem => MapPackageWorkItemToModel(workItem)).ToList();
         }
 
         public async Task<List<int>> FindPackageWorkItemIdsAsync(string packageName, string language, string packageVersionMajorMinor, CancellationToken ct = default)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -106,6 +106,7 @@ namespace Azure.Sdk.Tools.Cli.Services
         public Task<bool> UpdateApiSpecVersionAsync(int releasePlanWorkItemId, string apiVersion, CancellationToken ct);
         public Task<bool> LinkNamespaceApprovalIssueAsync(int releasePlanWorkItemId, string url, CancellationToken ct);
         public Task<PackageWorkitemResponse> GetPackageWorkItemAsync(string packageName, string language, string packageVersion = "", CancellationToken ct = default);
+        public Task<List<int>> FindPackageWorkItemIdsAsync(string packageName, string language, string packageVersionMajorMinor, CancellationToken ct = default);
         public Task<List<PackageWorkitemResponse>> FindPackageWorkItemsAsync(string packageName, string language, string packageVersionMajorMinor, CancellationToken ct = default);
         public Task<List<PackageWorkitemResponse>> ListPartialPackageWorkItemAsync(string packageName, string language, CancellationToken ct);
         public Task<Build> RunPipelineAsync(int pipelineDefinitionId, Dictionary<string, string> templateParams, string apiSpecBranchRef = "main", CancellationToken ct = default);
@@ -805,6 +806,20 @@ namespace Azure.Sdk.Tools.Cli.Services
             }
         }
 
+        private async Task<List<int>> FetchWorkItemIdsAsync(string query, CancellationToken ct)
+        {
+            try
+            {
+                var workItemClient = connection.GetWorkItemClient(ct);
+                var result = await workItemClient.QueryByWiqlAsync(new Wiql { Query = query }, cancellationToken: ct);
+                return result?.WorkItems?.Select(workItem => workItem.Id).ToList() ?? [];
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Failed to get work item IDs. Error: {ex.Message}", ex);
+            }
+        }
+
         public async Task<List<WorkItem>> FetchWorkItemsPagedAsync(string query, int top = 100000, int batchSize = 200, WorkItemExpand expand = WorkItemExpand.All, CancellationToken ct = default)
         {
             try
@@ -1326,6 +1341,20 @@ namespace Azure.Sdk.Tools.Cli.Services
 
             var packageWorkItems = await FetchWorkItemsAsync(query, ct);
             return packageWorkItems.Select(workItem => MapPackageWorkItemToModel(workItem)).ToList();
+        }
+
+        public async Task<List<int>> FindPackageWorkItemIdsAsync(string packageName, string language, string packageVersionMajorMinor, CancellationToken ct = default)
+        {
+            language = MapLanguageIdToName(language);
+            if (packageName.Contains(' ') || packageName.Contains('\'') || packageName.Contains('"') || language.Contains(' ') || language.Contains('\'') || language.Contains('"') || packageVersionMajorMinor.Contains(' ') || packageVersionMajorMinor.Contains('\'') || packageVersionMajorMinor.Contains('"'))
+            {
+                throw new ArgumentException("Invalid data in one of the parameters.");
+            }
+
+            var query = $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{Constants.AZURE_SDK_DEVOPS_RELEASE_PROJECT}' AND [System.WorkItemType] = 'Package' AND [Custom.Package] = '{packageName}' AND [Custom.PackageVersionMajorMinor] = '{packageVersionMajorMinor}' AND [Custom.Language] = '{language}' AND [System.State] NOT IN ('Closed','Duplicate','Abandoned') AND [System.Tags] NOT CONTAINS '{RELEASE_PLANNER_APP_TEST}'";
+            logger.LogDebug("Executing package work item ID lookup query: {query}", query);
+
+            return await FetchWorkItemIdsAsync(query, ct);
         }
 
         // /// <summary>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -106,6 +106,7 @@ namespace Azure.Sdk.Tools.Cli.Services
         public Task<bool> UpdateApiSpecVersionAsync(int releasePlanWorkItemId, string apiVersion, CancellationToken ct);
         public Task<bool> LinkNamespaceApprovalIssueAsync(int releasePlanWorkItemId, string url, CancellationToken ct);
         public Task<PackageWorkitemResponse> GetPackageWorkItemAsync(string packageName, string language, string packageVersion = "", CancellationToken ct = default);
+        public Task<List<PackageWorkitemResponse>> FindPackageWorkItemsAsync(string packageName, string language, string packageVersionMajorMinor, CancellationToken ct = default);
         public Task<List<PackageWorkitemResponse>> ListPartialPackageWorkItemAsync(string packageName, string language, CancellationToken ct);
         public Task<Build> RunPipelineAsync(int pipelineDefinitionId, Dictionary<string, string> templateParams, string apiSpecBranchRef = "main", CancellationToken ct = default);
         public Task<Dictionary<string, List<string>>> GetPipelineLlmArtifacts(string project, int buildId, CancellationToken ct);
@@ -1310,6 +1311,21 @@ namespace Azure.Sdk.Tools.Cli.Services
                 return null;
             }
             return MapPackageWorkItemToModel(packageWorkItems[0]); // Return the first package work item
+        }
+
+        public async Task<List<PackageWorkitemResponse>> FindPackageWorkItemsAsync(string packageName, string language, string packageVersionMajorMinor, CancellationToken ct = default)
+        {
+            language = MapLanguageIdToName(language);
+            if (packageName.Contains(' ') || packageName.Contains('\'') || packageName.Contains('"') || language.Contains(' ') || language.Contains('\'') || language.Contains('"') || packageVersionMajorMinor.Contains(' ') || packageVersionMajorMinor.Contains('\'') || packageVersionMajorMinor.Contains('"'))
+            {
+                throw new ArgumentException("Invalid data in one of the parameters.");
+            }
+
+            var query = $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{Constants.AZURE_SDK_DEVOPS_RELEASE_PROJECT}' AND [System.WorkItemType] = 'Package' AND [Custom.Package] = '{packageName}' AND [Custom.PackageVersionMajorMinor] = '{packageVersionMajorMinor}' AND [Custom.Language] = '{language}'";
+            logger.LogDebug("Executing package work item lookup query: {query}", query);
+
+            var packageWorkItems = await FetchWorkItemsAsync(query, ct);
+            return packageWorkItems.Select(workItem => MapPackageWorkItemToModel(workItem)).ToList();
         }
 
         // /// <summary>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -1321,7 +1321,7 @@ namespace Azure.Sdk.Tools.Cli.Services
                 throw new ArgumentException("Invalid data in one of the parameters.");
             }
 
-            var query = $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{Constants.AZURE_SDK_DEVOPS_RELEASE_PROJECT}' AND [System.WorkItemType] = 'Package' AND [Custom.Package] = '{packageName}' AND [Custom.PackageVersionMajorMinor] = '{packageVersionMajorMinor}' AND [Custom.Language] = '{language}'";
+            var query = $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{Constants.AZURE_SDK_DEVOPS_RELEASE_PROJECT}' AND [System.WorkItemType] = 'Package' AND [Custom.Package] = '{packageName}' AND [Custom.PackageVersionMajorMinor] = '{packageVersionMajorMinor}' AND [Custom.Language] = '{language}' AND [System.State] NOT IN ('Closed','Duplicate','Abandoned') AND [System.Tags] NOT CONTAINS '{RELEASE_PLANNER_APP_TEST}'";
             logger.LogDebug("Executing package work item lookup query: {query}", query);
 
             var packageWorkItems = await FetchWorkItemsAsync(query, ct);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/PackageWorkItemLookupTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/PackageWorkItemLookupTool.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System.CommandLine;
 using System.ComponentModel;
+using System.Text.RegularExpressions;
 using Azure.Sdk.Tools.Cli.Commands;
 using Azure.Sdk.Tools.Cli.Configuration;
 using Azure.Sdk.Tools.Cli.Models;
@@ -19,6 +20,7 @@ public class PackageWorkItemLookupTool(
 {
     private const string FindWorkItemCommandName = "find-work-item";
     private const string FindWorkItemToolName = "azsdk_package_find_work_item";
+    private static readonly Regex PackageVersionRegex = new(@"^(?<major>\d+)(?:\.(?<minor>\d+)(?:\.\d+(?:[-+][0-9A-Za-z.-]+)?)?)?$", RegexOptions.Compiled);
 
     public override CommandGroup[] CommandHierarchy { get; set; } = [SharedCommandGroups.Package];
 
@@ -84,6 +86,9 @@ public class PackageWorkItemLookupTool(
                 return response;
             }
 
+            NormalizePackageVersion(packageVersionMajorMinor);
+            response.PackageVersionMajorMinor = packageVersionMajorMinor;
+
             logger.LogInformation("Finding package work item for package {packageName}, package version major/minor {packageVersionMajorMinor}, language {language}.", packageName, packageVersionMajorMinor, language);
             var workItems = await devOpsService.FindPackageWorkItemsAsync(packageName, language, packageVersionMajorMinor, ct);
 
@@ -96,13 +101,17 @@ public class PackageWorkItemLookupTool(
             if (workItems.Count > 1)
             {
                 response.ResponseError = $"Expected one package work item for package '{packageName}', version '{packageVersionMajorMinor}', and language '{language}', but found {workItems.Count}.";
-                response.NextSteps = workItems.Select(workItem => GetWorkItemHtmlUrl(workItem.WorkItemId, workItem.WorkItemUrl)).ToList();
+                response.NextSteps = workItems.Select(workItem => new PackageWorkItemLookupResponse
+                {
+                    WorkItemId = workItem.WorkItemId,
+                    WorkItemUrl = workItem.WorkItemUrl
+                }.WorkItemUrl).ToList();
                 return response;
             }
 
             var match = workItems[0];
             response.WorkItemId = match.WorkItemId;
-            response.WorkItemUrl = GetWorkItemHtmlUrl(match.WorkItemId, match.WorkItemUrl);
+            response.WorkItemUrl = match.WorkItemUrl;
             response.PackageName = match.PackageName ?? packageName;
             response.Language = language;
             return response;
@@ -120,13 +129,16 @@ public class PackageWorkItemLookupTool(
         }
     }
 
-    private static string GetWorkItemHtmlUrl(int workItemId, string workItemUrl)
+    private static string NormalizePackageVersion(string packageVersion)
     {
-        if (workItemId > 0)
+        var match = PackageVersionRegex.Match(packageVersion.Trim());
+        if (!match.Success)
         {
-            return $"{Constants.AZURE_SDK_DEVOPS_BASE_URL}/{Constants.AZURE_SDK_DEVOPS_RELEASE_PROJECT}/_workitems/edit/{workItemId}";
+            throw new ArgumentException("Package version must be a major version, major.minor version, or full SemVer version.");
         }
 
-        return workItemUrl.Replace("_apis/wit/workItems", "_workitems/edit");
+        var major = match.Groups["major"].Value;
+        var minor = match.Groups["minor"].Success ? match.Groups["minor"].Value : "0";
+        return $"{major}.{minor}";
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/PackageWorkItemLookupTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/PackageWorkItemLookupTool.cs
@@ -4,22 +4,19 @@ using System.CommandLine;
 using System.ComponentModel;
 using System.Text.RegularExpressions;
 using Azure.Sdk.Tools.Cli.Commands;
-using Azure.Sdk.Tools.Cli.Configuration;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Models.Responses.Package;
 using Azure.Sdk.Tools.Cli.Services;
 using Azure.Sdk.Tools.Cli.Tools.Core;
-using ModelContextProtocol.Server;
 
 namespace Azure.Sdk.Tools.Cli.Tools.Package;
 
-[McpServerToolType, Description("Find Azure DevOps package work items")]
+[Description("Find Azure DevOps package work items")]
 public class PackageWorkItemLookupTool(
     IDevOpsService devOpsService,
     ILogger<PackageWorkItemLookupTool> logger) : MCPTool
 {
     private const string FindWorkItemCommandName = "find-work-item";
-    private const string FindWorkItemToolName = "azsdk_package_find_work_item";
     private static readonly Regex PackageVersionRegex = new(@"^(?<major>\d+)(?:\.(?<minor>\d+)(?:\.\d+(?:[-+][0-9A-Za-z.-]+)?)?)?$", RegexOptions.Compiled);
 
     public override CommandGroup[] CommandHierarchy { get; set; } = [SharedCommandGroups.Package];
@@ -43,7 +40,7 @@ public class PackageWorkItemLookupTool(
     };
 
     protected override Command GetCommand() =>
-        new McpCommand(FindWorkItemCommandName, "Find the Azure DevOps package work item link", FindWorkItemToolName)
+        new(FindWorkItemCommandName, "Find the Azure DevOps package work item ID")
         {
             packageNameOpt, packageVersionMajorMinorOpt, languageOpt
         };
@@ -56,7 +53,6 @@ public class PackageWorkItemLookupTool(
         return await FindPackageWorkItem(packageName, packageVersionMajorMinor, language, ct);
     }
 
-    [McpServerTool(Name = FindWorkItemToolName), Description("Finds the singular Azure DevOps Package work item matching package name, package major/minor version, and language, and returns its browser link.")]
     public async Task<PackageWorkItemLookupResponse> FindPackageWorkItem(string packageName, string packageVersionMajorMinor, string language, CancellationToken ct = default)
     {
         try
@@ -86,33 +82,26 @@ public class PackageWorkItemLookupTool(
                 return response;
             }
 
-            NormalizePackageVersion(packageVersionMajorMinor);
+            packageVersionMajorMinor = NormalizePackageVersion(packageVersionMajorMinor);
             response.PackageVersionMajorMinor = packageVersionMajorMinor;
 
-            logger.LogInformation("Finding package work item for package {packageName}, package version major/minor {packageVersionMajorMinor}, language {language}.", packageName, packageVersionMajorMinor, language);
-            var workItems = await devOpsService.FindPackageWorkItemsAsync(packageName, language, packageVersionMajorMinor, ct);
+            logger.LogDebug("Finding package work item for package {packageName}, package version major/minor {packageVersionMajorMinor}, language {language}.", packageName, packageVersionMajorMinor, language);
+            var workItemIds = await devOpsService.FindPackageWorkItemIdsAsync(packageName, language, packageVersionMajorMinor, ct);
 
-            if (workItems.Count == 0)
+            if (workItemIds.Count == 0)
             {
                 response.ResponseError = $"No package work item found for package '{packageName}', version '{packageVersionMajorMinor}', and language '{language}'.";
                 return response;
             }
 
-            if (workItems.Count > 1)
+            if (workItemIds.Count > 1)
             {
-                response.ResponseError = $"Expected one package work item for package '{packageName}', version '{packageVersionMajorMinor}', and language '{language}', but found {workItems.Count}.";
-                response.NextSteps = workItems.Select(workItem => new PackageWorkItemLookupResponse
-                {
-                    WorkItemId = workItem.WorkItemId,
-                    WorkItemUrl = workItem.WorkItemUrl
-                }.WorkItemUrl).ToList();
+                response.ResponseError = $"Expected one package work item for package '{packageName}', version '{packageVersionMajorMinor}', and language '{language}', but found {workItemIds.Count}: {string.Join(", ", workItemIds)}.";
                 return response;
             }
 
-            var match = workItems[0];
-            response.WorkItemId = match.WorkItemId;
-            response.WorkItemUrl = match.WorkItemUrl;
-            response.PackageName = match.PackageName ?? packageName;
+            response.WorkItemId = workItemIds[0];
+            response.PackageName = packageName;
             response.Language = language;
             return response;
         }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/PackageWorkItemLookupTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/PackageWorkItemLookupTool.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.CommandLine;
+using System.ComponentModel;
+using Azure.Sdk.Tools.Cli.Commands;
+using Azure.Sdk.Tools.Cli.Configuration;
+using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.Responses.Package;
+using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Tools.Core;
+using ModelContextProtocol.Server;
+
+namespace Azure.Sdk.Tools.Cli.Tools.Package;
+
+[McpServerToolType, Description("Find Azure DevOps package work items")]
+public class PackageWorkItemLookupTool(
+    IDevOpsService devOpsService,
+    ILogger<PackageWorkItemLookupTool> logger) : MCPTool
+{
+    private const string FindWorkItemCommandName = "find-work-item";
+    private const string FindWorkItemToolName = "azsdk_package_find_work_item";
+
+    public override CommandGroup[] CommandHierarchy { get; set; } = [SharedCommandGroups.Package];
+
+    private readonly Option<string> packageNameOpt = new("--package-name")
+    {
+        Description = "SDK package name.",
+        Required = true,
+    };
+
+    private readonly Option<string> packageVersionMajorMinorOpt = new("--package-version", "--package-version-major-minor")
+    {
+        Description = "SDK package major/minor version (for example, 12.30).",
+        Required = true,
+    };
+
+    private readonly Option<string> languageOpt = new("--language")
+    {
+        Description = "SDK language (for example, .NET, Java, JavaScript, Python, Go).",
+        Required = true,
+    };
+
+    protected override Command GetCommand() =>
+        new McpCommand(FindWorkItemCommandName, "Find the Azure DevOps package work item link", FindWorkItemToolName)
+        {
+            packageNameOpt, packageVersionMajorMinorOpt, languageOpt
+        };
+
+    public override async Task<CommandResponse> HandleCommand(ParseResult parseResult, CancellationToken ct)
+    {
+        var packageName = parseResult.GetValue(packageNameOpt);
+        var packageVersionMajorMinor = parseResult.GetValue(packageVersionMajorMinorOpt);
+        var language = parseResult.GetValue(languageOpt);
+        return await FindPackageWorkItem(packageName, packageVersionMajorMinor, language, ct);
+    }
+
+    [McpServerTool(Name = FindWorkItemToolName), Description("Finds the singular Azure DevOps Package work item matching package name, package major/minor version, and language, and returns its browser link.")]
+    public async Task<PackageWorkItemLookupResponse> FindPackageWorkItem(string packageName, string packageVersionMajorMinor, string language, CancellationToken ct = default)
+    {
+        try
+        {
+            var response = new PackageWorkItemLookupResponse
+            {
+                PackageName = packageName,
+                PackageVersionMajorMinor = packageVersionMajorMinor,
+                Language = language
+            };
+
+            if (string.IsNullOrWhiteSpace(packageName))
+            {
+                response.ResponseError = "Package name cannot be null or empty.";
+                return response;
+            }
+
+            if (string.IsNullOrWhiteSpace(packageVersionMajorMinor))
+            {
+                response.ResponseError = "Package version major/minor cannot be null or empty.";
+                return response;
+            }
+
+            if (string.IsNullOrWhiteSpace(language))
+            {
+                response.ResponseError = "Language cannot be null or empty.";
+                return response;
+            }
+
+            logger.LogInformation("Finding package work item for package {packageName}, package version major/minor {packageVersionMajorMinor}, language {language}.", packageName, packageVersionMajorMinor, language);
+            var workItems = await devOpsService.FindPackageWorkItemsAsync(packageName, language, packageVersionMajorMinor, ct);
+
+            if (workItems.Count == 0)
+            {
+                response.ResponseError = $"No package work item found for package '{packageName}', version '{packageVersionMajorMinor}', and language '{language}'.";
+                return response;
+            }
+
+            if (workItems.Count > 1)
+            {
+                response.ResponseError = $"Expected one package work item for package '{packageName}', version '{packageVersionMajorMinor}', and language '{language}', but found {workItems.Count}.";
+                response.NextSteps = workItems.Select(workItem => GetWorkItemHtmlUrl(workItem.WorkItemId, workItem.WorkItemUrl)).ToList();
+                return response;
+            }
+
+            var match = workItems[0];
+            response.WorkItemId = match.WorkItemId;
+            response.WorkItemUrl = GetWorkItemHtmlUrl(match.WorkItemId, match.WorkItemUrl);
+            response.PackageName = match.PackageName ?? packageName;
+            response.Language = language;
+            return response;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to find package work item for package {packageName}, version {packageVersionMajorMinor}, language {language}.", packageName, packageVersionMajorMinor, language);
+            return new PackageWorkItemLookupResponse
+            {
+                PackageName = packageName,
+                PackageVersionMajorMinor = packageVersionMajorMinor,
+                Language = language,
+                ResponseError = $"Failed to find package work item: {ex.Message}"
+            };
+        }
+    }
+
+    private static string GetWorkItemHtmlUrl(int workItemId, string workItemUrl)
+    {
+        if (workItemId > 0)
+        {
+            return $"{Constants.AZURE_SDK_DEVOPS_BASE_URL}/{Constants.AZURE_SDK_DEVOPS_RELEASE_PROJECT}/_workitems/edit/{workItemId}";
+        }
+
+        return workItemUrl.Replace("_apis/wit/workItems", "_workitems/edit");
+    }
+}


### PR DESCRIPTION
Adds a command to get the ADO work item for a package and major+minor version pair. This will be used by the new API review and could be useful in other contexts as well.