### PR TITLE
Release plan dashboard to avoid dynamic loading of test release plans

### DIFF
--- a/tools/release-plan-dashboard/routes/api.js
+++ b/tools/release-plan-dashboard/routes/api.js
@@ -314,12 +314,20 @@ router.get("/api/release-plans", async (req, res) => {
       }
       // Match by Custom.ReleasePlanID or by work item ID (numeric fallback)
       const isNumeric = /^\d+$/.test(filterPlanId);
+      const environment = (
+        process.env.ENVIRONMENT || "production"
+      ).toLowerCase();
+      const tagCondition =
+        environment === "test"
+          ? "AND [System.Tags] CONTAINS 'Release Planner App Test'"
+          : "AND [System.Tags] NOT CONTAINS 'Release Planner App Test'";
       const condition = isNumeric
         ? `AND ([Custom.ReleasePlanID] = '${filterPlanId}' OR [System.Id] = ${filterPlanId})`
         : `AND [Custom.ReleasePlanID] = '${filterPlanId}'`;
       const wiqlQuery = `SELECT [System.Id] FROM WorkItems
         WHERE [System.TeamProject] = 'Release'
           AND [System.WorkItemType] = 'Release Plan'
+          ${tagCondition}
           ${condition}`;
       const ids = await runWiql(wiqlQuery);
       if (!ids.length)


### PR DESCRIPTION
PR to avoid on-demand loading of test release plan in production. 