### PR TITLE
Add changelog entry for azsdk-cli 0.6.24 (optional Go / skip untracked SDK languages)

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- `azsdk_update_sdk_details_in_release_plan` no longer fails for data-plane release plans when the TypeSpec project emits an optional Go package. Go is now accepted as an optional data-plane language and its package name is written to the release plan (Go remains not required, so it is not flagged as an excluded language when absent). Languages the release plan does not track (e.g. Rust, C++) are now skipped instead of causing the update to fail, and are reported in the result message.
+
 ### Other Changes
 
 ## 0.6.23 (2026-06-24)


### PR DESCRIPTION
## Summary

Adds a changelog entry under **0.6.24 (Unreleased)** for the `azsdk-cli` (`Azure.Sdk.Tools.Cli`) documenting the data-plane optional-Go / skip-untracked-language fix for `azsdk_update_sdk_details_in_release_plan`.

Related to #16169 and the code fix in #16186.

## Changes

- `tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md` — added a **Bugs Fixed** entry to the existing `0.6.24 (Unreleased)` section. Documentation only; no code changes.
