### PR TITLE
Fix MCP tools doc formatting

### DIFF
--- a/tools/azsdk-cli/docs/mcp-tools.md
+++ b/tools/azsdk-cli/docs/mcp-tools.md
@@ -2,13 +2,6 @@
 
 This document provides a comprehensive list of all MCP (Model Context Protocol) tools and commands supported by the Azure SDK MCP server version 0.6.18.
 
-<style>
-table td:nth-child(2),
-table th:nth-child(2) {
-  white-space: nowrap;
-}
-</style>
-
 ## Tools list
 
 | Name | Command | Description |
@@ -67,20 +60,7 @@ table th:nth-child(2) {
 | azsdk_run_typespec_validation | `azsdk tsp validate` | Run TypeSpec validation. Provide absolute path to TypeSpec project root as param. This tool runs TypeSpec validation and TypeSpec configuration validation. |
 | azsdk_typespec_check_project_in_public_repo | `azsdk tsp check-public-repo` | Check if TypeSpec project is in public spec repo. Provide absolute path to TypeSpec project root as param. |
 | azsdk_typespec_delegate_apiview_feedback | `azsdk tsp delegate-apiview-feedback` | Address, fix, resolve, or delegate APIView feedback/comments from an APIView URL. Use this tool instead of making code changes directly: it reads the reviewer comments, creates a GitHub issue with the feedback, and assigns GitHub Copilot to determine and implement the required TypeSpec client customizations. |
-| azsdk_typespec_generate_authoring_plan |  | Generate solutions or execution plans for TypeSpec‑related tasks, such as defining and updating TypeSpec‑based API specifications for an Azure service.
-This tool applies to all tasks involving **TypeSpec**:
-- Writing new TypeSpec definitions: service, api version, resource, models, operations
-- Editing or refactoring existing TypeSpec files, editing api version, service, resource, models, operations, or properties.
-- Versioning evolution:
-  - Make a **preview** API **stable (GA)**.
-  - Replace an existing **preview** with a **new preview**.
-  - Replace a **preview** with a **stable**
-  - Replacing a preview API with a stable API and a new preview API.
-  - **Add** a preview or **add** a stable API version.
-- Resolving TypeSpec-related issues
-Pass in a `request` to get an AI-generated response with references.
-Returns an answer with supporting references and documentation links
- |
+| azsdk_typespec_generate_authoring_plan |  | Generate solutions or execution plans for TypeSpec‑related tasks, such as defining and updating TypeSpec‑based API specifications for an Azure service.<br>This tool applies to all tasks involving **TypeSpec**:<br>- Writing new TypeSpec definitions: service, api version, resource, models, operations<br>- Editing or refactoring existing TypeSpec files, editing api version, service, resource, models, operations, or properties.<br>- Versioning evolution:<br>  - Make a **preview** API **stable (GA)**.<br>  - Replace an existing **preview** with a **new preview**.<br>  - Replace a **preview** with a **stable**<br>  - Replacing a preview API with a stable API and a new preview API.<br>  - **Add** a preview or **add** a stable API version.<br>- Resolving TypeSpec-related issues<br>Pass in a `request` to get an AI-generated response with references.<br>Returns an answer with supporting references and documentation links<br> |
 | azsdk_typespec_init_project | `azsdk tsp init` | Use this tool to initialize a new TypeSpec project. Returns the path to the created project. |
 | azsdk_update_api_spec_pull_request_in_release_plan | `azsdk release-plan update-spec-pr` | Update TypeSpec pull request URL in a release plan using work item id or release plan id. |
 | azsdk_update_language_exclusion_justification |  | Update language exclusion justification in release plan work item. This tool is called to update justification for excluded languages in the release plan. Optionally pass a language name to explicitly request exclusion for a specific language. |

--- a/tools/azsdk-cli/update-mcp-tools-docs.ps1
+++ b/tools/azsdk-cli/update-mcp-tools-docs.ps1
@@ -75,13 +75,6 @@ function Generate-McpToolsMarkdown {
 
 This document provides a comprehensive list of all MCP (Model Context Protocol) tools and commands supported by the Azure SDK MCP server version $version.
 
-<style>
-table td:nth-child(2),
-table th:nth-child(2) {
-  white-space: nowrap;
-}
-</style>
-
 ## Tools list
 
 | Name | Command | Description |
@@ -92,7 +85,10 @@ table th:nth-child(2) {
     foreach ($tool in $mcpTools) {
         $name = $tool.mcpToolName
         $command = [string]::IsNullOrEmpty($tool.commandLine) ? "" : "``$($tool.commandLine)``"
+        # Escape pipes so they don't break table columns, then collapse any line
+        # breaks into <br> so multi-line descriptions stay within a single table row.
         $description = $tool.description -replace '\|', '\|'
+        $description = $description -replace '\r\n', '<br>' -replace '\n', '<br>' -replace '\r', '<br>'
         
         $markdown += "| $name | $command | $description |`n"
     }


### PR DESCRIPTION
## Description

Fixes #14989

The auto-generated MCP tools documentation (mcp-tools.md) was rendering incorrectly on GitHub. This PR fixes the generator script so the output renders correctly.

### Problems

1. **Multi-line tool descriptions broke the table.** Markdown table rows must be a single physical line, but some tool descriptions (e.g. `azsdk_typespec_generate_authoring_plan`) contain embedded newlines and bullet lists. The generator wrote these verbatim, so everything after the first line spilled out of the table cell and corrupted rendering for that row and beyond.

2. **A `<style>` block was showing up as raw text.** GitHub sanitizes rendered Markdown against an HTML allowlist; `<style>` is not allowed, so GitHub stripped the tag and displayed its CSS content as plain text. The CSS (`white-space: nowrap` on the Command column) never actually applied on GitHub anyway.

### Changes

- In update-mcp-tools-docs.ps1:
  - Collapse embedded line breaks (`\r\n`, `\n`, `\r`) in tool descriptions into `<br>` so multi-line content stays within a single table row.
  - Remove the unsupported `<style>` block from the document template.
- Regenerated mcp-tools.md using the script so the committed doc reflects the fix.

### Validation

Ran the generator locally against `azsdk` v0.6.18 and confirmed:
- The `<style>` block is gone.
- The `azsdk_typespec_generate_authoring_plan` description renders on a single table row using `<br>` line breaks.