### PR TITLE
Rename C# API parser NuGet package to Microsoft.ApiView.CsharpParser

### DIFF
--- a/src/dotnet/APIView/apiview.yml
+++ b/src/dotnet/APIView/apiview.yml
@@ -307,8 +307,7 @@ extends:
                     @echo off
                     echo Installing .NET tool
                     call dotnet tool uninstall --tool-path D:\home\site\wwwroot\csharp-parser CSharpAPIParser
-                    call dotnet tool uninstall --tool-path D:\home\site\wwwroot\csharp-parser Microsoft.ApiView.CsharpParser
-                    call dotnet tool install --add-source ${{ parameters.AzureSdkForNetDevOpsFeed }} --version  ${{ parameters.CSharpAPIParserVersion }} --tool-path D:\home\site\wwwroot\csharp-parser Microsoft.ApiView.CsharpParser
+                    call dotnet tool install --add-source ${{ parameters.AzureSdkForNetDevOpsFeed }} --version  ${{ parameters.CSharpAPIParserVersion }} --tool-path D:\home\site\wwwroot\csharp-parser CSharpAPIParser
                     echo Installing JavaScript parser
                     call npm install --prefix D:\home\site\wwwroot\js-parser ${{ parameters.JavaScriptAPIParser }} --registry ${{ parameters.JavaScriptArtifactRegistry }}
                     echo Installing Rust parser
@@ -364,8 +363,7 @@ extends:
                     @echo off
                     echo Installing .NET tool
                     call dotnet tool uninstall --tool-path D:\home\site\wwwroot\csharp-parser CSharpAPIParser
-                    call dotnet tool uninstall --tool-path D:\home\site\wwwroot\csharp-parser Microsoft.ApiView.CsharpParser
-                    call dotnet tool install --add-source ${{ parameters.AzureSdkForNetDevOpsFeed }} --version  ${{ parameters.CSharpAPIParserVersion }} --tool-path D:\home\site\wwwroot\csharp-parser Microsoft.ApiView.CsharpParser
+                    call dotnet tool install --add-source ${{ parameters.AzureSdkForNetDevOpsFeed }} --version  ${{ parameters.CSharpAPIParserVersion }} --tool-path D:\home\site\wwwroot\csharp-parser CSharpAPIParser
                     echo Installing JavaScript parser
                     call npm install --prefix D:\home\site\wwwroot\js-parser ${{ parameters.JavaScriptAPIParser }} --registry ${{ parameters.JavaScriptArtifactRegistry }}
                     echo Installing Rust parser
@@ -430,8 +428,7 @@ extends:
                           @echo off
                           echo Installing .NET tool
                           call dotnet tool uninstall --tool-path D:\home\site\wwwroot\csharp-parser CSharpAPIParser
-                          call dotnet tool uninstall --tool-path D:\home\site\wwwroot\csharp-parser Microsoft.ApiView.CsharpParser
-                          call dotnet tool install --add-source ${{ parameters.AzureSdkForNetDevOpsFeed }} --version  ${{ parameters.CSharpAPIParserVersion }} --tool-path D:\home\site\wwwroot\csharp-parser Microsoft.ApiView.CsharpParser
+                          call dotnet tool install --add-source ${{ parameters.AzureSdkForNetDevOpsFeed }} --version  ${{ parameters.CSharpAPIParserVersion }} --tool-path D:\home\site\wwwroot\csharp-parser CSharpAPIParser
                           echo Installing JavaScript parser
                           call npm install --prefix D:\home\site\wwwroot\js-parser ${{ parameters.JavaScriptAPIParser }} --registry ${{ parameters.JavaScriptArtifactRegistry }}
                           echo Installing Rust parser

--- a/src/dotnet/APIView/apiview.yml
+++ b/src/dotnet/APIView/apiview.yml
@@ -307,7 +307,8 @@ extends:
                     @echo off
                     echo Installing .NET tool
                     call dotnet tool uninstall --tool-path D:\home\site\wwwroot\csharp-parser CSharpAPIParser
