### PR TITLE
Add link verification github workflow

### DIFF
--- a/.github/workflows/verify-links.yml
+++ b/.github/workflows/verify-links.yml
@@ -1,0 +1,86 @@
+name: Verify Links
+
+# Runs the link verification check (eng/common/scripts/Verify-Links.ps1) that
+# previously lived as a step in the Azure DevOps "Compliance" job in
+# eng/pipelines/templates/jobs/ci.yml.
+#
+# Triggers:
+#   - pull_request: runs on every PR, scanning only changed *.md files (matches
+#     the prior Compliance-job behavior for PR builds).
+#   - check_run completed: fires when the Azure DevOps "net - pullrequest"
+#     pipeline (which owns the Compliance job) reports back to GitHub, so it
+#     effectively runs after the Compliance job. Same scanning behavior as PR.
+#   - workflow_dispatch: manual runs.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release/*
+      - hotfix/*
+  check_run:
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-links:
+    name: Verify Links
+    # When fired via check_run, only run after the Azure DevOps Compliance
+    # job in the Azure/azure-sdk-for-net repo completes.
+    if: >-
+      github.event.check_run.check_suite.app.name == 'Azure Pipelines' && 
+      (github.repository == 'Azure/azure-sdk-for-net' && contains(github.event.check_run.name, 'Compliance')) ||
+      (github.repository == 'Azure/azure-sdk-for-python' && contains(github.event.check_run.name, 'Analyze')) ||
+      (github.repository == 'Azure/azure-sdk-for-java' && contains(github.event.check_run.name, 'Analyze')) ||
+      (github.repository == 'Azure/azure-sdk-for-js' && contains(github.event.check_run.name, 'Analyze')) ||
+      (github.repository == 'Azure/azure-sdk-for-c' && contains(github.event.check_run.name, 'GenerateReleaseArtifacts')) ||
+      (github.repository == 'Azure/azure-sdk-for-cpp' && contains(github.event.check_run.name, 'Analyze')) ||
+      (github.repository == 'Azure/azure-sdk-for-go' && contains(github.event.check_run.name, 'Analyze')) ||
+      (github.repository == 'Azure/azure-sdk-for-ios' && contains(github.event.check_run.name, 'Analyze'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.event.check_run.head_sha || github.sha }}
+          # Need full history so get-markdown-files-from-changed-files.ps1 can
+          # diff against the target branch (origin/<base>) that checkout sets up.
+          fetch-depth: 0
+
+      - name: Link verification check
+        shell: pwsh
+        # The shared scripts read these Azure DevOps-style variables to compute
+        # the git diff range used by Get-ChangedFiles. Setting them lets the
+        # script's defaults work:
+        #   $TargetCommittish = ("origin/${env:SYSTEM_PULLREQUEST_TARGETBRANCH}" -replace "refs/heads/")
+        #   $SourceCommittish = "${env:SYSTEM_PULLREQUEST_SOURCECOMMITID}"
+        env:
+          SYSTEM_PULLREQUEST_TARGETBRANCH: ${{ github.base_ref }}
+          SYSTEM_PULLREQUEST_SOURCECOMMITID: ${{ github.event.pull_request.head.sha }}
+        run: |
+          $urls = & ./eng/common/scripts/get-markdown-files-from-changed-files.ps1
+          if (-not $urls -or $urls.Count -eq 0) {
+            Write-Host "No changed markdown files; nothing to verify."
+            exit 0
+          }
+
+          $sourceRepoUri  = '${{ github.event.pull_request.head.repo.html_url }}'
+          $defaultBranch  = '${{ github.event.repository.default_branch }}'
+          $branchReplaceRegex = "^($sourceRepoUri(?:\.git)?/(?:blob|tree)/)$defaultBranch(/.*)$"
+
+          ./eng/common/scripts/Verify-Links.ps1 `
+            -urls $urls `
+            -rootUrl "file://$env:GITHUB_WORKSPACE/" `
+            -recursive:$false `
+            -ignoreLinksFile "$env:GITHUB_WORKSPACE/eng/ignore-links.txt" `
+            -branchReplaceRegex $branchReplaceRegex `
+            -branchReplacementName '${{ github.event.pull_request.head.sha }}' `
+            -checkLinkGuidance:$true `
+            -localBuildRepoName '${{ github.repository }}' `
+            -localBuildRepoPath $env:GITHUB_WORKSPACE `
+            -inputCacheFile "https://azuresdkartifacts.blob.core.windows.net/verify-links-cache/verify-links-cache.txt" `
+            -allowRelativeLinksFile "$env:GITHUB_WORKSPACE/eng/common/scripts/allow-relative-links.txt"

--- a/eng/pipelines/sync-.github.yml
+++ b/eng/pipelines/sync-.github.yml
@@ -14,6 +14,7 @@ parameters:
     - '*event*'
     - 'post-apiview.yml'
     - 'protected-files.yml'
+    - 'verify-links.yml'
 - name: Repos
   type: object
   default:
@@ -42,7 +43,7 @@ pr:
       - .github/workflows/*event*
       - .github/workflows/post-apiview.yml
       - .github/workflows/protected-files.yml
-
+      - .github/workflows/verify-links.yml
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-repo-sync.yml
   parameters:


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate link verification checks on markdown files. The workflow, defined in `.github/verify-links.yml`, replicates and modernizes the link verification process previously handled in Azure DevOps, ensuring that all changed markdown files in pull requests are scanned for broken or invalid links.

**New workflow for link verification:**

* Added `.github/verify-links.yml` to define a GitHub Actions workflow that automatically runs link verification on changed markdown files for pull requests, completed check runs, and manual triggers.
* The workflow checks out the repository with full history, determines the default branch, and invokes the existing `Verify-Links.ps1` script with appropriate parameters to scan only changed markdown files.
* The workflow is triggered on pull requests targeting `main`, `release/*`, and `hotfix/*` branches, as well as on completion of specific check runs and via manual dispatch.
* The workflow ensures compatibility with the existing Azure DevOps Compliance job by mirroring its scanning behavior and integrating with shared scripts.