### PR TITLE
Enhance changelog generation to distinguish between new methods and constructors

### DIFF
--- a/tools/js-sdk-release-tools/src/changelog/v2/ChangelogGenerator.ts
+++ b/tools/js-sdk-release-tools/src/changelog/v2/ChangelogGenerator.ts
@@ -344,17 +344,28 @@ export class ChangelogGenerator {
         const message = template(this.classRemovedTemplate, { className });
         this.addChangelogItem(ChangelogItemCategory.ClassRemoved, message);
       }
-      // class signature added
+      // class signature added: only report when it is truly a constructor declaration,
+      // not a regular method (which also uses DiffLocation.Signature)
       if (p.location === DiffLocation.Signature && this.hasReasons(p.reasons, DiffReasons.Added)) {
-        const constructorSignature = p.source!.node.getText();
-        const message = template(this.classConstructorAddedTemplate, { className, constructorSignature });
-        this.addChangelogItem(ChangelogItemCategory.ClassConstructorAdded, message);
+        if (p.source!.node.getKind() === SyntaxKind.Constructor) {
+          const constructorSignature = p.source!.node.getText();
+          const message = template(this.classConstructorAddedTemplate, { className, constructorSignature });
+          this.addChangelogItem(ChangelogItemCategory.ClassConstructorAdded, message);
+        } else {
+          // new method added to the class (e.g. newly introduced operation on the client)
+          const signatureName = p.source!.name;
+          const message = template(this.operationAddedTemplate, { interfaceName: className, signatureName });
+          this.addChangelogItem(ChangelogItemCategory.OperationAdded, message);
+        }
       }
-      // class type changed
+      // class type changed (constructor removed / signature incompatible)
       // NOTE: not detected in v1 except constructor and it's parameters
       if (p.location === DiffLocation.Signature && this.hasReasons(p.reasons, DiffReasons.Removed)) {
-        const message = template(this.classChangedTemplate, { className });
-        this.addChangelogItem(ChangelogItemCategory.ClassChanged, message);
+        if (p.target!.node.getKind() === SyntaxKind.Constructor) {
+          const message = template(this.classChangedTemplate, { className });
+          this.addChangelogItem(ChangelogItemCategory.ClassChanged, message);
+        }
+        // method removal on the class is handled as ClassPropertyRemoved via DiffLocation.Property
       }
       // class property removed
       if (p.location === DiffLocation.Property && this.hasReasons(p.reasons, DiffReasons.Removed)) {

--- a/tools/js-sdk-release-tools/src/test/changelog/changelogGenerator.test.ts
+++ b/tools/js-sdk-release-tools/src/test/changelog/changelogGenerator.test.ts
@@ -1213,6 +1213,63 @@ export class DataProductClient {
       expect(items[0]).toBe('Parameter version of class DataProductClient is now required');
     });
 
+    test('New method added to class should be reported as OperationAdded, not ClassConstructorAdded', async () => {
+      // Regression test: HLC->Modular migration adds new methods (e.g. getAdooAuthInfo) directly
+      // on the client class. These must NOT appear as "has a new constructor" messages.
+      const baselineApiView = `
+\`\`\`ts
+// @public
+export class DeveloperHubServiceClient {
+    constructor(credentials: TokenCredential, subscriptionId: string, options?: DeveloperHubServiceClientOptionalParams);
+    gitHubOAuth(location: string, options?: GitHubOAuthOptionalParams): Promise<GitHubOAuthInfoResponse>;
+}
+
+// @public
+export interface DeveloperHubServiceClientOptionalParams {
+    $host?: string;
+    apiVersion?: string;
+    endpoint?: string;
+}
+\`\`\`
+`;
+      const currentApiView = `
+\`\`\`ts
+// @public
+export class DeveloperHubServiceClient {
+    constructor(credential: TokenCredential, options?: DeveloperHubServiceClientOptionalParams);
+    constructor(credential: TokenCredential, subscriptionId: string, options?: DeveloperHubServiceClientOptionalParams);
+    gitHubOAuth(location: string, options?: GitHubOAuthOptionalParams): Promise<GitHubOAuthInfoResponse>;
+    getAdooAuthInfo(location: string, options?: GetAdooAuthInfoOptionalParams): Promise<AdooAuthInfoResponse>;
+}
+
+// @public
+export interface DeveloperHubServiceClientOptionalParams {
+    apiVersion?: string;
+    endpoint?: string;
+}
+\`\`\`
+`;
+      const changelogItems = await generateChangelogItems(
+        {
+          apiView: baselineApiView,
+          sdkType: SDKType.HighLevelClient,
+        },
+        {
+          apiView: currentApiView,
+          sdkType: SDKType.ModularClient,
+        }
+      );
+
+      // The new method must appear as a feature (OperationAdded), not a constructor
+      const constructorAddedItems = getItemsByCategory(changelogItems, ChangelogItemCategory.ClassConstructorAdded);
+      const operationAddedItems = getItemsByCategory(changelogItems, ChangelogItemCategory.OperationAdded);
+
+      // Must not produce any "has a new constructor" entry for getAdooAuthInfo
+      expect(constructorAddedItems.some((msg) => msg.includes('getAdooAuthInfo'))).toBe(false);
+      // Must produce an OperationAdded entry for getAdooAuthInfo
+      expect(operationAddedItems.some((msg) => msg.includes('getAdooAuthInfo'))).toBe(true);
+    });
+
     test('Type Alias Added', async () => {
       const baselineApiView = `
 \`\`\`ts


### PR DESCRIPTION
fixes https://github.com/Azure/azure-sdk-tools/issues/15982
This pull request improves the changelog generation logic to correctly distinguish between new constructors and new methods added to classes. It ensures that new methods are reported as feature additions rather than as constructor changes, and includes a regression test to cover this behavior.

Changelog logic improvements:

* Updated `ChangelogGenerator` to only report a "ClassConstructorAdded" changelog item when a true constructor is added, and to report new methods as "OperationAdded" instead. This prevents misclassifying new methods as new constructors.

Testing enhancements:

* Added a regression test in `changelogGenerator.test.ts` to verify that newly added methods on a class are reported as "OperationAdded" and not as "ClassConstructorAdded". This test specifically checks for the correct reporting of the `getAdooAuthInfo` method.