### PR TITLE
Parse TypeSpec project when path contains tspconfig.yaml

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/TypeSpecHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/TypeSpecHelperTests.cs
@@ -110,6 +110,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Helpers
         [TestCase("https://github.com/Azure/azure-rest-api-specs/blob/main/specification/dell/Dell.Storage.Management", "specification/dell/Dell.Storage.Management")]
         [TestCase("https://github.com/Azure/azure-rest-api-specs/blob/feature/specification/contoso/Contoso.Service", "specification/contoso/Contoso.Service")]
         [TestCase("https://github.com/Azure/azure-rest-api-specs/blob/main/specification/test/Test.Service?query=param#L123", "specification/test/Test.Service")]
+        [TestCase("https://github.com/Azure/azure-rest-api-specs/blob/main/specification/dell/Dell.Storage.Management/tspconfig.yaml", "specification/dell/Dell.Storage.Management")]
+        [TestCase("https://github.com/Azure/azure-rest-api-specs/blob/main/specification/test/Test.Service/tspconfig.yaml?query=param", "specification/test/Test.Service")]
         [Test]
         public void Test_GetTypeSpecProjectRelativePathFromUrl(string url, string expected)
         {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TypeSpecHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TypeSpecHelper.cs
@@ -352,7 +352,13 @@ namespace Azure.Sdk.Tools.Cli.Helpers
             // Parse URL to get the path component (automatically strips query params and fragments)
             var uri = new Uri(url);
             var path = uri.AbsolutePath;
-            
+
+            // Strip tspconfig.yaml from the end of the path if present
+            if (path.EndsWith($"/{TypeSpecProject.TSPCONFIG_FILENAME}", StringComparison.OrdinalIgnoreCase))
+            {
+                path = path[..^(TypeSpecProject.TSPCONFIG_FILENAME.Length + 1)];
+            }
+
             int specIndex = path.IndexOf("specification", StringComparison.OrdinalIgnoreCase);
             return specIndex >= 0 ? path[specIndex..] : string.Empty;
         }


### PR DESCRIPTION
TypeSpec path from spec URL should exclude tspconfig.yaml to get proper relative path to TypeSpec project.