### PR TITLE
Enrich Teams bot PR-review guidance with reviewers and merge readiness

### DIFF
--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-backend/model/github.go
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-backend/model/github.go
@@ -90,15 +90,43 @@ type GitHubCheckRunsListResponse struct {
 	CheckRuns  []GitHubCheckRunResponse `json:"check_runs"`
 }
 
+// GitHubUser represents a minimal GitHub user reference.
+type GitHubUser struct {
+	Login   string `json:"login"`
+	HTMLURL string `json:"html_url"`
+}
+
 // GitHubPRResponse represents a GitHub pull request API response.
 type GitHubPRResponse struct {
 	Number int    `json:"number"`
 	Title  string `json:"title"`
 	State  string `json:"state"`
+	Body   string `json:"body"`
 	Head   struct {
 		SHA string `json:"sha"`
 	} `json:"head"`
-	HTMLURL string `json:"html_url"`
+	Base struct {
+		Ref string `json:"ref"`
+	} `json:"base"`
+	HTMLURL        string `json:"html_url"`
+	MergeableState string `json:"mergeable_state"`
+	Labels         []struct {
+		Name string `json:"name"`
+	} `json:"labels"`
+	RequestedReviewers []GitHubUser `json:"requested_reviewers"`
+}
+
+// GitHubReview represents a single review on a pull request.
+type GitHubReview struct {
+	User  GitHubUser `json:"user"`
+	State string     `json:"state"`
+}
+
+// GitHubIssueComment represents a comment on an issue or pull request.
+type GitHubIssueComment struct {
+	Body    string     `json:"body"`
+	User    GitHubUser `json:"user"`
+	HTMLURL string     `json:"html_url"`
 }
 
 // =====================================================================

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-backend/service/prompt/api_spec_review/qa.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-backend/service/prompt/api_spec_review/qa.md
@@ -49,6 +49,11 @@ For API specification review questions, follow this structured approach:
 
 # IMPORTANT REMINDERS
 - For `spec-pr-review` questions, guide user to follow the "next steps to merge" comment in the PR
+- When the provided PR context includes a **Reviewers** list and a **Merge Readiness** verdict (from the link content), use them:
+    - If merge readiness is "not ready", explain the listed blockers (failing/pending checks, requested changes, blocking labels) and the concrete next action for each.
+    - If merge readiness is "likely ready", tell the author the checks/labels look clean and that to merge they will need approval from the listed reviewers; suggest they request review from or @-mention those GitHub reviewers **on the PR**. List the reviewer @handles.
+    - Be conservative: never assert "this PR is ready to merge". Prefer phrasing like "checks look clean — to merge you'll need approval from <reviewers>".
+    - Only reference the "Next Steps to Merge" comment when it is present in the context (spec repos). For non-spec repositories, base guidance on the checks and reviewers instead.
 - For `spec-validation` questions, quote the exact rule name, explain what it checks, and provide clear fix steps. Show both incorrect and correct patterns when helpful. For development branch PRs, not all validation errors need to be fixed.
 - For `api-breaking-changes` questions, prioritize permanent fixes over suppressions; reference the breaking change review process
 - Distinguish between ARM (management plane) and data plane; verify public vs private repo context

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-backend/test/github_test.go
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-backend/test/github_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"testing"
 
+	"github.com/Azure/azure-sdk-tools/tools/sdk-ai-bots/azure-sdk-qa-bot-backend/model"
 	"github.com/Azure/azure-sdk-tools/tools/sdk-ai-bots/azure-sdk-qa-bot-backend/utils"
 	"github.com/stretchr/testify/assert"
 )
