### PR TITLE
Split skill changes for prepare-release-plan into separate PR (lint fix + canonical convergence + Release Plan ID docs)

### DIFF
--- a/.github/skills/azsdk-common-prepare-release-plan/SKILL.md
+++ b/.github/skills/azsdk-common-prepare-release-plan/SKILL.md
@@ -23,6 +23,7 @@ DO NOT USE FOR: SDK code generation, pipeline troubleshooting, API review feedba
 - Do not display Azure DevOps work item URLs; only provide the Release Plan Link and ID.
 - Require an API spec PR link or a TypeSpec project path before creating or updating a plan.
 - Validate that the spec PR repository matches the requested API release type before creation.
+- Release plan tools accept **either** a Release Plan ID or an Azure DevOps work item ID — pass whichever the user provides. Each tool resolves the value automatically (trying it as a Release Plan ID first, then as a work item ID), so you do not need to call `azure-sdk-mcp:azsdk_get_release_plan` first just to translate one ID into the other.
 
 ## MCP Tools
 
@@ -116,10 +117,10 @@ DO NOT USE FOR: SDK code generation, pipeline troubleshooting, API review feedba
 
 **Steps**:
 
-1. **Identify Plan** — Get the release plan work item ID from the user.
+1. **Identify Plan** — Get the Release Plan ID or work item ID from the user (either is accepted).
 2. **Identify TypeSpec Project** — Get or confirm the TypeSpec project path.
 3. **Update** — Run `azure-sdk-mcp:azsdk_update_sdk_details_in_release_plan` with:
-   - `releasePlanWorkItemId` (required)
+   - `workItemId` (required — accepts either the Release Plan ID or the work item ID)
    - `typeSpecProjectPath` (required)
 
 **Tool**: `azure-sdk-mcp:azsdk_update_sdk_details_in_release_plan`
@@ -147,12 +148,12 @@ DO NOT USE FOR: SDK code generation, pipeline troubleshooting, API review feedba
 
 **Steps**:
 
-1. **Identify Plan** — Get the work item ID or release plan ID.
+1. **Identify Plan** — Get the Release Plan ID or work item ID from the user (either is accepted).
 2. **Collect PR Info** — Get the SDK pull request URL and language from the user.
 3. **Link** — Run `azure-sdk-mcp:azsdk_link_sdk_pull_request_to_release_plan` with:
    - `pullRequestUrl` (required)
    - `language` (required — e.g., ".NET", "Java", "JavaScript", "Python", "Go")
-   - `workItemId` or `releasePlanId`
+   - `workItemId` or `releasePlanId` (either accepts the Release Plan ID or the work item ID)
 4. **Repeat** — If multiple SDK PRs exist for different languages, repeat for each.
 
 **Tool**: `azure-sdk-mcp:azsdk_link_sdk_pull_request_to_release_plan`
@@ -174,5 +175,5 @@ DO NOT USE FOR: SDK code generation, pipeline troubleshooting, API review feedba
 
 - Requires `azure-sdk-mcp` server; no CLI fallback — prompt user to configure MCP if unavailable.
 - If creation fails, verify spec PR URL and Service Tree IDs.
-- If update fails, ensure the work item ID or release plan ID is correct and the plan is not already abandoned.
+- If update fails, ensure the Release Plan ID or work item ID is correct and the plan is not already abandoned.
 - If linking fails, verify the SDK PR URL is valid and the language matches a supported value.

--- a/.github/skills/azsdk-common-prepare-release-plan/evals/eval.yaml
+++ b/.github/skills/azsdk-common-prepare-release-plan/evals/eval.yaml
@@ -39,6 +39,18 @@ stimuli:
         config:
           substring: "release plan"
 
+  # Regression for issue #15988: when the user provides a Release Plan ID, the
+  # agent can pass it directly to azsdk_update_sdk_details_in_release_plan. The
+  # tool resolves either a Release Plan ID or a work item ID, so the agent should
+  # NOT need a separate azsdk_get_release_plan call just to translate the ID.
+  - name: release-plan-resolve-work-item-id-001
+    prompt: "Update the SDK details in release plan 50001 for the TypeSpec project specification/contosowidgetmanager/Contoso.WidgetManager."
+    graders:
+      - type: tool-calls
+        config:
+          required:
+            - name: azure-sdk-mcp-azsdk_update_sdk_details_in_release_plan
+
   - name: release-plan-negative-001
     prompt: "Release the azure-mgmt-compute Python package to PyPI now."
     graders:

