### PR TITLE
Remove unsupported repos from skill sync

### DIFF
--- a/eng/pipelines/sync-.github-skills.yml
+++ b/eng/pipelines/sync-.github-skills.yml
@@ -19,9 +19,6 @@ parameters:
   type: object
   default:
     - azure-sdk
-    - azure-sdk-for-c
-    - azure-sdk-for-cpp
-    - azure-sdk-for-ios
     - azure-sdk-for-java
     - azure-sdk-for-js
     - azure-sdk-for-net


### PR DESCRIPTION
This PR removes the C, C++, and iOS repos from the shared skills sync pipeline list.

Why:
- The sync pipeline should only target the currently supported repos for shared skills updates.
- This avoids unnecessary sync PRs for the removed repos.

What changed:
- Updated eng/pipelines/sync-.github-skills.yml to stop syncing shared skills to azure-sdk-for-c, azure-sdk-for-cpp, and azure-sdk-for-ios.

Testing:
- N/A