@@ -89,3 +90,100 @@ func TestIsCIRelatedIntention(t *testing.T) {
 // 	}
 // 	t.Logf("Check run result:\n%s", result)
 // }
+
+// ============================================================
+// PR review enrichment helpers
+// ============================================================
+
+func TestIsSpecRepo(t *testing.T) {
+	assert.True(t, utils.IsSpecRepo("Azure", "azure-rest-api-specs"))
+	assert.True(t, utils.IsSpecRepo("azure", "azure-rest-api-specs-pr"))
+	assert.True(t, utils.IsSpecRepo("AZURE", "Azure-Rest-Api-Specs"))
+
+	assert.False(t, utils.IsSpecRepo("Azure", "azure-sdk-for-python"))
+	assert.False(t, utils.IsSpecRepo("Azure", "azure-sdk-tools"))
+	assert.False(t, utils.IsSpecRepo("contoso", "azure-rest-api-specs"))
+}
+
+func TestHasBlockingLabels(t *testing.T) {
+	// Spec-only labels apply in spec repos.
+	blocked, labels := utils.HasBlockingLabels("Azure", "azure-rest-api-specs",
+		[]string{"ARMReview", "Approved-OkToMerge"})
+	assert.True(t, blocked)
+	assert.Equal(t, []string{"ARMReview"}, labels)
+
+	// Spec-only labels do NOT apply in non-spec repos.
+	blocked, labels = utils.HasBlockingLabels("Azure", "azure-sdk-for-python",
+		[]string{"ARMReview"})
+	assert.False(t, blocked)
+	assert.Empty(t, labels)
+
+	// Common blocking labels apply everywhere (tolerant matching).
+	blocked, labels = utils.HasBlockingLabels("Azure", "azure-sdk-tools",
+		[]string{"Do Not Merge"})
+	assert.True(t, blocked)
+	assert.Equal(t, []string{"Do Not Merge"}, labels)
+
+	// No blocking labels.
+	blocked, labels = utils.HasBlockingLabels("Azure", "azure-rest-api-specs",
+		[]string{"feature", "documentation"})
+	assert.False(t, blocked)
+	assert.Empty(t, labels)
+}
+
+func TestBuildReviewerSet(t *testing.T) {
+	requested := []model.GitHubUser{
+		{Login: "alice", HTMLURL: "https://github.com/alice"},
+		{Login: "bob"},
+	}
+	reviews := []model.GitHubReview{
+		{User: model.GitHubUser{Login: "carol"}, State: "APPROVED"},
+		{User: model.GitHubUser{Login: "alice"}, State: "APPROVED"}, // dup of requested
+		{User: model.GitHubUser{Login: "dave"}, State: "COMMENTED"}, // excluded (comment only)
+	}
+
+	got := utils.BuildReviewerSet(requested, reviews)
+
+	logins := make([]string, 0, len(got))
+	for _, u := range got {
+		logins = append(logins, u.Login)
+	}
+	// Requested first (alice, bob), then meaningful reviewers (carol); dave excluded.
+	assert.Equal(t, []string{"alice", "bob", "carol"}, logins)
+}
+
+func TestLatestReviewDecision(t *testing.T) {
+	assert.Equal(t, "review_required", utils.LatestReviewDecision(nil))
+
+	assert.Equal(t, "approved", utils.LatestReviewDecision([]model.GitHubReview{
+		{User: model.GitHubUser{Login: "a"}, State: "APPROVED"},
+		{User: model.GitHubUser{Login: "b"}, State: "COMMENTED"},
+	}))
+
+	// Any latest changes_requested dominates.
+	assert.Equal(t, "changes_requested", utils.LatestReviewDecision([]model.GitHubReview{
+		{User: model.GitHubUser{Login: "a"}, State: "APPROVED"},
+		{User: model.GitHubUser{Login: "b"}, State: "CHANGES_REQUESTED"},
+	}))
+
+	// Latest state per user wins (chronological): a's later APPROVED supersedes earlier.
+	assert.Equal(t, "approved", utils.LatestReviewDecision([]model.GitHubReview{
+		{User: model.GitHubUser{Login: "a"}, State: "CHANGES_REQUESTED"},
+		{User: model.GitHubUser{Login: "a"}, State: "APPROVED"},
+	}))
+}
+
+func TestAssessMergeReadiness(t *testing.T) {
+	ready := utils.AssessMergeReadiness(0, 0, "approved", nil)
+	assert.True(t, ready.Ready)
+	assert.Empty(t, ready.Reasons)
+
+	// review_required (no approval yet) is still "ready" — checks/labels clean, just
+	// needs sign-off; readiness only blocks on concrete blockers.
+	ready = utils.AssessMergeReadiness(0, 0, "review_required", nil)
+	assert.True(t, ready.Ready)
+
+	notReady := utils.AssessMergeReadiness(2, 1, "changes_requested", []string{"ARMReview"})
+	assert.False(t, notReady.Ready)
+	assert.Len(t, notReady.Reasons, 4)
+}

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-backend/utils/github.go
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-backend/utils/github.go
@@ -297,6 +297,36 @@ func (g *GitHubClient) fetchPR(owner, repo, prNumber string) (model.GitHubPRResp
 	return apiGetJSON[model.GitHubPRResponse](g, url)
 }
 
+// fetchPRReviews fetches the reviews submitted on a pull request.
+func (g *GitHubClient) fetchPRReviews(owner, repo, prNumber string) ([]model.GitHubReview, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%s/reviews?per_page=%d", githubAPIBaseURL, owner, repo, prNumber, checkRunsPerPage)
+	log.Printf("Fetching GitHub PR reviews: %s", url)
+	return apiGetJSON[[]model.GitHubReview](g, url)
+}
+
+// fetchNextStepsComment returns the body of the "Next Steps to Merge" comment for a
+// spec-repo PR, or an empty string when not applicable or not found. The comment is only
+// posted by automation in the spec repos, so the call is skipped for other repos.
+func (g *GitHubClient) fetchNextStepsComment(owner, repo, prNumber string) string {
+	if !IsSpecRepo(owner, repo) {
+		return ""
+	}
+	url := fmt.Sprintf("%s/repos/%s/%s/issues/%s/comments?per_page=%d", githubAPIBaseURL, owner, repo, prNumber, checkRunsPerPage)
+	log.Printf("Fetching GitHub PR comments: %s", url)
+	comments, err := apiGetJSON[[]model.GitHubIssueComment](g, url)
+	if err != nil {
+		log.Printf("Failed to fetch PR comments: %v", err)
+		return ""
+	}
+	// Return the most recent comment that contains the marker.
+	for i := len(comments) - 1; i >= 0; i-- {
+		if strings.Contains(comments[i].Body, nextStepsMarker) {
+			return comments[i].Body
+		}
+	}
+	return ""
+}
+
 // fetchCommitCheckRuns fetches all check runs for a given commit SHA.
 func (g *GitHubClient) fetchCommitCheckRuns(owner, repo, sha string) (model.GitHubCheckRunsListResponse, error) {
 	url := fmt.Sprintf("%s/repos/%s/%s/commits/%s/check-runs?per_page=%d", githubAPIBaseURL, owner, repo, sha, checkRunsPerPage)
@@ -402,6 +432,76 @@ func (g *GitHubClient) downloadJobLogs(link *model.GitHubCheckLink) (string, err
 // =====================================================================
 
 // buildPRChecksSummary fetches all PR check runs and formats a summary of failed checks.
+// writePRReviewSummary appends review status, the responsible reviewer set, a conservative
+// merge-readiness verdict, and (for spec repos only) the "Next Steps to Merge" comment to
+// the PR summary. All fetches are best-effort: failures degrade gracefully rather than
+// aborting the overall summary.
+func (g *GitHubClient) writePRReviewSummary(sb *strings.Builder, prLink *model.GitHubPRLink, pr model.GitHubPRResponse, cls checkRunClassification) {
+	labelNames := make([]string, 0, len(pr.Labels))
+	for _, l := range pr.Labels {
+		labelNames = append(labelNames, l.Name)
+	}
+	_, blockingLabels := HasBlockingLabels(prLink.Owner, prLink.Repo, labelNames)
+
+	reviews, err := g.fetchPRReviews(prLink.Owner, prLink.Repo, prLink.PRNumber)
+	if err != nil {
+		log.Printf("Failed to fetch PR reviews: %v", err)
+	}
+	decision := LatestReviewDecision(reviews)
+	reviewers := BuildReviewerSet(pr.RequestedReviewers, reviews)
+	readiness := AssessMergeReadiness(len(cls.failed), cls.pending, decision, blockingLabels)
+
+	sb.WriteString("### Review Status\n")
+	if pr.Base.Ref != "" {
+		fmt.Fprintf(sb, "- **Target branch**: %s\n", pr.Base.Ref)
+	}
+	fmt.Fprintf(sb, "- **Review decision**: %s\n", decision)
+	if pr.MergeableState != "" {
+		fmt.Fprintf(sb, "- **Mergeable state**: %s\n", pr.MergeableState)
+	}
+	if len(blockingLabels) > 0 {
+		fmt.Fprintf(sb, "- **Blocking labels**: %s\n", strings.Join(blockingLabels, ", "))
+	}
+	sb.WriteString("\n")
+
+	sb.WriteString("### Reviewers\n")
+	if len(reviewers) == 0 {
+		sb.WriteString("- No reviewers requested yet.\n")
+	} else {
+		for _, r := range reviewers {
+			if r.HTMLURL != "" {
+				fmt.Fprintf(sb, "- [@%s](%s)\n", r.Login, r.HTMLURL)
+			} else {
+				fmt.Fprintf(sb, "- @%s\n", r.Login)
+			}
+		}
+	}
+	sb.WriteString("\n")
+
+	if readiness.Ready {
+		sb.WriteString("### Merge Readiness: likely ready for final review/approval\n")
+		sb.WriteString("No failing checks, pending checks, blocking labels, or requested changes were detected.\n\n")
+	} else {
+		sb.WriteString("### Merge Readiness: not ready\n")
+		sb.WriteString("Blockers:\n")
+		for _, reason := range readiness.Reasons {
+			fmt.Fprintf(sb, "- %s\n", reason)
+		}
+		sb.WriteString("\n")
+	}
+
+	if comment := g.fetchNextStepsComment(prLink.Owner, prLink.Repo, prLink.PRNumber); comment != "" {
+		const maxExcerpt = 4000
+		excerpt := comment
+		if len(excerpt) > maxExcerpt {
+			excerpt = excerpt[:maxExcerpt] + "\n...(truncated)"
+		}
+		sb.WriteString("### Next Steps to Merge (from PR comment)\n")
+		sb.WriteString(excerpt)
+		sb.WriteString("\n\n")
+	}
+}
+
 func (g *GitHubClient) buildPRChecksSummary(prLink *model.GitHubPRLink) (string, error) {
 	pr, err := g.fetchPR(prLink.Owner, prLink.Repo, prLink.PRNumber)
 	if err != nil {
@@ -424,6 +524,8 @@ func (g *GitHubClient) buildPRChecksSummary(prLink *model.GitHubPRLink) (string,
 
 	fmt.Fprintf(&sb, "### Checks Summary: %d total, %d failed, %d passed, %d skipped, %d pending\n\n",
 		checkRunsList.TotalCount, len(cls.failed), cls.passed, cls.skipped, cls.pending)
+
+	g.writePRReviewSummary(&sb, prLink, pr, cls)
 
 	if len(cls.failed) == 0 {
 		return sb.String(), nil
@@ -605,6 +707,136 @@ func classifyCheckRuns(checkRuns []model.GitHubCheckRunResponse) checkRunClassif
 		}
 	}
 	return c
+}
+
+// IsSpecRepo reports whether owner/repo is one of the Azure REST API spec repositories.
+// Spec-only behavior (the "Next Steps to Merge" comment and ARM/breaking-change labels)
+// is gated on this.
+func IsSpecRepo(owner, repo string) bool {
+	o := strings.ToLower(owner)
+	r := strings.ToLower(repo)
+	return o == "azure" && (r == "azure-rest-api-specs" || r == "azure-rest-api-specs-pr")
+}
+
+// nextStepsMarker identifies the automated spec-repo merge-guidance comment.
+const nextStepsMarker = "Next Steps to Merge"
+
+// specBlockingLabels are labels that block a spec PR from merging (normalized: lowercase,
+// spaces removed). Only applied for spec repos.
+var specBlockingLabels = map[string]bool{
+	"armreview":                    true,
+	"breakingchangereviewrequired": true,
+	"waitforarmfeedback":           true,
+}
+
+// commonBlockingLabels block merging in any repository.
+var commonBlockingLabels = map[string]bool{
+	"do-not-merge": true,
+	"donotmerge":   true,
+}
+
+// normalizeLabel lowercases a label and removes spaces for tolerant matching.
+func normalizeLabel(l string) string {
+	return strings.ReplaceAll(strings.ToLower(l), " ", "")
+}
+
+// HasBlockingLabels returns the labels on the PR that block merging, applying spec-only
+// labels only when owner/repo is a spec repo.
+func HasBlockingLabels(owner, repo string, labels []string) (bool, []string) {
+	spec := IsSpecRepo(owner, repo)
+	var blocking []string
+	for _, l := range labels {
+		key := normalizeLabel(l)
+		if commonBlockingLabels[key] || (spec && specBlockingLabels[key]) {
+			blocking = append(blocking, l)
+		}
+	}
+	return len(blocking) > 0, blocking
+}
+
+// BuildReviewerSet returns the deduplicated set of responsible reviewers for a PR: the
+// union of currently requested reviewers and users who have submitted a meaningful review
+// (approved, requested changes, or dismissed). A reviewer drops off requested_reviewers
+// once they submit a review, so the union is required to capture both.
+func BuildReviewerSet(requested []model.GitHubUser, reviews []model.GitHubReview) []model.GitHubUser {
+	seen := make(map[string]bool)
+	var out []model.GitHubUser
+	add := func(u model.GitHubUser) {
+		login := strings.ToLower(u.Login)
+		if login == "" || seen[login] {
+			return
+		}
+		seen[login] = true
+		out = append(out, u)
+	}
+	for _, u := range requested {
+		add(u)
+	}
+	for _, rv := range reviews {
+		switch strings.ToUpper(rv.State) {
+		case "APPROVED", "CHANGES_REQUESTED", "DISMISSED":
+			add(rv.User)
+		}
+	}
+	return out
+}
+
+// LatestReviewDecision aggregates per-user latest review state into an overall decision:
+// "changes_requested" if any reviewer's latest state requests changes, otherwise
+// "approved" if at least one approval exists, otherwise "review_required".
+// Reviews from the GitHub API are chronological, so the last state seen per user wins.
+func LatestReviewDecision(reviews []model.GitHubReview) string {
+	latest := make(map[string]string)
+	for _, rv := range reviews {
+		st := strings.ToUpper(rv.State)
+		if st == "APPROVED" || st == "CHANGES_REQUESTED" || st == "DISMISSED" {
+			latest[strings.ToLower(rv.User.Login)] = st
+		}
+	}
+	changes := false
+	approvals := 0
+	for _, st := range latest {
+		switch st {
+		case "CHANGES_REQUESTED":
+			changes = true
+		case "APPROVED":
+			approvals++
+		}
+	}
+	if changes {
+		return "changes_requested"
+	}
+	if approvals > 0 {
+		return "approved"
+	}
+	return "review_required"
+}
+
+// MergeReadiness describes whether a PR looks ready for final review/approval, and if not,
+// the blockers preventing it.
+type MergeReadiness struct {
+	Ready   bool
+	Reasons []string
+}
+
+// AssessMergeReadiness conservatively determines whether a PR is ready. It is ready only
+// when there are no failing checks, no pending checks, no requested changes, and no
+// blocking labels.
+func AssessMergeReadiness(failedChecks, pendingChecks int, decision string, blockingLabels []string) MergeReadiness {
+	var reasons []string
+	if failedChecks > 0 {
+		reasons = append(reasons, fmt.Sprintf("%d failing check(s)", failedChecks))
+	}
+	if pendingChecks > 0 {
+		reasons = append(reasons, fmt.Sprintf("%d pending check(s)", pendingChecks))
+	}
+	if decision == "changes_requested" {
+		reasons = append(reasons, "a reviewer requested changes")
+	}
+	if len(blockingLabels) > 0 {
+		reasons = append(reasons, "blocking label(s): "+strings.Join(blockingLabels, ", "))
+	}
+	return MergeReadiness{Ready: len(reasons) == 0, Reasons: reasons}
 }
 
 // partitionFailedChecks separates failed check runs into deduplicated GitHub Actions


### PR DESCRIPTION
## Issue
Fixes part of Azure/azure-sdk-tools#14961 — provide more actionable guidance when a user posts a PR for review in the Teams Q&A bot.

## What changed
Previously, when a user pasted a PR link the backend fetched only CI check runs, so `spec-pr-review` answers were generic. This PR enriches the PR context fed to the LLM and updates the prompt so the bot can tell authors what is blocking a PR and, when it looks ready, **who can approve/merge it**.

Backend (`azure-sdk-qa-bot-backend`):
- `model/github.go` — extend `GitHubPRResponse` (body, mergeable_state, base.ref, labels, requested_reviewers); add `GitHubUser`, `GitHubReview`, `GitHubIssueComment`.
- `utils/github.go` — new fetchers `fetchPRReviews` and `fetchNextStepsComment` (gated by `IsSpecRepo`); pure helpers `IsSpecRepo`, `HasBlockingLabels`, `BuildReviewerSet`, `LatestReviewDecision`, `AssessMergeReadiness`; `writePRReviewSummary` renders Review Status, Reviewers (GitHub @handles + links), a conservative Merge-Readiness verdict, and the spec-repo `Next Steps to Merge` comment.
- `service/prompt/api_spec_review/qa.md` — guidance to use the new context and advise requesting/@-mentioning reviewers on the PR, with conservative wording.
- `test/github_test.go` — unit tests for the new helpers.

## Design notes
- **Repo-aware:** spec-only labels (ARMReview, BreakingChangeReviewRequired, WaitForARMFeedback) and the `Next Steps to Merge` comment apply only to `azure-rest-api-specs(-pr)`; reviewer extraction, checks, and review decision work for any repo.
- **No infra/credential changes** — reuses the existing GitHub App installation token.
- **Out of scope (deferred):** resolving GitHub logins to Teams aliases (requires opensource-portal/AAD access) and a CODEOWNERS reviewer fallback. The bot surfaces GitHub @handles for the author to ping.

## Verification
- `go build ./...` and `go vet` pass.
- New + existing helper unit tests pass. (The only full-package failure, `TestQueryIndex`, is a pre-existing AI Search integration test that needs live Azure config — confirmed failing identically on the clean baseline.)
