### PR TITLE
[azsdk-cli] Add `azsdk package create-api-review` with Python support

### DIFF
--- a/command-logic.md
+++ b/command-logic.md
@@ -1,0 +1,21 @@
+# API Review PR Helper
+
+This folder contains the standalone Python helper used to create API review PRs from generated `api.md` files.
+
+## Purpose
+
+`create_api_review_pr.py` compares a baseline package release tag with a target API surface, creates or reuses dedicated API review branches, and opens a draft PR that shows the `api.md` diff.
+
+The API consistency workflow helpers live under `.github/workflows/src/api-md-consistency`.
+
+## Usage
+
+The script includes Python package discovery, version parsing, `api.md` generation, git branch orchestration, and GitHub PR creation in one file.
+
+`create_api_review_pr.py` compares a baseline package release tag with a target API surface. The target can be a package release tag, an `origin` branch, or an `owner:branch` fork reference. When the target is a tag, the generated PR body identifies it as a target tag instead of a working branch.
+
+Example comparing two package release tags:
+
+```bash
+python scripts/api_md_workflow/create_api_review_pr.py --package-name azure-ai-projects --base azure-ai-projects_2.1.0 --target azure-ai-projects_2.2.0
+```

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/CreateApiReviewToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/CreateApiReviewToolTests.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.ApiReview;
+using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Services.ApiReview;
+using Azure.Sdk.Tools.Cli.Services.Languages;
+using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
+using Azure.Sdk.Tools.Cli.Tools.Package;
+using Moq;
+using Octokit;
+
+namespace Azure.Sdk.Tools.Cli.Tests.Tools.Package;
+
+public class CreateApiReviewToolTests
+{
+    [Test]
+    public void ParseTargetSupportsTagRemoteBranchAndForkBranch()
+    {
+        var tag = ApiReviewTarget.Parse("azure-ai-projects_2.2.0");
+        var remoteBranch = ApiReviewTarget.Parse("upstream/release/api-review");
+        var forkBranch = ApiReviewTarget.Parse("someone:feature/api-review");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(tag.Kind, Is.EqualTo(ApiReviewTargetKind.Tag));
+            Assert.That(tag.GitRef, Is.EqualTo("azure-ai-projects_2.2.0"));
+
+            Assert.That(remoteBranch.Kind, Is.EqualTo(ApiReviewTargetKind.RemoteBranch));
+            Assert.That(remoteBranch.Remote, Is.EqualTo("upstream"));
+            Assert.That(remoteBranch.Branch, Is.EqualTo("release/api-review"));
+            Assert.That(remoteBranch.GitRef, Is.EqualTo("upstream/release/api-review"));
+
+            Assert.That(forkBranch.Kind, Is.EqualTo(ApiReviewTargetKind.ForkBranch));
+            Assert.That(forkBranch.Owner, Is.EqualTo("someone"));
+            Assert.That(forkBranch.Branch, Is.EqualTo("feature/api-review"));
+            Assert.That(forkBranch.GitRef, Is.EqualTo("someone/feature/api-review"));
+        });
+    }
+
+    [Test]
+    public void CommandParsesCreateApiReviewOptions()
+    {
+        var tool = CreateTool(out _, out _, out _, out _, out _);
+        var command = tool.GetCommandInstances().Single(command => command.Name == "create-api-review");
+        var parseConfig = new CommandLineConfiguration(command)
+        {
+            ResponseFileTokenReplacer = null
+        };
+
+        var parseResult = command.Parse("--package-name azure-ai-projects --base azure-ai-projects_2.1.0 --target azure-ai-projects_2.2.0 --dry-run", parseConfig);
+
+        Assert.That(parseResult.Errors, Is.Empty);
+    }
+
+    [Test]
+    public async Task CreateApiReviewDryRunGeneratesArtifactsWithoutPushingOrCreatingPr()
+    {
+        var tool = CreateTool(out var gitHelper, out var gitHubService, out var apiReviewGitService, out var packageResolver, out var languageService);
+
+        gitHelper.Setup(helper => helper.DiscoverRepoRootAsync(Environment.CurrentDirectory, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("/repo");
+        gitHelper.Setup(helper => helper.GetRepoNameAsync("/repo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("azure-sdk-for-python");
+        packageResolver.Setup(resolver => resolver.ResolvePackage("azure-ai-projects", It.IsAny<string>()))
+            .Returns((string _, string worktreeRoot) => ApiReviewPackageResult.CreateSuccess(new ApiReviewPackageInfo
+            {
+                PackagePath = Path.Combine(worktreeRoot, "sdk", "ai", "azure-ai-projects"),
+                RelativePath = "sdk/ai/azure-ai-projects",
+                CodeownersPathExpression = "/sdk/ai/azure-ai-projects/"
+            }));
+
+        languageService.Setup(service => service.GenerateApiReviewArtifactsAsync(It.IsAny<ApiReviewArtifactRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ApiReviewArtifactRequest request, CancellationToken _) => ApiReviewArtifactResult.CreateSuccess(
+                request.PackagePath,
+                [
+                    new ApiReviewArtifact
+                    {
+                        SourcePath = Path.Combine(request.OutputDirectory, "api.md"),
+                        ReviewPath = "sdk/ai/azure-ai-projects/api-review/api.md"
+                    },
+                    new ApiReviewArtifact
+                    {
+                        SourcePath = Path.Combine(request.OutputDirectory, "api.metadata.yml"),
+                        ReviewPath = "sdk/ai/azure-ai-projects/api-review/api.metadata.yml"
+                    }
+                ]));
+
+        var result = await tool.CreateApiReviewAsync("azure-ai-projects", "azure-ai-projects_2.1.0", "azure-ai-projects_2.2.0", dryRun: true, CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(0));
+            Assert.That(result.Language, Is.EqualTo(SdkLanguage.Python));
+            Assert.That(result.Artifacts, Has.Count.EqualTo(2));
+            Assert.That(result.Artifacts!.Select(artifact => artifact.ReviewPath), Does.Contain("sdk/ai/azure-ai-projects/api-review/api.md"));
+            Assert.That(result.Artifacts!.Select(artifact => artifact.ReviewPath), Does.Contain("sdk/ai/azure-ai-projects/api-review/api.metadata.yml"));
+            Assert.That(result.PullRequestUrl, Is.Null);
+            Assert.That(result.Messages, Does.Contain("Dry run completed. No branches were pushed and no pull request was created."));
+        });
+
+        packageResolver.Verify(resolver => resolver.ResolvePackage("azure-ai-projects", It.IsAny<string>()), Times.Exactly(2));
+        languageService.Verify(service => service.GenerateApiReviewArtifactsAsync(It.Is<ApiReviewArtifactRequest>(request =>
+            request.PackagePath.Replace('\\', '/').EndsWith("sdk/ai/azure-ai-projects") && request.PackageRelativePath == "sdk/ai/azure-ai-projects"), It.IsAny<CancellationToken>()), Times.Exactly(2));
+        apiReviewGitService.Verify(service => service.FetchTargetAsync("/repo", "azure-sdk-for-python", It.IsAny<ApiReviewTarget>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+        apiReviewGitService.Verify(service => service.AddWorktreeAsync("/repo", It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+        apiReviewGitService.Verify(service => service.MaterializeReviewBranchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<ApiReviewArtifact>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        apiReviewGitService.Verify(service => service.PushBranchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        gitHubService.Verify(service => service.CreatePullRequestAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public void PackageResolverFindsPackagePathFromCodeownersParser()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "azsdk-cli-tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(tempRoot, ".github"));
+            Directory.CreateDirectory(Path.Combine(tempRoot, "sdk", "ai", "azure-ai-projects"));
+            File.WriteAllText(Path.Combine(tempRoot, ".github", "CODEOWNERS"), """
+            # PRLabel: %Azure.AI.Projects
+            /sdk/ai/azure-ai-projects/ @azure-sdk-write
+            """);
+
+            var resolver = new ApiReviewPackageResolver();
+            var result = resolver.ResolvePackage("azure-ai-projects", tempRoot);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Success, Is.True);
+                Assert.That(result.Package!.RelativePath, Is.EqualTo("sdk/ai/azure-ai-projects"));
+                Assert.That(result.Package.PackagePath, Is.EqualTo(Path.Combine(tempRoot, "sdk", "ai", "azure-ai-projects")));
+                Assert.That(result.Package.CodeownersPathExpression, Is.EqualTo("/sdk/ai/azure-ai-projects/"));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
+    private static CreateApiReviewTool CreateTool(
+        out Mock<IGitHelper> gitHelper,
+        out Mock<IGitHubService> gitHubService,
+        out Mock<IApiReviewGitService> apiReviewGitService,
+        out Mock<IApiReviewPackageResolver> packageResolver,
+        out Mock<LanguageService> languageService)
+    {
+        gitHelper = new Mock<IGitHelper>();
+        gitHubService = new Mock<IGitHubService>();
+        apiReviewGitService = new Mock<IApiReviewGitService>();
+        packageResolver = new Mock<IApiReviewPackageResolver>();
+        languageService = new Mock<LanguageService>();
+        languageService.SetupGet(service => service.Language).Returns(SdkLanguage.Python);
+
+        apiReviewGitService.Setup(service => service.FetchTargetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ApiReviewTarget>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        apiReviewGitService.Setup(service => service.AddWorktreeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        apiReviewGitService.Setup(service => service.RemoveWorktreeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        return new CreateApiReviewTool(
+            gitHelper.Object,
+            gitHubService.Object,
+            apiReviewGitService.Object,
+                packageResolver.Object,
+            new TestLogger<CreateApiReviewTool>(),
+            [languageService.Object]);
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedOptions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedOptions.cs
@@ -43,6 +43,7 @@ namespace Azure.Sdk.Tools.Cli.Commands
             typeof(ChangelogContentUpdateTool),
             typeof(VersionUpdateTool),
             typeof(SdkReleaseTool),
+            typeof(CreateApiReviewTool),
             typeof(SpecCommonTools),
             typeof(PullRequestTools),
             typeof(SpecValidationTools),

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ApiReview/ApiReviewArtifact.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ApiReview/ApiReviewArtifact.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.Sdk.Tools.Cli.Models.ApiReview;
+
+public class ApiReviewArtifact
+{
+    [JsonPropertyName("source_path")]
+    public required string SourcePath { get; set; }
+
+    [JsonPropertyName("review_path")]
+    public required string ReviewPath { get; set; }
+}
+
+public class ApiReviewArtifactRequest
+{
+    public required string PackageName { get; set; }
+    public required string PackagePath { get; set; }
+    public required string PackageRelativePath { get; set; }
+    public required string RepoRoot { get; set; }
+    public required string WorktreeRoot { get; set; }
+    public required string Ref { get; set; }
+    public required string OutputDirectory { get; set; }
+}
+
+public class ApiReviewArtifactResult
+{
+    public bool Success { get; set; }
+    public string? ErrorMessage { get; set; }
+    public string? PackagePath { get; set; }
+    public List<ApiReviewArtifact> Artifacts { get; set; } = [];
+
+    public static ApiReviewArtifactResult CreateFailure(string errorMessage) => new()
+    {
+        Success = false,
+        ErrorMessage = errorMessage
+    };
+
+    public static ApiReviewArtifactResult CreateSuccess(string packagePath, List<ApiReviewArtifact> artifacts) => new()
+    {
+        Success = true,
+        PackagePath = packagePath,
+        Artifacts = artifacts
+    };
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ApiReview/ApiReviewTarget.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ApiReview/ApiReviewTarget.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.Sdk.Tools.Cli.Models.ApiReview;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ApiReviewTargetKind
+{
+    Tag,
+    RemoteBranch,
+    ForkBranch
+}
+
+public class ApiReviewTarget
+{
+    [JsonPropertyName("raw")]
+    public required string Raw { get; set; }
+
+    [JsonPropertyName("kind")]
+    public ApiReviewTargetKind Kind { get; set; }
+
+    [JsonPropertyName("remote")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Remote { get; set; }
+
+    [JsonPropertyName("owner")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Owner { get; set; }
+
+    [JsonPropertyName("branch")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Branch { get; set; }
+
+    public string GitRef => Kind switch
+    {
+        ApiReviewTargetKind.RemoteBranch => $"{Remote}/{Branch}",
+        ApiReviewTargetKind.ForkBranch => $"{Owner}/{Branch}",
+        _ => Raw,
+    };
+
+    public static ApiReviewTarget Parse(string raw)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(raw, nameof(raw));
+
+        var value = raw.Trim();
+        var colonIndex = value.IndexOf(':');
+        if (colonIndex > 0 && colonIndex < value.Length - 1 && !value[..colonIndex].Contains('/'))
+        {
+            return new ApiReviewTarget
+            {
+                Raw = value,
+                Kind = ApiReviewTargetKind.ForkBranch,
+                Owner = value[..colonIndex],
+                Branch = value[(colonIndex + 1)..]
+            };
+        }
+
+        var slashIndex = value.IndexOf('/');
+        if (slashIndex > 0 && slashIndex < value.Length - 1)
+        {
+            return new ApiReviewTarget
+            {
+                Raw = value,
+                Kind = ApiReviewTargetKind.RemoteBranch,
+                Remote = value[..slashIndex],
+                Branch = value[(slashIndex + 1)..]
+            };
+        }
+
+        return new ApiReviewTarget
+        {
+            Raw = value,
+            Kind = ApiReviewTargetKind.Tag
+        };
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/CreateApiReviewResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/CreateApiReviewResponse.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+using Azure.Sdk.Tools.Cli.Models.ApiReview;
+
+namespace Azure.Sdk.Tools.Cli.Models.Responses.Package;
+
+public class CreateApiReviewResponse : PackageResponseBase
+{
+    [JsonPropertyName("base")]
+    public string? Base { get; set; }
+
+    [JsonPropertyName("target")]
+    public ApiReviewTarget? Target { get; set; }
+
+    [JsonPropertyName("base_branch")]
+    public string? BaseBranch { get; set; }
+
+    [JsonPropertyName("head_branch")]
+    public string? HeadBranch { get; set; }
+
+    [JsonPropertyName("pull_request_url")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PullRequestUrl { get; set; }
+
+    [JsonPropertyName("artifacts")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<ApiReviewArtifact>? Artifacts { get; set; }
+
+    [JsonPropertyName("messages")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? Messages { get; set; }
+
+    protected override string Format()
+    {
+        var output = new List<string>();
+        if (!string.IsNullOrWhiteSpace(PullRequestUrl))
+        {
+            output.Add($"Pull request URL: {PullRequestUrl}");
+        }
+        if (!string.IsNullOrWhiteSpace(BaseBranch))
+        {
+            output.Add($"Base branch: {BaseBranch}");
+        }
+        if (!string.IsNullOrWhiteSpace(HeadBranch))
+        {
+            output.Add($"Head branch: {HeadBranch}");
+        }
+        if (Artifacts?.Count > 0)
+        {
+            output.Add("Artifacts:");
+            output.AddRange(Artifacts.Select(artifact => artifact.ReviewPath));
+        }
+        if (Messages?.Count > 0)
+        {
+            output.AddRange(Messages);
+        }
+        return string.Join(Environment.NewLine, output);
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ApiReview/ApiReviewGitService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ApiReview/ApiReviewGitService.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Models.ApiReview;
+
+namespace Azure.Sdk.Tools.Cli.Services.ApiReview;
+
+public interface IApiReviewGitService
+{
+    Task<string> GetDefaultBranchAsync(string repoRoot, CancellationToken ct);
+    Task FetchTargetAsync(string repoRoot, string repoName, ApiReviewTarget target, CancellationToken ct);
+    Task AddWorktreeAsync(string repoRoot, string worktreePath, string gitRef, CancellationToken ct);
+    Task RemoveWorktreeAsync(string repoRoot, string worktreePath, CancellationToken ct);
+    Task MaterializeReviewBranchAsync(string repoRoot, string branchName, string startPoint, IEnumerable<ApiReviewArtifact> artifacts, string commitMessage, CancellationToken ct);
+    Task PushBranchAsync(string repoRoot, string branchName, CancellationToken ct);
+}
+
+public class ApiReviewGitService(IGitCommandHelper gitCommandHelper, ILogger<ApiReviewGitService> logger) : IApiReviewGitService
+{
+    public async Task<string> GetDefaultBranchAsync(string repoRoot, CancellationToken ct)
+    {
+        var result = await RunGitAsync(repoRoot, ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"], ct, throwOnFailure: false);
+        if (result.ExitCode == 0)
+        {
+            var value = result.Stdout.Trim();
+            const string originPrefix = "origin/";
+            if (value.StartsWith(originPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return value[originPrefix.Length..];
+            }
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return "main";
+    }
+
+    public async Task FetchTargetAsync(string repoRoot, string repoName, ApiReviewTarget target, CancellationToken ct)
+    {
+        switch (target.Kind)
+        {
+            case ApiReviewTargetKind.RemoteBranch:
+                await RunGitAsync(repoRoot, ["fetch", target.Remote!, target.Branch!], ct);
+                break;
+            case ApiReviewTargetKind.ForkBranch:
+                var remoteUrl = $"https://github.com/{target.Owner}/{repoName}.git";
+                await RunGitAsync(repoRoot, ["fetch", remoteUrl, $"{target.Branch}:refs/remotes/{target.Owner}/{target.Branch}"], ct);
+                break;
+            default:
+                await RunGitAsync(repoRoot, ["fetch", "--tags"], ct);
+                break;
+        }
+    }
+
+    public async Task AddWorktreeAsync(string repoRoot, string worktreePath, string gitRef, CancellationToken ct)
+    {
+        await RunGitAsync(repoRoot, ["worktree", "add", "--detach", worktreePath, gitRef], ct);
+    }
+
+    public async Task RemoveWorktreeAsync(string repoRoot, string worktreePath, CancellationToken ct)
+    {
+        if (Directory.Exists(worktreePath))
+        {
+            await RunGitAsync(repoRoot, ["worktree", "remove", "--force", worktreePath], ct, throwOnFailure: false);
+        }
+    }
+
+    public async Task MaterializeReviewBranchAsync(string repoRoot, string branchName, string startPoint, IEnumerable<ApiReviewArtifact> artifacts, string commitMessage, CancellationToken ct)
+    {
+        var worktreePath = Path.Combine(Path.GetTempPath(), "azsdk-api-review-branches", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.GetDirectoryName(worktreePath)!);
+
+        try
+        {
+            await RunGitAsync(repoRoot, ["worktree", "add", "-B", branchName, worktreePath, startPoint], ct);
+            foreach (var artifact in artifacts)
+            {
+                var targetPath = Path.Combine(worktreePath, artifact.ReviewPath.Replace('/', Path.DirectorySeparatorChar));
+                Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+                File.Copy(artifact.SourcePath, targetPath, overwrite: true);
+            }
+
+            await RunGitAsync(worktreePath, ["add", "--", "."], ct);
+            var diffResult = await RunGitAsync(worktreePath, ["diff", "--cached", "--quiet"], ct, throwOnFailure: false);
+            if (diffResult.ExitCode != 0)
+            {
+                await RunGitAsync(worktreePath, ["commit", "-m", commitMessage], ct);
+            }
+            else
+            {
+                logger.LogInformation("No artifact changes to commit on {BranchName}", branchName);
+            }
+        }
+        finally
+        {
+            await RemoveWorktreeAsync(repoRoot, worktreePath, ct);
+        }
+    }
+
+    public async Task PushBranchAsync(string repoRoot, string branchName, CancellationToken ct)
+    {
+        await RunGitAsync(repoRoot, ["push", "-u", "origin", branchName, "--force-with-lease"], ct);
+    }
+
+    private async Task<ProcessResult> RunGitAsync(string workingDirectory, string[] args, CancellationToken ct, bool throwOnFailure = true)
+    {
+        var result = await gitCommandHelper.Run(new GitOptions(args, workingDirectory, logOutputStream: true, timeout: TimeSpan.FromMinutes(10)), ct);
+        if (throwOnFailure && result.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"Git command failed: git {string.Join(' ', args)}{Environment.NewLine}{result.Output}".Trim());
+        }
+
+        return result;
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ApiReview/ApiReviewPackageResolver.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ApiReview/ApiReviewPackageResolver.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Sdk.Tools.Cli.Configuration;
+using Azure.Sdk.Tools.CodeownersUtils.Parsing;
+
+namespace Azure.Sdk.Tools.Cli.Services.ApiReview;
+
+public interface IApiReviewPackageResolver
+{
+    ApiReviewPackageResult ResolvePackage(string packageName, string worktreeRoot);
+}
+
+public class ApiReviewPackageResolver : IApiReviewPackageResolver
+{
+    public ApiReviewPackageResult ResolvePackage(string packageName, string worktreeRoot)
+    {
+        if (string.IsNullOrWhiteSpace(packageName))
+        {
+            return ApiReviewPackageResult.CreateFailure("Package name is required.");
+        }
+
+        var codeownersPath = Path.Combine(worktreeRoot, Constants.AZURE_CODEOWNERS_PATH);
+        if (!File.Exists(codeownersPath))
+        {
+            return ApiReviewPackageResult.CreateFailure($"CODEOWNERS file not found: {codeownersPath}");
+        }
+
+        var entries = CodeownersParser.ParseCodeownersFile(codeownersPath);
+        var normalizedPackageName = NormalizePath(packageName);
+        var matchingPackages = entries
+            .Where(entry => entry.IsValid && !entry.ContainsWildcard)
+            .Select(entry => new
+            {
+                Entry = entry,
+                RelativePath = NormalizePath(entry.PathExpression)
+            })
+            .Where(candidate => MatchesPackage(candidate.RelativePath, normalizedPackageName))
+            .Where(candidate => Directory.Exists(Path.Combine(worktreeRoot, candidate.RelativePath)))
+            .ToList();
+
+        if (matchingPackages.Count == 0)
+        {
+            return ApiReviewPackageResult.CreateFailure($"Unable to find package '{packageName}' in CODEOWNERS at {codeownersPath}.");
+        }
+
+        if (matchingPackages.Count > 1)
+        {
+            return ApiReviewPackageResult.CreateFailure($"Package '{packageName}' matched multiple CODEOWNERS entries: {string.Join(", ", matchingPackages.Select(package => package.Entry.PathExpression))}.");
+        }
+
+        var match = matchingPackages.Single();
+        return ApiReviewPackageResult.CreateSuccess(new ApiReviewPackageInfo
+        {
+            PackagePath = Path.GetFullPath(Path.Combine(worktreeRoot, match.RelativePath.Replace('/', Path.DirectorySeparatorChar))),
+            RelativePath = match.RelativePath,
+            CodeownersPathExpression = match.Entry.PathExpression
+        });
+    }
+
+    private static bool MatchesPackage(string relativePath, string packageName)
+    {
+        return string.Equals(relativePath, packageName, StringComparison.OrdinalIgnoreCase)
+            || relativePath.EndsWith($"/{packageName}", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizePath(string path)
+    {
+        return path.Replace('\\', '/').Trim().Trim('/');
+    }
+}
+
+public class ApiReviewPackageResult
+{
+    public bool Success { get; set; }
+    public string? ErrorMessage { get; set; }
+    public ApiReviewPackageInfo? Package { get; set; }
+
+    public static ApiReviewPackageResult CreateFailure(string errorMessage) => new()
+    {
+        Success = false,
+        ErrorMessage = errorMessage
+    };
+
+    public static ApiReviewPackageResult CreateSuccess(ApiReviewPackageInfo package) => new()
+    {
+        Success = true,
+        Package = package
+    };
+}
+
+public class ApiReviewPackageInfo
+{
+    public required string PackagePath { get; set; }
+    public required string RelativePath { get; set; }
+    public required string CodeownersPathExpression { get; set; }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/LanguageService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/LanguageService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Models.ApiReview;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Models.Responses.Package;
 using Azure.Sdk.Tools.Cli.Services.Languages.Samples;
@@ -746,6 +747,11 @@ namespace Azure.Sdk.Tools.Cli.Services.Languages
             string packagePath, string? outputPath = null, int timeoutMinutes = 30, CancellationToken ct = default)
         {
             return Task.FromResult<(bool, string?, PackageInfo?, string?)>((false, $"Pack is not supported for {Language}.", null, null));
+        }
+
+        public virtual Task<ApiReviewArtifactResult> GenerateApiReviewArtifactsAsync(ApiReviewArtifactRequest request, CancellationToken ct = default)
+        {
+            return Task.FromResult(ApiReviewArtifactResult.CreateFailure($"API review artifact generation is not supported for {Language}."));
         }
 
         protected static string? GetSpecProjectPath(string packagePath)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/PythonLanguageService.ApiReview.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Languages/PythonLanguageService.ApiReview.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Models.ApiReview;
+
+namespace Azure.Sdk.Tools.Cli.Services.Languages;
+
+public sealed partial class PythonLanguageService : LanguageService
+{
+    private static readonly string[] PythonApiReviewArtifactNames = ["api.md", "api.metadata.yml"];
+
+    public override async Task<ApiReviewArtifactResult> GenerateApiReviewArtifactsAsync(ApiReviewArtifactRequest request, CancellationToken ct = default)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(request.PackagePath) || !Directory.Exists(request.PackagePath))
+            {
+                return ApiReviewArtifactResult.CreateFailure($"Unable to find Python package '{request.PackageName}' at {request.PackagePath}.");
+            }
+
+            Directory.CreateDirectory(request.OutputDirectory);
+            var tempPath = Path.Combine(request.OutputDirectory, "temp");
+            Directory.CreateDirectory(tempPath);
+
+            var result = await pythonHelper.Run(new PythonOptions(
+                    "apistubgen",
+                    ["--pkg-path", request.PackagePath, "--out-path", request.OutputDirectory, "--temp-path", tempPath, "--skip-pylint"],
+                    workingDirectory: request.WorktreeRoot,
+                    timeout: TimeSpan.FromMinutes(10),
+                    logOutputStream: true),
+                ct);
+
+            if (result.ExitCode != 0)
+            {
+                return ApiReviewArtifactResult.CreateFailure($"apistubgen failed for package '{request.PackageName}' at ref '{request.Ref}'. Output:{Environment.NewLine}{result.Output}".Trim());
+            }
+
+            var reviewDirectory = Path.Combine(request.PackageRelativePath, "api-review").Replace(Path.DirectorySeparatorChar, '/');
+            var artifacts = new List<ApiReviewArtifact>();
+            foreach (var artifactName in PythonApiReviewArtifactNames)
+            {
+                var sourcePath = Path.Combine(request.OutputDirectory, artifactName);
+                if (!File.Exists(sourcePath))
+                {
+                    return ApiReviewArtifactResult.CreateFailure($"Expected Python API review artifact '{artifactName}' was not generated for package '{request.PackageName}' at ref '{request.Ref}'.");
+                }
+
+                artifacts.Add(new ApiReviewArtifact
+                {
+                    SourcePath = sourcePath,
+                    ReviewPath = $"{reviewDirectory}/{artifactName}"
+                });
+            }
+
+            return ApiReviewArtifactResult.CreateSuccess(request.PackagePath, artifacts);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to generate Python API review artifacts for {PackageName}", request.PackageName);
+            return ApiReviewArtifactResult.CreateFailure($"Failed to generate Python API review artifacts: {ex.Message}");
+        }
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
@@ -14,6 +14,7 @@ using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Helpers.Codeowners;
 using Azure.Sdk.Tools.Cli.Helpers.Codeowners.Rules;
 using Azure.Sdk.Tools.Cli.Tools.Core;
+using Azure.Sdk.Tools.Cli.Services.ApiReview;
 using Azure.Sdk.Tools.Cli.Services.APIView;
 using Azure.Sdk.Tools.Cli.Services.Languages;
 using Azure.Sdk.Tools.Cli.Services.SetupRequirements;
@@ -41,6 +42,8 @@ namespace Azure.Sdk.Tools.Cli.Services
             services.AddSingleton<IGitHubService, GitHubService>();
             services.AddSingleton<IAzureSdkKnowledgeBaseService, AzureSdkKnowledgeBaseService>();
             services.AddSingleton<IUpgradeService, UpgradeService>();
+            services.AddSingleton<IApiReviewGitService, ApiReviewGitService>();
+            services.AddSingleton<IApiReviewPackageResolver, ApiReviewPackageResolver>();
 
             // APIView Services
             services.AddSingleton<IAPIViewAuthenticationService, APIViewAuthenticationService>();

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/CreateApiReviewTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/CreateApiReviewTool.cs
@@ -1,0 +1,259 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.ComponentModel;
+using System.Text.RegularExpressions;
+using Azure.Sdk.Tools.Cli.Commands;
+using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.ApiReview;
+using Azure.Sdk.Tools.Cli.Models.Responses.Package;
+using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Services.ApiReview;
+using Azure.Sdk.Tools.Cli.Services.Languages;
+using Azure.Sdk.Tools.Cli.Tools.Core;
+using ModelContextProtocol.Server;
+
+namespace Azure.Sdk.Tools.Cli.Tools.Package;
+
+[McpServerToolType, Description("Create API review pull requests from package API artifacts.")]
+public class CreateApiReviewTool(
+    IGitHelper gitHelper,
+    IGitHubService gitHubService,
+    IApiReviewGitService apiReviewGitService,
+    IApiReviewPackageResolver apiReviewPackageResolver,
+    ILogger<CreateApiReviewTool> toolLogger,
+    IEnumerable<LanguageService> languageServices) : LanguageMcpTool(languageServices, gitHelper, toolLogger)
+{
+    private const string CommandName = "create-api-review";
+    private const string ToolName = "azsdk_package_create_api_review";
+    private const bool CreateDraftPullRequest = true;
+
+    private readonly Option<string> packageNameOption = new("--package-name")
+    {
+        Description = "Package name to create an API review for.",
+        Required = true
+    };
+
+    private readonly Option<string> baseOption = new("--base")
+    {
+        Description = "Baseline package release tag or ref.",
+        Required = true
+    };
+
+    private readonly Option<string> targetOption = new("--target")
+    {
+        Description = "Target package release tag, remote branch, or owner:branch fork reference.",
+        Required = true
+    };
+
+    private readonly Option<bool> dryRunOption = new("--dry-run")
+    {
+        Description = "Generate and validate API review artifacts without pushing branches or opening a pull request.",
+        DefaultValueFactory = _ => false
+    };
+
+    public override CommandGroup[] CommandHierarchy { get; set; } = [SharedCommandGroups.Package];
+
+    protected override Command GetCommand() =>
+        new McpCommand(CommandName, "Create an API review pull request for a package API diff", ToolName)
+        {
+            packageNameOption,
+            baseOption,
+            targetOption,
+            dryRunOption
+        };
+
+    public override async Task<CommandResponse> HandleCommand(ParseResult parseResult, CancellationToken ct)
+    {
+        return await CreateApiReviewAsync(
+            parseResult.GetValue(packageNameOption)!,
+            parseResult.GetValue(baseOption)!,
+            parseResult.GetValue(targetOption)!,
+            parseResult.GetValue(dryRunOption),
+            ct);
+    }
+
+    [McpServerTool(Name = ToolName), Description("Create an API review pull request for a package API diff. The target can be a tag, remote branch, or owner:branch fork reference.")]
+    public async Task<CreateApiReviewResponse> CreateApiReviewAsync(
+        [Description("Package name to create an API review for.")]
+        string packageName,
+        [Description("Baseline package release tag or ref.")]
+        string baseRef,
+        [Description("Target package release tag, remote branch, or owner:branch fork reference.")]
+        string target,
+        bool dryRun = false,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var response = new CreateApiReviewResponse
+            {
+                PackageName = packageName,
+                Base = baseRef,
+                Target = ApiReviewTarget.Parse(target),
+                Messages = []
+            };
+
+            if (string.IsNullOrWhiteSpace(packageName))
+            {
+                response.ResponseError = "Package name is required.";
+                return response;
+            }
+
+            var repoRoot = await gitHelper.DiscoverRepoRootAsync(Environment.CurrentDirectory, ct);
+            var repoName = await gitHelper.GetRepoNameAsync(repoRoot, ct);
+            response.SdkRepoName = repoName;
+
+            var language = await SdkLanguageHelpers.GetLanguageForRepoPathAsync(gitHelper, repoRoot, ct);
+            var languageService = GetLanguageService(language);
+            if (languageService == null)
+            {
+                response.ResponseError = $"API review creation is not supported for repository '{repoName}'.";
+                return response;
+            }
+
+            response.Language = language;
+            var baseTarget = ApiReviewTarget.Parse(baseRef);
+            var targetRef = response.Target;
+            var tempRoot = Path.Combine(Path.GetTempPath(), "azsdk-api-review", Guid.NewGuid().ToString("N"));
+            var baseWorktree = Path.Combine(tempRoot, "base");
+            var targetWorktree = Path.Combine(tempRoot, "target");
+
+            try
+            {
+                await apiReviewGitService.FetchTargetAsync(repoRoot, repoName, baseTarget, ct);
+                await apiReviewGitService.FetchTargetAsync(repoRoot, repoName, targetRef, ct);
+                await apiReviewGitService.AddWorktreeAsync(repoRoot, baseWorktree, baseTarget.GitRef, ct);
+                await apiReviewGitService.AddWorktreeAsync(repoRoot, targetWorktree, targetRef.GitRef, ct);
+
+                var basePackage = apiReviewPackageResolver.ResolvePackage(packageName, baseWorktree);
+                if (!basePackage.Success || basePackage.Package == null)
+                {
+                    response.ResponseError = basePackage.ErrorMessage;
+                    return response;
+                }
+
+                var targetPackage = apiReviewPackageResolver.ResolvePackage(packageName, targetWorktree);
+                if (!targetPackage.Success || targetPackage.Package == null)
+                {
+                    response.ResponseError = targetPackage.ErrorMessage;
+                    return response;
+                }
+
+                var baseArtifacts = await GenerateArtifactsAsync(languageService, packageName, basePackage.Package, repoRoot, baseWorktree, baseRef, Path.Combine(tempRoot, "base-artifacts"), ct);
+                if (!baseArtifacts.Success)
+                {
+                    response.ResponseError = baseArtifacts.ErrorMessage;
+                    return response;
+                }
+
+                var targetArtifacts = await GenerateArtifactsAsync(languageService, packageName, targetPackage.Package, repoRoot, targetWorktree, target, Path.Combine(tempRoot, "target-artifacts"), ct);
+                if (!targetArtifacts.Success)
+                {
+                    response.ResponseError = targetArtifacts.ErrorMessage;
+                    return response;
+                }
+
+                response.Artifacts = targetArtifacts.Artifacts;
+                response.Messages.Add($"Generated {baseArtifacts.Artifacts.Count} baseline artifact(s) and {targetArtifacts.Artifacts.Count} target artifact(s).");
+
+                response.BaseBranch = CreateBranchName(packageName, "base", baseRef);
+                response.HeadBranch = CreateBranchName(packageName, "target", $"{baseRef}-{target}");
+
+                if (dryRun)
+                {
+                    response.Messages.Add("Dry run completed. No branches were pushed and no pull request was created.");
+                    return response;
+                }
+
+                await apiReviewGitService.MaterializeReviewBranchAsync(repoRoot, response.BaseBranch, baseTarget.GitRef, baseArtifacts.Artifacts, $"Generate baseline API review artifacts for {packageName}", ct);
+                await apiReviewGitService.MaterializeReviewBranchAsync(repoRoot, response.HeadBranch, response.BaseBranch, targetArtifacts.Artifacts, $"Generate target API review artifacts for {packageName}", ct);
+                await apiReviewGitService.PushBranchAsync(repoRoot, response.BaseBranch, ct);
+                await apiReviewGitService.PushBranchAsync(repoRoot, response.HeadBranch, ct);
+
+                var headRepoOwner = await gitHelper.GetRepoOwnerNameAsync(repoRoot, findUpstreamParent: false, ct);
+                var targetRepoOwner = await gitHelper.GetRepoOwnerNameAsync(repoRoot, findUpstreamParent: true, ct);
+                var headBranch = $"{headRepoOwner}:{response.HeadBranch}";
+                var title = $"API review for {packageName}: {baseRef} -> {target}";
+                var body = BuildPullRequestBody(packageName, baseRef, targetRef, baseArtifacts.Artifacts);
+                var prResult = await gitHubService.CreatePullRequestAsync(repoName, targetRepoOwner, response.BaseBranch, headBranch, title, body, CreateDraftPullRequest, ct);
+
+                response.PullRequestUrl = prResult.Url;
+                response.Messages.AddRange(prResult.Messages);
+                if (string.IsNullOrWhiteSpace(prResult.Url))
+                {
+                    response.ResponseError = "Failed to create API review pull request. See messages for details.";
+                }
+            }
+            finally
+            {
+                await apiReviewGitService.RemoveWorktreeAsync(repoRoot, baseWorktree, ct);
+                await apiReviewGitService.RemoveWorktreeAsync(repoRoot, targetWorktree, ct);
+                if (Directory.Exists(tempRoot))
+                {
+                    Directory.Delete(tempRoot, recursive: true);
+                }
+            }
+
+            return response;
+        }
+        catch (Exception ex)
+        {
+            toolLogger.LogError(ex, "Failed to create API review for package {PackageName}", packageName);
+            return new CreateApiReviewResponse
+            {
+                PackageName = packageName,
+                Base = baseRef,
+                ResponseError = $"Failed to create API review: {ex.Message}"
+            };
+        }
+    }
+
+    private static async Task<ApiReviewArtifactResult> GenerateArtifactsAsync(LanguageService languageService, string packageName, ApiReviewPackageInfo packageInfo, string repoRoot, string worktreeRoot, string refName, string outputDirectory, CancellationToken ct)
+    {
+        return await languageService.GenerateApiReviewArtifactsAsync(new ApiReviewArtifactRequest
+        {
+            PackageName = packageName,
+            PackagePath = packageInfo.PackagePath,
+            PackageRelativePath = packageInfo.RelativePath,
+            RepoRoot = repoRoot,
+            WorktreeRoot = worktreeRoot,
+            Ref = refName,
+            OutputDirectory = outputDirectory
+        }, ct);
+    }
+
+    private static string CreateBranchName(string packageName, string kind, string refName)
+    {
+        return $"api-review/{SanitizeGitRefSegment(packageName)}/{kind}/{SanitizeGitRefSegment(refName)}";
+    }
+
+    private static string SanitizeGitRefSegment(string value)
+    {
+        var sanitized = Regex.Replace(value.Trim(), @"[^A-Za-z0-9._/-]+", "-");
+        sanitized = sanitized.Replace("..", ".", StringComparison.Ordinal).Trim('/', '.', '-');
+        return string.IsNullOrWhiteSpace(sanitized) ? "ref" : sanitized;
+    }
+
+    private static string BuildPullRequestBody(string packageName, string baseRef, ApiReviewTarget target, IReadOnlyList<ApiReviewArtifact> artifacts)
+    {
+        var targetDescription = target.Kind switch
+        {
+            ApiReviewTargetKind.ForkBranch => $"fork branch `{target.Owner}:{target.Branch}`",
+            ApiReviewTargetKind.RemoteBranch => $"remote branch `{target.Remote}/{target.Branch}`",
+            _ => $"target tag `{target.Raw}`"
+        };
+
+        return $"""
+        This draft PR contains generated API review artifacts for `{packageName}`.
+
+        Baseline: `{baseRef}`
+        Target: {targetDescription}
+
+        Artifacts:
+        {string.Join(Environment.NewLine, artifacts.Select(artifact => $"- `{artifact.ReviewPath}`"))}
+        """;
+    }
+}


### PR DESCRIPTION
Replace the standalone script in the `azure-sdk-for-python` repo.

Has extensibility to support other languages. 