### PR TITLE
[APIView] Update latest pending revisions in place instead of soft-deleting and re-creating

### DIFF
--- a/src/dotnet/APIView/APIViewUnitTests/AutoReviewServiceTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/AutoReviewServiceTests.cs
@@ -43,6 +43,9 @@ namespace APIViewUnitTests
                 {
                     PackageVersion = codeFile.PackageVersion
                 });
+            _mockCodeFileManager
+                .Setup(x => x.TryDeleteCodeFileModelAsync(It.IsAny<string>(), It.IsAny<APICodeFileModel>()))
+                .Returns(Task.CompletedTask);
 
             _service = new AutoReviewService(
                 _mockReviewManager.Object,
@@ -1137,6 +1140,59 @@ namespace APIViewUnitTests
 
             _mockApiRevisionsManager.Verify(m => m.UpdateAPIRevisionAsync(
                 It.Is<APIRevisionListItemModel>(r => r.Id == "b1-approved")), Times.Never, "B1 is approved and must never be touched");
+        }
+
+        [Fact]
+        public async Task CreateAutomaticRevisionAsync_WhenUpdatingExistingRevisionWithoutOriginalName_PreservesFileName()
+        {
+            var codeFile = CreateCodeFile("TestPackage", "2.0.0", "C#");
+            using var memoryStream = new MemoryStream();
+
+            var review = new ReviewListItemModel { Id = "review-id", PackageName = "TestPackage", Language = "C#" };
+            var existingRevision = new APIRevisionListItemModel
+            {
+                Id = "existing-revision-id",
+                ReviewId = "review-id",
+                APIRevisionType = APIRevisionType.Automatic,
+                CreatedOn = DateTime.UtcNow,
+                Files = new List<APICodeFileModel>
+                {
+                    new APICodeFileModel { FileId = "old-file-id", FileName = "original.json", HasOriginal = true, PackageVersion = "2.0.0" }
+                }
+            };
+
+            APIRevisionListItemModel updatedRevision = null;
+
+            _mockReviewManager.Setup(m => m.GetReviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
+                .ReturnsAsync(review);
+
+            _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
+                .ReturnsAsync(new List<APIRevisionListItemModel> { existingRevision });
+
+            _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>()))
+                .ReturnsAsync(new List<CommentItemModel>());
+
+            _mockApiRevisionsManager.Setup(m => m.UpdateAPIRevisionAsync(It.IsAny<APIRevisionListItemModel>()))
+                .Callback<APIRevisionListItemModel>(revision => updatedRevision = revision)
+                .Returns(Task.CompletedTask);
+
+            _mockCodeFileManager
+                .Setup(x => x.CreateReviewCodeFileModel(It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>()))
+                .ReturnsAsync((string apiRevisionId, MemoryStream memoryStream, CodeFile codeFile) => new APICodeFileModel
+                {
+                    FileId = "new-file-id",
+                    PackageVersion = codeFile.PackageVersion
+                });
+
+            await _service.CreateAutomaticRevisionAsync(
+                _testUser, codeFile, "build-label", null, memoryStream, null);
+
+            updatedRevision.Should().NotBeNull();
+            updatedRevision.Files.Should().ContainSingle();
+            updatedRevision.Files[0].FileName.Should().Be("original.json");
+            _mockCodeFileManager.Verify(m => m.TryDeleteCodeFileModelAsync(
+                "existing-revision-id",
+                It.Is<APICodeFileModel>(file => file.FileId == "old-file-id" && file.HasOriginal)), Times.Once);
         }
 
         #endregion

--- a/src/dotnet/APIView/APIViewUnitTests/AutoReviewServiceTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/AutoReviewServiceTests.cs
@@ -37,6 +37,12 @@ namespace APIViewUnitTests
             _mockCodeFileManager
                 .Setup(x => x.ComputeAPIContentHashAsync(It.IsAny<CodeFile>()))
                 .ReturnsAsync("test-hash");
