### PR TITLE
[azsdk-cli] Update to release azsdk-cli 0.6.23

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
@@ -13,7 +13,7 @@
     <WarningsAsErrors>CA2254</WarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AssemblyName>azsdk</AssemblyName>
-    <VersionPrefix>0.6.22</VersionPrefix>
+    <VersionPrefix>0.6.23</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <!-- Package metadata -->

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.6.23 (2026-06-22)
+
+### Other Changes
+
+- `azsdk_get_release_plan` now appends a next step prompting the agent to run SDK generation for all languages via the `azsdk_run_generate_sdk` tool once the API spec is approved, and the generate-sdk-locally skill clarifies that all-language, pipeline-based, or no-local-clone SDK generation must route through `azsdk_run_generate_sdk`.
+
 ## 0.6.22 (2026-06-22)
 
 ### Features Added


### PR DESCRIPTION
Prepares the next `azsdk-cli` release (`0.6.23`) per the documented [release process](https://github.com/Azure/azure-sdk-tools/blob/main/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CONTRIBUTING.md#releasing-a-new-version).

## Changes
- Bumped `<VersionPrefix>` in `Azure.Sdk.Tools.Cli.csproj` from `0.6.22` to `0.6.23`.
- Added a dated `## 0.6.23 (2026-06-22)` entry to `CHANGELOG.md` covering the user-visible change merged since the 0.6.22 changelog was finalized:
  - #16089 - `azsdk_get_release_plan` now appends a next step to run SDK generation via `azsdk_run_generate_sdk` once the API spec is approved, and the generate-sdk-locally skill routes all-language / pipeline / no-local-clone generation through `azsdk_run_generate_sdk`.

Changelog validation (`Confirm-ChangeLogEntry -ForRelease`) passes locally.

--generated by Copilot