### PR TITLE
Add CODEOWNERS entry for .github/skills

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -71,7 +71,6 @@
 /tools/azsdk-cli/                       @azure/azsdk-cli
 # PRLabel: %azsdk-cli %design-discussion
 /tools/azsdk-cli/docs/specs/            @azure/azsdk-cli
-# PRLabel: %azsdk-cli
 /.github/skills/                        @azure/azsdk-cli
 
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -71,6 +71,8 @@
 /tools/azsdk-cli/                       @azure/azsdk-cli
 # PRLabel: %azsdk-cli %design-discussion
 /tools/azsdk-cli/docs/specs/            @azure/azsdk-cli
+# PRLabel: %azsdk-cli
+/.github/skills/                        @azure/azsdk-cli
 
 
 ###########


### PR DESCRIPTION
## Summary

Adds a CODEOWNERS entry for the `.github/skills/` directory, assigning ownership to `@azure/azsdk-cli`.

## Changes

- Added a new entry under the "Azure SDK Tools MCP" section in `.github/CODEOWNERS`:
  ```
  # PRLabel: %azsdk-cli
  /.github/skills/                        @azure/azsdk-cli
  ```

## Rationale

The `.github/skills/` directory contains skill definitions used by the azsdk-cli (e.g., `azsdk-common-generate-sdk-locally`, `azure-typespec-author`, `skill-authoring`, `sensei`, etc.) but previously had no explicit code owners. This change ensures the `@azure/azsdk-cli` team is automatically requested for review on changes to skill definitions.