+            _mockCodeFileManager
+                .Setup(x => x.CreateReviewCodeFileModel(It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>()))
+                .ReturnsAsync((string apiRevisionId, MemoryStream memoryStream, CodeFile codeFile) => new APICodeFileModel
+                {
+                    PackageVersion = codeFile.PackageVersion
+                });
 
             _service = new AutoReviewService(
                 _mockReviewManager.Object,
@@ -588,10 +594,8 @@ namespace APIViewUnitTests
         }
 
         [Fact]
-        public async Task CreateAutomaticRevisionAsync_WhenCandidateHasSameContent_StillDeletesAndCreatesNew()
+        public async Task CreateAutomaticRevisionAsync_WhenCandidateHasSameContent_UpdatesExistingRevision()
         {
-            // Even when the incoming upload is byte-for-byte identical to the existing revision,
-            // we always delete the candidate and create a fresh revision. No reuse.
             var codeFile = CreateCodeFile("TestPackage", "1.0.0", "C#");
             using var memoryStream = new MemoryStream();
 
@@ -606,39 +610,32 @@ namespace APIViewUnitTests
                 Files = [new APICodeFileModel { PackageVersion = "1.0.0" }]
             };
 
-            var newRevision = new APIRevisionListItemModel { Id = "new-revision", ReviewId = "review-id" };
-
             _mockReviewManager.Setup(m => m.GetReviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
                 .ReturnsAsync(review);
             _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
                 .ReturnsAsync(new List<APIRevisionListItemModel> { existingRevision });
             _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>()))
                 .ReturnsAsync(new List<CommentItemModel>());
-            _mockApiRevisionsManager.Setup(m => m.SoftDeleteAPIRevisionAsync(
-                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()))
+            _mockApiRevisionsManager.Setup(m => m.UpdateAPIRevisionAsync(It.IsAny<APIRevisionListItemModel>()))
                 .Returns(Task.CompletedTask);
-            _mockApiRevisionsManager.Setup(m => m.CreateAPIRevisionAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
-                    It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
-                    It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
-                .ReturnsAsync(newRevision);
 
             var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
                 _testUser, codeFile, "test-label", "test.json", memoryStream, null);
 
-            // Candidate must be deleted even though content is identical
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "existing-revision"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+                It.IsAny<APIRevisionListItemModel>(),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never);
 
-            // A new revision must always be created
             _mockApiRevisionsManager.Verify(m => m.CreateAPIRevisionAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
                 It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
-                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Once);
+                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never);
+
+            _mockApiRevisionsManager.Verify(m => m.UpdateAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "existing-revision" && r.Label == "test-label" && r.Files[0].FileName == "test.json")), Times.Once);
 
             apiRevision.Should().NotBeNull();
-            apiRevision.Id.Should().Be("new-revision");
+            apiRevision.Id.Should().Be("existing-revision");
         }
 
         #endregion
@@ -646,12 +643,12 @@ namespace APIViewUnitTests
         #region Rolling Build / Package Version Tests
 
         /// <summary>
-        /// Rollin builds that re-run with the same version string
-        /// (e.g. a CI retry) delete the previous pending revision and create a fresh one.
+        /// Rolling builds that re-run with the same version string
+        /// (e.g. a CI retry) update the previous pending revision in place.
         /// Both belong to the same <c>APIVersionId</c> so the v1-stable bucket is never touched.
         /// </summary>
         [Fact]
-        public async Task CreateAutomaticRevisionAsync_RollingAlphaBuild_DeletesPreviousAndCreatesNew()
+        public async Task CreateAutomaticRevisionAsync_RollingAlphaBuild_UpdatesPreviousRevision()
         {
             var codeFile = CreateCodeFile("TestPackage", "1.4.0-alpha.20201212.0", "C#");
             using var memoryStream = new MemoryStream();
@@ -671,8 +668,6 @@ namespace APIViewUnitTests
                 Files = [new APICodeFileModel { PackageVersion = "1.4.0-alpha.20201212.0" }]
             };
 
