### PR TITLE
Improve GEPA skill quality scores for all skills

### DIFF
--- a/.github/skills/azsdk-common-apiview-feedback-resolution/SKILL.md
+++ b/.github/skills/azsdk-common-apiview-feedback-resolution/SKILL.md
@@ -4,13 +4,25 @@ license: MIT
 metadata:
   version: "1.0.0"
   distribution: shared
-description: "Analyze and resolve APIView review feedback on Azure SDK PRs. **UTILITY SKILL**. USE FOR: APIView comments, API review feedback, SDK API surface changes. DO NOT USE FOR: general code review, non-APIView feedback. INVOKES: azure-sdk-mcp:azsdk_apiview_get_comments, azure-sdk-mcp:azsdk_customized_code_update."
+description: "Analyze and resolve APIView review feedback on Azure SDK PRs. **UTILITY SKILL**. USE FOR: APIView comments, API review feedback, SDK API surface changes. DO NOT USE FOR: general code review, non-APIView feedback. INVOKES: azure-sdk-mcp:azsdk_apiview_get_comments, azure-sdk-mcp:azsdk_customized_code_update, azure-sdk-mcp:azsdk_typespec_delegate_apiview_feedback, azure-sdk-mcp:azsdk_run_typespec_validation, azure-sdk-mcp:azsdk_package_generate_code."
 compatibility: "azure-sdk-mcp server, SDK pull request with APIView review link"
 ---
 
 # APIView Feedback Resolution
 
-**Prerequisites:** azure-sdk-mcp server required; no CLI fallback. Without MCP, this skill cannot retrieve APIView comments or apply TypeSpec changes. Connect the `azure-sdk-mcp` server before use.
+This skill analyzes and resolves APIView review feedback on Azure SDK pull requests by retrieving reviewer comments, categorizing them, and applying TypeSpec or customization updates that bring the SDK API surface into compliance before re-review.
+
+## Triggers
+
+USE FOR: APIView comments, API review feedback, SDK API surface changes
+WHEN: "resolve APIView comments", "address API review feedback", "update SDK API surface after APIView"
+DO NOT USE FOR: general code review, non-APIView feedback
+
+## Rules
+
+- Requires the `azure-sdk-mcp` server; there is no CLI fallback for retrieving APIView comments or applying TypeSpec changes.
+- Retrieve and categorize APIView comments before making changes so fixes map to reviewer intent.
+- Validate, regenerate, build, and test after applying fixes before requesting re-review.
 
 ## MCP Tools
 

--- a/.github/skills/azsdk-common-generate-sdk-locally/SKILL.md
+++ b/.github/skills/azsdk-common-generate-sdk-locally/SKILL.md
@@ -10,6 +10,20 @@ compatibility: "azure-sdk-mcp server, local azure-sdk-for-{language} clone, lang
 
 # Generate SDK Locally
 
+This skill generates, builds, and tests Azure SDKs locally from TypeSpec with automatic customization support, covering the end-to-end workflow for fixing generation issues, applying SDK-specific updates, and refreshing package metadata when needed.
+
+## Triggers
+
+USE FOR: generate, build, and test Azure SDKs locally from TypeSpec with automatic customization; update changelog; fix SDK build errors; fix breaking changes; resolve SDK generation errors; customize TypeSpec; rename SDK client or model; hide operation from SDK; fix analyzer errors; resolve customization drift; create subclient; update metadata; update version
+WHEN: "generate SDK locally", "build SDK", "run SDK tests", "update changelog", "fix SDK build errors", "fix breaking changes", "resolve SDK generation errors", "customize TypeSpec", "rename SDK client", "rename SDK model", "hide operation from SDK", "fix analyzer errors", "resolve customization drift", "create subclient", "update metadata", "update version"
+DO NOT USE FOR: publishing to package registries, CI pipeline configuration, API design review
+
+## Rules
+
+- Requires the `azure-sdk-mcp` server for the MCP workflow; without MCP, use `npm exec --prefix eng/common/tsp-client -- tsp-client` CLI.
+- Verify the target language repo and the correct TypeSpec configuration file before generation.
+- After generation or customization, run the check and test steps before updating metadata or finalizing changes.
+
 ## MCP Tools
 
 | Tool | Purpose |

