### PR TITLE
[TypeSpec Authoring][Benchmark] Run evals with 2 trials 

### DIFF
--- a/.github/skills/azure-typespec-author/evaluate/evals/001001.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001001.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/001002.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001002.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/001003.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001003.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/001004.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001004.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/001005.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001005.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/001006.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001006.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/001007.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001007.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/001008.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001008.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/001009.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001009.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/001010.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001010.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/001011.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001011.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/001013.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001013.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/002001.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002001.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/002002.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002002.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/002003.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002003.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/002004.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002004.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/002005.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002005.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/002006.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002006.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/002007.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002007.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/002008.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002008.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/002009.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002009.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/002010.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002010.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/002011.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002011.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/003001.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/003001.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/003002.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/003002.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/004001.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/004001.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/004002.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/004002.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/004003.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/004003.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/evals/005001.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/005001.eval.yaml
@@ -8,7 +8,7 @@ environment: azsdk-mcp
 
 # Execution configuration
 config:
-  runs: 1 # Trials per stimulus
+  runs: 2 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
   executor: copilot-sdk # Which executor to use

--- a/.github/skills/azure-typespec-author/evaluate/scripts/report-eval-results.sh
+++ b/.github/skills/azure-typespec-author/evaluate/scripts/report-eval-results.sh
@@ -18,74 +18,103 @@ if [ -z "$LATEST" ]; then
 fi
 
 python3 << EOF
-import json, sys
+import json
 from collections import defaultdict
 
 REPORT_GRADERS = {"tool-calls", "skill-invocation"}
 
-failed_count = 0
-# Track per case: overall pass and non-tool grader results
-case_data = {}
+def trial_passed(grade):
+    score = grade.get("score", 1)
+    return isinstance(score, (int, float)) and score >= 1.0
 
+# With config.runs > 1, Vally emits one record per trial. Group trials by
+# stimulus so a flaky stimulus is judged with pass@k semantics: it passes the
+# suite if it succeeds in at least one of its trials.
+trials = defaultdict(list)  # stimulus name -> list of gradeResult dicts
 with open("$LATEST") as f:
     for line in f:
         r = json.loads(line)
-        name = r.get("gradeResult", {}).get("stimulusName", "")
+        grade = r.get("gradeResult", {})
+        name = grade.get("stimulusName", "")
         if not name:
             continue
-        grade = r.get("gradeResult", {})
-        score = grade.get("score", 1)
-        case_id = name.split("-")[0] if name else "unknown"
-        passed = isinstance(score, (int, float)) and score >= 1.0
+        trials[name].append(grade)
 
-        # Collect tool-calls grader result
-        tool_calls_passed = None
-        for g in grade.get("details", []):
-            gname = g.get("name", g.get("type", "?"))
-            if gname == "tool-calls":
-                tool_calls_passed = g.get("passed", True)
-                break
+failed_count = 0
+flaky_count = 0
+# Per case (numeric prefix) summary.
+case_data = {}
 
-        case_data[case_id] = {"passed": passed, "score": score, "tool_calls_passed": tool_calls_passed}
+for name in sorted(trials):
+    grades = trials[name]
+    total = len(grades)
+    passed_trials = sum(1 for g in grades if trial_passed(g))
+    # pass@k: the stimulus passes if any trial passed.
+    passed = passed_trials > 0
+    flaky = 0 < passed_trials < total
+    case_id = name.split("-")[0] if name else "unknown"
 