-            var newBuild = new APIRevisionListItemModel { Id = "alpha-20201212-new", ReviewId = "review-id" };
-
             _mockReviewManager.Setup(m => m.GetReviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
                 .ReturnsAsync(review);
             _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
@@ -681,29 +676,25 @@ namespace APIViewUnitTests
                 .ReturnsAsync(versionModel);
             _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>()))
                 .ReturnsAsync(new List<CommentItemModel>());
-            _mockApiRevisionsManager.Setup(m => m.SoftDeleteAPIRevisionAsync(
-                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()))
+            _mockApiRevisionsManager.Setup(m => m.UpdateAPIRevisionAsync(It.IsAny<APIRevisionListItemModel>()))
                 .Returns(Task.CompletedTask);
-            _mockApiRevisionsManager.Setup(m => m.CreateAPIRevisionAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
-                    It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
-                    It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
-                .ReturnsAsync(newBuild);
 
             var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
                 _testUser, codeFile, "build-label", "test.json", memoryStream, null);
 
-            // Previous build (same version) is deleted; fresh revision created
+            // Previous build (same version) is updated in place so links stay stable.
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "alpha-20201212-prev"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+                It.IsAny<APIRevisionListItemModel>(),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never);
             _mockApiRevisionsManager.Verify(m => m.CreateAPIRevisionAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
                 It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
-                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Once);
+                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never);
+            _mockApiRevisionsManager.Verify(m => m.UpdateAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "alpha-20201212-prev" && r.Label == "build-label")), Times.Once);
 
             apiRevision.Should().NotBeNull();
-            apiRevision.Id.Should().Be("alpha-20201212-new");
+            apiRevision.Id.Should().Be("alpha-20201212-prev");
         }
 
         [Fact]
@@ -837,7 +828,7 @@ namespace APIViewUnitTests
         [Fact]
         public async Task CreateAutomaticRevisionAsync_SupersessionScopedToSameVersionId()
         {
-            // Supersession (soft-delete of stale pending revisions) must only affect revisions
+            // Supersession (in-place update of stale pending revisions) must only affect revisions
             // belonging to the same APIVersionId as the incoming upload
             var codeFile = CreateCodeFile("TestPackage", "1.0.0", "C#");
             using var memoryStream = new MemoryStream();
@@ -873,8 +864,7 @@ namespace APIViewUnitTests
             _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
                     It.IsAny<APIRevisionListItemModel>(), It.IsAny<RenderedCodeFile>(), It.IsAny<bool>(), It.IsAny<string>()))
                 .ReturnsAsync(false);