-                    call dotnet tool install --add-source ${{ parameters.AzureSdkForNetDevOpsFeed }} --version  ${{ parameters.CSharpAPIParserVersion }} --tool-path D:\home\site\wwwroot\csharp-parser CSharpAPIParser
+                    call dotnet tool uninstall --tool-path D:\home\site\wwwroot\csharp-parser Microsoft.ApiView.CsharpParser
+                    call dotnet tool install --add-source ${{ parameters.AzureSdkForNetDevOpsFeed }} --version  ${{ parameters.CSharpAPIParserVersion }} --tool-path D:\home\site\wwwroot\csharp-parser Microsoft.ApiView.CsharpParser
                     echo Installing JavaScript parser
                     call npm install --prefix D:\home\site\wwwroot\js-parser ${{ parameters.JavaScriptAPIParser }} --registry ${{ parameters.JavaScriptArtifactRegistry }}
                     echo Installing Rust parser
@@ -363,7 +364,8 @@ extends:
                     @echo off
                     echo Installing .NET tool
                     call dotnet tool uninstall --tool-path D:\home\site\wwwroot\csharp-parser CSharpAPIParser
-                    call dotnet tool install --add-source ${{ parameters.AzureSdkForNetDevOpsFeed }} --version  ${{ parameters.CSharpAPIParserVersion }} --tool-path D:\home\site\wwwroot\csharp-parser CSharpAPIParser
+                    call dotnet tool uninstall --tool-path D:\home\site\wwwroot\csharp-parser Microsoft.ApiView.CsharpParser
+                    call dotnet tool install --add-source ${{ parameters.AzureSdkForNetDevOpsFeed }} --version  ${{ parameters.CSharpAPIParserVersion }} --tool-path D:\home\site\wwwroot\csharp-parser Microsoft.ApiView.CsharpParser
                     echo Installing JavaScript parser
                     call npm install --prefix D:\home\site\wwwroot\js-parser ${{ parameters.JavaScriptAPIParser }} --registry ${{ parameters.JavaScriptArtifactRegistry }}
                     echo Installing Rust parser
@@ -428,7 +430,8 @@ extends:
                           @echo off
                           echo Installing .NET tool
                           call dotnet tool uninstall --tool-path D:\home\site\wwwroot\csharp-parser CSharpAPIParser
-                          call dotnet tool install --add-source ${{ parameters.AzureSdkForNetDevOpsFeed }} --version  ${{ parameters.CSharpAPIParserVersion }} --tool-path D:\home\site\wwwroot\csharp-parser CSharpAPIParser
+                          call dotnet tool uninstall --tool-path D:\home\site\wwwroot\csharp-parser Microsoft.ApiView.CsharpParser
+                          call dotnet tool install --add-source ${{ parameters.AzureSdkForNetDevOpsFeed }} --version  ${{ parameters.CSharpAPIParserVersion }} --tool-path D:\home\site\wwwroot\csharp-parser Microsoft.ApiView.CsharpParser
                           echo Installing JavaScript parser
                           call npm install --prefix D:\home\site\wwwroot\js-parser ${{ parameters.JavaScriptAPIParser }} --registry ${{ parameters.JavaScriptArtifactRegistry }}
                           echo Installing Rust parser

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/CSharpAPIParser.csproj
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/CSharpAPIParser.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
+    <PackageId>Microsoft.ApiView.CsharpParser</PackageId>
     <ToolCommandName>CSharpAPIParserForAPIView</ToolCommandName>
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>CSharpAPIParser</RootNamespace>


### PR DESCRIPTION
## Summary
Sets an explicit NuGet package id for the C# API parser tool. Previously `CSharpAPIParser.csproj` had no `<PackageId>`, so it defaulted to the assembly name `CSharpAPIParser`. This renames the published package to `Microsoft.ApiView.CsharpParser`.

## Changes
- **`tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/CSharpAPIParser.csproj`**: add `<PackageId>Microsoft.ApiView.CsharpParser</PackageId>`.

## Intentionally unchanged
- Tool command name `CSharpAPIParserForAPIView` (the executable APIView invokes is unchanged).
- Root namespace, assembly name, and solution/project names.

## Follow-up
The APIView deployment pipeline (`src/dotnet/APIView/apiview.yml`) installs this tool by package id via `dotnet tool install`. Updating those commands to the new id will be handled in the APIView update PR once the parser is published under `Microsoft.ApiView.CsharpParser`.

## Verification
- `dotnet pack` on the parser project produces `Microsoft.ApiView.CsharpParser.<version>.nupkg`.
