### PR TITLE
Remove @smw-ms from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,15 +58,15 @@
 #####################
 # Attestation
 #####################              
-/eng/pipelines/cpex-attestation.yml     @smw-ms @praveenkuttappan @maririos 
-/eng/scripts/Attest-CPEX-KPIs.ps1       @smw-ms @praveenkuttappan @maririos 
+/eng/pipelines/cpex-attestation.yml     @praveenkuttappan @maririos 
+/eng/scripts/Attest-CPEX-KPIs.ps1       @praveenkuttappan @maririos 
 
 #####################
 # Azure SDK Tools MCP
 #####################
 /eng/common/instructions/azsdk-tools/   @maririos @praveenkuttappan @MrJustinB 
 # PRLabel: %azsdk-cli
-/tools/ai-evals/azsdk-mcp/              @jeo02 @smw-ms @praveenkuttappan @maririos
+/tools/ai-evals/azsdk-mcp/              @jeo02 @praveenkuttappan @maririos
 # PRLabel: %azsdk-cli
 /tools/azsdk-cli/                       @azure/azsdk-cli
 # PRLabel: %azsdk-cli %design-discussion


### PR DESCRIPTION
Removing myself (`@smw-ms`) as a code owner since I'm moving to a new team. All affected paths still have other owners, so nothing is left unowned.