-            _mockApiRevisionsManager.Setup(m => m.SoftDeleteAPIRevisionAsync(
-                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()))
+            _mockApiRevisionsManager.Setup(m => m.UpdateAPIRevisionAsync(It.IsAny<APIRevisionListItemModel>()))
                 .Returns(Task.CompletedTask);
             _mockApiRevisionsManager.Setup(m => m.CreateAPIRevisionAsync(
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
@@ -884,17 +874,18 @@ namespace APIViewUnitTests
 
             await _service.CreateAutomaticRevisionAsync(_testUser, codeFile, "test-label", "test.json", memoryStream, null);
 
-            // Only the v1 revision (same version as incoming) should be considered for deletion.
+            // Only the v1 revision (same version as incoming) should be considered for update.
             _mockApiRevisionsManager.Verify(
-                m => m.SoftDeleteAPIRevisionAsync(
-                    It.Is<APIRevisionListItemModel>(r => r.Id == "rev-v1"),
-                    It.IsAny<string>(), It.IsAny<string>()),
+                m => m.UpdateAPIRevisionAsync(
+                    It.Is<APIRevisionListItemModel>(r => r.Id == "rev-v1")),
                 Times.Once);
             _mockApiRevisionsManager.Verify(
-                m => m.SoftDeleteAPIRevisionAsync(
-                    It.Is<APIRevisionListItemModel>(r => r.Id == "rev-v2"),
-                    It.IsAny<string>(), It.IsAny<string>()),
+                m => m.UpdateAPIRevisionAsync(
+                    It.Is<APIRevisionListItemModel>(r => r.Id == "rev-v2")),
                 Times.Never);
+            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
+                It.IsAny<APIRevisionListItemModel>(),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
 
         /// <summary>
@@ -963,20 +954,20 @@ namespace APIViewUnitTests
                 _testUser, codeFile, "build-label", "test.json", memoryStream, null);
 
             apiRevision.Should().NotBeNull();
-            apiRevision.Id.Should().Be("new-v2beta");
+            apiRevision.Id.Should().Be("b3-v2beta");
 
-            // B3 (v2-beta candidate) is deleted and replaced
+            // B3 (v2-beta candidate) is updated in place
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "b3-v2beta"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+                It.IsAny<APIRevisionListItemModel>(),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            _mockApiRevisionsManager.Verify(m => m.UpdateAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b3-v2beta")), Times.Once);
 
             // v1-stable revisions are never touched
-            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "b1-v1stable"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "b2-v1stable"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            _mockApiRevisionsManager.Verify(m => m.UpdateAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b1-v1stable")), Times.Never);
+            _mockApiRevisionsManager.Verify(m => m.UpdateAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b2-v1stable")), Times.Never);
         }
 
         #endregion
@@ -985,17 +976,17 @@ namespace APIViewUnitTests
 
         /// <summary>
         /// When incoming content does NOT match the candidate (newest unprotected),
-        /// only the candidate is deleted and a new revision is created.
+        /// only the candidate is updated in place.
         /// Older pending revisions are not touched.
         ///
         /// History (newest first):
-        ///   B2 — pending (candidate — doesn't match → deleted)
+        ///   B2 — pending (candidate — updated)
         ///   B1 — pending (older, not the candidate — not touched)
         ///
-        /// Expected outcome: B2 deleted, B3 created, B1 untouched.
+        /// Expected outcome: B2 updated, B1 untouched.
         /// </summary>
         [Fact]
-        public async Task CreateAutomaticRevisionAsync_WhenCandidateDoesntMatch_OnlyCandidateIsDeleted()
+        public async Task CreateAutomaticRevisionAsync_WhenCandidateDoesntMatch_OnlyCandidateIsUpdated()
         {
             var codeFile = CreateCodeFile("TestPackage", "2.0.0", "C#");
             using var memoryStream = new MemoryStream();
@@ -1018,44 +1009,37 @@ namespace APIViewUnitTests
                 Files = [new APICodeFileModel { PackageVersion = "2.0.0" }]
             };
 
-            var b3New = new APIRevisionListItemModel { Id = "b3-new", ReviewId = "review-id" };
-
             _mockReviewManager.Setup(m => m.GetReviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
                 .ReturnsAsync(review);
             _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
                 .ReturnsAsync(new List<APIRevisionListItemModel> { b2Pending, b1Pending });
             _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>()))
                 .ReturnsAsync(new List<CommentItemModel>());
-            _mockApiRevisionsManager.Setup(m => m.SoftDeleteAPIRevisionAsync(
-                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()))
+            _mockApiRevisionsManager.Setup(m => m.UpdateAPIRevisionAsync(It.IsAny<APIRevisionListItemModel>()))
                 .Returns(Task.CompletedTask);
             _mockApiRevisionsManager.Setup(m => m.AreAPIRevisionsTheSame(
                     It.IsAny<APIRevisionListItemModel>(), It.IsAny<RenderedCodeFile>(), It.IsAny<bool>(), It.IsAny<string>()))
                 .ReturnsAsync(false);
-            _mockApiRevisionsManager.Setup(m => m.CreateAPIRevisionAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
-                    It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
-                    It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
-                .ReturnsAsync(b3New);
-
             var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
                 _testUser, codeFile, "build-label", "test.json", memoryStream, null);
 
             apiRevision.Should().NotBeNull();
-            apiRevision.Id.Should().Be("b3-new");
+            apiRevision.Id.Should().Be("b2-pending");
 
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "b2-pending"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Once, "B2 is the candidate and must be deleted");
+                It.IsAny<APIRevisionListItemModel>(),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never);
 
