### PR TITLE
fix(apiview-copilot): bump PyJWT to 2.13.0 and aiohttp to 3.14.1

### DIFF
--- a/packages/python-packages/apiview-copilot/dev_requirements.txt
+++ b/packages/python-packages/apiview-copilot/dev_requirements.txt
@@ -1,5 +1,5 @@
 # regular requirements
-aiohttp==3.14.0
+aiohttp==3.14.1
 azure-ai-agents==1.1.0
 azure-ai-inference==1.0.0b9
 azure-monitor-opentelemetry==1.6.7
@@ -21,7 +21,7 @@ markdown-it-py==3.0.0
 openai==2.4.0
 python-dotenv==1.2.2
 pydantic==2.10.6
-PyJWT==2.12.0
+PyJWT==2.13.0
 pyyaml==6.0.2
 pytest==9.0.3
 uvicorn[standard]==0.29.0

--- a/packages/python-packages/apiview-copilot/requirements.txt
+++ b/packages/python-packages/apiview-copilot/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.14.0
+aiohttp==3.14.1
 azure-ai-agents==1.1.0
 azure-ai-inference==1.0.0b9
 azure-monitor-opentelemetry==1.6.7
@@ -20,7 +20,7 @@ markdown-it-py==3.0.0
 openai==2.4.0
 python-dotenv==1.2.2
 pydantic==2.10.6
-PyJWT==2.12.0
+PyJWT==2.13.0
 pyyaml==6.0.2
 pytest==9.0.3
 uvicorn[standard]==0.29.0


### PR DESCRIPTION
Resolves Dependabot alerts for apiview-copilot:
- PyJWT 2.12.0 -> 2.13.0 (high; CVE-2026-48526 / GHSA-xgmm-8j9v-c9wx, JWT algorithm-confusion forged HS256 tokens)
- aiohttp 3.14.0 -> 3.14.1 (medium/low)

Applied to both requirements.txt and dev_requirements.txt.