### PR TITLE
Auto complete a release plan when release status is updated

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/PackageReleaseStatusToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/PackageReleaseStatusToolTests.cs
@@ -240,7 +240,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
 
             // Verify the one with merged PR was selected (work item 11111)
             mockDevOpsService.Verify(
-                x => x.UpdateWorkItemAsync(11111, It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()),
+                x => x.UpdateWorkItemAsync(11111, It.Is<Dictionary<string, string>>(d =>
+                    d.ContainsKey("Custom.ReleaseStatusForPython")), It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 
@@ -294,7 +295,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
 
             // Verify the first one was selected (work item 11111)
             mockDevOpsService.Verify(
-                x => x.UpdateWorkItemAsync(11111, It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()),
+                x => x.UpdateWorkItemAsync(11111, It.Is<Dictionary<string, string>>(d =>
+                    d.ContainsKey("Custom.ReleaseStatusForPython")), It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 
@@ -714,7 +716,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 Times.Once);
             // Verify the correct plan was updated
             mockDevOpsService.Verify(
-                x => x.UpdateWorkItemAsync(22222, It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()),
+                x => x.UpdateWorkItemAsync(22222, It.Is<Dictionary<string, string>>(d =>
+                    d.ContainsKey("Custom.ReleaseStatusForPython")), It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 
@@ -776,6 +779,342 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             // release-plan-id is optional
             parseResult = command.Parse("--package-name azure-template --language Python", parseConfig);
             Assert.That(parseResult.Errors, Is.Empty);
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_MgmtPlane_AllReleased_MarksFinished()
+        {
+            // Arrange
+            var releasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 12345,
+                ReleasePlanId = 100,
+                IsManagementPlane = true,
+                IsDataPlane = false,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo { Language = ".NET", PackageName = "Azure.Test", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Java", PackageName = "azure-test", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Python", PackageName = "azure-test", ReleaseStatus = "", ReleaseExclusionStatus = "Not applicable", PullRequestStatus = "Merged" },
+                    new SDKInfo { Language = "JavaScript", PackageName = "@azure/test", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Go", PackageName = "sdk/test/aztest", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" }
+                }
+            };
+
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync("azure-test", "python", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem> { releasePlan });
+
+            mockDevOpsService
+                .Setup(x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
+
+            // Act - releasing the last language (Python)
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test", "python", "Released", null, 0, CancellationToken.None);
+
+            // Assert
+            Assert.That(result.ResponseError, Is.Null);
+            Assert.That(result.ReleasePlanFinished, Is.True);
+
+            // Verify state was set to Finished
+            mockDevOpsService.Verify(
+                x => x.UpdateWorkItemAsync(12345, It.Is<Dictionary<string, string>>(d =>
+                    d.ContainsKey("System.State") && d["System.State"] == "Finished"), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_MgmtPlane_ReleasedAndExcluded_MarksFinished()
+        {
+            // Arrange
+            var releasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 12345,
+                ReleasePlanId = 100,
+                IsManagementPlane = true,
+                IsDataPlane = false,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo { Language = ".NET", PackageName = "Azure.Test", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Java", PackageName = "azure-test", ReleaseStatus = "", ReleaseExclusionStatus = "Approved" },
+                    new SDKInfo { Language = "Python", PackageName = "azure-test", ReleaseStatus = "", ReleaseExclusionStatus = "Not applicable", PullRequestStatus = "Merged" },
+                    new SDKInfo { Language = "JavaScript", PackageName = "@azure/test", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Go", PackageName = "sdk/test/aztest", ReleaseStatus = "", ReleaseExclusionStatus = "Approved" }
+                }
+            };
+
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync("azure-test", "python", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem> { releasePlan });
+
+            mockDevOpsService
+                .Setup(x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
+
+            // Act - releasing Python (last non-excluded language)
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test", "python", "Released", null, 0, CancellationToken.None);
+
+            // Assert
+            Assert.That(result.ResponseError, Is.Null);
+            Assert.That(result.ReleasePlanFinished, Is.True);
+
+            mockDevOpsService.Verify(
+                x => x.UpdateWorkItemAsync(12345, It.Is<Dictionary<string, string>>(d =>
+                    d.ContainsKey("System.State") && d["System.State"] == "Finished"), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_MgmtPlane_NotAllComplete_DoesNotFinish()
+        {
+            // Arrange
+            var releasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 12345,
+                ReleasePlanId = 100,
+                IsManagementPlane = true,
+                IsDataPlane = false,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo { Language = ".NET", PackageName = "Azure.Test", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Java", PackageName = "azure-test", ReleaseStatus = "", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Python", PackageName = "azure-test", ReleaseStatus = "", ReleaseExclusionStatus = "Not applicable", PullRequestStatus = "Merged" },
+                    new SDKInfo { Language = "JavaScript", PackageName = "@azure/test", ReleaseStatus = "", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Go", PackageName = "sdk/test/aztest", ReleaseStatus = "", ReleaseExclusionStatus = "Not applicable" }
+                }
+            };
+
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync("azure-test", "python", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem> { releasePlan });
+
+            mockDevOpsService
+                .Setup(x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
+
+            // Act - releasing Python but Java, JS, Go still pending
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test", "python", "Released", null, 0, CancellationToken.None);
+
+            // Assert
+            Assert.That(result.ResponseError, Is.Null);
+            Assert.That(result.ReleasePlanFinished, Is.False);
+
+            // Verify state was NOT set to Finished (only the release status update happened)
+            mockDevOpsService.Verify(
+                x => x.UpdateWorkItemAsync(12345, It.Is<Dictionary<string, string>>(d =>
+                    d.ContainsKey("System.State")), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_DataPlane_AllFourLanguagesReleased_MarksFinished()
+        {
+            // Arrange - data plane: Go should be ignored
+            var releasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 12345,
+                ReleasePlanId = 100,
+                IsManagementPlane = false,
+                IsDataPlane = true,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo { Language = ".NET", PackageName = "Azure.Test", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Java", PackageName = "azure-test", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Python", PackageName = "azure-test", ReleaseStatus = "", ReleaseExclusionStatus = "Not applicable", PullRequestStatus = "Merged" },
+                    new SDKInfo { Language = "JavaScript", PackageName = "@azure/test", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Go", PackageName = "sdk/test/aztest", ReleaseStatus = "", ReleaseExclusionStatus = "Not applicable" }
+                }
+            };
+
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync("azure-test", "python", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem> { releasePlan });
+
+            mockDevOpsService
+                .Setup(x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
+
+            // Act - releasing Python (last of the 4 data plane languages)
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test", "python", "Released", null, 0, CancellationToken.None);
+
+            // Assert - Go is not released but should be ignored for data plane
+            Assert.That(result.ResponseError, Is.Null);
+            Assert.That(result.ReleasePlanFinished, Is.True);
+
+            mockDevOpsService.Verify(
+                x => x.UpdateWorkItemAsync(12345, It.Is<Dictionary<string, string>>(d =>
+                    d.ContainsKey("System.State") && d["System.State"] == "Finished"), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_DataPlane_NotAllFourComplete_DoesNotFinish()
+        {
+            // Arrange
+            var releasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 12345,
+                ReleasePlanId = 100,
+                IsManagementPlane = false,
+                IsDataPlane = true,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo { Language = ".NET", PackageName = "Azure.Test", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Java", PackageName = "azure-test", ReleaseStatus = "", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Python", PackageName = "azure-test", ReleaseStatus = "", ReleaseExclusionStatus = "Not applicable", PullRequestStatus = "Merged" },
+                    new SDKInfo { Language = "JavaScript", PackageName = "@azure/test", ReleaseStatus = "", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Go", PackageName = "sdk/test/aztest", ReleaseStatus = "", ReleaseExclusionStatus = "Not applicable" }
+                }
+            };
+
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync("azure-test", "python", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem> { releasePlan });
+
+            mockDevOpsService
+                .Setup(x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
+
+            // Act - releasing Python but Java and JS still pending
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test", "python", "Released", null, 0, CancellationToken.None);
+
+            // Assert
+            Assert.That(result.ResponseError, Is.Null);
+            Assert.That(result.ReleasePlanFinished, Is.False);
+
+            mockDevOpsService.Verify(
+                x => x.UpdateWorkItemAsync(12345, It.Is<Dictionary<string, string>>(d =>
+                    d.ContainsKey("System.State")), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_StatusNotReleased_DoesNotTriggerFinishCheck()
+        {
+            // Arrange
+            var releasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 12345,
+                ReleasePlanId = 100,
+                IsManagementPlane = true,
+                IsDataPlane = false,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo { Language = ".NET", PackageName = "Azure.Test", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Java", PackageName = "azure-test", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Python", PackageName = "azure-test", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable", PullRequestStatus = "Merged" },
+                    new SDKInfo { Language = "JavaScript", PackageName = "@azure/test", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Go", PackageName = "sdk/test/aztest", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" }
+                }
+            };
+
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync("azure-test", "python", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem> { releasePlan });
+
+            mockDevOpsService
+                .Setup(x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
+
+            // Act - setting status to "Pending" (not "Released")
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test", "python", "Pending", null, 0, CancellationToken.None);
+
+            // Assert - finish check should not be triggered
+            Assert.That(result.ResponseError, Is.Null);
+            Assert.That(result.ReleasePlanFinished, Is.False);
+
+            // Only one UpdateWorkItemAsync call for the status update, none for System.State
+            mockDevOpsService.Verify(
+                x => x.UpdateWorkItemAsync(12345, It.Is<Dictionary<string, string>>(d =>
+                    d.ContainsKey("System.State")), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_DataPlane_GoNotReleasedOthersComplete_MarksFinished()
+        {
+            // Arrange - specifically testing that Go being unreleased doesn't block data plane finish
+            var releasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 12345,
+                ReleasePlanId = 100,
+                IsManagementPlane = false,
+                IsDataPlane = true,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo { Language = ".NET", PackageName = "Azure.Test", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Java", PackageName = "azure-test", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Python", PackageName = "azure-test", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "JavaScript", PackageName = "@azure/test", ReleaseStatus = "", ReleaseExclusionStatus = "Not applicable", PullRequestStatus = "Merged" },
+                    new SDKInfo { Language = "Go", PackageName = "sdk/test/aztest", ReleaseStatus = "", ReleaseExclusionStatus = "Not applicable" }
+                }
+            };
+
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync("@azure/test", "javascript", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem> { releasePlan });
+
+            mockDevOpsService
+                .Setup(x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
+
+            // Act - releasing JavaScript (last of the 4 data plane languages)
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("@azure/test", "javascript", "Released", null, 0, CancellationToken.None);
+
+            // Assert
+            Assert.That(result.ResponseError, Is.Null);
+            Assert.That(result.ReleasePlanFinished, Is.True);
+
+            mockDevOpsService.Verify(
+                x => x.UpdateWorkItemAsync(12345, It.Is<Dictionary<string, string>>(d =>
+                    d.ContainsKey("System.State") && d["System.State"] == "Finished"), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_FinishFails_StillReturnsSuccessfulStatusUpdate()
+        {
+            // Arrange - all languages complete, but the Finished state update will throw
+            var releasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 12345,
+                ReleasePlanId = 100,
+                IsManagementPlane = true,
+                IsDataPlane = false,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo { Language = ".NET", PackageName = "Azure.Test", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Java", PackageName = "azure-test", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Python", PackageName = "azure-test", ReleaseStatus = "", ReleaseExclusionStatus = "Not applicable", PullRequestStatus = "Merged" },
+                    new SDKInfo { Language = "JavaScript", PackageName = "@azure/test", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" },
+                    new SDKInfo { Language = "Go", PackageName = "sdk/test/aztest", ReleaseStatus = "Released", ReleaseExclusionStatus = "Not applicable" }
+                }
+            };
+
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync("azure-test", "python", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem> { releasePlan });
+
+            // Release status update succeeds
+            mockDevOpsService
+                .Setup(x => x.UpdateWorkItemAsync(12345, It.Is<Dictionary<string, string>>(d =>
+                    d.ContainsKey("Custom.ReleaseStatusForPython")), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
+
+            // Finished state update fails
+            mockDevOpsService
+                .Setup(x => x.UpdateWorkItemAsync(12345, It.Is<Dictionary<string, string>>(d =>
+                    d.ContainsKey("System.State")), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("State transition not allowed"));
+
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test", "python", "Released", null, 0, CancellationToken.None);
+
+            // Assert - release status update succeeded, no ResponseError
+            Assert.That(result.ResponseError, Is.Null);
+            Assert.That(result.ReleaseStatus, Is.EqualTo("Released"));
+            Assert.That(result.ReleasePlanFinished, Is.False);
+            Assert.That(result.Message, Does.Contain("failed to auto-finish"));
         }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Release plan is automatically marked as "Finished" when all required language SDKs are either Released or have an Approved exclusion. Management plane checks all 5 languages; data plane checks .NET, Java, Python, and JavaScript only.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ReleasePlan/ReleaseStatusUpdateResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ReleasePlan/ReleaseStatusUpdateResponse.cs
@@ -30,6 +30,10 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses.ReleasePlan
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Message { get; set; }
 
+        [JsonPropertyName("release_plan_finished")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public bool ReleasePlanFinished { get; set; }
+
         public void SetLanguage(string language)
         {
             Language = SdkLanguageHelpers.GetSdkLanguage(language);
@@ -60,6 +64,10 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses.ReleasePlan
             if (!string.IsNullOrEmpty(Message))
             {
                 result.AppendLine(Message);
+            }
+            if (ReleasePlanFinished)
+            {
+                result.AppendLine("Release plan has been marked as Finished.");
             }
             return result.ToString();
         }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/PackageReleaseStatusTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/PackageReleaseStatusTool.cs
@@ -229,17 +229,16 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
 
         internal static bool IsReleasePlanComplete(ReleasePlanWorkItem releasePlan)
         {
-            var languagesToCheck = releasePlan.SDKInfo.AsEnumerable();
+            var requiredLanguages = releasePlan.IsManagementPlane
+                ? ReleasePlanTool.languagesforMgmtplane
+                : ReleasePlanTool.languagesforDataplane;
 
-            // Filter the language list for dataplane
-            if (releasePlan.IsDataPlane)
-            {
-                languagesToCheck = languagesToCheck.Where(info => ReleasePlanTool.languagesforDataplane.Contains(info.Language));
-            }
+            var sdkInfoByLanguage = releasePlan.SDKInfo.ToDictionary(i => i.Language, System.StringComparer.OrdinalIgnoreCase);
 
-            return languagesToCheck.All(info =>
-                string.Equals(info.ReleaseStatus, "Released", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(info.ReleaseExclusionStatus, "Approved", StringComparison.OrdinalIgnoreCase));
+            return requiredLanguages.All(lang =>
+                sdkInfoByLanguage.TryGetValue(lang, out var info)
+                && (string.Equals(info.ReleaseStatus, "Released", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(info.ReleaseExclusionStatus, "Approved", StringComparison.OrdinalIgnoreCase)));
         }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/PackageReleaseStatusTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/PackageReleaseStatusTool.cs
@@ -163,6 +163,37 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 await devOpsService.UpdateWorkItemAsync(releasePlan.WorkItemId, fieldsToUpdate, ct);
                 logger.LogInformation("Successfully updated release status for package {packageName} in release plan {workItemId}", packageName, releasePlan.WorkItemId);
                 response.ReleaseStatus = releaseStatus;
+
+                // Check if the release plan can be marked as Finished
+                if (string.Equals(releaseStatus, "Released", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Update in-memory SDKInfo to reflect the new status
+                    var currentLanguageName = DevOpsService.MapLanguageIdToName(languageId);
+                    var sdkInfo = releasePlan.SDKInfo.FirstOrDefault(s => string.Equals(s.Language, currentLanguageName, StringComparison.OrdinalIgnoreCase));
+                    if (sdkInfo != null)
+                    {
+                        sdkInfo.ReleaseStatus = releaseStatus;
+                    }
+
+                    if (IsReleasePlanComplete(releasePlan))
+                    {
+                        try
+                        {
+                            logger.LogInformation("All required languages are complete for release plan {workItemId}. Marking as Finished.", releasePlan.WorkItemId);
+                            await devOpsService.UpdateWorkItemAsync(releasePlan.WorkItemId, new Dictionary<string, string>
+                            {
+                                { "System.State", "Finished" }
+                            }, ct);
+                            response.ReleasePlanFinished = true;
+                        }
+                        catch (Exception ex)
+                        {
+                            logger.LogWarning(ex, "Failed to mark release plan {workItemId} as Finished", releasePlan.WorkItemId);
+                            response.Message = "Release status updated successfully but failed to auto-finish the release plan.";
+                        }
+                    }
+                }
+
                 return response;
             }
             catch (Exception ex)
@@ -194,6 +225,21 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 logger.LogInformation("Found release plan work item {workItemId} for package {packageName}", releasePlan.WorkItemId, packageName);
             }
             return releasePlan;
+        }
+
+        internal static bool IsReleasePlanComplete(ReleasePlanWorkItem releasePlan)
+        {
+            var languagesToCheck = releasePlan.SDKInfo.AsEnumerable();
+
+            // Filter the language list for dataplane
+            if (releasePlan.IsDataPlane)
+            {
+                languagesToCheck = languagesToCheck.Where(info => ReleasePlanTool.languagesforDataplane.Contains(info.Language));
+            }
+
+            return languagesToCheck.All(info =>
+                string.Equals(info.ReleaseStatus, "Released", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(info.ReleaseExclusionStatus, "Approved", StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -249,11 +249,11 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             "go"
         };
 
-        private readonly HashSet<string> languagesforDataplane = [
+        public static readonly HashSet<string> languagesforDataplane = [
             ".NET","Java","Python","JavaScript"
         ];
 
-        private readonly HashSet<string> languagesforMgmtplane = [
+        public static readonly HashSet<string> languagesforMgmtplane = [
            ".NET","Java","Python","JavaScript","Go"
        ];
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -249,13 +249,15 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             "go"
         };
 
-        public static readonly HashSet<string> languagesforDataplane = [
-            ".NET","Java","Python","JavaScript"
-        ];
+        internal static readonly HashSet<string> languagesforDataplane = new(System.StringComparer.OrdinalIgnoreCase)
+        {
+            ".NET", "Java", "Python", "JavaScript"
+        };
 
-        public static readonly HashSet<string> languagesforMgmtplane = [
-           ".NET","Java","Python","JavaScript","Go"
-       ];
+        internal static readonly HashSet<string> languagesforMgmtplane = new(System.StringComparer.OrdinalIgnoreCase)
+        {
+            ".NET", "Java", "Python", "JavaScript", "Go"
+        };
 
         [GeneratedRegex("https:\\/\\/github.com\\/Azure\\/azure-sdk\\/issues\\/([0-9]+)")]
         private static partial Regex NameSpaceIssueUrlRegex();


### PR DESCRIPTION
Auto complete a release plan when all languages are either released or excluded. This change is required to replace the current cloud flow in PowerApps side.