-        if passed:
-            continue
-        failed_count += 1
-        print(f"[FAILED] {name} (score: {score})")
-        for g in grade.get("details", []):
-            gname = g.get("name", g.get("type", "?"))
+    # tool-calls grader is considered satisfied if it passed in any trial.
+    tool_calls_passed = None
+    for g in grades:
+        for d in g.get("details", []):
+            if d.get("name", d.get("type", "?")) == "tool-calls":
+                tc = d.get("passed", True)
+                tool_calls_passed = tc if tool_calls_passed is None else (tool_calls_passed or tc)
+    case_data[case_id] = {
+        "passed": passed,
+        "flaky": flaky,
+        "passed_trials": passed_trials,
+        "total": total,
+        "tool_calls_passed": tool_calls_passed,
+    }
+
+    if flaky:
+        flaky_count += 1
+        print(f"[FLAKY] {name} (passed {passed_trials}/{total} trials)")
+
+    if passed:
+        continue
+
+    # Hard failure: every trial failed. Report evidence from the first trial.
+    failed_count += 1
+    print(f"[FAILED] {name} (passed {passed_trials}/{total} trials)")
+    for g in grades[:1]:
+        for d in g.get("details", []):
+            gname = d.get("name", d.get("type", "?"))
             if gname not in REPORT_GRADERS:
                 continue
-            if not g.get("passed", True):
-                evidence = g.get("evidence", "no evidence")
+            if not d.get("passed", True):
+                evidence = d.get("evidence", "no evidence")
                 evidence_lines = [l for l in evidence.splitlines() if not l.startswith("No disallowed")]
                 evidence = "\n".join(evidence_lines).strip()
                 if evidence:
                     print(f'  - {gname}: {evidence}')
                 else:
                     print(f'  - {gname}')
-            elif isinstance(g.get("score"), (int, float)) and g.get("score") < 1.0:
-                evidence = g.get("evidence", "")
+            elif isinstance(d.get("score"), (int, float)) and d.get("score") < 1.0:
+                evidence = d.get("evidence", "")
                 evidence_lines = [l for l in evidence.splitlines() if not l.startswith("No disallowed")]
                 evidence = "\n".join(evidence_lines).strip()
                 if evidence:
-                    print(f'  - {gname} (score: {g.get("score")}): {evidence}')
+                    print(f'  - {gname} (score: {d.get("score")}): {evidence}')
                 else:
-                    print(f'  - {gname} (score: {g.get("score")})')
+                    print(f'  - {gname} (score: {d.get("score")})')
 
-# Print per-case pass rate summary
+# Print per-case pass rate summary (pass@k).
 total_cases = len(case_data)
 total_passed = sum(1 for v in case_data.values() if v["passed"])
-print(f"\n--- Suite $SUITE_NAME Pass Rate: {total_passed}/{total_cases} ({total_passed*100//total_cases if total_cases else 0}%) ---")
+print(f"\n--- Suite $SUITE_NAME Pass Rate (pass@k): {total_passed}/{total_cases} ({total_passed*100//total_cases if total_cases else 0}%) ---")
 for case_id in sorted(case_data.keys()):
     r = case_data[case_id]
     status = "PASS" if r["passed"] else "FAIL"
+    flaky_mark = f"flaky({r['passed_trials']}/{r['total']})" if r["flaky"] else ""
     tc = r.get("tool_calls_passed")
-    tc_mark = "✔tool-calls" if tc else "✘tool-calls" if tc is not None else ""
-    print(f"  {case_id} [{status}] {tc_mark}")
+    tc_mark = "tool-calls:pass" if tc else "tool-calls:fail" if tc is not None else ""
+    print(f"  {case_id} [{status}] {tc_mark} {flaky_mark}".rstrip())
 
 if failed_count > 0:
-    print(f"\n##vso[task.logissue type=error]Suite $SUITE_NAME: {failed_count} stimulus/stimuli failed (pass rate: {total_passed}/{total_cases})")
+    print(f"\n##vso[task.logissue type=error]Suite $SUITE_NAME: {failed_count} stimulus/stimuli failed all trials (pass rate: {total_passed}/{total_cases})")
 else:
-    print(f"Suite $SUITE_NAME: all stimuli passed ({total_passed}/{total_cases})")
+    print(f"Suite $SUITE_NAME: all stimuli passed within trials ({total_passed}/{total_cases}, {flaky_count} flaky)")
 EOF

