### PR TITLE
Fix CODEOWNERS invalid owners and baseline missing paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,8 +39,8 @@
 /tools/github/                          @jsquire @lmazuel
 /tools/github-event-processor/          @benbp @jsquire
 /tools/github-team-user-store/          @weshaggard
-/tools/issue-labeler/                   @jsquire @jeo02 @radhgupta
-/tools/js-sdk-release-tools/            @qiaozha @MaryGao @JialinHuang803 @jeremymeng
+/tools/issue-labeler/                   @jsquire @jeo02
+/tools/js-sdk-release-tools/            @qiaozha @JialinHuang803 @jeremymeng
 /tools/keyvault-mock-attestation/       @maorleger
 /tools/perf-automation/                 @mikeharder @benbp
 /tools/perf-automation/**/*Rust*.cs     @heaths @LarryOsterman @RickWinter

--- a/.github/CODEOWNERS_baseline_errors.txt
+++ b/.github/CODEOWNERS_baseline_errors.txt
@@ -1,1 +1,3 @@
-MaryGao is not a public member of Azure.
+/eng/pipelines/cpex-attestation.yml path or file does not exist in repository.
+/eng/scripts/Attest-CPEX-KPIs.ps1 path or file does not exist in repository.
+/tools/ai-evals/azsdk-mcp/ path or file does not exist in repository.


### PR DESCRIPTION
## Summary
- remove invalid CODEOWNERS users from issue-labeler and js-sdk-release-tools
- baseline the known missing-path CODEOWNERS linter errors
