### PR TITLE
Proxy Link Verification to avoid network isolation flag

### DIFF
--- a/eng/common/pipelines/templates/steps/verify-links.yml
+++ b/eng/common/pipelines/templates/steps/verify-links.yml
@@ -1,5 +1,6 @@
 parameters:
   Directory: 'not-specified'
+  AppRegistrationResource: 'api://2d83e5a3-929f-49d5-9835-516849ceb9f4'
   IgnoreLinksFile: '$(Build.SourcesDirectory)/eng/ignore-links.txt'
   WorkingDirectory: '$(System.DefaultWorkingDirectory)'
   ScriptDirectory: 'eng/common/scripts'
@@ -15,9 +16,28 @@ steps:
   - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
     parameters:
       Condition: ${{ parameters.Condition }}
+
+  - task: AzureCLI@2
+    displayName: Get app registration access token
+    inputs:
+      azureSubscription: "Azure SDK Engineering System"
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript: |
+        $resource = "${{ parameters.AppRegistrationResource }}"
+        $scope = "$resource/.default"
+        $token = az account get-access-token --scope $scope --query "accessToken" --output tsv
+        if ([string]::IsNullOrWhiteSpace($token)) {
+          throw "Failed to acquire app registration access token."
+        }
+
+        Write-Host "##vso[task.setvariable variable=APP_REGISTRATION_TOKEN;issecret=true]$token"
+
   - task: PowerShell@2
     displayName: Link verification check
     condition: ${{ parameters.Condition }}
+    env:
+      APP_REGISTRATION_TOKEN: $(APP_REGISTRATION_TOKEN)
     inputs:
       pwsh: true
       workingDirectory: '${{ parameters.WorkingDirectory }}/${{ parameters.Directory }}'

--- a/eng/common/scripts/Verify-Links.ps1
+++ b/eng/common/scripts/Verify-Links.ps1
@@ -95,6 +95,54 @@ Set-StrictMode -Version 3.0
 
 $ProgressPreference = "SilentlyContinue"; # Disable invoke-webrequest progress dialog
 