-            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "b1-pending"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B1 is not the candidate and must not be touched");
+            _mockApiRevisionsManager.Verify(m => m.UpdateAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b2-pending")), Times.Once, "B2 is the candidate and must be updated");
+
+            _mockApiRevisionsManager.Verify(m => m.UpdateAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b1-pending")), Times.Never, "B1 is not the candidate and must not be touched");
 
             _mockApiRevisionsManager.Verify(m => m.CreateAPIRevisionAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
                 It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
-                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Once);
+                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never);
         }
 
         /// <summary>
@@ -1064,11 +1048,11 @@ namespace APIViewUnitTests
         ///
         /// History (newest first):
         ///   B4 — HAS a comment  (protected — skipped by FirstOrDefault)
-        ///   B3 — pending, no comments  ← candidate
+        ///   B3 — pending, no comments  ← candidate, updated
         ///   B2 — pending, no comments  (not the candidate)
         ///   B1 — approved anchor       (protected — skipped)
         ///
-        /// Expected outcome: B3 deleted (candidate, doesn't match), B5 created, B4/B2/B1 untouched.
+        /// Expected outcome: B3 updated, B4/B2/B1 untouched.
         /// </summary>
         [Fact]
         public async Task CreateAutomaticRevisionAsync_WhenNewestRevisionHasComment_SkipsItAndSelectsNextAsCandidate()
@@ -1111,7 +1095,6 @@ namespace APIViewUnitTests
                 Files = new List<APICodeFileModel> { new APICodeFileModel { PackageVersion = "2.0.0" } }
             };
 
-            var b5New = new APIRevisionListItemModel { Id = "b5-new", ReviewId = "review-id" };
             var comment = new CommentItemModel { APIRevisionId = "b4-with-comment", ReviewId = "review-id" };
 
             _mockReviewManager.Setup(m => m.GetReviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
@@ -1123,8 +1106,7 @@ namespace APIViewUnitTests
             _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>()))
                 .ReturnsAsync(new List<CommentItemModel> { comment });
 
-            _mockApiRevisionsManager.Setup(m => m.SoftDeleteAPIRevisionAsync(
-                    It.IsAny<APIRevisionListItemModel>(), It.IsAny<string>(), It.IsAny<string>()))
+            _mockApiRevisionsManager.Setup(m => m.UpdateAPIRevisionAsync(It.IsAny<APIRevisionListItemModel>()))
                 .Returns(Task.CompletedTask);
 
             // B3 (candidate) doesn't match incoming content
@@ -1132,36 +1114,29 @@ namespace APIViewUnitTests
                     It.IsAny<APIRevisionListItemModel>(), It.IsAny<RenderedCodeFile>(), It.IsAny<bool>(), It.IsAny<string>()))
                 .ReturnsAsync(false);
 
-            _mockApiRevisionsManager.Setup(m => m.CreateAPIRevisionAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>(),
-                    It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>(),
-                    It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>()))
-                .ReturnsAsync(b5New);
-
             var (_, apiRevision) = await _service.CreateAutomaticRevisionAsync(
                 _testUser, codeFile, "build-5-label", "test.json", memoryStream, null);
 
             apiRevision.Should().NotBeNull();
-            apiRevision.Id.Should().Be("b5-new");
+            apiRevision.Id.Should().Be("b3-pending");
 
-            // B3 is the candidate (B4 was skipped due to comment) — it must be deleted
+            // B3 is the candidate (B4 was skipped due to comment) — it must be updated
             _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "b3-pending"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Once, "B3 is the candidate and must be deleted");