--- a/.github/skills/azsdk-common-prepare-release-plan/references/release-plan-details.md
+++ b/.github/skills/azsdk-common-prepare-release-plan/references/release-plan-details.md
@@ -2,6 +2,19 @@
 
 > **CRITICAL**: Do not mention or display Azure DevOps work item links/URLs. Only provide Release Plan Link and Release Plan ID to the user. All manual updates must be made through the Release Planner Tool (https://aka.ms/sdk-release-planner).
 
+## Release Plan ID vs Work Item ID
+
+A release plan has two distinct identifiers:
+
+- **Release Plan ID**: the value users typically refer to (e.g. in a prompt), shown in the Release Planner.
+- **Work Item ID**: the Azure DevOps work item backing the release plan.
+
+The release plan tools (update release plan, update SDK details, run SDK
+generation, link SDK PR) accept **either** value — pass whichever the user gives
+you. Each tool resolves the supplied number automatically, trying it as a
+Release Plan ID first and then as a work item ID, so you do **not** need to run
+`azsdk_get_release_plan` first just to translate one ID into the other.
+
 ## Required Information
 
 Collect these details (do not use temporary values):
@@ -25,7 +38,7 @@ If user provides an invalid combination, inform them of the correct pairing.
 
 To update SDK details in the release plan:
 
-- Run `azsdk_update_sdk_details_in_release_plan` with the release plan work item ID and TypeSpec project path
+- Run `azsdk_update_sdk_details_in_release_plan` with the `workItemId` (either the Release Plan ID or the work item ID is accepted) and TypeSpec project path.
 
 ## Namespace Approval (Management Plane Only)
 
@@ -40,4 +53,4 @@ For first release of management plane SDK:
 If SDK PRs exist:
 
 1. Ensure GitHub CLI authentication (`gh auth login`)
-2. Run `azsdk_link_sdk_pull_request_to_release_plan` for each PR
+2. Run `azsdk_link_sdk_pull_request_to_release_plan` for each PR, passing the Release Plan ID or work item ID as `workItemId` (or as `releasePlanId`) — either value is accepted.

--- a/plugins/azure-sdk-tools/skills/prepare-release-plan/SKILL.md
+++ b/plugins/azure-sdk-tools/skills/prepare-release-plan/SKILL.md
@@ -4,14 +4,26 @@ license: MIT
 metadata:
   version: "1.0.0"
   distribution: shared
-description: 'Create, get, update, abandon, and link SDK PRs to release plan work items for Azure SDK releases. **UTILITY SKILL**. USE FOR: "create release plan", "get release plan", "update release plan", "update API spec in release plan", "update SDK details in release plan", "abandon release plan", "link SDK PR to plan", "namespace approval", "check release plan status". DO NOT USE FOR: SDK code generation, pipeline troubleshooting, API review feedback. INVOKES: azure-sdk-mcp:azsdk_create_release_plan, azure-sdk-mcp:azsdk_get_release_plan, azure-sdk-mcp:azsdk_get_release_plan_for_spec_pr, azure-sdk-mcp:azsdk_update_release_plan, azure-sdk-mcp:azsdk_update_api_spec_pull_request_in_release_plan, azure-sdk-mcp:azsdk_update_sdk_details_in_release_plan, azure-sdk-mcp:azsdk_abandon_release_plan, azure-sdk-mcp:azsdk_link_sdk_pull_request_to_release_plan.'
-compatibility:
-  requires: "azure-sdk-mcp server, API spec PR in Azure/azure-rest-api-specs"
+description: 'Create, get, update, abandon, and link SDK PRs to release plan work items for Azure SDK releases. **UTILITY SKILL**. USE FOR: "create release plan", "get release plan", "update release plan", "update API spec in release plan", "update SDK details in release plan", "abandon release plan", "link SDK PR to plan", "namespace approval", "check release plan status". DO NOT USE FOR: SDK code generation, pipeline troubleshooting, API review feedback. INVOKES: azure-sdk-mcp:azsdk_create_release_plan, azure-sdk-mcp:azsdk_get_release_plan, azure-sdk-mcp:azsdk_get_release_plan_for_spec_pr, azure-sdk-mcp:azsdk_update_release_plan, azure-sdk-mcp:azsdk_update_api_spec_pull_request_in_release_plan, azure-sdk-mcp:azsdk_update_sdk_details_in_release_plan, azure-sdk-mcp:azsdk_abandon_release_plan, azure-sdk-mcp:azsdk_link_sdk_pull_request_to_release_plan, azure-sdk-mcp:azsdk_link_namespace_approval_issue.'
+compatibility: "azure-sdk-mcp server, API spec PR in Azure/azure-rest-api-specs"
 ---
 
 # Prepare Release Plan
 
-> **CRITICAL**: Do not display Azure DevOps work item URLs. Only provide Release Plan Link and Release Plan ID to the user.
+This skill creates, gets, updates, abandons, and links SDK PRs to release plan work items for Azure SDK releases, helping gather required release data, validate spec inputs, and link related approvals or SDK pull requests without exposing internal work item URLs.
+
+## Triggers
+
+USE FOR: create release plan, get release plan, update release plan, update API spec in release plan, update SDK details in release plan, abandon release plan, link SDK PR to plan, namespace approval, check release plan status
+WHEN: "create release plan", "get release plan", "update release plan", "abandon release plan", "link SDK PR to plan", "namespace approval", "check release plan status"
+DO NOT USE FOR: SDK code generation, pipeline troubleshooting, API review feedback
+
+## Rules
+
+- Do not display Azure DevOps work item URLs; only provide the Release Plan Link and ID.
+- Require an API spec PR link or a TypeSpec project path before creating or updating a plan.
+- Validate that the spec PR repository matches the requested API release type before creation.
+- Release plan tools accept **either** a Release Plan ID or an Azure DevOps work item ID — pass whichever the user provides. Each tool resolves the value automatically (trying it as a Release Plan ID first, then as a work item ID), so you do not need to call `azure-sdk-mcp:azsdk_get_release_plan` first just to translate one ID into the other.
 
 ## MCP Tools
 
@@ -105,10 +117,10 @@ compatibility:
 
 **Steps**:
 
-1. **Identify Plan** — Get the release plan work item ID from the user.
+1. **Identify Plan** — Get the Release Plan ID or work item ID from the user (either is accepted).
 2. **Identify TypeSpec Project** — Get or confirm the TypeSpec project path.
 3. **Update** — Run `azure-sdk-mcp:azsdk_update_sdk_details_in_release_plan` with:
-   - `releasePlanWorkItemId` (required)
+   - `workItemId` (required — accepts either the Release Plan ID or the work item ID)
    - `typeSpecProjectPath` (required)
 
 **Tool**: `azure-sdk-mcp:azsdk_update_sdk_details_in_release_plan`
@@ -136,12 +148,12 @@ compatibility:
 
 **Steps**:
 
-1. **Identify Plan** — Get the work item ID or release plan ID.
+1. **Identify Plan** — Get the Release Plan ID or work item ID from the user (either is accepted).
 2. **Collect PR Info** — Get the SDK pull request URL and language from the user.
 3. **Link** — Run `azure-sdk-mcp:azsdk_link_sdk_pull_request_to_release_plan` with:
    - `pullRequestUrl` (required)
    - `language` (required — e.g., ".NET", "Java", "JavaScript", "Python", "Go")
-   - `workItemId` or `releasePlanId`
+   - `workItemId` or `releasePlanId` (either accepts the Release Plan ID or the work item ID)
 4. **Repeat** — If multiple SDK PRs exist for different languages, repeat for each.
 
 **Tool**: `azure-sdk-mcp:azsdk_link_sdk_pull_request_to_release_plan`
@@ -163,5 +175,5 @@ compatibility:
 
 - Requires `azure-sdk-mcp` server; no CLI fallback — prompt user to configure MCP if unavailable.
 - If creation fails, verify spec PR URL and Service Tree IDs.
-- If update fails, ensure the work item ID or release plan ID is correct and the plan is not already abandoned.
+- If update fails, ensure the Release Plan ID or work item ID is correct and the plan is not already abandoned.
 - If linking fails, verify the SDK PR URL is valid and the language matches a supported value.


### PR DESCRIPTION
## Summary

Skill-only changes for the `azsdk-common-prepare-release-plan` skill, split out from tool PR #15998 so the tool PR can merge/release independently and the skill changes can be synced to the language repos.

### What changed
1. **Lint fix** — `compatibility` frontmatter changed from an object to a string (required by the agentskills.io spec; the object form was failing the Vally `compatibility-type` check and blocking the Skill Compliance Check).
2. **Canonical convergence** — body brought in line with the canonical version already live in azure-sdk / -net / -python / -java / -js (adds the `Triggers` / `Rules` sections and the `azsdk_link_namespace_approval_issue` MCP tool).
3. **Release Plan ID / work item ID feature docs** (moved from #15998) — documents that the release plan tools accept either a Release Plan ID or an Azure DevOps work item ID and resolve it automatically. Updates `SKILL.md`, `references/release-plan-details.md`, and adds a regression eval (`release-plan-resolve-work-item-id-001`).

Both the `.github/skills/` copy (synced to other repos) and the `plugins/azure-sdk-tools/skills/` `SKILL.md` mirror are kept in sync.

### Validation
- `vally lint .` → 10/10 skills pass.

### Note on the `tools - sync-skills` check
The ADO sync check may show red due to pre-existing cross-repo drift (`git am -3` cannot apply onto targets that already hold a different version). This is an engsys-owned reconcile concern, not a defect in this PR. The gating check for this PR is the **Skill Compliance Check (Vally lint)**, which passes.