### PR TITLE
Authenticate GitHub requests in azsdk installer and upgrade check

### DIFF
--- a/eng/common/scripts/Helpers/AzSdkTool-Helpers.ps1
+++ b/eng/common/scripts/Helpers/AzSdkTool-Helpers.ps1
@@ -1,5 +1,20 @@
 Set-StrictMode -Version 4
 
+function Get-GitHubAuthHeaders {
+    # Returns Authorization headers when a GitHub token is present in the environment.
+    # Authenticated requests get a much higher rate limit (5000/hour) than the
+    # anonymous limit (60/hour per IP), which otherwise causes 403 failures.
+    $headers = @{}
+    foreach ($variable in @('GITHUB_TOKEN', 'GH_TOKEN')) {
+        $token = [Environment]::GetEnvironmentVariable($variable)
+        if ($token) {
+            $headers['Authorization'] = "Bearer $($token.Trim())"
+            break
+        }
+    }
+    return $headers
+}
+
 function Get-SystemArchitecture {
     $unameOutput = uname -m
     switch ($unameOutput) {
@@ -136,10 +151,14 @@ function Install-Standalone-Tool (
 
     $tag = "${Package}_${Version}"
 
+    # Authenticate GitHub requests when a token is available so the unauthenticated
+    # rate limit (60 requests/hour per IP) doesn't cause installs to fail with 403.
+    $githubHeaders = Get-GitHubAuthHeaders
+
     if (!$Version -or $Version -eq "*") {
         Write-Host "Attempting to find latest version for package '$Package'"
         $releasesUrl = "https://api.github.com/repos/$Repository/releases"
-        $releases = Invoke-RestMethod -Uri $releasesUrl
+        $releases = Invoke-RestMethod -Uri $releasesUrl -Headers $githubHeaders
         $found = $false
         foreach ($release in $releases) {
             if ($release.tag_name -like "$Package*") {
@@ -163,7 +182,7 @@ function Install-Standalone-Tool (
 
     if (isNewVersion $version $downloadFolder) {
         Write-Host "Installing '$Package' '$Version' to '$downloadFolder' from $downloadUrl"
-        Invoke-WebRequest -Uri $downloadUrl -OutFile $downloadLocation
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $downloadLocation -Headers $githubHeaders
 
         if ($downloadFile -like "*.zip") {
             Expand-Archive -Path $downloadLocation -DestinationPath $downloadFolder -Force

--- a/plugins/azure-sdk-tools/scripts/AzSdkTool-Helpers.ps1
+++ b/plugins/azure-sdk-tools/scripts/AzSdkTool-Helpers.ps1
@@ -1,5 +1,20 @@
 Set-StrictMode -Version 4
 
+function Get-GitHubAuthHeaders {
+    # Returns Authorization headers when a GitHub token is present in the environment.
+    # Authenticated requests get a much higher rate limit (5000/hour) than the
+    # anonymous limit (60/hour per IP), which otherwise causes 403 failures.
+    $headers = @{}
+    foreach ($variable in @('GITHUB_TOKEN', 'GH_TOKEN')) {
+        $token = [Environment]::GetEnvironmentVariable($variable)
+        if ($token) {
+            $headers['Authorization'] = "Bearer $($token.Trim())"
+            break
+        }
+    }
+    return $headers
+}
+
 function Get-SystemArchitecture {
     $unameOutput = uname -m
     switch ($unameOutput) {
@@ -136,10 +151,14 @@ function Install-Standalone-Tool (
 
     $tag = "${Package}_${Version}"
 
+    # Authenticate GitHub requests when a token is available so the unauthenticated
+    # rate limit (60 requests/hour per IP) doesn't cause installs to fail with 403.
+    $githubHeaders = Get-GitHubAuthHeaders
+
     if (!$Version -or $Version -eq "*") {
         Write-Host "Attempting to find latest version for package '$Package'"
         $releasesUrl = "https://api.github.com/repos/$Repository/releases"
-        $releases = Invoke-RestMethod -Uri $releasesUrl
+        $releases = Invoke-RestMethod -Uri $releasesUrl -Headers $githubHeaders
         $found = $false
         foreach ($release in $releases) {
             if ($release.tag_name -like "$Package*") {
@@ -163,7 +182,7 @@ function Install-Standalone-Tool (
 
     if (isNewVersion $version $downloadFolder) {
         Write-Host "Installing '$Package' '$Version' to '$downloadFolder' from $downloadUrl"
-        Invoke-WebRequest -Uri $downloadUrl -OutFile $downloadLocation
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $downloadLocation -Headers $githubHeaders
 
         if ($downloadFile -like "*.zip") {
             Expand-Archive -Path $downloadLocation -DestinationPath $downloadFolder -Force

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Upgrade/UpgradeService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Upgrade/UpgradeService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.IO.Compression;
+using System.Net.Http.Headers;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -43,7 +44,31 @@ public class UpgradeService(
         var client = httpClientFactory.CreateClient(nameof(UpgradeService));
         client.DefaultRequestHeaders.Add("User-Agent", SharedCommandNames.BaseExecutableName);
         client.DefaultRequestHeaders.Add("Accept", "application/vnd.github+json");
+
+        // Authenticate requests when a GitHub token is available so the unauthenticated
+        // rate limit (60 requests/hour per IP) doesn't cause upgrade checks to fail with 403.
+        var token = GetGitHubToken();
+        if (!string.IsNullOrEmpty(token))
+        {
+            client.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", token);
+        }
+
         return client;
+    }
+
+    private static string? GetGitHubToken()
+    {
+        foreach (var variable in new[] { "GITHUB_TOKEN", "GH_TOKEN" })
+        {
+            var value = Environment.GetEnvironmentVariable(variable);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value.Trim();
+            }
+        }
+
+        return null;
     }
 
     private static readonly JsonSerializerOptions jsonOptions = new()


### PR DESCRIPTION
## Problem

When opening Copilot in repos that wire up the azure-sdk MCP server (e.g. zure-sdk-for-net), the server can fail to start with:

> failed to connect to azure-sdk-mcp server

The root cause is **unauthenticated GitHub API rate limiting**. The MCP launch flow makes anonymous GitHub calls in two places:

1. **CLI upgrade check** `UpgradeService` — `GET https://api.github.com/repos/Azure/azure-sdk-tools/releases` to check/find the latest version.
2. **Installer script** `eng/common/scripts/Helpers/AzSdkTool-Helpers.ps1` — `Invoke-RestMethod`/`Invoke-WebRequest` to list releases and download the asset.

Anonymous GitHub requests are limited to **60/hour per IP**. Once exhausted, every call returns `403 (rate limit exceeded)` and the MCP server never starts. Repeated launches keep the quota drained, so the failure persists.

## Fix

Authenticate the GitHub requests when a token (`GITHUB_TOKEN` or `GH_TOKEN`) is available, raising the limit to **5000/hour**. When no token is present, requests stay anonymous so behavior is unchanged for existing users.

- `UpgradeService.createGitHubClient()` now adds a `Bearer` auth header when a token env var is set.
- `AzSdkTool-Helpers.ps1` adds a `Get-GitHubAuthHeaders` helper and passes the headers to both the releases lookup and the asset download. (The duplicate copy under `plugins/azure-sdk-tools/scripts/` is kept in sync.)

## Validation

- `dotnet build -c Release` succeeds.
- Verified the patched CLI's `azsdk upgrade --check` succeeds with a token set while the anonymous limit was exhausted (previously 403).
- Verified the MCP stdio server starts and returns a valid `initialize` response.
- PowerShell helper parses cleanly and `Get-GitHubAuthHeaders` returns the expected header with a token / empty without one.

--generated by Copilot
