### PR TITLE
Allow optional Go and skip untracked SDK languages in UpdateSDKDetails (#16169)

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
@@ -615,6 +615,33 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             Assert.That(updateStatus.Message, Does.Not.Contain("excluded"));
         }
 
+        [Test]
+        public async Task Test_Update_SDK_Details_Data_skips_untracked_language()
+        {
+            // A data plane TypeSpec project may also emit packages for languages the release plan
+            // does not track (e.g. Rust). The tool must not fail; it should update the supported
+            // languages and skip the untracked ones, reporting them in the message.
+            var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
+            var project = TypeSpecProject.ParseTypeSpecConfig(testCodeFilePath);
+            project.Packages = new List<PackageInfo>
+            {
+                new() { PackageName = "Azure.Contoso", Language = SdkLanguage.DotNet },
+                new() { PackageName = "azure-contoso", Language = SdkLanguage.Python },
+                new() { PackageName = "com.azure.contoso", Language = SdkLanguage.Java },
+                new() { PackageName = "@azure/contoso", Language = SdkLanguage.JavaScript },
+                new() { PackageName = "sdk/contoso/azcontoso", Language = SdkLanguage.Go },
+                new() { PackageName = "azure_contoso", Language = SdkLanguage.Rust }
+            };
+            var tool = CreateReleasePlanToolWithMockedTypeSpec(testCodeFilePath, project);
+            var updateStatus = await tool.UpdateSDKDetailsInReleasePlan(1001, testCodeFilePath, CancellationToken.None);
+            Assert.That(updateStatus.ResponseError, Is.Null);
+            Assert.That(updateStatus.Message, Does.Contain("Updated SDK details in release plan"));
+            Assert.That(updateStatus.Message, Does.Contain("Language: Go, Package name: sdk/contoso/azcontoso"));
+            // Rust is not tracked by the data plane release plan and must be skipped, not fail.
+            Assert.That(updateStatus.Message, Does.Contain("skipped: Rust"));
+            Assert.That(updateStatus.Message, Does.Not.Contain("Language: Rust"));
+        }
+
         [TestCase("Javascript", "@invalid/package/name")]
         [TestCase("Go", "invalid/package/name")]
         [Test]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
@@ -590,6 +590,31 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             Assert.That(updateStatus.NextSteps?.Contains("Prompt the user for justification for excluded languages and update it in the release plan.") ?? false);
         }
 
+        [Test]
+        public async Task Test_Update_SDK_Details_Data_optional_go()
+        {
+            // Data plane only requires .NET, Java, Python and JavaScript, but Go is optional.
+            // When a data plane TypeSpec project also emits Go, the tool must not fail with an
+            // "Unsupported SDK language" error and should still update the Go package name.
+            var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
+            var project = TypeSpecProject.ParseTypeSpecConfig(testCodeFilePath);
+            project.Packages = new List<PackageInfo>
+            {
+                new() { PackageName = "Azure.Contoso", Language = SdkLanguage.DotNet },
+                new() { PackageName = "azure-contoso", Language = SdkLanguage.Python },
+                new() { PackageName = "com.azure.contoso", Language = SdkLanguage.Java },
+                new() { PackageName = "@azure/contoso", Language = SdkLanguage.JavaScript },
+                new() { PackageName = "sdk/contoso/azcontoso", Language = SdkLanguage.Go }
+            };
+            var tool = CreateReleasePlanToolWithMockedTypeSpec(testCodeFilePath, project);
+            var updateStatus = await tool.UpdateSDKDetailsInReleasePlan(1001, testCodeFilePath, CancellationToken.None);
+            Assert.That(updateStatus.ResponseError, Is.Null);
+            Assert.That(updateStatus.Message, Does.Contain("Updated SDK details in release plan"));
+            Assert.That(updateStatus.Message, Does.Contain("Language: Go, Package name: sdk/contoso/azcontoso"));
+            // Go is optional for data plane, so it must not be reported as an excluded language.
+            Assert.That(updateStatus.Message, Does.Not.Contain("excluded"));
+        }
+
         [TestCase("Javascript", "@invalid/package/name")]
         [TestCase("Go", "invalid/package/name")]
         [Test]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -273,6 +273,14 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             ".NET", "Java", "Python", "JavaScript", "Go"
         };
 
