### PR TITLE
Route all-language/pipeline SDK generation to azsdk_run_generate_sdk (#16072)

### DIFF
--- a/.github/skills/azsdk-common-generate-sdk-locally/SKILL.md
+++ b/.github/skills/azsdk-common-generate-sdk-locally/SKILL.md
@@ -21,7 +21,7 @@ DO NOT USE FOR: publishing to package registries, CI pipeline configuration, API
 ## Rules
 
 - This skill generates a **single language** SDK **locally**. If the user asks to "generate SDK for **all languages**", to generate **without a local clone**, or wants SDK **pull requests created** for them (release plan / pipeline flow), do **not** generate locally — call `azure-sdk-mcp:azsdk_run_generate_sdk` instead. It runs the SDK generation pipeline for each language and produces the SDK pull requests.
-- Never use `azsdk_get_sdk_pull_request_link` or `azsdk_get_pull_request` to *generate* an SDK; those only retrieve links for SDKs that were already generated.
+- Never use `azure-sdk-mcp:azsdk_get_sdk_pull_request_link` or `azure-sdk-mcp:azsdk_get_pull_request` to *generate* an SDK; those only retrieve links for SDKs that were already generated.
 - Requires the `azure-sdk-mcp` server for the MCP workflow; without MCP, use `npm exec --prefix eng/common/tsp-client -- tsp-client` CLI.
 - Verify the target language repo and the correct TypeSpec configuration file before generation.
 - After generation or customization, run the check and test steps before updating metadata or finalizing changes.

--- a/.github/skills/azsdk-common-generate-sdk-locally/SKILL.md
+++ b/.github/skills/azsdk-common-generate-sdk-locally/SKILL.md
@@ -21,7 +21,7 @@ DO NOT USE FOR: publishing to package registries, CI pipeline configuration, API
 ## Rules
 
 - This skill generates a **single language** SDK **locally**. If the user asks to "generate SDK for **all languages**", to generate **without a local clone**, or wants SDK **pull requests created** for them (release plan / pipeline flow), do **not** generate locally — call `azure-sdk-mcp:azsdk_run_generate_sdk` instead. It runs the SDK generation pipeline for each language and produces the SDK pull requests.
-- Never use `azure-sdk-mcp:azsdk_get_sdk_pull_request_link` or `azure-sdk-mcp:azsdk_get_pull_request` to *generate* an SDK; those only retrieve links for SDKs that were already generated.
+- Never use `azure-sdk-mcp:azsdk_get_sdk_pull_request_link` or `azure-sdk-mcp:azsdk_get_pull_request` to _generate_ an SDK; those only retrieve links for SDKs that were already generated.
 - Requires the `azure-sdk-mcp` server for the MCP workflow; without MCP, use `npm exec --prefix eng/common/tsp-client -- tsp-client` CLI.
 - Verify the target language repo and the correct TypeSpec configuration file before generation.
 - After generation or customization, run the check and test steps before updating metadata or finalizing changes.

--- a/.github/skills/azsdk-common-generate-sdk-locally/SKILL.md
+++ b/.github/skills/azsdk-common-generate-sdk-locally/SKILL.md
@@ -85,7 +85,7 @@ Prerequisites: azure-sdk-mcp server must be running. Without MCP, use `npx tsp-c
 
 ## Troubleshooting
 
-- For "generate SDK for all languages", pipeline-based generation, or when no local SDK clone exists, call `azure-sdk-mcp:azsdk_run_generate_sdk` instead of the local generate flow, and never substitute `azsdk_get_sdk_pull_request_link` / `azsdk_get_pull_request` for generation.
+- For "generate SDK for all languages", pipeline-based generation, or when no local SDK clone exists, call `azure-sdk-mcp:azsdk_run_generate_sdk` instead of the local generate flow, and never substitute `azure-sdk-mcp:azsdk_get_sdk_pull_request_link` / `azure-sdk-mcp:azsdk_get_pull_request` for generation.
 - Run `azure-sdk-mcp:azsdk_verify_setup` to confirm MCP and tools.
 - If build fails with type conflicts, breaking changes, analyzer errors, or customization drift, use `azure-sdk-mcp:azsdk_customized_code_update` to apply customizations.
 - The customization tool uses a two-phase approach: TypeSpec decorators first (Phase A), then code repairs if needed (Phase B).

--- a/.github/skills/azsdk-common-generate-sdk-locally/SKILL.md
+++ b/.github/skills/azsdk-common-generate-sdk-locally/SKILL.md
@@ -20,6 +20,8 @@ DO NOT USE FOR: publishing to package registries, CI pipeline configuration, API
 
 ## Rules
 
+- This skill generates a **single language** SDK **locally**. If the user asks to "generate SDK for **all languages**", to generate **without a local clone**, or wants SDK **pull requests created** for them (release plan / pipeline flow), do **not** generate locally — call `azure-sdk-mcp:azsdk_run_generate_sdk` instead. It runs the SDK generation pipeline for each language and produces the SDK pull requests.
+- Never use `azsdk_get_sdk_pull_request_link` or `azsdk_get_pull_request` to *generate* an SDK; those only retrieve links for SDKs that were already generated.
 - Requires the `azure-sdk-mcp` server for the MCP workflow; without MCP, use `npm exec --prefix eng/common/tsp-client -- tsp-client` CLI.
 - Verify the target language repo and the correct TypeSpec configuration file before generation.
 - After generation or customization, run the check and test steps before updating metadata or finalizing changes.
@@ -83,6 +85,7 @@ Prerequisites: azure-sdk-mcp server must be running. Without MCP, use `npx tsp-c
 
 ## Troubleshooting
 
+- For "generate SDK for all languages", pipeline-based generation, or when no local SDK clone exists, call `azure-sdk-mcp:azsdk_run_generate_sdk` instead of the local generate flow, and never substitute `azsdk_get_sdk_pull_request_link` / `azsdk_get_pull_request` for generation.
 - Run `azure-sdk-mcp:azsdk_verify_setup` to confirm MCP and tools.
 - If build fails with type conflicts, breaking changes, analyzer errors, or customization drift, use `azure-sdk-mcp:azsdk_customized_code_update` to apply customizations.
 - The customization tool uses a two-phase approach: TypeSpec decorators first (Phase A), then code repairs if needed (Phase B).

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -478,8 +478,8 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                                 releasePlan.IsSpecApproved = true;
                                 // API spec is approved/merged, so the next step is to generate the SDK.
                                 // Surface the pipeline-based generation tool explicitly so the agent does
-                                // not pick an unrelated tool (e.g. azsdk_get_sdk_pull_request_link).
-                                response.NextSteps = ["API spec is approved. Run SDK generation for all languages using the azsdk_run_generate_sdk tool."];
+                                // not pick an unrelated tool (e.g. azsdk_get_sdk_pull_request_link).                                // Append so we don't clobber any NextSteps set by earlier logic.
+                                (response.NextSteps ??= []).Add("API spec is approved. Run SDK generation for all languages using the azsdk_run_generate_sdk tool.");
                             }
                         }
                     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -476,6 +476,10 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                             if (specReadiness.Status == "Success")
                             {
                                 releasePlan.IsSpecApproved = true;
+                                // API spec is approved/merged, so the next step is to generate the SDK.
+                                // Surface the pipeline-based generation tool explicitly so the agent does
+                                // not pick an unrelated tool (e.g. azsdk_get_sdk_pull_request_link).
+                                response.NextSteps = ["API spec is approved. Run SDK generation for all languages using the azsdk_run_generate_sdk tool."];
                             }
                         }
                     }