+$ProxyBaseUrl = "https://net-iso-proxy-b5b9dgb3h5h4fqf8.westus2-01.azurewebsites.net/api/proxy"
+
+function Invoke-ProxiedWebRequest {
+  param(
+    [Parameter(Mandatory = $true)]
+    [System.Uri]$Uri,
+    [ValidateSet('GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE')]
+    [string]$Method = 'GET',
+    [string]$UserAgent = $script:userAgent,
+    [int]$TimeoutSec = $script:requestTimeoutSec,
+    [switch]$SkipHttpErrorCheck,
+    [int]$MaximumRetryCount = 0,
+    [switch]$MaximumRedirection
+  )
+
+  $token = [Environment]::GetEnvironmentVariable('APP_REGISTRATION_TOKEN', 'Process')
+  if ([string]::IsNullOrWhiteSpace($token)) {
+    throw 'APP_REGISTRATION_TOKEN environment variable is not set.'
+  }
+
+  $proxyUri = [System.Uri]::new("${ProxyBaseUrl}?url=" + [System.Uri]::EscapeDataString($Uri.ToString()))
+  $headers = @{ Authorization = "Bearer $token" }
+  if ($UserAgent) {
+    $headers['User-Agent'] = $UserAgent
+  }
+
+  $parameters = @{
+    Uri = $proxyUri
+    Method = if ($Method -eq 'HEAD') { 'GET' } else { $Method }
+    Headers = $headers
+    TimeoutSec = $TimeoutSec
+  }
+
+  if ($SkipHttpErrorCheck) {
+    $parameters['SkipHttpErrorCheck'] = $true
+  }
+
+  if ($MaximumRetryCount -gt 0) {
+    $parameters['MaximumRetryCount'] = $MaximumRetryCount
+  }
+
+  if ($MaximumRedirection.IsPresent) {
+    $parameters['MaximumRedirection'] = 0
+  }
+
+  return Invoke-WebRequest @parameters
+}
+
 function ProcessLink([System.Uri]$linkUri) {
   # To help improve performance and rate limiting issues with github links we try to resolve them based on a local clone if one exists.
   if (($localGithubClonedRoot -or $localBuildRepoName) -and $linkUri -match '^https://github.com/(?<org>Azure)/(?<repo>[^/]+)/(?:blob|tree)/(main|.*_[^/]+|.*/v[^/]+)/(?<path>.*)$') {
@@ -136,7 +184,7 @@ function ProcessLink([System.Uri]$linkUri) {
 
 function ProcessRedirectLink([System.Uri]$linkUri, [int[]]$invalidStatusCodes) {
   # ProcessRedirectLink checks the status code of the initial response.
-  $response = Invoke-WebRequest -Uri $linkUri -Method GET -UserAgent $userAgent -TimeoutSec $requestTimeoutSec -MaximumRedirection 0 -SkipHttpErrorCheck -ErrorAction SilentlyContinue
+  $response = Invoke-ProxiedWebRequest -Uri $linkUri -Method GET -UserAgent $userAgent -TimeoutSec $requestTimeoutSec -MaximumRedirection -SkipHttpErrorCheck -ErrorAction SilentlyContinue
   $statusCode = $response.StatusCode
 
   if ($statusCode -in $invalidStatusCodes) {
@@ -161,7 +209,7 @@ function ProcessCratesIoLink([System.Uri]$linkUri, $path) {
   $apiUri = "https://crates.io/api/v1/$path"
 
   # Invoke-WebRequest will throw an exception for invalid status codes. They are handled in CheckLink
-  Invoke-WebRequest -Uri $apiUri -Method GET -UserAgent $userAgent -TimeoutSec $requestTimeoutSec | Out-Null
+  Invoke-ProxiedWebRequest -Uri $apiUri -Method GET -UserAgent $userAgent -TimeoutSec $requestTimeoutSec | Out-Null
   
   return $true
 }
@@ -169,7 +217,7 @@ function ProcessCratesIoLink([System.Uri]$linkUri, $path) {
 function ProcessNpmLink([System.Uri]$linkUri) {
   # npmjs.com started using Cloudflare which returns 403 and we need to instead check the registry api for existence checks
   # https://github.com/orgs/community/discussions/174098#discussioncomment-14461226
-  
+
   # Handle versioned URLs: https://www.npmjs.com/package/@azure/ai-agents/v/1.1.0 -> https://registry.npmjs.org/@azure/ai-agents/1.1.0
   # Handle non-versioned URLs: https://www.npmjs.com/package/@azure/ai-agents -> https://registry.npmjs.org/@azure/ai-agents
   # The regex captures the package name (which may contain a slash for scoped packages) and optionally the version.
@@ -195,14 +243,14 @@ function ProcessStandardLink([System.Uri]$linkUri) {
   $headRequestSucceeded = $true
   try {
     # Attempt HEAD request first
-    $response = Invoke-WebRequest -Uri $linkUri -Method HEAD -UserAgent $userAgent -TimeoutSec $requestTimeoutSec
+    $response = Invoke-ProxiedWebRequest -Uri $linkUri -Method HEAD -UserAgent $userAgent -TimeoutSec $requestTimeoutSec
   }
   catch {
     $headRequestSucceeded = $false
   }
   if (!$headRequestSucceeded) {
     # Attempt a GET request if the HEAD request failed.
-    $response = Invoke-WebRequest -Uri $linkUri -Method GET -UserAgent $userAgent -TimeoutSec $requestTimeoutSec
+    $response = Invoke-ProxiedWebRequest -Uri $linkUri -Method GET -UserAgent $userAgent -TimeoutSec $requestTimeoutSec
   }
   $statusCode = $response.StatusCode
   if ($statusCode -ne 200) {
@@ -467,7 +515,7 @@ function GetLinks([System.Uri]$pageUri)
 {
   if ($pageUri.Scheme.StartsWith("http")) {
     try {
-      $response = Invoke-WebRequest -Uri $pageUri -UserAgent $userAgent -TimeoutSec $requestTimeoutSec -MaximumRetryCount 3
+      $response = Invoke-ProxiedWebRequest -Uri $pageUri -Method GET -UserAgent $userAgent -TimeoutSec $requestTimeoutSec -MaximumRetryCount 3
       $content = $response.Content
 
       if ($pageUri.ToString().EndsWith(".md")) {
@@ -560,7 +608,7 @@ if ($inputCacheFile)
   $cacheContent = ""
   if ($inputCacheFile.StartsWith("http")) {
     try {
-      $response = Invoke-WebRequest -Uri $inputCacheFile -TimeoutSec $requestTimeoutSec -MaximumRetryCount 3
+      $response = Invoke-ProxiedWebRequest -Uri $inputCacheFile -Method GET -TimeoutSec $requestTimeoutSec -MaximumRetryCount 3
       $cacheContent = $response.Content
     }
     catch {


### PR DESCRIPTION
This pull request enhances the link verification process by introducing a proxy-based approach for all outgoing web requests in the verification scripts. The changes ensure that all HTTP requests are routed through a secure proxy and authenticated using an Azure app registration access token. This improves security, enables centralized traffic control, and helps avoid rate limiting issues. The most important changes are as follows:

**Pipeline and Authentication Updates:**

* Added a new pipeline step in `verify-links.yml` to acquire an Azure app registration access token and set it as a secret environment variable (`APP_REGISTRATION_TOKEN`) for use during link verification. [[1]](diffhunk://#diff-6833a0ff61d734167e7708dba8180c69a5b5f918be83672a79e8db9a678f1350R3) [[2]](diffhunk://#diff-6833a0ff61d734167e7708dba8180c69a5b5f918be83672a79e8db9a678f1350R19-R40)

**Proxy Integration in Link Verification Script:**

* Introduced the `Invoke-ProxiedWebRequest` function in `Verify-Links.ps1` to wrap all HTTP requests with proxy routing and bearer token authentication using the acquired access token.
* Replaced all direct calls to `Invoke-WebRequest` in the link processing functions (`ProcessRedirectLink`, `ProcessCratesIoLink`, `ProcessStandardLink`, `GetLinks`, and cache file retrieval) with `Invoke-ProxiedWebRequest`, ensuring all requests are proxied and authenticated. [[1]](diffhunk://#diff-1dd2b5d15ee69646f32e1481f170e8090f921037353b16d0122b483099eeadc5L139-R187) [[2]](diffhunk://#diff-1dd2b5d15ee69646f32e1481f170e8090f921037353b16d0122b483099eeadc5L164-R212) [[3]](diffhunk://#diff-1dd2b5d15ee69646f32e1481f170e8090f921037353b16d0122b483099eeadc5L198-R253) [[4]](diffhunk://#diff-1dd2b5d15ee69646f32e1481f170e8090f921037353b16d0122b483099eeadc5L470-R518) [[5]](diffhunk://#diff-1dd2b5d15ee69646f32e1481f170e8090f921037353b16d0122b483099eeadc5L563-R611)

Passing run [js - template 20260612.15](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6432094&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=36c846a1-c915-5245-6540-4815941d24fa)