### PR TITLE
Fix MCP server infinite respawn loop on upgrade/install failure

### DIFF
--- a/eng/common/mcp/azure-sdk-mcp.ps1
+++ b/eng/common/mcp/azure-sdk-mcp.ps1
@@ -106,27 +106,51 @@ $tempInstallDirectory = Join-Path $tmp "azsdk-install-$($guid)"
 
 # If already installed, use first class version mechanism
 $azsdkCmd = Get-Command -ErrorAction Ignore $packageName
+# Also check the default install directory (~/bin) in case it's not on PATH
+if (!$azsdkCmd -and !$InstallDirectory) {
+    $existingExe = Join-Path $toolInstallDirectory ($IsWindows ? "$packageName.exe" : $packageName)
+    if (Test-Path -PathType Leaf $existingExe) {
+        $azsdkCmd = Get-Command -ErrorAction Ignore $existingExe
+    }
+}
 if ($azsdkCmd -and !$InstallDirectory) {
-    $ErrorActionPreference = "Stop"
-    $upgrade = & $packageName upgrade --check --output json | out-string
-    if (!$LASTEXITCODE) {
-        $ErrorActionPreference = 'Ignore'
-        $localVersion = $upgrade | ConvertFrom-Json -AsHashtable
-        $ErrorActionPreference = 'Stop'
-        if ($localVersion -and $localVersion.old_version -and $localVersion.old_version -eq ($Version ? $Version : $localVersion.new_version)) {
-            log "Version up to date at $($localVersion.old_version)"
-            if ($Run) {
-                $proc = Start-Process -PassThru -WorkingDirectory $RunDirectory -FilePath $azsdkCmd.Path -ArgumentList 'mcp' -NoNewWindow -Wait
-                exit $proc.ExitCode
+    try {
+        $ErrorActionPreference = "Stop"
+        $upgrade = & $azsdkCmd.Path upgrade --check --output json | out-string
+        if (!$LASTEXITCODE) {
+            $ErrorActionPreference = 'Ignore'
+            $localVersion = $upgrade | ConvertFrom-Json -AsHashtable
+            $ErrorActionPreference = 'Stop'
+            if ($localVersion -and $localVersion.old_version -and $localVersion.old_version -eq ($Version ? $Version : $localVersion.new_version)) {
+                log "Version up to date at $($localVersion.old_version)"
+                if ($Run) {
+                    $proc = Start-Process -PassThru -WorkingDirectory $RunDirectory -FilePath $azsdkCmd.Path -ArgumentList 'mcp' -NoNewWindow -Wait
+                    exit $proc.ExitCode
+                }
+                exit 0
             }
-            exit 0
+            if ($localVersion) {
+                log "Version not up to date at " + $localVersion.old_version
+            } else {
+                log "Failed to parse version:"
+                log $upgrade
+            }
+        } elseif ($Run) {
+            # Upgrade check failed (e.g. network error, rate limit, timeout),
+            # but the binary already exists — fall back to running it as-is
+            # rather than attempting a fresh install that will likely also fail.
+            log -warn "Upgrade check failed, falling back to existing installation at '$($azsdkCmd.Path)'"
+            $proc = Start-Process -PassThru -WorkingDirectory $RunDirectory -FilePath $azsdkCmd.Path -ArgumentList 'mcp' -NoNewWindow -Wait
+            exit $proc.ExitCode
         }
-        if ($localVersion) {
-            log "Version not up to date at " + $localVersion.old_version
-        } else {
-            log "Failed to parse version:"
-            log $upgrade
+    }
+    catch {
+        if ($Run) {
+            log -warn "Upgrade check error: $($_.Exception.Message). Falling back to existing installation."
+            $proc = Start-Process -PassThru -WorkingDirectory $RunDirectory -FilePath $azsdkCmd.Path -ArgumentList 'mcp' -NoNewWindow -Wait
+            exit $proc.ExitCode
         }
+        throw
     }
 }
 
@@ -147,6 +171,14 @@ if ($mcpMode) {
     }
     catch {
         log -err $_
+        # If install failed but an existing binary is available, fall back to it
+        # instead of exiting (which causes the MCP client to respawn in a loop).
+        $existingExe = Join-Path $toolInstallDirectory ($IsWindows ? "$packageName.exe" : $packageName)
+        if ($Run -and (Test-Path -PathType Leaf $existingExe)) {
+            log -warn "Installation failed, falling back to existing installation at '$existingExe'"
+            $proc = Start-Process -PassThru -WorkingDirectory $RunDirectory -FilePath $existingExe -ArgumentList 'mcp' -NoNewWindow -Wait
+            exit $proc.ExitCode
+        }
         exit 1
     }
 }


### PR DESCRIPTION
## Problem

When the MCP server launch script (`azure-sdk-mcp.ps1`) fails to check for upgrades or download updates — due to GitHub API rate limiting (403), gateway timeouts (504), or network errors — it exits with a non-zero code. The MCP client (VS Code, Copilot CLI) immediately respawns the process, creating an infinite loop that can spawn hundreds of `pwsh` processes and choke the machine.

Additionally, when the binary is installed at `~/bin` (the default) but that directory isn't on `$PATH`, the script doesn't find the existing binary and always attempts a fresh install.

## Fix

**Fall back to the existing binary** when upgrade or install fails in `-Run` (MCP) mode:

1. **Check default install directory**: When `Get-Command` doesn't find `azsdk` on PATH, also check `~/bin` (the default install directory from `Get-CommonInstallDirectory`).

2. **Upgrade check failure fallback**: When `azsdk upgrade --check` returns a non-zero exit code (rate limit, network error) but the binary already exists, log a warning and run the existing binary instead of falling through to `Install-Standalone-Tool`.

3. **Install failure fallback**: When `Install-Standalone-Tool` throws in MCP mode, check if an existing binary is available at the known install directory and fall back to it instead of `exit 1`.

## Validation

- PowerShell script parses cleanly (no syntax errors)
- Non-MCP mode behavior is unchanged (still exits with error)
- When no binary exists at all, behavior is unchanged (`exit 1`)

Fixes #15973
Fixes #15953