### PR TITLE
Update verifiy-links if block

### DIFF
--- a/.github/workflows/verify-links.yml
+++ b/.github/workflows/verify-links.yml
@@ -18,15 +18,21 @@ jobs:
   verify-links:
     name: Verify Links
     if: >-
-      github.event.check_run.check_suite.app.name == 'Azure Pipelines' && 
-      (github.repository == 'Azure/azure-sdk-for-net' && contains(github.event.check_run.name, 'Compliance')) ||
-      (github.repository == 'Azure/azure-sdk-for-python' && contains(github.event.check_run.name, 'Analyze')) ||
-      (github.repository == 'Azure/azure-sdk-for-java' && contains(github.event.check_run.name, 'Analyze')) ||
-      (github.repository == 'Azure/azure-sdk-for-js' && contains(github.event.check_run.name, 'Analyze')) ||
-      (github.repository == 'Azure/azure-sdk-for-c' && contains(github.event.check_run.name, 'GenerateReleaseArtifacts')) ||
-      (github.repository == 'Azure/azure-sdk-for-cpp' && contains(github.event.check_run.name, 'Analyze')) ||
-      (github.repository == 'Azure/azure-sdk-for-go' && contains(github.event.check_run.name, 'Analyze')) ||
-      (github.repository == 'Azure/azure-sdk-for-ios' && contains(github.event.check_run.name, 'Analyze'))
+      github.event_name == 'pull_request' ||
+      (
+        github.event_name == 'check_run' &&
+        github.event.check_run.check_suite.app.name == 'Azure Pipelines' &&
+        (
+          (github.repository == 'Azure/azure-sdk-for-net' && contains(github.event.check_run.name, 'Compliance')) ||
+          (github.repository == 'Azure/azure-sdk-for-python' && contains(github.event.check_run.name, 'Analyze')) ||
+          (github.repository == 'Azure/azure-sdk-for-java' && contains(github.event.check_run.name, 'Analyze')) ||
+          (github.repository == 'Azure/azure-sdk-for-js' && contains(github.event.check_run.name, 'Analyze')) ||
+          (github.repository == 'Azure/azure-sdk-for-c' && contains(github.event.check_run.name, 'GenerateReleaseArtifacts')) ||
+          (github.repository == 'Azure/azure-sdk-for-cpp' && contains(github.event.check_run.name, 'Analyze')) ||
+          (github.repository == 'Azure/azure-sdk-for-go' && contains(github.event.check_run.name, 'Analyze')) ||
+          (github.repository == 'Azure/azure-sdk-for-ios' && contains(github.event.check_run.name, 'Analyze'))
+        )
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This pull request updates the workflow conditions in `.github/workflows/verify-links.yml` to improve when the "Verify Links" job runs. The main change is expanding the logic so that the job is triggered not only for pull requests and manual dispatches, but also for certain `check_run` events, with more precise grouping and evaluation.

Workflow trigger logic improvements:

* Updated the `if` condition for the `verify-links` job to:
  * Explicitly include both `pull_request` and `workflow_dispatch` events.
  * Refactor the `check_run` event logic to ensure the job only runs when the event is from "Azure Pipelines" and the repository and check run name match specific criteria, grouping these conditions for clarity and correctness. [[1]](diffhunk://#diff-25b234aeaa84a5c4bb420cfde36b0e438f672f3ece98492296b829a87c4d558cR21-R26) [[2]](diffhunk://#diff-25b234aeaa84a5c4bb420cfde36b0e438f672f3ece98492296b829a87c4d558cR35-R36)