### PR TITLE
Expand eng/common syn to more related Azure repos

### DIFF
--- a/eng/pipelines/sync-eng-common.yml
+++ b/eng/pipelines/sync-eng-common.yml
@@ -19,7 +19,6 @@ parameters:
     - azure-sdk-for-net
     - azure-sdk-for-python
     - azure-sdk-for-rust
-    - azure-sdk-for-android
     - azure-rest-api-specs
     - autorest.csharp
     - autorest.go

--- a/eng/pipelines/sync-eng-common.yml
+++ b/eng/pipelines/sync-eng-common.yml
@@ -19,7 +19,14 @@ parameters:
     - azure-sdk-for-net
     - azure-sdk-for-python
     - azure-sdk-for-rust
+    - azure-sdk-for-android
     - azure-rest-api-specs
+    - autorest.csharp
+    - autorest.go
+    - autorest.swift
+    - awesome-azd
+    - azure-dev
+    - typespec-azure
 
 trigger: none
 


### PR DESCRIPTION
This pull request adds several new repositories to the `parameters` list in the `eng/pipelines/sync-eng-common.yml` file. These additions will allow the pipeline to include and synchronize more repositories as part of its operations.

Repository additions:

* Added `azure-sdk-for-android`, `autorest.csharp`, `autorest.go`, `autorest.swift`, `awesome-azd`, `azure-dev`, and `typespec-azure` to the pipeline parameters, expanding the set of repositories managed by the pipeline.