--- a/.github/skills/azure-typespec-author/evaluate/scripts/report-eval-results.sh
+++ b/.github/skills/azure-typespec-author/evaluate/scripts/report-eval-results.sh
@@ -67,6 +67,7 @@ for name in sorted(trials):
         "passed_trials": passed_trials,
         "total": total,
         "tool_calls_passed": tool_calls_passed,
+        "trial_statuses": [trial_passed(g) for g in grades],
     }
 
     if flaky:
@@ -101,20 +102,40 @@ for name in sorted(trials):
                 else:
                     print(f'  - {gname} (score: {d.get("score")})')
 
-# Print per-case pass rate summary (pass@k).
+# Per-trial pass rate: for trial index t, how many stimuli passed that trial.
+# The i-th record of a stimulus is its i-th trial (Vally writes one record per
+# trial when config.runs > 1).
+max_trials = max((len(g) for g in trials.values()), default=0)
+trial_passed_counts = [0] * max_trials
+trial_total_counts = [0] * max_trials
+for grades in trials.values():
+    for t, g in enumerate(grades):
+        trial_total_counts[t] += 1
+        if trial_passed(g):
+            trial_passed_counts[t] += 1
+
+# Print per-trial summary, then the count of stimuli that failed every trial.
 total_cases = len(case_data)
 total_passed = sum(1 for v in case_data.values() if v["passed"])
-print(f"\n--- Suite $SUITE_NAME Pass Rate (pass@k): {total_passed}/{total_cases} ({total_passed*100//total_cases if total_cases else 0}%) ---")
+print(f"\n--- Suite $SUITE_NAME trial results ---")
+for t in range(max_trials):
+    print(f"trial {t + 1} ({trial_passed_counts[t]}/{trial_total_counts[t]})")
+print(f"fail in {'both' if max_trials == 2 else 'all'} trials: {failed_count}")
+
+# Per-case pass@k breakdown with each trial's status (a case passes if any trial passes).
+print(f"\nPass@k: {total_passed}/{total_cases} ({total_passed*100//total_cases if total_cases else 0}%), {flaky_count} flaky")
 for case_id in sorted(case_data.keys()):
     r = case_data[case_id]
     status = "PASS" if r["passed"] else "FAIL"
-    flaky_mark = f"flaky({r['passed_trials']}/{r['total']})" if r["flaky"] else ""
+    trial_marks = " ".join(
+        f"trial{i + 1}:{'PASS' if ok else 'FAIL'}" for i, ok in enumerate(r["trial_statuses"])
+    )
     tc = r.get("tool_calls_passed")
     tc_mark = "tool-calls:pass" if tc else "tool-calls:fail" if tc is not None else ""
-    print(f"  {case_id} [{status}] {tc_mark} {flaky_mark}".rstrip())
+    print(f"  {case_id} [{status}] {trial_marks} {tc_mark}".rstrip())
 
 if failed_count > 0:
-    print(f"\n##vso[task.logissue type=error]Suite $SUITE_NAME: {failed_count} stimulus/stimuli failed all trials (pass rate: {total_passed}/{total_cases})")
+    print(f"\n##vso[task.logissue type=error]Suite $SUITE_NAME: {failed_count} stimulus/stimuli failed all trials (pass@k: {total_passed}/{total_cases})")
 else:
     print(f"Suite $SUITE_NAME: all stimuli passed within trials ({total_passed}/{total_cases}, {flaky_count} flaky)")
 EOF

--- a/.github/skills/azure-typespec-author/evaluate/suites/forced.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/suites/forced.eval.yaml
@@ -6,7 +6,7 @@ type: capability
 environment: azsdk-mcp
 
 config:
-  runs: 1
+  runs: 2
   timeout: "660s"
   model: claude-opus-4.6
   executor: copilot-sdk

