### PR TITLE
Add System.Memory.Data to C# APIView parser dependency allowlist

### DIFF
--- a/src/dotnet/APIView/APIView/Languages/CompilationFactory.cs
+++ b/src/dotnet/APIView/APIView/Languages/CompilationFactory.cs
@@ -14,7 +14,8 @@ namespace APIView
         private static HashSet<string> AllowedAssemblies = new HashSet<string>(new[]
         {
             "Microsoft.Bcl.AsyncInterfaces",
-            "System.ClientModel"
+            "System.ClientModel",
+            "System.Memory.Data"
 
         }, StringComparer.InvariantCultureIgnoreCase);
 

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/Program.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/Program.cs
@@ -24,7 +24,8 @@ public static class Program
     private static readonly HashSet<string> _allowedDependencies = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
     {
         "Azure.Core",
-        "System.ClientModel"
+        "System.ClientModel",
+        "System.Memory.Data"
     };
 
     public static int Main(string[] args)


### PR DESCRIPTION
## Problem

The C# APIView parser drops explicit interface implementations (`IPersistableModel<T>.Create` and `.Write`) from its output when the analyzed package and its `System.ClientModel` dependency reference different assembly versions of `System.Memory.Data` (which provides `BinaryData`).

This manifests as a **false removal diff** in APIView — e.g., Azure.Core 1.60.0 shows `IPersistableModel<ResponseError>.Create` and `.Write` as deleted even though no source change was made.

### Root Cause

The parser builds a Roslyn compilation but does not load `System.Memory.Data` into it. Roslyn cannot resolve `BinaryData` and instead tries to unify the type by matching assembly identity. When both the analyzed package and `System.ClientModel` reference the **same** `System.Memory.Data` assembly version, Roslyn unifies successfully by coincidence. But after [azure-sdk-for-net#59871](https://github.com/Azure/azure-sdk-for-net/pull/59871) bumped `System.Memory.Data` from 10.0.3 to 10.0.9 (CVE-2026-26127), the version skew causes Roslyn to treat them as distinct unresolved types, `ExplicitInterfaceImplementations` returns empty, and methods get excluded.

`GetFormatFromOptions` survives because its signature only uses `string` and `ModelReaderWriterOptions` (both resolvable without `System.Memory.Data`).

## Fix

Add `System.Memory.Data` to both allowlists so the parser downloads and loads the DLL into the Roslyn compilation:
- `CompilationFactory.AllowedAssemblies`
- `Program._allowedDependencies`

## Validation

Ran the fixed parser against Azure.Core 1.59.0 and 1.60.0 nupkgs:
- **Before fix:** 1.59.0 produces 12 `IPersistableModel` lines, 1.60.0 produces only 4 (8 missing)
- **After fix:** Both produce identical 12 lines, zero diff

## Files Changed

- `src/dotnet/APIView/APIView/Languages/CompilationFactory.cs`
- `tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/Program.cs`
