### PR TITLE
Include Teams support channel fo azsdk in MCP failed response

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "Microsoft.Build.Traversal": "3.2.0"
   },
   "sdk": {
-    "version": "10.0",
+    "version": "9.0.306",
     "rollForward": "feature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "Microsoft.Build.Traversal": "3.2.0"
   },
   "sdk": {
-    "version": "9.0.306",
+    "version": "10.0",
     "rollForward": "feature"
   }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Example/HelloWorldToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Example/HelloWorldToolTests.cs
@@ -9,6 +9,7 @@ using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 using Azure.Sdk.Tools.Cli.Tools.Example;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Tests.Mocks.Services;
+using Azure.Sdk.Tools.Cli.Models;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Tools.Example;
 
@@ -51,7 +52,7 @@ Duration: 1ms
         var exitCode = await parseResult.InvokeAsync();
         Assert.That(exitCode, Is.EqualTo(1));
 
-        var expected = "[ERROR] RESPONDING TO 'HI. MY NAME IS' with FAIL: 1";
+        var expected = $"[ERROR] RESPONDING TO 'HI. MY NAME IS' with FAIL: 1{Environment.NewLine}{CommandResponse.SupportChannelMessage}";
 
         Assert.That(outputHelper.Outputs.Count(), Is.EqualTo(1));
         Assert.That(outputHelper.Outputs.First().Stream, Is.EqualTo(OutputHelper.StreamType.Stderr));

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Generators/ReadMeGeneratorToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Generators/ReadMeGeneratorToolTests.cs
@@ -1,12 +1,13 @@
 using System.CommandLine;
 using System.CommandLine.Parsing;
-using Moq;
 using Azure.Sdk.Tools.Cli.CopilotAgents;
+using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Telemetry;
+using Azure.Sdk.Tools.Cli.Tests.Mocks.Services;
 using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 using Azure.Sdk.Tools.Cli.Tools.Package;
-using Azure.Sdk.Tools.Cli.Telemetry;
-using Azure.Sdk.Tools.Cli.Helpers;
-using Azure.Sdk.Tools.Cli.Tests.Mocks.Services;
+using Moq;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Tools.Generators
 {
@@ -131,7 +132,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.Generators
                 {
                     Assert.That(exitCode, Is.EqualTo(1), "Command should fail, as the final readme doesn't pass validation");
                     Assert.That(outputHelper.Outputs.First().Stream, Is.EqualTo(OutputHelper.StreamType.Stderr));
-                    Assert.That(outputHelper.Outputs.First().Output, Is.EqualTo($"[ERROR] ReadmeGenerator failed with validation errors: {expectedFeedback}"));
+                    Assert.That(outputHelper.Outputs.First().Output, Is.EqualTo($"[ERROR] ReadmeGenerator failed with validation errors: {expectedFeedback}{Environment.NewLine}{CommandResponse.SupportChannelMessage}"));
                 });
 
                 Assert.That(File.Exists(readmeOutputPath), Is.True, "Readme output file should be created");

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/CommandResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/CommandResponse.cs
@@ -62,6 +62,20 @@ public abstract class CommandResponse
         }
     }
 
+    /// <summary>
+    /// Support channel details
+    /// </summary>
+    [JsonPropertyName("support_channel")]
+    public string SupportChannel
+    {
+        get
+        {
+            return OperationStatus != Status.Failed? string.Empty :
+                "If you need any assistance, please reach out to the AzSDK Agent team via the Teams channel: https://teams.microsoft.com/l/channel/19%3A6d2c19322c254a80bcc521675134da03%40thread.skype/AzSDK%20Tools%20Agent?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47";
+        }
+    }
+    
+
     protected abstract string Format();
 
     public override string ToString()

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/CommandResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/CommandResponse.cs
@@ -62,18 +62,15 @@ public abstract class CommandResponse
         }
     }
 
+    private const string SupportChannelMessage =
+        "If you need any assistance, please reach out to the AzSDK Agent team via the Teams channel: https://teams.microsoft.com/l/channel/19%3A6d2c19322c254a80bcc521675134da03%40thread.skype/AzSDK%20Tools%20Agent?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47";
+
     /// <summary>
-    /// Support channel details
+    /// Support channel details.
     /// </summary>
     [JsonPropertyName("support_channel")]
-    public string SupportChannel
-    {
-        get
-        {
-            return OperationStatus != Status.Failed? string.Empty :
-                "If you need any assistance, please reach out to the AzSDK Agent team via the Teams channel: https://teams.microsoft.com/l/channel/19%3A6d2c19322c254a80bcc521675134da03%40thread.skype/AzSDK%20Tools%20Agent?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47";
-        }
-    }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SupportChannel => OperationStatus == Status.Failed ? SupportChannelMessage : null;
     
 
     protected abstract string Format();

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/CommandResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/CommandResponse.cs
@@ -103,6 +103,11 @@ public abstract class CommandResponse
             }
         }
 
+        if (SupportChannel != null)
+        {
+            messages.Add(SupportChannel);
+        }
+
         if (messages.Count > 0)
         {
             value = string.Join(Environment.NewLine, messages);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/CommandResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/CommandResponse.cs
@@ -62,7 +62,7 @@ public abstract class CommandResponse
         }
     }
 
-    private const string SupportChannelMessage =
+    public static readonly string SupportChannelMessage =
         "If you need any assistance, please reach out to the AzSDK Agent team via the Teams channel: https://teams.microsoft.com/l/channel/19%3A6d2c19322c254a80bcc521675134da03%40thread.skype/AzSDK%20Tools%20Agent?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47";
 
     /// <summary>


### PR DESCRIPTION
Include support channel details in MCP response when tool call fails.