+                It.IsAny<APIRevisionListItemModel>(),
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            _mockApiRevisionsManager.Verify(m => m.UpdateAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b3-pending")), Times.Once, "B3 is the candidate and must be updated");
 
             // B4 has a comment — it was skipped as candidate and must NOT be deleted
-            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "b4-with-comment"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B4 has a comment and must not be touched");
+            _mockApiRevisionsManager.Verify(m => m.UpdateAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b4-with-comment")), Times.Never, "B4 has a comment and must not be touched");
 
             // B2 is not the candidate and must not be touched
-            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "b2-pending"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B2 is not the candidate and must not be touched");
+            _mockApiRevisionsManager.Verify(m => m.UpdateAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b2-pending")), Times.Never, "B2 is not the candidate and must not be touched");
 
-            _mockApiRevisionsManager.Verify(m => m.SoftDeleteAPIRevisionAsync(
-                It.Is<APIRevisionListItemModel>(r => r.Id == "b1-approved"),
-                It.IsAny<string>(), It.IsAny<string>()), Times.Never, "B1 is approved and must never be touched");
+            _mockApiRevisionsManager.Verify(m => m.UpdateAPIRevisionAsync(
+                It.Is<APIRevisionListItemModel>(r => r.Id == "b1-approved")), Times.Never, "B1 is approved and must never be touched");
         }
 
         #endregion

--- a/src/dotnet/APIView/APIViewUnitTests/AutoReviewServiceTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/AutoReviewServiceTests.cs
@@ -1195,6 +1195,56 @@ namespace APIViewUnitTests
                 It.Is<APICodeFileModel>(file => file.FileId == "old-file-id" && file.HasOriginal)), Times.Once);
         }
 
+        [Fact]
+        public async Task CreateAutomaticRevisionAsync_WhenUpdatingExistingRevisionWithoutSourceBranch_PreservesSourceBranch()
+        {
+            var codeFile = CreateCodeFile("TestPackage", "2.0.0", "C#");
+            using var memoryStream = new MemoryStream();
+
+            var review = new ReviewListItemModel { Id = "review-id", PackageName = "TestPackage", Language = "C#" };
+            var existingRevision = new APIRevisionListItemModel
+            {
+                Id = "existing-revision-id",
+                ReviewId = "review-id",
+                APIRevisionType = APIRevisionType.Automatic,
+                CreatedOn = DateTime.UtcNow,
+                SourceBranch = "feature/existing",
+                Files = new List<APICodeFileModel>
+                {
+                    new APICodeFileModel { FileId = "old-file-id", FileName = "original.json", PackageVersion = "2.0.0" }
+                }
+            };
+
+            APIRevisionListItemModel updatedRevision = null;
+
+            _mockReviewManager.Setup(m => m.GetReviewAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool?>()))
+                .ReturnsAsync(review);
+
+            _mockApiRevisionsManager.Setup(m => m.GetAPIRevisionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<APIRevisionType>()))
+                .ReturnsAsync(new List<APIRevisionListItemModel> { existingRevision });
+
+            _mockCommentsManager.Setup(m => m.GetCommentsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CommentType?>()))
+                .ReturnsAsync(new List<CommentItemModel>());
+
+            _mockApiRevisionsManager.Setup(m => m.UpdateAPIRevisionAsync(It.IsAny<APIRevisionListItemModel>()))
+                .Callback<APIRevisionListItemModel>(revision => updatedRevision = revision)
+                .Returns(Task.CompletedTask);
+
+            _mockCodeFileManager
+                .Setup(x => x.CreateReviewCodeFileModel(It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CodeFile>()))
+                .ReturnsAsync((string apiRevisionId, MemoryStream memoryStream, CodeFile codeFile) => new APICodeFileModel
+                {
+                    FileId = "new-file-id",
+                    PackageVersion = codeFile.PackageVersion
+                });
+
+            await _service.CreateAutomaticRevisionAsync(
+                _testUser, codeFile, "build-label", "new.json", memoryStream, null);
+
+            updatedRevision.Should().NotBeNull();
+            updatedRevision.SourceBranch.Should().Be("feature/existing");
+        }
+
         #endregion
 
         #region Helper Methods