--- a/.github/skills/azsdk-common-pipeline-troubleshooting/SKILL.md
+++ b/.github/skills/azsdk-common-pipeline-troubleshooting/SKILL.md
@@ -4,11 +4,25 @@ license: MIT
 metadata:
   version: "1.0.0"
   distribution: shared
-description: "Diagnose and resolve failures in Azure SDK CI and generation pipelines. **UTILITY SKILL**. USE FOR: \"pipeline failed\", \"build failure\", \"CI check failing\", \"SDK generation error\", \"reproduce pipeline locally\", \"debug SDK pipeline\". DO NOT USE FOR: local build issues without pipeline context, API design review, SDK publishing. INVOKES: azure-sdk-mcp:azsdk_analyze_pipeline, azure-sdk-mcp:azsdk_package_build_code, azure-sdk-mcp:azsdk_package_run_check."
+description: "Diagnose and resolve failures in Azure SDK CI and generation pipelines. **UTILITY SKILL**. USE FOR: \"pipeline failed\", \"build failure\", \"CI check failing\", \"SDK generation error\", \"reproduce pipeline locally\", \"debug SDK pipeline\". DO NOT USE FOR: local build issues without pipeline context, API design review, SDK publishing. INVOKES: azure-sdk-mcp:azsdk_analyze_pipeline, azure-sdk-mcp:azsdk_verify_setup, azure-sdk-mcp:azsdk_package_build_code, azure-sdk-mcp:azsdk_package_run_check, azure-sdk-mcp:azsdk_package_pack."
 compatibility: "azure-sdk-mcp server, Azure DevOps pipeline build ID"
 ---
 
 # Pipeline Troubleshooting
+
+This skill diagnoses and resolves failures in Azure SDK CI and generation pipelines by analyzing pipeline runs, reproducing issues locally, and applying targeted fixes for build, validation, or TypeSpec problems before verifying the rerun.
+
+## Triggers
+
+USE FOR: pipeline failed, build failure, CI check failing, SDK generation error, reproduce pipeline locally, debug SDK pipeline
+WHEN: "pipeline failed", "build failure", "CI check failing", "SDK generation error", "reproduce pipeline locally", "debug SDK pipeline"
+DO NOT USE FOR: local build issues without pipeline context, API design review, SDK publishing
+
+## Rules
+
+- Requires the `azure-sdk-mcp` server; without MCP, inspect logs in the Azure DevOps UI.
+- Start with the pipeline build ID and run pipeline analysis before attempting local reproduction.
+- Verify the local environment before running build or check commands to reproduce the failure.
 
 ## MCP Tools
 

--- a/.github/skills/azsdk-common-prepare-release-plan/SKILL.md
+++ b/.github/skills/azsdk-common-prepare-release-plan/SKILL.md
@@ -4,14 +4,26 @@ license: MIT
 metadata:
   version: "1.0.0"
   distribution: shared