--- a/.github/skills/azure-typespec-author/evaluate/suites/forced.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/suites/forced.eval.yaml
@@ -10,7 +10,7 @@ config:
   timeout: "660s"
   model: claude-opus-4.6
   executor: copilot-sdk
-  workers: 3
+  workers: 6
 
 stimuli:
   - name: 001001-version-spread-property

--- a/.github/skills/azure-typespec-author/evaluate/suites/no-skill.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/suites/no-skill.eval.yaml
@@ -4,7 +4,7 @@ version: "1.0"
 type: capability
 
 config:
-  runs: 1
+  runs: 2
   timeout: "660s"
   model: claude-opus-4.6
   executor: copilot-sdk

--- a/.github/skills/azure-typespec-author/evaluate/suites/no-skill.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/suites/no-skill.eval.yaml
@@ -8,7 +8,7 @@ config:
   timeout: "660s"
   model: claude-opus-4.6
   executor: copilot-sdk
-  workers: 3
+  workers: 6
 
 stimuli:
   - name: 001001-version-spread-property

--- a/.github/skills/azure-typespec-author/evaluate/suites/trigger.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/suites/trigger.eval.yaml
@@ -6,7 +6,7 @@ type: capability
 environment: azsdk-mcp-mock
 
 config:
-  runs: 1
+  runs: 2
   timeout: "660s"
   model: claude-opus-4.6
   executor: copilot-sdk

--- a/.github/skills/azure-typespec-author/evaluate/suites/trigger.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/suites/trigger.eval.yaml
@@ -10,7 +10,7 @@ config:
   timeout: "660s"
   model: claude-opus-4.6
   executor: copilot-sdk
-  workers: 3
+  workers: 6
 
 stimuli:
   - name: 001001-version-spread-property


### PR DESCRIPTION
## Summary
Adds multi-trial support to the `azure-typespec-author` skill evaluation suite using Vally's native [`config.runs` mechanism](https://microsoft.github.io/vally/concepts/scoring/#why-run-multiple-trials), and updates the result reporter to aggregate trials with **pass@k** semantics and surface each trial's per-case status.

## Motivation
Single-run evals are flaky: a transient miss on one stimulus drops the suite pass rate and produces noisy red builds. Running each stimulus twice and judging pass@k separates real capability failures (fail every trial) from flakiness (passes at least once).

## Changes
- **`config.runs: 1 → 2`** across all 28 `evals/*.eval.yaml` and 3 `suites/{forced,trigger,no-skill}.eval.yaml` specs — every stimulus now runs twice per evaluation.
- **`scripts/report-eval-results.sh`** updated to:
  - Group the now-multiple `results.jsonl` records per stimulus by `stimulusName` (Vally emits one record per trial when `runs > 1`).
  - Apply **pass@k**: a stimulus passes if **any** trial passes; only stimuli that fail **every** trial raise an ADO `##vso[task.logissue type=error]`.
  - Print a per-trial headline, flag `[FLAKY]` stimuli (pass some-but-not-all trials), and list each case's status across trials.

## Sample output
```
--- Suite versioning trial results ---
trial 1 (10/11)
trial 2 (9/11)
fail in both trials: 1

Pass@k: 10/11 (90%), 1 flaky
  010 [PASS] trial1:PASS trial2:FAIL tool-calls:pass
  011 [FAIL] trial1:FAIL trial2:FAIL
```

## Validation
- All 32 eval/suite specs confirmed at `runs: 2` (0 leftover `runs: 1`).
- `bash -n` clean on the report script.
- Report logic verified against synthetic 2-trial data: flaky → PASS (flagged), fail-both → FAILED + error, correct trial counts and pass@k rate.

## ⚠️ Follow-up (not in this PR)
2 trials roughly **doubles** runtime. The per-suite `TimeoutMinutes` in `eng/pipelines/azure-typespec-author-benchmark.yml` (versioning 50, armtemplate 40, lro 25, decorators 15, warning 25) may need bumping.
