### PR TITLE
fix(azure-sdk-qa-bot-evaluation): bump aiohttp to 3.14.1 python-dotenv to 1.2.2

### DIFF
--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-evaluation/requirements.txt
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-evaluation/requirements.txt
@@ -1,9 +1,9 @@
 azure-ai-evaluation>=1.10.0
 azure.ai.projects>=1.0.0
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 tabulate==0.9.0
 openai>=1.78.0
 azure-identity>=1.23.1
-aiohttp==3.13.3
+aiohttp==3.14.1
 azure-storage-blob==12.26.0
 PyYAML==6.0.2


### PR DESCRIPTION
bump aiohttp to 3.14.1 and python-dotenv to 1.2.2

Resolves Dependabot alerts:
- aiohttp 3.13.3 -> 3.14.1 (medium/low)
- python-dotenv 1.0.1 -> 1.2.2 (medium)