-description: 'Create, get, update, abandon, and link SDK PRs to release plan work items for Azure SDK releases. **UTILITY SKILL**. USE FOR: "create release plan", "get release plan", "update release plan", "update API spec in release plan", "update SDK details in release plan", "abandon release plan", "link SDK PR to plan", "namespace approval", "check release plan status". DO NOT USE FOR: SDK code generation, pipeline troubleshooting, API review feedback. INVOKES: azure-sdk-mcp:azsdk_create_release_plan, azure-sdk-mcp:azsdk_get_release_plan, azure-sdk-mcp:azsdk_get_release_plan_for_spec_pr, azure-sdk-mcp:azsdk_update_release_plan, azure-sdk-mcp:azsdk_update_api_spec_pull_request_in_release_plan, azure-sdk-mcp:azsdk_update_sdk_details_in_release_plan, azure-sdk-mcp:azsdk_abandon_release_plan, azure-sdk-mcp:azsdk_link_sdk_pull_request_to_release_plan.'
+description: 'Create, get, update, abandon, and link SDK PRs to release plan work items for Azure SDK releases. **UTILITY SKILL**. USE FOR: "create release plan", "get release plan", "update release plan", "update API spec in release plan", "update SDK details in release plan", "abandon release plan", "link SDK PR to plan", "namespace approval", "check release plan status". DO NOT USE FOR: SDK code generation, pipeline troubleshooting, API review feedback. INVOKES: azure-sdk-mcp:azsdk_create_release_plan, azure-sdk-mcp:azsdk_get_release_plan, azure-sdk-mcp:azsdk_get_release_plan_for_spec_pr, azure-sdk-mcp:azsdk_update_release_plan, azure-sdk-mcp:azsdk_update_api_spec_pull_request_in_release_plan, azure-sdk-mcp:azsdk_update_sdk_details_in_release_plan, azure-sdk-mcp:azsdk_abandon_release_plan, azure-sdk-mcp:azsdk_link_sdk_pull_request_to_release_plan, azure-sdk-mcp:azsdk_link_namespace_approval_issue.'
 compatibility:
   requires: "azure-sdk-mcp server, API spec PR in Azure/azure-rest-api-specs"
 ---
 
 # Prepare Release Plan
 
-> **CRITICAL**: Do not display Azure DevOps work item URLs. Only provide Release Plan Link and Release Plan ID to the user.
+This skill creates, gets, updates, abandons, and links SDK PRs to release plan work items for Azure SDK releases, helping gather required release data, validate spec inputs, and link related approvals or SDK pull requests without exposing internal work item URLs.
+
+## Triggers
+
+USE FOR: create release plan, get release plan, update release plan, update API spec in release plan, update SDK details in release plan, abandon release plan, link SDK PR to plan, namespace approval, check release plan status
+WHEN: "create release plan", "get release plan", "update release plan", "abandon release plan", "link SDK PR to plan", "namespace approval", "check release plan status"
+DO NOT USE FOR: SDK code generation, pipeline troubleshooting, API review feedback
+
+## Rules
+
+- Do not display Azure DevOps work item URLs; only provide the Release Plan Link and ID.
+- Require an API spec PR link or a TypeSpec project path before creating or updating a plan.
+- Validate that the spec PR repository matches the requested API release type before creation.
 
 ## MCP Tools
 

--- a/.github/skills/azsdk-common-prepare-release-plan/SKILL.md
+++ b/.github/skills/azsdk-common-prepare-release-plan/SKILL.md
@@ -5,8 +5,7 @@ metadata:
   version: "1.0.0"
   distribution: shared
 description: 'Create, get, update, abandon, and link SDK PRs to release plan work items for Azure SDK releases. **UTILITY SKILL**. USE FOR: "create release plan", "get release plan", "update release plan", "update API spec in release plan", "update SDK details in release plan", "abandon release plan", "link SDK PR to plan", "namespace approval", "check release plan status". DO NOT USE FOR: SDK code generation, pipeline troubleshooting, API review feedback. INVOKES: azure-sdk-mcp:azsdk_create_release_plan, azure-sdk-mcp:azsdk_get_release_plan, azure-sdk-mcp:azsdk_get_release_plan_for_spec_pr, azure-sdk-mcp:azsdk_update_release_plan, azure-sdk-mcp:azsdk_update_api_spec_pull_request_in_release_plan, azure-sdk-mcp:azsdk_update_sdk_details_in_release_plan, azure-sdk-mcp:azsdk_abandon_release_plan, azure-sdk-mcp:azsdk_link_sdk_pull_request_to_release_plan, azure-sdk-mcp:azsdk_link_namespace_approval_issue.'
-compatibility:
-  requires: "azure-sdk-mcp server, API spec PR in Azure/azure-rest-api-specs"
+compatibility: "azure-sdk-mcp server, API spec PR in Azure/azure-rest-api-specs"
 ---
 
 # Prepare Release Plan