+        // Languages that are supported (allowed) for a data plane release plan. Go is optional for
+        // data plane: it must not cause an "unsupported language" failure when present, but it is
+        // not part of the mandatory language set (languagesforDataplane) used for exclusion tracking.
+        internal static readonly HashSet<string> supportedLanguagesforDataplane = new(System.StringComparer.OrdinalIgnoreCase)
+        {
+            ".NET", "Java", "Python", "JavaScript", "Go"
+        };
+
         [GeneratedRegex("https:\\/\\/github.com\\/Azure\\/azure-sdk\\/issues\\/([0-9]+)")]
         private static partial Regex NameSpaceIssueUrlRegex();
 
@@ -1150,11 +1158,13 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 releasePlanWorkItemId = releasePlan.WorkItemId;
 
                 var requiredLanguages = releasePlan.IsManagementPlane ? languagesforMgmtplane : languagesforDataplane;
+                var supportedLanguages = releasePlan.IsManagementPlane ? languagesforMgmtplane : supportedLanguagesforDataplane;
 
-                // Validate SDK language name
-                if (SdkInfos.Any(sdk => !requiredLanguages.Contains(sdk.Language, StringComparer.OrdinalIgnoreCase)))
+                // Validate SDK language name. Use the supported set so optional languages (e.g. Go for
+                // data plane) are accepted and their package names updated without failing.
+                if (SdkInfos.Any(sdk => !supportedLanguages.Contains(sdk.Language, StringComparer.OrdinalIgnoreCase)))
                 {
-                    return new DefaultCommandResponse { ResponseError = $"Unsupported SDK language found. Supported languages are: {string.Join(", ", requiredLanguages)}" };
+                    return new DefaultCommandResponse { ResponseError = $"Unsupported SDK language found. Supported languages are: {string.Join(", ", supportedLanguages)}" };
                 }
 
                 // Validate SDK Package names

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -1160,11 +1160,23 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 var requiredLanguages = releasePlan.IsManagementPlane ? languagesforMgmtplane : languagesforDataplane;
                 var supportedLanguages = releasePlan.IsManagementPlane ? languagesforMgmtplane : supportedLanguagesforDataplane;
 
-                // Validate SDK language name. Use the supported set so optional languages (e.g. Go for
-                // data plane) are accepted and their package names updated without failing.
-                if (SdkInfos.Any(sdk => !supportedLanguages.Contains(sdk.Language, StringComparer.OrdinalIgnoreCase)))
+                // A TypeSpec project may emit packages for languages the release plan does not track
+                // (e.g. Rust, C++). Optional languages such as Go for data plane are part of the
+                // supported set and must be updated. Skip any other detected language instead of
+                // failing, so the tool still updates the supported languages it found.
+                var skippedLanguages = SdkInfos
+                    .Where(sdk => !supportedLanguages.Contains(sdk.Language, StringComparer.OrdinalIgnoreCase))
+                    .Select(sdk => sdk.Language)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                SdkInfos = SdkInfos
+                    .Where(sdk => supportedLanguages.Contains(sdk.Language, StringComparer.OrdinalIgnoreCase))
+                    .ToList();
+
+                if (SdkInfos.Count == 0)
                 {
-                    return new DefaultCommandResponse { ResponseError = $"Unsupported SDK language found. Supported languages are: {string.Join(", ", supportedLanguages)}" };
+                    return new DefaultCommandResponse { ResponseError = $"No supported SDK languages found in the TypeSpec project metadata. Supported languages are: {string.Join(", ", supportedLanguages)}" };
                 }
 
                 // Validate SDK Package names