--- a/src/dotnet/APIView/APIViewWeb/Managers/AutoReviewService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/AutoReviewService.cs
@@ -106,7 +106,14 @@ public class AutoReviewService : IAutoReviewService
 
                     if (latestAutomaticAPIRevision != null)
                     {
-                        await _apiRevisionsManager.SoftDeleteAPIRevisionAsync(apiRevision: latestAutomaticAPIRevision, notes: "Deleted by Automatic Review Creation...");
+                        apiRevision = await UpdateAutomaticAPIRevisionCodeFile(
+                            latestAutomaticAPIRevision,
+                            label,
+                            originalName,
+                            memoryStream,
+                            codeFile,
+                            sourceBranch,
+                            incomingVersionModel?.Id);
                     }
                 }
             }
@@ -116,7 +123,10 @@ public class AutoReviewService : IAutoReviewService
             review = await _reviewManager.CreateReviewAsync(packageName: codeFile.PackageName, language: codeFile.Language, isClosed: false, packageType: parsedPackageType, crossLanguagePackageId: codeFile.CrossLanguagePackageId);
         }
 
-        apiRevision = await _apiRevisionsManager.CreateAPIRevisionAsync(userName: user.GetGitHubLogin(), reviewId: review.Id, apiRevisionType: APIRevisionType.Automatic, label: label, memoryStream: memoryStream, codeFile: codeFile, originalName: originalName, sourceBranch: sourceBranch);
+        if (apiRevision == null)
+        {
+            apiRevision = await _apiRevisionsManager.CreateAPIRevisionAsync(userName: user.GetGitHubLogin(), reviewId: review.Id, apiRevisionType: APIRevisionType.Automatic, label: label, memoryStream: memoryStream, codeFile: codeFile, originalName: originalName, sourceBranch: sourceBranch);
+        }
 
         await _projectsManager.TryLinkReviewToProjectAsync(user.GetGitHubLogin(), review);
 
@@ -134,5 +144,45 @@ public class AutoReviewService : IAutoReviewService
             }
         }
         return (review, apiRevision);
+    }
+
+    private async Task<APIRevisionListItemModel> UpdateAutomaticAPIRevisionCodeFile(
+        APIRevisionListItemModel apiRevision,
+        string label,
+        string originalName,
+        MemoryStream memoryStream,
+        CodeFile codeFile,
+        string sourceBranch,
+        string apiVersionId)
+    {
+        var codeFileModel = await _codeFileManager.CreateReviewCodeFileModel(apiRevision.Id, memoryStream, codeFile);
+        if (!string.IsNullOrEmpty(originalName))
+        {
+            codeFileModel.FileName = originalName;
+        }
+
+        if (apiRevision.Files.Any())
+        {
+            apiRevision.Files[0] = codeFileModel;
+        }
+        else
+        {
+            apiRevision.Files.Add(codeFileModel);
+        }
+
+        apiRevision.PackageName = codeFile.PackageName;
+        apiRevision.Language = codeFile.Language;
+        apiRevision.Label = label;
+        apiRevision.SourceBranch = sourceBranch;
+        apiRevision.LastUpdatedOn = DateTime.UtcNow;
+        apiRevision.IsDeleted = false;
+
+        if (!string.IsNullOrEmpty(apiVersionId))
+        {
+            apiRevision.APIVersionId = apiVersionId;
+        }
+
+        await _apiRevisionsManager.UpdateAPIRevisionAsync(apiRevision);
+        return apiRevision;
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Managers/AutoReviewService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/AutoReviewService.cs
@@ -155,10 +155,12 @@ public class AutoReviewService : IAutoReviewService
         string sourceBranch,
         string apiVersionId)
     {
+        var previousCodeFileModel = apiRevision.Files.FirstOrDefault();
         var codeFileModel = await _codeFileManager.CreateReviewCodeFileModel(apiRevision.Id, memoryStream, codeFile);
-        if (!string.IsNullOrEmpty(originalName))
+        var fileName = !string.IsNullOrEmpty(originalName) ? originalName : apiRevision.Files.FirstOrDefault()?.FileName;
+        if (!string.IsNullOrEmpty(fileName))
         {
-            codeFileModel.FileName = originalName;
+            codeFileModel.FileName = fileName;
         }
 
         if (apiRevision.Files.Any())
@@ -183,6 +185,12 @@ public class AutoReviewService : IAutoReviewService
         }
 
         await _apiRevisionsManager.UpdateAPIRevisionAsync(apiRevision);