--- a/.github/skills/azsdk-common-sdk-release/SKILL.md
+++ b/.github/skills/azsdk-common-sdk-release/SKILL.md
@@ -10,6 +10,20 @@ compatibility: "azure-sdk-mcp server, SDK package merged on release branch. Supp
 
 # SDK Release
 
+This skill checks release readiness and triggers the Azure SDK release pipeline for packages that are already prepared, guiding the user through prerequisite validation, readiness review, and the final pipeline launch with required approval steps.
+
+## Triggers
+
+USE FOR: release SDK, trigger release, check release readiness, release pipeline, publish package, ship SDK
+WHEN: "release SDK", "trigger release", "check release readiness", "release pipeline", "publish package", "ship SDK"
+DO NOT USE FOR: SDK development, code generation, pipeline debugging, release plan creation
+
+## Rules
+
+- Requires the `azure-sdk-mcp` server; there is no CLI fallback for the release workflow.
+- Collect `packageName` and `language`, then run the readiness check before attempting to trigger release.
+- If release is triggered, show the pipeline link and remind the user that the release stage still requires approval.
+
 ## MCP Tools
 
 | Tool                              | Purpose                                                     |

--- a/.github/skills/azure-typespec-author/SKILL.md
+++ b/.github/skills/azure-typespec-author/SKILL.md
@@ -9,16 +9,13 @@ compatibility: "azure-sdk-mcp server with azsdk_typespec_generate_authoring_plan
 
 # Azure TypeSpec Author
 
-## MCP Tools
+This skill authors and modifies Azure TypeSpec (`.tsp`) API specifications for ARM resource-manager and data-plane services, covering versioning, resources, operations, models, decorators, constraints, and other schema changes that must follow the repository's TypeSpec authoring workflow.
 
-| Tool                                                   | Purpose                                                   |
-| ------------------------------------------------------ | --------------------------------------------------------- |
-| `azure-sdk-mcp:azsdk_typespec_generate_authoring_plan` | Generate grounded authoring plan (General Authoring only) |
-| `azure-sdk-mcp:azsdk_run_typespec_validation`          | Validate TypeSpec                                         |
+## Triggers
 
-**Prerequisite:** `azure-sdk-mcp` server must be running.
-
-# When to invoke the azure-typespec-author skill
+USE FOR: any TypeSpec/tsp change — api versions (add, bump, preview, stable, promote), resources, operations, models, properties, decorators, visibility, constraints, breaking changes, LRO, suppressions, operationId, spread model
+WHEN: "add TypeSpec API version", "modify .tsp file", "change TypeSpec decorators", "update TypeSpec models or operations", "author Azure TypeSpec"
+DO NOT USE FOR: SDK generation, releasing SDK packages, or single MCP tool calls
 
 The `azure-typespec-author` skill **must** be invoked immediately in all modes (including plan mode) for any task that involves creating and modifying TypeSpec (`.tsp`) files except for `client.tsp` under the specification directory in this repository. This includes but is not limited to:
 
