### PR TITLE
[CODEOWNERS] Improve cache-building job reliability

### DIFF
--- a/eng/pipelines/pipeline-owners-extraction.yml
+++ b/eng/pipelines/pipeline-owners-extraction.yml
@@ -69,10 +69,13 @@ stages:
               --auth-mode login `
               --overwrite true
 
-      - publish: $(CacheOutputDirectory)
-        displayName: Publish cache files artifact
-        artifact: github-team-user-store-cache
-        condition: succeededOrFailed()
+      - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
+        parameters:
+          # This artifact is published for debugging/information only and has no downstream
+          # consumer, so scope its name per job attempt to avoid "cannot override artifact"
+          # collisions when the job is retried.
+          ArtifactName: 'github-team-user-store-cache-Attempt$(System.JobAttempt)'
+          ArtifactPath: '$(CacheOutputDirectory)'
 
       - ${{ if or(parameters.AuditCodeowners, eq(variables['Build.Reason'], 'Schedule')) }}:
         - template: /eng/common/pipelines/templates/steps/install-azsdk-cli.yml
@@ -101,10 +104,13 @@ stages:
           scriptType: pscore
           scriptLocation: inlineScript
           inlineScript: pipeline-owners-extractor --output "$(OutputPath)"
-      - publish: $(OutputPath)
-        displayName: Publish pipelineOwners artifact
-        artifact: pipelineOwners
-        condition: succeededOrFailed()
+      - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
+        parameters:
+          # The pipeline-witness service consumes this artifact by the exact name 'pipelineOwners'.
+          # publish-artifact.yml keeps this name on success and only renames it on failure, so the
+          # consumer keeps working while retries no longer collide.
+          ArtifactName: 'pipelineOwners'
+          ArtifactPath: '$(OutputPath)'
 
 - stage: GenerateCodeowners
   dependsOn: BuildTeamCache

--- a/eng/pipelines/pipeline-owners-extraction.yml
+++ b/eng/pipelines/pipeline-owners-extraction.yml
@@ -71,11 +71,11 @@ stages:
 
       - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
         parameters:
-          # This artifact is published for debugging/information only and has no downstream
-          # consumer, so scope its name per job attempt to avoid "cannot override artifact"
-          # collisions when the job is retried.
-          ArtifactName: 'github-team-user-store-cache-Attempt$(System.JobAttempt)'
+          # Published for debugging/information only; no downstream consumer. The template
+          # renames to a per-attempt name on failure, so retries don't collide on this artifact.
+          ArtifactName: 'github-team-user-store-cache'
           ArtifactPath: '$(CacheOutputDirectory)'
+          CustomCondition: succeededOrFailed()
 
       - ${{ if or(parameters.AuditCodeowners, eq(variables['Build.Reason'], 'Schedule')) }}:
         - template: /eng/common/pipelines/templates/steps/install-azsdk-cli.yml
@@ -104,13 +104,15 @@ stages:
           scriptType: pscore
           scriptLocation: inlineScript
           inlineScript: pipeline-owners-extractor --output "$(OutputPath)"
-      - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
-        parameters:
-          # The pipeline-witness service consumes this artifact by the exact name 'pipelineOwners'.
-          # publish-artifact.yml keeps this name on success and only renames it on failure, so the
-          # consumer keeps working while retries no longer collide.
-          ArtifactName: 'pipelineOwners'
-          ArtifactPath: '$(OutputPath)'
+      # The pipeline-witness service consumes this artifact by the exact name 'pipelineOwners'
+      # (AzurePipelinesProcessor.GetOwnersFromBuildArtifactAsync), so it must keep that stable
+      # name on every run. It is the last step in the job, so a fixed name does not collide on
+      # retry: a successful publish means the job succeeds (no retry), and if an earlier step
+      # failed the extractor never produced $(OutputPath) to publish.
+      - publish: $(OutputPath)
+        displayName: Publish pipelineOwners artifact
+        artifact: pipelineOwners
+        condition: succeededOrFailed()
 
 - stage: GenerateCodeowners
   dependsOn: BuildTeamCache

--- a/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/OpenSourceApiClient.cs
+++ b/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/OpenSourceApiClient.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -12,6 +13,12 @@ namespace GitHubTeamUserStore
         private static readonly TokenRequestContext OpenSourceApiTokenRequestContext = new([ProductAndTeamConstants.OpenSourceApiScope]);
         private static readonly string[] UnsupportedPaginationHeaders = ["Link", "x-ms-continuation", "x-next-page"];
         private static readonly HttpClient SharedHttpClient = new HttpClient();
+
+        // The Open Source API occasionally returns transient 5xx/throttling errors. Retry those
+        // with exponential backoff so the scheduled cache-building job does not fail spuriously.
+        private const int MaxAttempts = 5;
+        private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromSeconds(30);
+
         private readonly TokenCredential _credential;
 
         public OpenSourceApiClient()
@@ -126,21 +133,90 @@ namespace GitHubTeamUserStore
 
         private async Task<T> GetFromOpenSourceApi<T>(string relativePath)
         {
-            AccessToken accessToken = await _credential.GetTokenAsync(OpenSourceApiTokenRequestContext, CancellationToken.None);
+            string requestUri = $"{ProductAndTeamConstants.OpenSourceApiBaseUrl}/{relativePath}";
 
-            using HttpRequestMessage request = new HttpRequestMessage(
-                HttpMethod.Get,
-                $"{ProductAndTeamConstants.OpenSourceApiBaseUrl}/{relativePath}");
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.Token);
-            request.Headers.Add("api-version", ProductAndTeamConstants.OpenSourceApiVersion);
+            for (int attempt = 1; ; attempt++)
+            {
+                // Re-acquire the token each attempt (the credential caches internally, so this is
+                // cheap) and rebuild the request because HttpRequestMessage instances are single-use.
+                AccessToken accessToken = await _credential.GetTokenAsync(OpenSourceApiTokenRequestContext, CancellationToken.None);
 
-            using HttpResponseMessage response = await SharedHttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
-            response.EnsureSuccessStatusCode();
-            EnsureNoUnsupportedPagination(response, relativePath);
+                using HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.Token);
+                request.Headers.Add("api-version", ProductAndTeamConstants.OpenSourceApiVersion);
 
-            await using Stream responseStream = await response.Content.ReadAsStreamAsync();
-            return await JsonSerializer.DeserializeAsync<T>(responseStream)
-                ?? throw new InvalidOperationException($"Open Source API returned an empty payload for '{relativePath}'.");
+                HttpResponseMessage response;
+                try
+                {
+                    response = await SharedHttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+                }
+                catch (HttpRequestException ex) when (attempt < MaxAttempts)
+                {
+                    TimeSpan delay = GetRetryDelay(attempt, null);
+                    Console.WriteLine($"Network failure calling Open Source API '{relativePath}' (attempt {attempt}/{MaxAttempts}): {ex.Message}. Retrying in {delay.TotalSeconds:0.#}s.");
+                    await Task.Delay(delay);
+                    continue;
+                }
+
+                // Only SendAsync is guarded above; EnsureSuccessStatusCode below intentionally throws
+                // (and is not retried) for non-transient statuses such as 4xx.
+                using (response)
+                {
+                    if (IsTransientStatusCode(response.StatusCode) && attempt < MaxAttempts)
+                    {
+                        TimeSpan delay = GetRetryDelay(attempt, GetRetryAfterDelay(response));
+                        Console.WriteLine($"Transient status {(int)response.StatusCode} from Open Source API '{relativePath}' (attempt {attempt}/{MaxAttempts}). Retrying in {delay.TotalSeconds:0.#}s.");
+                        await Task.Delay(delay);
+                        continue;
+                    }
+
+                    // On the final attempt a transient status falls through here so the real failure surfaces.
+                    response.EnsureSuccessStatusCode();
+                    EnsureNoUnsupportedPagination(response, relativePath);
+
+                    await using Stream responseStream = await response.Content.ReadAsStreamAsync();
+                    return await JsonSerializer.DeserializeAsync<T>(responseStream)
+                        ?? throw new InvalidOperationException($"Open Source API returned an empty payload for '{relativePath}'.");
+                }
+            }
+        }
+
+        private static bool IsTransientStatusCode(HttpStatusCode statusCode)
+        {
+            int code = (int)statusCode;
+            return (code >= 500 && code <= 599)
+                || statusCode == HttpStatusCode.RequestTimeout
+                || statusCode == HttpStatusCode.TooManyRequests;
+        }
+
+        private static TimeSpan? GetRetryAfterDelay(HttpResponseMessage response)
+        {
+            RetryConditionHeaderValue retryAfter = response.Headers.RetryAfter;
+            if (retryAfter == null)
+            {
+                return null;
+            }
+
+            if (retryAfter.Delta.HasValue)
+            {
+                return retryAfter.Delta;
+            }
+
+            if (retryAfter.Date.HasValue)
+            {
+                TimeSpan delay = retryAfter.Date.Value - DateTimeOffset.UtcNow;
+                return delay > TimeSpan.Zero ? delay : TimeSpan.Zero;
+            }
+
+            return null;
+        }
+
+        private static TimeSpan GetRetryDelay(int attempt, TimeSpan? retryAfter)
+        {
+            // Exponential backoff: 1s, 2s, 4s, 8s, ... capped at MaxRetryDelay.
+            TimeSpan backoff = TimeSpan.FromSeconds(Math.Pow(2, attempt - 1));
+            TimeSpan delay = (retryAfter.HasValue && retryAfter.Value > backoff) ? retryAfter.Value : backoff;
+            return delay < MaxRetryDelay ? delay : MaxRetryDelay;
         }
 
         private static void EnsureNoUnsupportedPagination(HttpResponseMessage response, string relativePath)

--- a/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/OpenSourceApiClient.cs
+++ b/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/OpenSourceApiClient.cs
@@ -16,8 +16,11 @@ namespace GitHubTeamUserStore
 
         // The Open Source API occasionally returns transient 5xx/throttling errors. Retry those
         // with exponential backoff so the scheduled cache-building job does not fail spuriously.
+        // The API's rate limiter is the only response that carries a Retry-After header (on 429),
+        // and that delta is bounded by its request window (60s by default), so the max delay is
+        // sized to honor it. 5xx/408/network failures carry no Retry-After and use plain backoff.
         private const int MaxAttempts = 5;
-        private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromSeconds(60);
 
         private readonly TokenCredential _credential;
 


### PR DESCRIPTION
Fixes #16190

The scheduled `pipeline-owners-extraction` pipeline (Azure DevOps definition **5112**, `eng/pipelines/pipeline-owners-extraction.yml`) that builds the CODEOWNERS team/user cache was failing for two reasons:

1. The Open Source API (`repos.opensource.microsoft.com`) returned transient 5xx errors and the client failed immediately with no retry (original failing run: build 6482217).
2. On job **retry**, the artifact-publishing steps used `condition: succeededOrFailed()` with fixed artifact names, so the second attempt hit a "cannot override artifact" collision.

This PR fixes both.

## Changes

### 1. Retry/backoff for transient Open Source API failures
`tools/github-team-user-store/.../OpenSourceApiClient.cs` — `GetFromOpenSourceApi<T>` now retries transient failures instead of failing immediately:

- Retries on **5xx**, **408 (RequestTimeout)**, **429 (TooManyRequests)**, and `HttpRequestException` (network failures).
- Up to **5 attempts** with **exponential backoff** (1s, 2s, 4s, 8s). On **429** it honors the `Retry-After` header; the max delay is **60s** so that header is honored in full (see verification below).
- **Non-transient 4xx still fail immediately** — only `SendAsync` is wrapped in the transient catch, so the `HttpRequestException` thrown by `EnsureSuccessStatusCode()` for a 4xx is never retried. This matches the fail-fast philosophy appropriate for a short-lived CLI tool.
- The **final attempt surfaces the real error**: a transient status on the last attempt falls through to `EnsureSuccessStatusCode()`; a final network exception propagates.
- The access token is re-acquired per attempt (the credential caches internally, so this is cheap) and the single-use `HttpRequestMessage` is rebuilt each attempt; each `HttpResponseMessage` is disposed per iteration.

**`Retry-After` verification (against the Open Source API source, `opensource-management-portal`):** the only response that emits a `Retry-After` header is the global rate-limit middleware on **HTTP 429** (`middleware/rateLimit.ts`), as a **delta in seconds** bounded by its request window (60s default). 5xx/408/network failures carry no `Retry-After`, so they use plain exponential backoff. The 60s max delay is sized to honor the 429 header without truncation; it does not affect 5xx backoff, which never exceeds 8s within 5 attempts.

### 2. Retry-safe artifact publishing
`eng/pipelines/pipeline-owners-extraction.yml`:

- **`github-team-user-store-cache`** (debug/informational, **no downstream consumer**) → switched to the common template `eng/common/pipelines/templates/steps/publish-artifact.yml` with `CustomCondition: succeededOrFailed()`. The template publishes the stable name on success and a `-FailedAttempt$(System.JobAttempt)` name on failure, so a failed attempt no longer leaves behind the fixed-name artifact that a retry would collide with. (Confirmed no consumer: the cache is delivered to consumers via `az storage blob upload-batch` to the `azure-sdk-write-teams` blob container, not via this pipeline artifact.)
- **`pipelineOwners`** (IS consumed downstream — see below) → kept as the original inline `- publish:` with the fixed name `pipelineOwners`. It is the **last step** in the job, so the fixed name cannot collide on retry: a successful publish means the job succeeds (no retry), and if an earlier step failed the extractor never produced `$(OutputPath)` to publish. Deliberately **not** routed through `publish-artifact.yml`, because that template renames the artifact on failure and the consumer looks it up by exact name.

## The `pipelineOwners` artifact dependency (for future investigations)

This coupling is otherwise undocumented in code, so capturing it here:

**Producer -> consumer chain:**
1. **This pipeline (def 5112)** publishes the `pipelineOwners` artifact containing `pipelineOwners/pipelineOwners.json` — a map of `{ buildDefinitionId: [owners] }`.
2. **pipeline-witness** (a separate hosted service) handles each `build.complete` event (`BuildCompleteQueueWorker` -> `AzurePipelinesProcessor.UploadBuildBlobsAsync`). For builds of definition 5112 (`PipelineOwnersDefinitionId`) it calls `GetOwnersFromBuildArtifactAsync`, which uses the **Azure DevOps Build REST API** (`BuildHttpClient.GetArtifactAsync` / `GetArtifactContentZipAsync`) to download the artifact **by the exact name `pipelineOwners`** and read the zip entry **`pipelineOwners/pipelineOwners.json`** (`PipelineOwnersArtifactName` / `PipelineOwnersFilePath` in `appsettings.json`). It writes one JSON line per owner mapping to the **`pipelineowners`** blob container.
3. A **Kusto (Azure Data Explorer)** data connection (`tools/pipeline-witness/infrastructure/bicep/logsResourceGroup.bicep`) ingests that container into the **`PipelineOwner`** table (`infrastructure/kusto/tables/PipelineOwner.kql`).
4. The Kusto functions **`LatestOwners()`** and **`WeightedAverageCalc()`** (`infrastructure/kusto/functions/*.kql`) read that table to attribute build success/failure to owners and compute **per-owner pipeline reliability scores**.

**Implications:**
- The artifact **name** (`pipelineOwners`) and the **internal path** (`pipelineOwners/pipelineOwners.json`) are load-bearing — do not change them without updating pipeline-witness (`PipelineWitnessSettings` / `appsettings.json`).
- The consumer is **telemetry/reporting, not a release gate**. If a run fails and the artifact is absent/renamed, pipeline-witness logs a warning and skips that run (`ArtifactNotFoundException` is handled gracefully); `LatestOwners()` simply keeps the previous successful snapshot. This is why renaming on failure is safe for the *cache* artifact but unnecessary (and avoided) for `pipelineOwners`.

## Out of scope (known, intentionally not addressed here)

This PR hardens only the `OpenSourceApiClient` used by the "Generate cache files" step. There is **another OSP API caller that runs later in the same pipeline (def 5112) and is not covered**: the "Run Pipeline Owners Extractor" step uses `GitHubToAADConverter.GetPeopleLinksAsync` (`tools/identity-resolution/Helpers/GitHubToAADConverter.cs`), which calls `GET https://repos.opensource.microsoft.com/api/people/links` via a plain `HttpClient.GetStringAsync` with **no retry**, so it has the same transient-5xx fragility. It was left as-is for now because it is a shared library also consumed by notification-configuration (any change there must stay backward compatible) and is best handled as a separate, focused change. For reference, the PowerShell helper `eng/common/scripts/Helpers/Metadata-Helpers.ps1` (`GetAllGithubUsers`) hits the same `people/links` endpoint but already retries via `Invoke-RestMethod -MaximumRetryCount 3`.

## Validation
- `dotnet build` of the GitHubTeamUserStore solution succeeds.
- Retry loop and YAML reviewed for correctness (attempt counting, resource disposal, non-retry of 4xx, final-attempt error surfacing, template parameter names, consumer compatibility).
- **Ran the pipeline against this branch — [build 6488071](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6488071) succeeded.** "Generate cache files" (the retry code path) ran cleanly; the cache artifact published via the template with the failure branch correctly skipped (no collision); `pipelineOwners` published with its stable name. Both artifacts were produced as expected. Note: this run did not encounter a transient 5xx, so the retry branch itself was exercised only by static review, not in production.
