### PR TITLE
Update APIView to C# parser Microsoft.ApiView.CsharpParser 1.0.0-dev.20260623.4

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Languages/CSharpLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/CSharpLanguageService.cs
@@ -14,7 +14,7 @@ namespace APIViewWeb
         public override string Name { get; } = "C#";
         public override string[] Extensions { get; } = { ".dll" };
         public override string ProcessName => _csharpParserToolPath;
-        public override string VersionString { get; } = "29.91";
+        public override string VersionString { get; } = "29.92";
 
         public CSharpLanguageService(IConfiguration configuration, TelemetryClient telemetryClient) : base(telemetryClient)
         {

--- a/src/dotnet/APIView/apiview.yml
+++ b/src/dotnet/APIView/apiview.yml
@@ -4,7 +4,7 @@ parameters:
     default: 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json'
   - name: CSharpAPIParserVersion
     type: string
-    default: '1.0.0-dev.20260223.3'
+    default: '1.0.0-dev.20260623.4'
   - name: JavaScriptAPIParser
     type: string
     default: '@azure-tools/ts-genapi@2.0.11'
@@ -307,7 +307,8 @@ extends:
                     @echo off
                     echo Installing .NET tool
                     call dotnet tool uninstall --tool-path D:\home\site\wwwroot\csharp-parser CSharpAPIParser
-                    call dotnet tool install --add-source ${{ parameters.AzureSdkForNetDevOpsFeed }} --version  ${{ parameters.CSharpAPIParserVersion }} --tool-path D:\home\site\wwwroot\csharp-parser CSharpAPIParser
+                    call dotnet tool uninstall --tool-path D:\home\site\wwwroot\csharp-parser Microsoft.ApiView.CsharpParser
+                    call dotnet tool install --add-source ${{ parameters.AzureSdkForNetDevOpsFeed }} --version  ${{ parameters.CSharpAPIParserVersion }} --tool-path D:\home\site\wwwroot\csharp-parser Microsoft.ApiView.CsharpParser
                     echo Installing JavaScript parser
                     call npm install --prefix D:\home\site\wwwroot\js-parser ${{ parameters.JavaScriptAPIParser }} --registry ${{ parameters.JavaScriptArtifactRegistry }}
                     echo Installing Rust parser
@@ -363,7 +364,8 @@ extends:
                     @echo off
                     echo Installing .NET tool
                     call dotnet tool uninstall --tool-path D:\home\site\wwwroot\csharp-parser CSharpAPIParser
-                    call dotnet tool install --add-source ${{ parameters.AzureSdkForNetDevOpsFeed }} --version  ${{ parameters.CSharpAPIParserVersion }} --tool-path D:\home\site\wwwroot\csharp-parser CSharpAPIParser
+                    call dotnet tool uninstall --tool-path D:\home\site\wwwroot\csharp-parser Microsoft.ApiView.CsharpParser
+                    call dotnet tool install --add-source ${{ parameters.AzureSdkForNetDevOpsFeed }} --version  ${{ parameters.CSharpAPIParserVersion }} --tool-path D:\home\site\wwwroot\csharp-parser Microsoft.ApiView.CsharpParser
                     echo Installing JavaScript parser
                     call npm install --prefix D:\home\site\wwwroot\js-parser ${{ parameters.JavaScriptAPIParser }} --registry ${{ parameters.JavaScriptArtifactRegistry }}
                     echo Installing Rust parser
@@ -428,7 +430,8 @@ extends:
                           @echo off
                           echo Installing .NET tool
                           call dotnet tool uninstall --tool-path D:\home\site\wwwroot\csharp-parser CSharpAPIParser
-                          call dotnet tool install --add-source ${{ parameters.AzureSdkForNetDevOpsFeed }} --version  ${{ parameters.CSharpAPIParserVersion }} --tool-path D:\home\site\wwwroot\csharp-parser CSharpAPIParser
+                          call dotnet tool uninstall --tool-path D:\home\site\wwwroot\csharp-parser Microsoft.ApiView.CsharpParser
+                          call dotnet tool install --add-source ${{ parameters.AzureSdkForNetDevOpsFeed }} --version  ${{ parameters.CSharpAPIParserVersion }} --tool-path D:\home\site\wwwroot\csharp-parser Microsoft.ApiView.CsharpParser
                           echo Installing JavaScript parser
                           call npm install --prefix D:\home\site\wwwroot\js-parser ${{ parameters.JavaScriptAPIParser }} --registry ${{ parameters.JavaScriptArtifactRegistry }}
                           echo Installing Rust parser


### PR DESCRIPTION
## Summary
Brings the C# API parser fix (#16081 — `System.Memory.Data` dependency allowlist) into APIView production under the renamed package (#16102), and forces existing C# reviews to re-parse so they pick up the fix (correcting reviews currently showing false "removed" methods).

## Changes

**`src/dotnet/APIView/apiview.yml`**
- Bump `CSharpAPIParserVersion` `1.0.0-dev.20260223.3` → `1.0.0-dev.20260623.4` (the build containing the fix, published under the new package id).
- Update the `dotnet tool install`/`uninstall` commands in all three deployment stages (`apiviewstaging`, `apiviewuat`, and the `apiview` production staging slot) to the new package id `Microsoft.ApiView.CsharpParser`. The existing `uninstall CSharpAPIParser` line is kept to remove the previously-installed tool on the first post-rename deploy; an `uninstall Microsoft.ApiView.CsharpParser` line is added for redeploy idempotency.

**`src/dotnet/APIView/APIViewWeb/Languages/CSharpLanguageService.cs`**
- Bump `VersionString` `29.91` → `29.92`. This makes `CanUpdate` return true for existing C# revisions (stored at `29.91`), so APIView re-parses them with the newly deployed parser binary that contains the fix. After re-parse, `LanguageProcessor` sets the stored version to `29.92`, so it's self-consistent and does not loop.

## Notes
- The parser tool command name `CSharpAPIParserForAPIView` and the executable path consumed via `CSHARPPARSEREXECUTABLEPATH` are unchanged — no other APIView code change is required.
- In `CodeFile`, `VersionString` and `ParserVersion` share one backing field, so no metadata divergence results from the bump.
- This re-parses all C# reviews (standard behavior when the C# `VersionString` changes, as in #14156).