+
+        if (previousCodeFileModel != null && previousCodeFileModel.FileId != codeFileModel.FileId)
+        {
+            await _codeFileManager.TryDeleteCodeFileModelAsync(apiRevision.Id, previousCodeFileModel);
+        }
+
         return apiRevision;
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Managers/AutoReviewService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/AutoReviewService.cs
@@ -175,7 +175,10 @@ public class AutoReviewService : IAutoReviewService
         apiRevision.PackageName = codeFile.PackageName;
         apiRevision.Language = codeFile.Language;
         apiRevision.Label = label;
-        apiRevision.SourceBranch = sourceBranch;
+        if (!string.IsNullOrEmpty(sourceBranch))
+        {
+            apiRevision.SourceBranch = sourceBranch;
+        }
         apiRevision.LastUpdatedOn = DateTime.UtcNow;
         apiRevision.IsDeleted = false;
 

--- a/src/dotnet/APIView/APIViewWeb/Managers/CodeFileManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/CodeFileManager.cs
@@ -224,6 +224,37 @@ namespace APIViewWeb.Managers
             return reviewCodeFileModel;
         }
 
+        public async Task TryDeleteCodeFileModelAsync(string apiRevisionId, APICodeFileModel codeFileModel)
+        {
+            if (codeFileModel == null)
+            {
+                return;
+            }
+
+            try
+            {
+                await _codeFileRepository.DeleteCodeFileAsync(apiRevisionId, codeFileModel.FileId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to delete code file blob for revision {ApiRevisionId} and file {FileId}", apiRevisionId, codeFileModel.FileId);
+            }
+
+            if (!codeFileModel.HasOriginal)
+            {
+                return;
+            }
+
+            try
+            {
+                await _originalsRepository.DeleteOriginalAsync(codeFileModel.FileId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to delete original blob for file {FileId}", codeFileModel.FileId);
+            }
+        }
+
         /// <summary>
         /// Computes a SHA-256 hash of the API surface content, using the same filtering logic
         /// as <see cref="AreAPICodeFilesTheSame"/> so that hashes are invariant to skip-diff

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/ICodeFileManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/ICodeFileManager.cs
@@ -12,6 +12,7 @@ namespace APIViewWeb.Managers.Interfaces
         public Task<APICodeFileModel> CreateCodeFileAsync(string apiRevisionId, string originalName, bool runAnalysis, Stream fileStream = null, string language = null);
         public Task<CodeFile> CreateCodeFileAsync(string originalName, bool runAnalysis, MemoryStream memoryStream, Stream fileStream = null, string language = null);
         public Task<APICodeFileModel> CreateReviewCodeFileModel(string apiRevisionId, MemoryStream memoryStream, CodeFile codeFile);
+        public Task TryDeleteCodeFileModelAsync(string apiRevisionId, APICodeFileModel codeFileModel);
         public Task<string> ComputeAPIContentHashAsync(CodeFile codeFile);
         public bool AreAPICodeFilesTheSame(RenderedCodeFile codeFileA, RenderedCodeFile codeFileB);
         public bool AreCodeFilesTheSame(CodeFile codeFileA, CodeFile codeFileB);


### PR DESCRIPTION
By updating in place, we avoid churning the revision ID which breaks pre-existing links when the API did not actually change. 

Also does a best-effort clean-up of orphaned blobs after the update. 