@@ -1200,6 +1212,10 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     foreach (var sdk in SdkInfos)
                     {
                         sb.AppendLine($"Language: {sdk.Language}, Package name: {sdk.PackageName}");
+                    }
+                    if (skippedLanguages.Any())
+                    {
+                        sb.AppendLine($"Note: The following detected languages are not tracked in the release plan and were skipped: {string.Join(", ", skippedLanguages)}");
                     }
                 }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -1165,13 +1165,13 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 // supported set and must be updated. Skip any other detected language instead of
                 // failing, so the tool still updates the supported languages it found.
                 var skippedLanguages = SdkInfos
-                    .Where(sdk => !supportedLanguages.Contains(sdk.Language, StringComparer.OrdinalIgnoreCase))
+                    .Where(sdk => !supportedLanguages.Contains(sdk.Language))
                     .Select(sdk => sdk.Language)
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .ToList();
 
                 SdkInfos = SdkInfos
-                    .Where(sdk => supportedLanguages.Contains(sdk.Language, StringComparer.OrdinalIgnoreCase))
+                    .Where(sdk => supportedLanguages.Contains(sdk.Language))
                     .ToList();
 
                 if (SdkInfos.Count == 0)


### PR DESCRIPTION
## Summary

Fixes #16169.

`azsdk_update_sdk_details_in_release_plan` failed for **data-plane** TypeSpec projects that emit an optional **Go** package, returning an `Unknown language` / `Unsupported SDK language` error and refusing to update the release plan. Go is a valid (but not mandatory) language for data plane.

This PR makes the tool tolerant of optional and untracked languages:

1. **Optional Go for data plane** — Go is now part of the data-plane *supported* language set, so the tool no longer fails when a data-plane project emits Go, and it writes the Go package name into the release plan. Go remains **not required** for data plane (it is not flagged as an excluded language when absent).
2. **Skip untracked languages instead of hard-failing** — A TypeSpec project may also emit packages for languages the release plan does not track (e.g. **Rust**, **C++**). Instead of failing on the first untracked language, the tool now skips those, updates the supported languages it found, and reports the skipped languages in the result message.

### Behavior

| Language (data plane) | Before | After | Written to release plan? |
| --- | --- | --- | --- |
| .NET / Java / Python / JavaScript | updated | updated | Yes (required) |
| **Go** | ❌ failed | ✅ updated | Yes (optional, not required) |
| **Rust / C++** | ❌ failed | ✅ skipped (no failure) | No (not tracked) |

Required-language exclusion reporting is unchanged: the four mandatory data-plane languages are still flagged as excluded when missing, and Go is not.

## Changes

- `tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs`
  - Added a `supportedLanguagesforDataplane` set (the four required languages **+ Go**) used for validation, separate from the required set used for exclusion reporting.
  - Replaced the hard-fail on unsupported languages with: filter `SdkInfos` to supported languages, skip the rest, and append a `Note: ... skipped: <languages>` line to the result.
- `tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs`
  - `Test_Update_SDK_Details_Data_optional_go` — data plane emitting the 4 required + Go succeeds, writes Go, and does not report Go as excluded.
  - `Test_Update_SDK_Details_Data_skips_untracked_language` — data plane emitting the 4 required + Go + **Rust** succeeds, writes Go, and skips Rust.

## Testing

- Unit tests: all `Test_Update_SDK_Details*` tests pass (`dotnet test --filter "FullyQualifiedName~Test_Update_SDK_Details"`, 10 passed).
- End-to-end against a real data-plane TypeSpec project (`Contoso.WidgetManager`, which emits .NET/Java/Python/JS/**Go**/**Rust**) on a **test** release plan:
  - Result: `Updated SDK details in release plan.` with Go package `sdk/contosowidgetmanager/azmanager` written and `Note: ... skipped: Rust`.
  - Verified the plan persisted languages `Python, .NET, JavaScript, Java, Go` (Rust correctly not written).
