### PR TITLE
Replace Product lifecycle value with release plan type when getting KPI attestation status

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
@@ -307,7 +307,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
                 return Task.FromResult<ReleasePlanWorkItem?>(new ReleasePlanWorkItem
                 {
                     ProductTreeId = "12345678-1234-5678-9012-123456789012",
-                    ProductLifecycle = "GA",
+                    ReleasePlanType = "GA",
                     Title = "Contoso Management Release Plan",
                 });
             }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
@@ -1435,10 +1435,10 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         public async Task Test_GetKPIAttestationStatus_NoInputs_ReturnsError()
         {
             var result = await releasePlanTool.GetKPIAttestationStatus("", "", "");
-            Assert.That(result.ResponseError, Does.Contain("Either provide both product ID and lifecycle"));
+            Assert.That(result.ResponseError, Does.Contain("Either provide both product ID and release plan type"));
 
             var badLifecycle = await releasePlanTool.GetKPIAttestationStatus("product-123", "InvalidLifecycle");
-            Assert.That(badLifecycle.ResponseError, Does.Contain("Invalid lifecycle value"));
+            Assert.That(badLifecycle.ResponseError, Does.Contain("Invalid release plan type"));
         }
 
         [Test]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.6.21 (Unreleased)
+## 0.6.21 (2026-06-18)
 
 ### Features Added
 
@@ -12,9 +12,10 @@
 
 - Removed upstream RAG-based/hosted model pipeline analysis mode via `azsdk azp analyze --agent`
 
-### Bugs Fixed
-
 ### Other Changes
+
+- Added service ID and product ID as optional when creating a release plan
+- Replaced product life cycle property with release plan type when fetching attestation status
 
 ## 0.6.20 (2026-06-16)
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AzureDevOps/ReleasePlanWorkItem.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AzureDevOps/ReleasePlanWorkItem.cs
@@ -71,9 +71,6 @@ namespace Azure.Sdk.Tools.Cli.Models.AzureDevOps
         [FieldName("Custom.AttestationStatus")]
         public string AttestationStatus { get; set; } = string.Empty;
 
-        [FieldName("Custom.ProductLifecycle")]
-        public string ProductLifecycle { get; set; } = string.Empty;
-
         [FieldName("Custom.ReleasePlanType")]
         public string ReleasePlanType { get; set; } = string.Empty;
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -93,7 +93,7 @@ namespace Azure.Sdk.Tools.Cli.Services
         public Task<ReleasePlanWorkItem> GetReleasePlanAsync(string pullRequestUrl, ApiReleaseType apiReleaseType = ApiReleaseType.Unknown, CancellationToken ct = default);
         public Task<ReleasePlanWorkItem?> ResolveReleasePlanByIdAsync(int id, CancellationToken ct);
         public Task<List<ReleasePlanWorkItem>> GetReleasePlansForPackageAsync(string packageName, string language, bool isTestReleasePlan = false, CancellationToken ct = default);
-        public Task<List<ReleasePlanWorkItem>> GetReleasePlansByProductAndLifecycleAsync(string productTreeId, string productLifecycle, bool isTestReleasePlan = false, CancellationToken ct = default);
+        public Task<List<ReleasePlanWorkItem>> GetReleasePlansByProductAndLifecycleAsync(string productTreeId, string releasePlanType, bool isTestReleasePlan = false, CancellationToken ct = default);
         public Task<WorkItem> CreateReleasePlanWorkItemAsync(ReleasePlanWorkItem releasePlan, CancellationToken ct);
         public Task<Build> RunSDKGenerationPipelineAsync(string apiSpecBranchRef, string typespecProjectRoot, string apiVersion, string sdkReleaseType, string language, int workItemId, string sdkRepoBranch = "", CancellationToken ct = default);
         public Task<Build> GetPipelineRunAsync(int buildId, CancellationToken ct);
@@ -248,7 +248,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             }
         }
 