@@ -28,7 +25,16 @@ The `azure-typespec-author` skill **must** be invoked immediately in all modes (
 - Defining or updating operationId, spread models, or extension resources
 - Converting Swagger to TypeSpec (post-conversion edits)
 
-## Constraints
+## MCP Tools
+
+| Tool                                                   | Purpose                                                   |
+| ------------------------------------------------------ | --------------------------------------------------------- |
+| `azure-sdk-mcp:azsdk_typespec_generate_authoring_plan` | Generate grounded authoring plan (General Authoring only) |
+| `azure-sdk-mcp:azsdk_run_typespec_validation`          | Validate TypeSpec                                         |
+
+**Prerequisite:** `azure-sdk-mcp` server must be running.
+
+## Rules
 
 - **Always follow the full workflow** — even seemingly simple changes (e.g. adding a default value) can require complex versioning decorator changes. Never skip steps.
 - **Mandatory for ALL `.tsp` edits** — even a single `?` change can be breaking.
@@ -37,7 +43,7 @@ The `azure-typespec-author` skill **must** be invoked immediately in all modes (
 - **Always cite references** — provide links that justify the approach.
 - **Follow the authoring plan exactly** — code changes in Step 4 MUST follow the authoring plan generated in Step 3. Do not deviate by referring to existing code patterns in the TypeSpec project; the authoring plan is the single source of truth for what to change.
 
-## Workflow
+## Steps
 
 > Analyze → Intake → Plan → Apply → Validate → Output reference links
 

--- a/.github/skills/markdown-token-optimizer/SKILL.md
+++ b/.github/skills/markdown-token-optimizer/SKILL.md
@@ -10,15 +10,15 @@ compatibility: "copilot-chat"
 
 # Markdown Token Optimizer
 
-Analyzes markdown files and suggests optimizations to reduce token consumption while maintaining clarity.
+This skill analyzes markdown files for token efficiency and reduces context-window bloat by identifying verbose patterns, duplicated content, and oversized sections, then suggesting concise revisions that preserve meaning while making documentation easier for AI systems to consume.
 
-## When to Use
+## Triggers
 
-- Optimize markdown files for token efficiency
-- Reduce SKILL.md file size or check for bloat
-- Make documentation more concise for AI consumption
+USE FOR: analyze markdown files for token efficiency and reduce context-window bloat
+WHEN: "optimize markdown", "reduce tokens", "token count", "token bloat", "too many tokens", "make concise", "shrink file", "file too large", "optimize for AI", "token efficiency", "verbose markdown", "reduce file size"
+DO NOT USE FOR: code optimization, general file editing, non-markdown files
 
-## Workflow
+## Steps
 
 1. **Count** - Calculate tokens (~4 chars = 1 token), report totals
 2. **Scan** - Find patterns: emojis, verbosity, duplication, large blocks

--- a/.github/skills/skill-authoring/SKILL.md
+++ b/.github/skills/skill-authoring/SKILL.md
@@ -10,7 +10,15 @@ compatibility: "copilot-chat"
 
 # Skill Authoring Guide
 
-## Constraints
+This skill helps write Agent Skills that comply with the agentskills.io specification by defining valid frontmatter, structure, and routing patterns, while guiding authors toward compliant `SKILL.md` files, supporting references, and local validation with the waza CLI.
+
+## Triggers
+
+USE FOR: write Agent Skills that comply with the agentskills.io specification; skill template; skill structure; review skill; skill PR; skill compliance; SKILL.md format; skill frontmatter; skill best practices
+WHEN: "create a skill", "new skill", "write a skill", "skill template", "skill structure", "review skill", "skill PR", "skill compliance", "SKILL.md format", "skill frontmatter", "skill best practices"
+DO NOT USE FOR: improving existing skills (use sensei), general documentation
+
+## Rules
 
 - `name`: 1-64 chars, lowercase + hyphens, match directory
 - `description`: inline double-quoted, ≤60 words, ≤1024 chars
@@ -36,7 +44,7 @@ Metadata loads at startup. SKILL.md on activation. References load when linked v
 
 **CLI fallback:** Primary mode is CLI-based. No MCP servers required.
 
-## Quick Start
+## Steps
 
 1. Create skill directory with `SKILL.md`
 2. Add frontmatter: `name`, `description`, `license`


### PR DESCRIPTION
## What
Improve GEPA content quality scores for all 8 scoreable skills from ~0.30-0.48 to 1.00.

### Changes
- Add description paragraphs, \## Triggers\, and \## Rules\ sections to all skills
- Sync frontmatter \INVOKES\ with MCP Tools tables (apiview-feedback-resolution, pipeline-troubleshooting, prepare-release-plan)
- Fix tsp-client CLI reference to use \
pm exec --prefix\ pattern

### Skills updated
- azsdk-common-apiview-feedback-resolution
- azsdk-common-generate-sdk-locally
- azsdk-common-pipeline-troubleshooting
- azsdk-common-prepare-release-plan
- azsdk-common-sdk-release
- azure-typespec-author
- markdown-token-optimizer
- skill-authoring

Relates to #15871
Supersedes #15956 (had CI issues due to merge conflicts)