### PR TITLE
fix(ai-evals/azure-mcp): bump python-dotenv to 1.2.2

### DIFF
--- a/tools/ai-evals/azure-mcp/requirements.txt
+++ b/tools/ai-evals/azure-mcp/requirements.txt
@@ -1,5 +1,5 @@
 azure-ai-evaluation==1.8.0
 azure-identity==1.23.0
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 mcp==1.23.0
 openai==1.86.0


### PR DESCRIPTION
Resolves Dependabot alert: python-dotenv 1.0.1 -> 1.2.2 (medium).