### PR TITLE
Get and update api spec status using spec PR status and approval

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/DevOpsServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/DevOpsServiceTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.AzureDevOps;
 using Azure.Sdk.Tools.Cli.Services;
 using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 using Microsoft.TeamFoundation.Build.WebApi;
@@ -209,11 +210,154 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
 
         #endregion
 
+        #region GetReleasePlansForPackageAsync Tests
+
+        [TestCase("python", "Python")]
+        [TestCase(".net", "Dotnet")]
+        [TestCase("javascript", "JavaScript")]
+        [TestCase("java", "Java")]
+        [TestCase("go", "Go")]
+        public async Task GetReleasePlansForPackageAsync_QueryIncludesReleaseStatusFilter(string language, string expectedLanguageId)
+        {
+            // Arrange
+            var packageName = "azure-test-package";
+            var releasePlanWorkItem = CreateReleasePlanWorkItemForPackage(100, packageName, language);
+            _connection.AddWorkItemToQuery(releasePlanWorkItem);
+
+            // Act
+            await _devOpsService.GetReleasePlansForPackageAsync(packageName, language, false, CancellationToken.None);
+
+            // Assert - verify query includes the release status filter
+            var capturedQuery = _connection.LastCapturedQuery;
+            Assert.That(capturedQuery, Is.Not.Null, "Expected a WIQL query to be captured");
+            Assert.That(capturedQuery, Does.Contain($"[Custom.ReleaseStatusFor{expectedLanguageId}] <> 'Released'"),
+                $"Query should filter out already-released packages for language '{language}'");
+        }
+
+        [Test]
+        public async Task GetReleasePlansForPackageAsync_QueryIncludesPackageNameFilter()
+        {
+            // Arrange
+            var packageName = "azure-test-package";
+            var releasePlanWorkItem = CreateReleasePlanWorkItemForPackage(100, packageName, "python");
+            _connection.AddWorkItemToQuery(releasePlanWorkItem);
+
+            // Act
+            await _devOpsService.GetReleasePlansForPackageAsync(packageName, "python", false, CancellationToken.None);
+
+            // Assert
+            var capturedQuery = _connection.LastCapturedQuery;
+            Assert.That(capturedQuery, Does.Contain($"[Custom.PythonPackageName] = '{packageName}'"));
+        }
+
+        [Test]
+        public async Task GetReleasePlansForPackageAsync_QueryIncludesInProgressStateFilter()
+        {
+            // Arrange
+            var packageName = "azure-test-package";
+            var releasePlanWorkItem = CreateReleasePlanWorkItemForPackage(100, packageName, "python");
+            _connection.AddWorkItemToQuery(releasePlanWorkItem);
+
+            // Act
+            await _devOpsService.GetReleasePlansForPackageAsync(packageName, "python", false, CancellationToken.None);
+
+            // Assert
+            var capturedQuery = _connection.LastCapturedQuery;
+            Assert.That(capturedQuery, Does.Contain("[System.State] = 'In Progress'"));
+        }
+
+        [Test]
+        public async Task GetReleasePlansForPackageAsync_ReturnsEmptyList_WhenNoMatchingWorkItems()
+        {
+            // Arrange - no work items added to query results
+
+            // Act
+            var result = await _devOpsService.GetReleasePlansForPackageAsync("azure-test-package", "python", false, CancellationToken.None);
+
+            // Assert
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public async Task GetReleasePlansForPackageAsync_TestReleasePlan_QueryContainsTestTag()
+        {
+            // Arrange
+            var packageName = "azure-test-package";
+            var releasePlanWorkItem = CreateReleasePlanWorkItemForPackage(100, packageName, "python");
+            _connection.AddWorkItemToQuery(releasePlanWorkItem);
+
+            // Act
+            await _devOpsService.GetReleasePlansForPackageAsync(packageName, "python", isTestReleasePlan: true, CancellationToken.None);
+
+            // Assert
+            var capturedQuery = _connection.LastCapturedQuery;
+            Assert.That(capturedQuery, Does.Contain("[System.Tags] CONTAINS"));
+            Assert.That(capturedQuery, Does.Contain("Release Planner App Test"));
+        }
+
+        [Test]
+        public async Task GetReleasePlansForPackageAsync_NonTestReleasePlan_QueryExcludesTestTag()
+        {
+            // Arrange
+            var packageName = "azure-test-package";
+            var releasePlanWorkItem = CreateReleasePlanWorkItemForPackage(100, packageName, "python");
+            _connection.AddWorkItemToQuery(releasePlanWorkItem);
+
+            // Act
+            await _devOpsService.GetReleasePlansForPackageAsync(packageName, "python", isTestReleasePlan: false, CancellationToken.None);
+
+            // Assert
+            var capturedQuery = _connection.LastCapturedQuery;
+            Assert.That(capturedQuery, Does.Contain("[System.Tags] NOT CONTAINS"));
+            Assert.That(capturedQuery, Does.Contain("Release Planner App Test"));
+        }
+
+        [Test]
+        public async Task GetReleasePlansForPackageAsync_EscapesSingleQuoteInPackageName()
+        {
+            // Arrange
+            var packageName = "azure-test's-package";
+            var releasePlanWorkItem = CreateReleasePlanWorkItemForPackage(100, packageName, "python");
+            _connection.AddWorkItemToQuery(releasePlanWorkItem);
+
+            // Act
+            await _devOpsService.GetReleasePlansForPackageAsync(packageName, "python", false, CancellationToken.None);
+
+            // Assert
+            var capturedQuery = _connection.LastCapturedQuery;
+            Assert.That(capturedQuery, Does.Contain("azure-test''s-package"), "Single quotes should be escaped in WIQL query");
+        }
+
+        private WorkItem CreateReleasePlanWorkItemForPackage(int id, string packageName, string language)
+        {
+            var languageId = DevOpsService.MapLanguageToId(language);
+            var workItem = new WorkItem
+            {
+                Id = id,
+                Fields = new Dictionary<string, object>
+                {
+                    { "System.WorkItemType", "Release Plan" },
+                    { "System.State", "In Progress" },
+                    { "System.Title", $"Release Plan {id}" },
+                    { "System.TeamProject", "internal" },
+                    { "Custom.ReleasePlanID", id.ToString() },
+                    { $"Custom.{languageId}PackageName", packageName },
+                    { $"Custom.ReleaseStatusFor{languageId}", "" }
+                },
+                Relations = new List<WorkItemRelation>()
+            };
+            return workItem;
+        }
+
+        #endregion
+
         #region TestDevOpsConnection
 
         private class TestDevOpsConnection : IDevOpsConnection
         {
             private readonly TestWorkItemClient _workItemClient = new();
+
+            public string? LastCapturedQuery => _workItemClient.LastCapturedQuery;
 
             public BuildHttpClient GetBuildClient(CancellationToken ct = default)
             {
@@ -246,6 +390,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
             private readonly List<WorkItem> _queryWorkItems = new();
             private readonly Dictionary<int, WorkItem> _workItems = new();
 
+            public string? LastCapturedQuery { get; private set; }
+
             public TestWorkItemClient() : base(new Uri("https://dev.azure.com/test"), null)
             {
             }
@@ -271,6 +417,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
                 object? userState = null,
                 CancellationToken cancellationToken = default)
             {
+                LastCapturedQuery = wiql?.Query;
                 var result = new WorkItemQueryResult
                 {
                     WorkItems = _queryWorkItems.Select(wi => new WorkItemReference { Id = wi.Id ?? 0 }).ToList()
@@ -286,6 +433,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
                 object? userState = null,
                 CancellationToken cancellationToken = default)
             {
+                LastCapturedQuery = wiql?.Query;
                 var result = new WorkItemQueryResult
                 {
                     WorkItems = _queryWorkItems.Select(wi => new WorkItemReference { Id = wi.Id ?? 0 }).ToList()

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/PackageReleaseStatusToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/PackageReleaseStatusToolTests.cs
@@ -1115,6 +1115,96 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             Assert.That(result.ReleaseStatus, Is.EqualTo("Released"));
             Assert.That(result.ReleasePlanFinished, Is.False);
             Assert.That(result.Message, Does.Contain("failed to auto-finish"));
+        public async Task UpdatePackageReleaseStatus_AlreadyReleasedPackage_ReturnsNoReleasePlansFound()
+        {
+            // Arrange - GetReleasePlansForPackageAsync now filters out released packages at query level,
+            // so it returns an empty list when all matching release plans already have "Released" status
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync("azure-test-package", "python", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem>());
+
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", "2.0.0", 0, CancellationToken.None);
+
+            // Assert - The tool should report no in-progress release plans found
+            Assert.That(result.ResponseError, Is.Null);
+            Assert.That(result.Message, Does.Contain("No in-progress release plans found"));
+            Assert.That(result.Message, Does.Contain("azure-test-package"));
+            Assert.That(result.Message, Does.Contain("python"));
+
+            // Verify no work item update was attempted
+            mockDevOpsService.Verify(
+                x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_OnlyNonReleasedPlansReturned_UpdatesCorrectPlan()
+        {
+            // Arrange - Simulate that GetReleasePlansForPackageAsync only returns plans where
+            // the package has NOT been released (the released ones are filtered out by the query)
+            var nonReleasedPlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 33333,
+                ReleasePlanId = 300,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo
+                    {
+                        Language = "python",
+                        PackageName = "azure-test-package",
+                        PullRequestStatus = "Merged"
+                    }
+                },
+                APISpecProjectPath = "specification/test/project"
+            };
+
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync("azure-test-package", "python", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem> { nonReleasedPlan });
+
+            mockDevOpsService
+                .Setup(x => x.UpdateWorkItemAsync(33333, It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 33333 });
+
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", "1.0.0", 0, CancellationToken.None);
+
+            // Assert
+            Assert.That(result.ResponseError, Is.Null);
+            Assert.That(result.ReleaseStatus, Is.EqualTo("Released"));
+            Assert.That(result.ReleasePlanId, Is.EqualTo(300));
+            Assert.That(result.TypeSpecProject, Is.EqualTo("specification/test/project"));
+
+            // Verify the correct work item was updated
+            mockDevOpsService.Verify(
+                x => x.UpdateWorkItemAsync(33333, It.Is<Dictionary<string, string>>(d =>
+                    d.ContainsKey("Custom.ReleaseStatusForPython") && d["Custom.ReleaseStatusForPython"] == "Released"),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [TestCase("python", "Custom.ReleaseStatusForPython")]
+        [TestCase(".net", "Custom.ReleaseStatusForDotnet")]
+        [TestCase("javascript", "Custom.ReleaseStatusForJavaScript")]
+        [TestCase("java", "Custom.ReleaseStatusForJava")]
+        [TestCase("go", "Custom.ReleaseStatusForGo")]
+        public async Task UpdatePackageReleaseStatus_FiltersByCorrectReleaseStatusField_PerLanguage(string language, string expectedField)
+        {
+            // Arrange - When GetReleasePlansForPackageAsync is called, it should use
+            // the language-specific release status field in the filter query.
+            // Here we verify the tool correctly passes language to the service method.
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync("azure-test-package", language, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem>());
+
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", language, "Released", null, 0, CancellationToken.None);
+
+            // Assert - Verify the service was called with the correct language
+            mockDevOpsService.Verify(
+                x => x.GetReleasePlansForPackageAsync("azure-test-package", language, It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+                Times.Once);
         }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/PackageReleaseStatusToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/PackageReleaseStatusToolTests.cs
@@ -1115,6 +1115,9 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             Assert.That(result.ReleaseStatus, Is.EqualTo("Released"));
             Assert.That(result.ReleasePlanFinished, Is.False);
             Assert.That(result.Message, Does.Contain("failed to auto-finish"));
+        }
+
+        [Test]
         public async Task UpdatePackageReleaseStatus_AlreadyReleasedPackage_ReturnsNoReleasePlansFound()
         {
             // Arrange - GetReleasePlansForPackageAsync now filters out released packages at query level,
@@ -1184,12 +1187,12 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 Times.Once);
         }
 
-        [TestCase("python", "Custom.ReleaseStatusForPython")]
-        [TestCase(".net", "Custom.ReleaseStatusForDotnet")]
-        [TestCase("javascript", "Custom.ReleaseStatusForJavaScript")]
-        [TestCase("java", "Custom.ReleaseStatusForJava")]
-        [TestCase("go", "Custom.ReleaseStatusForGo")]
-        public async Task UpdatePackageReleaseStatus_FiltersByCorrectReleaseStatusField_PerLanguage(string language, string expectedField)
+        [TestCase("python")]
+        [TestCase(".net")]
+        [TestCase("javascript")]
+        [TestCase("java")]
+        [TestCase("go")]
+        public async Task UpdatePackageReleaseStatus_FiltersByCorrectReleaseStatusField_PerLanguage(string language)
         {
             // Arrange - When GetReleasePlansForPackageAsync is called, it should use
             // the language-specific release status field in the filter query.

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
@@ -231,26 +231,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             // Verify the environment helper was called
             environmentHelperMock.Verify(x => x.GetBooleanVariable("AZSDKTOOLS_AGENT_TESTING", false), Times.Once);
         }
-
-        [Test]
-        public async Task Test_Get_Release_Plan_For_Pull_Request_with_valid_inputs()
-        {
-            var releaseplan = await releasePlanTool.GetReleasePlanForPullRequest("https://github.com/Azure/azure-rest-api-specs/pull/35446");
-            Assert.IsNotNull(releaseplan);
-            Assert.IsNull(releaseplan.ResponseError);
-            Assert.IsNotNull(releaseplan.ReleasePlanDetails);
-            Assert.That(releaseplan.Message, Does.Contain("Successfully retrieved release plan"));
-        }
-
-        [Test]
-        public async Task Test_Get_Release_Plan_For_Pull_Request_with_invalid_pr_link()
-        {
-            var releaseplan = await releasePlanTool.GetReleasePlanForPullRequest("invalid-pr-link");
-            Assert.IsNotNull(releaseplan);
-            Assert.IsNotNull(releaseplan.ResponseError);
-            Assert.True(releaseplan.ResponseError.Contains("Failed to get release plan details"));
-        }
-
+        
         [Test]
         public async Task Test_Create_releasePlan_private_preview_accepts_azure_rest_api_specs_pr_repo()
         {
@@ -375,16 +356,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             Assert.That(releasePlanDetails.SpecPullRequests, Is.Empty);
         }
 
-        [Test]
-        public async Task Test_Get_Release_Plan_For_Pull_Request_accepts_azure_rest_api_specs_pr_repo()
-        {
-            var releaseplan = await releasePlanTool.GetReleasePlanForPullRequest("https://github.com/Azure/azure-rest-api-specs-pr/pull/35446");
-            Assert.IsNotNull(releaseplan);
-            // The PR URL is now valid; the mock returns a release plan with WorkItemId=0 for any PR URL
-            // so GetReleasePlanForPullRequest should still succeed without error
-            Assert.IsNull(releaseplan.ResponseError);
-        }
-
+        
         [Test]
         public async Task Test_Get_Release_Plan_by_spec_pull_request_url()
         {
@@ -1229,7 +1201,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             Assert.That(result.Message, Does.Contain("Successfully updated release plan 500"));
             Assert.That(result.PackageType, Is.EqualTo(SdkType.Management));
 
-            mockDevOps.Verify(x => x.GetReleasePlanByTypeSpecProjectPathAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
+            mockDevOps.Verify(x => x.GetReleasePlanByTypeSpecProjectPathAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
             mockDevOps.Verify(x => x.GetReleasePlanAsync("https://github.com/Azure/azure-rest-api-specs/pull/99999", It.IsAny<CancellationToken>()), Times.Once);
         }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
@@ -1167,7 +1167,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         }
 
         [Test]
-        public async Task Test_UpdateReleasePlan_finds_by_pr_url_when_work_item_and_path_not_found()
+        public async Task Test_UpdateReleasePlan_finds_by_pr_url_skipping_path_lookup()
         {
             var mockDevOps = new Mock<IDevOpsService>();
             var releasePlan = new ReleasePlanWorkItem

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ReleasePlan/ReleasePlanResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ReleasePlan/ReleasePlanResponse.cs
@@ -27,6 +27,7 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses.ReleasePlan
                 result.AppendLine($"Owner: {ReleasePlanDetails.Owner}");
                 result.AppendLine($"SDK Release Month: {ReleasePlanDetails.SDKReleaseMonth}");
                 result.AppendLine($"Release Plan Link: {ReleasePlanLink}");
+                result.AppendLine($"Is API spec approved: {ReleasePlanDetails.IsSpecApproved}");
             }
             else
             {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -280,6 +280,7 @@ namespace Azure.Sdk.Tools.Cli.Services
                 var query = $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{Constants.AZURE_SDK_DEVOPS_RELEASE_PROJECT}'";
                 query += $" AND [System.Tags] {(isTestReleasePlan ? "CONTAINS" : "NOT CONTAINS")} '{RELEASE_PLANNER_APP_TEST}'";
                 query += $" AND [Custom.{languageId}PackageName] = '{escapedPackageName}'";
+                query += $" AND [Custom.ReleaseStatusFor{languageId}] <> 'Released'";
                 query += " AND [System.WorkItemType] = 'Release Plan'";
                 query += " AND [System.State] = 'In Progress'";
                 var releasePlanWorkItems = await FetchWorkItemsAsync(query, ct);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -702,36 +702,37 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
 
                 releasePlan = await devOpsService.GetReleasePlanForWorkItemAsync(releasePlan.WorkItemId, ct);
 
-                // Check API spec readiness if release plan has a spec PR
-                if (releasePlan != null)
+                if (releasePlan == null)
                 {
-                    var activeSpecPr = !string.IsNullOrEmpty(releasePlan.ActiveSpecPullRequest) ? releasePlan.ActiveSpecPullRequest : specPullRequestUrl;
-                    if (!string.IsNullOrEmpty(activeSpecPr))
-                    {
-                        var prNumber = ParsePullRequestNumberFromUrl(activeSpecPr);
-                        if (prNumber > 0)
-                        {
-                            var specReadiness = await CheckApiReadyForSDKGeneration(specProject, prNumber, releasePlan.WorkItemId, ct);
-                            if (specReadiness.Status == "Success")
-                            {
-                                await devOpsService.UpdateApiSpecStatusAsync(releasePlan.WorkItemId, "Approved", ct);
-                                releasePlan.IsSpecApproved = true;                                
-                            }
+                    return new ReleasePlanResponse { ResponseError = "Failed to retrieve updated release plan after update." };
+                }
 
-                            // For private preview release plans, mark as finished if spec PR is merged
-                            if (releasePlan.ApiReleaseType == ApiReleaseType.PrivatePreview)
+                // Check API spec readiness if release plan has a spec PR
+                var activeSpecPr = !string.IsNullOrEmpty(releasePlan.ActiveSpecPullRequest) ? releasePlan.ActiveSpecPullRequest : specPullRequestUrl;
+                if (!string.IsNullOrEmpty(activeSpecPr))
+                {
+                    var prNumber = ParsePullRequestNumberFromUrl(activeSpecPr);
+                    if (prNumber > 0)
+                    {
+                        var specReadiness = await CheckApiReadyForSDKGeneration(specProject, prNumber, releasePlan.WorkItemId, ct);
+                        if (specReadiness.Status == "Success")
+                        {
+                            releasePlan.IsSpecApproved = true;
+                        }
+
+                        // For private preview release plans, mark as finished if spec PR is merged
+                        if (releasePlan.ApiReleaseType == ApiReleaseType.PrivatePreview)
+                        {
+                            var isPrivateSpec = activeSpecPr.Contains(PRIVATE_SPECS_REPO, StringComparison.OrdinalIgnoreCase);
+                            var specRepoName = isPrivateSpec ? PRIVATE_SPECS_REPO : PUBLIC_SPECS_REPO;
+                            var specPr = await githubService.GetPullRequestAsync(REPO_OWNER, specRepoName, prNumber, ct);
+                            if (specPr?.Merged == true)
                             {
-                                var isPrivateSpec = activeSpecPr.Contains(PRIVATE_SPECS_REPO, StringComparison.OrdinalIgnoreCase);
-                                var specRepoName = isPrivateSpec ? PRIVATE_SPECS_REPO : PUBLIC_SPECS_REPO;
-                                var specPr = await githubService.GetPullRequestAsync(REPO_OWNER, specRepoName, prNumber, ct);
-                                if (specPr?.Merged == true)
-                                {
-                                    await devOpsService.UpdateWorkItemAsync(releasePlan.WorkItemId, new Dictionary<string, string>
-                                        {
-                                            { "System.State", "Finished" }
-                                        }, ct);
-                                    logger.LogInformation("Private preview release plan {WorkItemId} marked as Finished because spec PR is merged", releasePlan.WorkItemId);
-                                }
+                                await devOpsService.UpdateWorkItemAsync(releasePlan.WorkItemId, new Dictionary<string, string>
+                                    {
+                                        { "System.State", "Finished" }
+                                    }, ct);
+                                logger.LogInformation("Private preview release plan {WorkItemId} marked as Finished because spec PR is merged", releasePlan.WorkItemId);
                             }
                         }
                     }
@@ -739,7 +740,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
 
                 return new ReleasePlanResponse
                 {
-                    Message = $"Successfully updated release plan {releasePlan!.WorkItemId}.",
+                    Message = $"Successfully updated release plan {releasePlan.WorkItemId}.",
                     ReleasePlanDetails = releasePlan,
                     TypeSpecProject = specProject,
                     PackageType = isMgmt ? SdkType.Management : SdkType.Dataplane

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -236,6 +236,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
         private const string sdkApexEmail = "azsdkapex@microsoft.com";
         private static readonly string DEFAULT_BRANCH = "main";
         private static readonly string PUBLIC_SPECS_REPO = "azure-rest-api-specs";
+        private static readonly string PRIVATE_SPECS_REPO = "azure-rest-api-specs-pr";
         private static readonly string NAMESPACE_APPROVAL_REPO = "azure-sdk";
         private static readonly string REPO_OWNER = "Azure";
         public static readonly string ARM_SIGN_OFF_LABEL = "ARMSignedOff";
@@ -387,31 +388,6 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
         }
 
 
-        [McpServerTool(Name = GetReleasePlanForSpecPrToolName), Description("Get release plan for API spec pull request. This tool should be used only if work item Id is unknown.")]
-        public async Task<ReleasePlanResponse> GetReleasePlanForPullRequest(string pullRequestLink, CancellationToken ct = default)
-        {
-            try
-            {
-                ValidatePullRequestUrl(pullRequestLink);
-                var releasePlan = await devOpsService.GetReleasePlanAsync(pullRequestLink, ct);
-                if (releasePlan == null)
-                {
-                    return new ReleasePlanResponse { ResponseError = "No release plan associated with pull request link." };
-                }
-
-                return new ReleasePlanResponse
-                {
-                    ReleasePlanDetails = releasePlan,
-                    Message = "Successfully retrieved release plan."
-                };
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Failed to get release plan details");
-                return new ReleasePlanResponse { ResponseError = $"Failed to get release plan details: {ex.Message}" };
-            }
-        }
-
         [McpServerTool(Name = GetReleasePlanToolName), Description("Get Release Plan: Get release plan work item details for a given release plan number/Id or work item id. If neither is provided, finds the active release plan by TypeSpec project path or spec PR URL.")]
         public async Task<ReleasePlanResponse> GetReleasePlan(int releasePlanId = 0, int workItemId = 0, string? specPullRequestUrl = null, string? typeSpecProjectPath = null, CancellationToken ct = default)
         {
@@ -461,11 +437,34 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     return new ReleasePlanResponse { ResponseError = "Failed to get release plan details." };
                 }
 
-                return new ReleasePlanResponse
+                var response = new ReleasePlanResponse
                 {
                     ReleasePlanDetails = releasePlan,
                     Message = "Successfully retrieved release plan."
                 };
+
+                // Check API spec readiness if spec PR is linked
+                if (!string.IsNullOrEmpty(releasePlan.ActiveSpecPullRequest))
+                {
+                    if (string.IsNullOrEmpty(releasePlan.APISpecProjectPath))
+                    {
+                        response.NextSteps = ["Update the release plan to set the TypeSpec project path. TypeSpec project path is required to check API spec readiness."];
+                    }
+                    else
+                    {
+                        var prNumber = ParsePullRequestNumberFromUrl(releasePlan.ActiveSpecPullRequest);
+                        if (prNumber > 0)
+                        {
+                            var specReadiness = await CheckApiReadyForSDKGeneration(releasePlan.APISpecProjectPath, prNumber, releasePlan.WorkItemId, ct);
+                            if (specReadiness.Status == "Success")
+                            {
+                                releasePlan.IsSpecApproved = true;
+                            }
+                        }
+                    }
+                }
+
+                return response;
             }
             catch (Exception ex)
             {
@@ -613,19 +612,20 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                         NextSteps = ["Retry with valid TypeSpec project path"]
                     };
                 }
+                               
+                //Checkfor release plan using spec PR first and then using spec path
+                if (releasePlan == null && !string.IsNullOrEmpty(specPullRequestUrl))
+                {
+                    // Try to find by spec PR URL
+                    logger.LogInformation("Release plan not found by TypeSpec project path, searching by spec PR URL: {specPullRequestUrl}", specPullRequestUrl);
+                    releasePlan = await devOpsService.GetReleasePlanAsync(specPullRequestUrl, ct);
+                }
 
                 if (releasePlan == null)
                 {
                     // Try to find by TypeSpec project path
                     logger.LogInformation("Work item not found or not provided, searching by TypeSpec project path: {typeSpecProjectPath}", specProject);
                     releasePlan = await devOpsService.GetReleasePlanByTypeSpecProjectPathAsync(specProject, ct: ct);
-                }
-
-                if (releasePlan == null && !string.IsNullOrEmpty(specPullRequestUrl))
-                {
-                    // Try to find by spec PR URL
-                    logger.LogInformation("Release plan not found by TypeSpec project path, searching by spec PR URL: {specPullRequestUrl}", specPullRequestUrl);
-                    releasePlan = await devOpsService.GetReleasePlanAsync(specPullRequestUrl, ct);
                 }
 
                 if (releasePlan == null)
@@ -699,10 +699,47 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 {
                     logger.LogWarning("No package names resolved from TypeSpec metadata emitter for {typeSpecProjectPath}", typeSpecProjectPath);
                 }
+
                 releasePlan = await devOpsService.GetReleasePlanForWorkItemAsync(releasePlan.WorkItemId, ct);
+
+                // Check API spec readiness if release plan has a spec PR
+                if (releasePlan != null)
+                {
+                    var activeSpecPr = !string.IsNullOrEmpty(releasePlan.ActiveSpecPullRequest) ? releasePlan.ActiveSpecPullRequest : specPullRequestUrl;
+                    if (!string.IsNullOrEmpty(activeSpecPr))
+                    {
+                        var prNumber = ParsePullRequestNumberFromUrl(activeSpecPr);
+                        if (prNumber > 0)
+                        {
+                            var specReadiness = await CheckApiReadyForSDKGeneration(specProject, prNumber, releasePlan.WorkItemId, ct);
+                            if (specReadiness.Status == "Success")
+                            {
+                                await devOpsService.UpdateApiSpecStatusAsync(releasePlan.WorkItemId, "Approved", ct);
+                                releasePlan.IsSpecApproved = true;                                
+                            }
+
+                            // For private preview release plans, mark as finished if spec PR is merged
+                            if (releasePlan.ApiReleaseType == ApiReleaseType.PrivatePreview)
+                            {
+                                var isPrivateSpec = activeSpecPr.Contains(PRIVATE_SPECS_REPO, StringComparison.OrdinalIgnoreCase);
+                                var specRepoName = isPrivateSpec ? PRIVATE_SPECS_REPO : PUBLIC_SPECS_REPO;
+                                var specPr = await githubService.GetPullRequestAsync(REPO_OWNER, specRepoName, prNumber, ct);
+                                if (specPr?.Merged == true)
+                                {
+                                    await devOpsService.UpdateWorkItemAsync(releasePlan.WorkItemId, new Dictionary<string, string>
+                                        {
+                                            { "System.State", "Finished" }
+                                        }, ct);
+                                    logger.LogInformation("Private preview release plan {WorkItemId} marked as Finished because spec PR is merged", releasePlan.WorkItemId);
+                                }
+                            }
+                        }
+                    }
+                }
+
                 return new ReleasePlanResponse
                 {
-                    Message = $"Successfully updated release plan {releasePlan.WorkItemId}.",
+                    Message = $"Successfully updated release plan {releasePlan!.WorkItemId}.",
                     ReleasePlanDetails = releasePlan,
                     TypeSpecProject = specProject,
                     PackageType = isMgmt ? SdkType.Management : SdkType.Dataplane
@@ -737,6 +774,20 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             {
                 throw new Exception(error);
             }
+        }
+
+        /// <summary>
+        /// Extracts the pull request number from a spec pull request URL.
+        /// </summary>
+        private static int ParsePullRequestNumberFromUrl(string pullRequestUrl)
+        {
+            if (string.IsNullOrEmpty(pullRequestUrl))
+            {
+                return 0;
+            }
+
+            var match = Regex.Match(pullRequestUrl, @"/pull/(\d+)");
+            return match.Success ? int.Parse(match.Groups[1].Value) : 0;
         }
 
         private async Task ValidateCreateReleasePlanInputAsync(string typeSpecProjectPath, string serviceTreeId, string productTreeId, string specPullRequestUrl, string sdkReleaseType, ApiReleaseType apiReleaseType, CancellationToken ct)


### PR DESCRIPTION
Get API spec approval status using current API spec readiness and update it in ADO work item. API spec status was earlier based on API readiness milestone in the release planner, and this no longer exists. API spec status should now be based on API spec PR approval/merge.