### PR DESCRIPTION
Fixes #16072.

## Problem

A service team prompt like "Generate SDK from TypeSpec project" routed to the wrong MCP tool (`azsdk_get_sdk_pull_request_link`) instead of running SDK generation. The `azsdk-common-generate-sdk-locally` skill over-matches "generate SDK" and gave no guidance on the pipeline/all-languages path. Separately, `azsdk_get_release_plan` gave no direction once the API spec was approved, so the agent had nothing pointing it at the generation tool.

## Changes

1. **`azsdk-common-generate-sdk-locally` skill** — explicit tool routing: "generate SDK for all languages" / pipeline / no-local-clone requests must call `azsdk_run_generate_sdk` (not the local generate flow); never substitute `azsdk_get_sdk_pull_request_link` / `azsdk_get_pull_request` to *generate* an SDK.

2. **`azsdk_get_release_plan` (`ReleasePlanTool.GetReleasePlan`)** — when the API spec readiness check succeeds (`IsSpecApproved`), the response now includes a NextStep: "API spec is approved. Run SDK generation for all languages using the azsdk_run_generate_sdk tool."

## Validation

- CLI builds clean; 93 `ReleasePlanTool` unit tests pass.
- Routing validated with Vally mock workflow evals (tracked separately): the agent picks `azsdk_get_release_plan` + `azsdk_run_generate_sdk` and avoids the PR-link retrieval tools.