-        public async Task<List<ReleasePlanWorkItem>> GetReleasePlansByProductAndLifecycleAsync(string productTreeId, string productLifecycle, bool isTestReleasePlan = false, CancellationToken ct = default)
+        public async Task<List<ReleasePlanWorkItem>> GetReleasePlansByProductAndLifecycleAsync(string productTreeId, string releasePlanType, bool isTestReleasePlan = false, CancellationToken ct = default)
         {
             try
             {
@@ -257,7 +257,7 @@ namespace Azure.Sdk.Tools.Cli.Services
                 query += $" AND [Custom.ProductServiceTreeID] = '{productTreeId}'";
                 query += " AND [System.WorkItemType] = 'Release Plan'";
                 query += " AND [System.State] IN ('New','Not Started','In Progress','Finished')";
-                query += $" AND [Custom.ProductLifecycle] = '{productLifecycle}'";
+                query += $" AND [Custom.ReleasePlanType] = '{releasePlanType}'";
                 var releasePlanWorkItems = await FetchWorkItemsAsync(query, ct);
                 if (releasePlanWorkItems.Count == 0)
                 {
@@ -342,8 +342,7 @@ namespace Azure.Sdk.Tools.Cli.Services
                 LanguageExclusionRequesterNote = workItem.Fields.TryGetValue("Custom.ReleaseExclusionRequestNote", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 LanguageExclusionApproverNote = workItem.Fields.TryGetValue("Custom.ReleaseExclusionApprovalNote", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 APISpecProjectPath = workItem.Fields.TryGetValue("Custom.ApiSpecProjectPath", out value) ? value?.ToString() ?? string.Empty : string.Empty,
-                AttestationStatus = workItem.Fields.TryGetValue("Custom.AttestationStatus", out value) ? value?.ToString() ?? string.Empty : string.Empty,
-                ProductLifecycle = workItem.Fields.TryGetValue("Custom.ProductLifecycle", out value) ? value?.ToString() ?? string.Empty : string.Empty,
+                AttestationStatus = workItem.Fields.TryGetValue("Custom.AttestationStatus", out value) ? value?.ToString() ?? string.Empty : string.Empty,                
                 ReleasePlanType = workItem.Fields.TryGetValue("Custom.ReleasePlanType", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 Owner = workItem.Fields.TryGetValue("Custom.PrimaryPM", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 IsTestReleasePlan = workItem.Fields.TryGetValue("System.Tags", out value) && value is String tags && tags.Contains(RELEASE_PLANNER_APP_TEST)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -1851,15 +1851,6 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             }
         }
 
-        private static readonly HashSet<string> SupportedLifecycles = new(StringComparer.OrdinalIgnoreCase)
-        {
-            "In Dev",
-            "Private Preview",
-            "Public Preview",
-            "GA",
-            "Retired"
-        };
-
         [McpServerTool(Name = GetKPIAttestationStatusToolName), Description("Get KPI attestation status for release plans with given product tree ID and release plan type. If product ID and release plan type are not provided, a TypeSpec project path can be used to resolve them.")]
         public async Task<ReleasePlanListResponse> GetKPIAttestationStatus(string productId = "", string releasePlanType = "", string typeSpecProjectPath = "", bool isTestReleasePlan = false, CancellationToken ct = default)
         {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -220,9 +220,9 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             Required = false,
         };
 
-        private readonly Option<string> lifecycleOpt = new("--lifecycle")
+        private readonly Option<string> releasePlanTypeOpt = new("--release-plan-type")
         {
-            Description = "Product lifecycle stage: 'In Dev', 'Private Preview', 'Public Preview', 'GA', or 'Retired'",
+            Description = "Release plan type: 'In Dev', 'Private Preview', 'Public Preview', 'GA'",
             Required = false,
         };
 
@@ -297,7 +297,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             new McpCommand(updateApiSpecPullRequestCommandName, "Update TypeSpec pull request URL in a release plan", UpdateApiSpecPullRequestToolName) { pullRequestOpt, workItemIdOpt, releasePlanNumberOpt, },
             new McpCommand(getServiceDetailsCommandName, "Get service and product details (service tree ID, service ID, package display name) in service tree for TypeSpec project", GetServiceDetailsToolName) { typeSpecProjectOpt, },
             new McpCommand(abandonReleasePlanCommandName, "Abandon a release plan", AbandonReleasePlanToolName) { workItemIdOpt, releasePlanNumberOpt, },
-            new McpCommand(getKpiAttestationStatusCommandName, "Get KPI attestation status for a product by product ID and lifecycle", GetKPIAttestationStatusToolName) { kpiProductIdOpt, lifecycleOpt, kpiTypeSpecProjectPathOpt, kpiIsTestReleasePlanOpt, },
+            new McpCommand(getKpiAttestationStatusCommandName, "Get KPI attestation status for a product by product ID and release plan type", GetKPIAttestationStatusToolName) { kpiProductIdOpt, releasePlanTypeOpt, kpiTypeSpecProjectPathOpt, kpiIsTestReleasePlanOpt, },
             new McpCommand(updateReleasePlanCommandName, "Update an existing release plan", UpdateReleasePlanToolName)
             {
                 updateTypeSpecProjectPathOpt,
@@ -368,7 +368,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     return await AbandonReleasePlan(workItemId: commandParser.GetValue(workItemIdOpt), releasePlanId: commandParser.GetValue(releasePlanNumberOpt), ct: ct);
 
                 case getKpiAttestationStatusCommandName:
-                    return await GetKPIAttestationStatus(commandParser.GetValue(kpiProductIdOpt), commandParser.GetValue(lifecycleOpt), commandParser.GetValue(kpiTypeSpecProjectPathOpt), commandParser.GetValue(kpiIsTestReleasePlanOpt), ct);
+                    return await GetKPIAttestationStatus(commandParser.GetValue(kpiProductIdOpt), commandParser.GetValue(releasePlanTypeOpt), commandParser.GetValue(kpiTypeSpecProjectPathOpt), commandParser.GetValue(kpiIsTestReleasePlanOpt), ct);
 
                 case updateReleasePlanCommandName:
                     return await UpdateReleasePlan(
@@ -1860,12 +1860,13 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             "Retired"
         };
 
-        [McpServerTool(Name = GetKPIAttestationStatusToolName), Description("Get KPI attestation status for release plans with given product tree ID and lifecycle. If product ID and lifecycle are not provided, a TypeSpec project path can be used to resolve them.")]
-        public async Task<ReleasePlanListResponse> GetKPIAttestationStatus(string productId = "", string lifecycle = "", string typeSpecProjectPath = "", bool isTestReleasePlan = false, CancellationToken ct = default)
+        [McpServerTool(Name = GetKPIAttestationStatusToolName), Description("Get KPI attestation status for release plans with given product tree ID and release plan type. If product ID and release plan type are not provided, a TypeSpec project path can be used to resolve them.")]
+        public async Task<ReleasePlanListResponse> GetKPIAttestationStatus(string productId = "", string releasePlanType = "", string typeSpecProjectPath = "", bool isTestReleasePlan = false, CancellationToken ct = default)
         {
             var releasePlans = new List<ReleasePlanWorkItem>();
             try
             {
+                ApiReleaseType apiReleaseType = ApiReleaseType.Unknown;
                 // Check environment variable to determine if this should be a test release plan
                 var isAgentTesting = environmentHelper.GetBooleanVariable("AZSDKTOOLS_AGENT_TESTING", false);
                 if (isAgentTesting)
@@ -1874,52 +1875,52 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     logger.LogInformation("AZSDKTOOLS_AGENT_TESTING environment variable is set to true, creating test release plan");
                 }
 
-                // If productId or lifecycle not provided, try to resolve from TypeSpec project path
-                if (string.IsNullOrWhiteSpace(productId) || string.IsNullOrWhiteSpace(lifecycle))
+                // If productId or releasePlanType not provided, try to resolve from TypeSpec project path
+                if (string.IsNullOrWhiteSpace(productId) || string.IsNullOrWhiteSpace(releasePlanType))
                 {
                     if (string.IsNullOrWhiteSpace(typeSpecProjectPath))
                     {
                         return new ReleasePlanListResponse
                         {
-                            ResponseError = "Either provide both product ID and lifecycle, or provide a TypeSpec project path to resolve them."
+                            ResponseError = "Either provide both product ID and release plan type, or provide a TypeSpec project path to resolve them."
                         };
                     }
 
-                    logger.LogInformation("Resolving product ID and lifecycle from TypeSpec project path: {typeSpecProjectPath}", typeSpecProjectPath);
+                    logger.LogInformation("Resolving product ID and release plan type from TypeSpec project path: {typeSpecProjectPath}", typeSpecProjectPath);
 
                     var releasePlan = await devOpsService.GetReleasePlanByTypeSpecProjectPathAsync(typeSpecProjectPath, includeFinishedPlans: true, ct: ct);
                     if (releasePlan == null)
                     {
                         return new ReleasePlanListResponse
                         {
-                            ResponseError = $"No release plan found for TypeSpec project path '{typeSpecProjectPath}'. Cannot resolve product ID and lifecycle."
+                            ResponseError = $"No release plan found for TypeSpec project path '{typeSpecProjectPath}'. Cannot resolve product ID and release plan type."
                         };
                     }
 
                     // Fill these in for logging later on
                     productId = releasePlan.ProductTreeId;
-                    lifecycle = releasePlan.ProductLifecycle;
+                    apiReleaseType = ApiReleaseTypeExtensions.FromAdoFieldValue(releasePlan.ReleasePlanType);
                     releasePlans.Add(releasePlan);
                 }
                 else
                 {
-                    if (!SupportedLifecycles.Contains(lifecycle))
+                    if (!ApiReleaseTypeExtensions.TryParseFromUserInput(releasePlanType, out apiReleaseType))
                     {
                         return new ReleasePlanListResponse
                         {
-                            ResponseError = $"Invalid lifecycle value '{lifecycle}'. Supported values are: In Dev, Private Preview, Public Preview, GA, Retired."
+                            ResponseError = $"Invalid release plan type value '{releasePlanType}'. Supported values are: Private Preview, Public Preview, GA."
                         };
                     }
 
-                    logger.LogInformation("Getting KPI attestation status for product {productId} with lifecycle {lifecycle}", productId, lifecycle);
+                    logger.LogInformation("Getting KPI attestation status for product {productId} with release plan type {releasePlanType}", productId, releasePlanType);
 
-                    releasePlans = await devOpsService.GetReleasePlansByProductAndLifecycleAsync(productId, lifecycle, isTestReleasePlan, ct);
+                    releasePlans = await devOpsService.GetReleasePlansByProductAndLifecycleAsync(productId, apiReleaseType.ToAdoFieldValue(), isTestReleasePlan, ct);
 
                     if (releasePlans.Count == 0)
                     {
                         return new ReleasePlanListResponse
                         {
-                            Message = $"No release plans found for product '{productId}' with lifecycle '{lifecycle}'. " +
+                            Message = $"No release plans found for product '{productId}' with release plan type '{releasePlanType}'. " +
                                       "A release plan must be created and completed before KPI attestation can be fulfilled."
                         };
                     }
@@ -1934,7 +1935,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     return new ReleasePlanListResponse
                     {
                         ReleasePlanDetailsList = releasePlans,
-                        Message = $"KPI attestation is completed for product '{productId}' ({lifecycle}). " +
+                        Message = $"KPI attestation is completed for product '{productId}' ({apiReleaseType.ToDisplayLabel()}). " +
                                   $"Found {attestedPlans.Count} finished release plan(s) with attestation completed."
                     };
                 }
@@ -1944,7 +1945,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     return new ReleasePlanListResponse
                     {
                         ReleasePlanDetailsList = releasePlans,
-                        Message = $"Found {finishedPlans.Count} finished release plan(s) for product '{productId}' ({lifecycle}), " +
+                        Message = $"Found {finishedPlans.Count} finished release plan(s) for product '{productId}' ({apiReleaseType.ToDisplayLabel()}), " +
                                   "but none have attestation status marked as completed."
                     };
                 }
@@ -1953,7 +1954,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 return new ReleasePlanListResponse
                 {
                     ReleasePlanDetailsList = pendingPlans,
-                    Message = $"KPI attestation is not yet completed for product '{productId}' ({lifecycle}). " +
+                    Message = $"KPI attestation is not yet completed for product '{productId}' ({apiReleaseType.ToDisplayLabel()}). " +
                               $"Found {pendingPlans.Count} release plan(s) in pending status. " +
                               "KPI attestation will be completed once one of these release plans is finished: " +
                               string.Join(", ", pendingPlans.Select(rp => $"'{rp.Title}' (ID: {rp.ReleasePlanId}, Status: {rp.Status})"))

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -222,7 +222,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
 
         private readonly Option<string> releasePlanTypeOpt = new("--release-plan-type")
         {
-            Description = "Release plan type: 'In Dev', 'Private Preview', 'Public Preview', 'GA'",
+            Description = "Release plan type: 'Private Preview', 'Public Preview', 'GA'",
             Required = false,
         };
 


### PR DESCRIPTION
Product life cycle was setup by PowerApps backend earlier and this has been completely turned off. KPI attestation tool should not refer Product life cycle property anymore.