### PR TITLE
Export installationToken as output variable

### DIFF
--- a/eng/common/pipelines/templates/steps/login-to-github.yml
+++ b/eng/common/pipelines/templates/steps/login-to-github.yml
@@ -8,6 +8,9 @@ parameters:
 - name: VariableNamePrefix
   type: string 
   default: GH_TOKEN
+- name: ExportAsOutputVariable
+  type: boolean 
+  default: false
 - name: ScriptDirectory
   default: eng/common/scripts
 
@@ -20,6 +23,6 @@ steps:
     scriptLocation: scriptPath
     scriptPath: ${{ parameters.ScriptDirectory }}/login-to-github.ps1
     arguments: >
-     -InstallationTokenOwners '${{ join(''',''', parameters.TokenOwners) }}'
-     -VariableNamePrefix '${{ parameters.VariableNamePrefix }}'
-     
+      -InstallationTokenOwners '${{ join(''',''', parameters.TokenOwners) }}'
+      -VariableNamePrefix '${{ parameters.VariableNamePrefix }}'
+      -ExportAsOutputVariable:$${{ parameters.ExportAsOutputVariable }}

--- a/eng/common/scripts/login-to-github.ps1
+++ b/eng/common/scripts/login-to-github.ps1
@@ -22,6 +22,10 @@
   Prefix for the exported variable name (default: GH_TOKEN).
   With a single owner, exports as GH_TOKEN. With multiple owners, exports as GH_TOKEN_<Owner>.
 
+.PARAMETER ExportAsOutputVariable
+  When set in Azure DevOps, also exports the variable as an output variable
+  (##vso[task.setvariable ...;isOutput=true]) for downstream jobs/stages.
+
 .OUTPUTS
   Sets environment variables in the current process and exports them to the CI system:
   - Azure DevOps: sets secret pipeline variables via ##vso logging commands
@@ -34,7 +38,8 @@ param(
   [string] $KeyName = "azure-sdk-automation",
   [string] $GitHubAppId = '1086291', # Azure SDK Automation App ID
   [string[]] $InstallationTokenOwners = @("Azure"),
-  [string] $VariableNamePrefix = "GH_TOKEN"
+  [string] $VariableNamePrefix = "GH_TOKEN",
+  [switch] $ExportAsOutputVariable
 )
 
 $ErrorActionPreference = 'Stop'
@@ -239,6 +244,11 @@ function Invoke-LoginToGitHub {
     if ($null -ne $env:SYSTEM_TEAMPROJECTID) {
       Write-Host "##vso[task.setvariable variable=$variableName;issecret=true]$installationToken"
       Write-Host "Azure DevOps variable '$variableName' has been set (secret)."
+
+      if ($ExportAsOutputVariable) {
+        Write-Host "##vso[task.setvariable variable=$variableName;issecret=true;isOutput=true]$installationToken"
+        Write-Host "Azure DevOps output variable '$variableName' has been set (secret)."
+      }
     }
 
     # GitHub Actions: mask the token and export to GITHUB_ENV


### PR DESCRIPTION
This pull request enhances the GitHub login automation by adding support for exporting authentication tokens as Azure DevOps output variables, making it easier to pass secrets between pipeline stages and jobs. The changes introduce a new parameter to control this behavior and update both the pipeline template and the PowerShell script accordingly.

**Pipeline and script improvements for output variable support:**

* Added a new boolean parameter `ExportAsOutputVariable` to the `login-to-github.yml` pipeline template, allowing users to specify whether tokens should be exported as output variables for downstream Azure DevOps jobs.
* Updated the invocation of the login script in the pipeline template to include the new `ExportAsOutputVariable` parameter.

**PowerShell script enhancements:**

* Documented the new `ExportAsOutputVariable` parameter in the `login-to-github.ps1` script, explaining its effect in Azure DevOps environments.
* Added the `ExportAsOutputVariable` switch to the script's parameter list to accept the new option.
* Modified the `Invoke-LoginToGitHub` function to export tokens as Azure DevOps output variables when the new switch is set, using the appropriate logging command.