### PR TITLE
Update KPI attestation script to ignore product life cycle and product type

### DIFF
--- a/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
+++ b/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
@@ -1240,8 +1240,6 @@ function Get-ReleasePlansForCPEXAttestation()
   $query += " AND [System.Tags] NOT CONTAINS 'APEX out of scope'"
   $query += " AND [System.Tags] NOT CONTAINS 'validate APEX out of scope'"
   $query += " AND [Custom.ProductServiceTreeID] <> ''"
-  $query += " AND [Custom.ProductLifecycle] <> ''"
-  $query += " AND [Custom.ProductType] IN ('Feature', 'Offering', 'Sku')"
 
   $workItems = Invoke-Query $fields $query
   return $workItems

--- a/eng/scripts/tests/CPEX-Attestation.tests.ps1
+++ b/eng/scripts/tests/CPEX-Attestation.tests.ps1
@@ -203,6 +203,10 @@ Describe "Get-ReleasePlansForCPEXAttestation" {
 
             # Required non-empty fields
             $norm | Should -Match "\[Custom\.ProductServiceTreeID\]\s*<>\s*''"
+
+            # Ensure we don't depend on fields no longer set for new Release Plans
+            $norm | Should -Not -Match "\[Custom\.ProductLifecycle\]\s*<>\s*''"
+            $norm | Should -Not -Match "\[Custom\.ProductType\]\s*IN\s*\('Feature'\s*,\s*'Offering'\s*,\s*'Sku'\)"
         }
     }
 

--- a/eng/scripts/tests/CPEX-Attestation.tests.ps1
+++ b/eng/scripts/tests/CPEX-Attestation.tests.ps1
@@ -203,10 +203,6 @@ Describe "Get-ReleasePlansForCPEXAttestation" {
 
             # Required non-empty fields
             $norm | Should -Match "\[Custom\.ProductServiceTreeID\]\s*<>\s*''"
-            $norm | Should -Match "\[Custom\.ProductLifecycle\]\s*<>\s*''"
-
-            # ProductType filter
-            $norm | Should -Match "\[Custom\.ProductType\]\s*IN\s*\('Feature'\s*,\s*'Offering'\s*,\s*'Sku'\)"
         }
     }
 


### PR DESCRIPTION
Product life cycle and product type fields were set by PowerApps backend, and this will no longer be set for any new release plan. KPI attestation is performed based on release plan type and not using product life cycle value.