### PR TITLE
Use authenticated npmrc by default for cspell

### DIFF
--- a/eng/common/pipelines/templates/steps/check-spelling.yml
+++ b/eng/common/pipelines/templates/steps/check-spelling.yml
@@ -35,6 +35,7 @@ parameters:
 
 steps:
   - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
     - task: PowerShell@2
       displayName: Check spelling (cspell)
       condition: and(succeeded(), ne(variables['Skip.SpellCheck'],'true'))
@@ -46,9 +47,6 @@ steps:
           -CspellConfigPath ${{ parameters.CspellConfigPath }}
           -ExitWithError:(!$${{ parameters.ContinueOnError }})
         pwsh: true
-      env:
-        ${{ if ne(parameters.NpmConfigUserConfig, '') }}:
-          npm_config_userconfig: ${{ parameters.NpmConfigUserConfig }}
     - ${{ if ne('', parameters.ScriptToValidateUpgrade) }}:
       - pwsh: |
           $changedFiles = ./eng/common/scripts/get-changedfiles.ps1


### PR DESCRIPTION
This pull request updates the `check-spelling.yml` pipeline template to ensure authenticated access to npm registries during spell check runs and removes now-unnecessary environment variable configuration. The main goal is to improve reliability and maintainability of the spell check step in pull requests.

**Pipeline improvements:**

* Added the `create-authenticated-npmrc.yml` template to the steps, ensuring that an authenticated `.npmrc` is created for npm operations during pull request builds.

**Code cleanup:**

* Removed conditional setting of the `npm_config_userconfig` environment variable, as this is now handled by the authenticated `.npmrc` step.