### PR TITLE
Update verifiy-links errorStatusCodes

### DIFF
--- a/eng/common/scripts/Verify-Links.ps1
+++ b/eng/common/scripts/Verify-Links.ps1
@@ -22,7 +22,7 @@
   Path to the root of the site for resolving rooted relative links, defaults to host root for http and file directory for local files.
 
   .PARAMETER errorStatusCodes
-  List of http status codes that count as broken links. Defaults to 400, 404, SocketError.HostNotFound = 11001, SocketError.NoData = 11004.
+  List of http status codes that count as broken links. Defaults to 400, 404, SocketError.HostNotFound = 11001, SocketError.NoData = 11004, and -131073 (socket error on Linux).
 
   .PARAMETER branchReplaceRegex
   Regex to check if the link needs to be replaced. E.g. ^(https://github.com/.*/(?:blob|tree)/)main(/.*)$
@@ -75,7 +75,7 @@ param (
   [switch] $recursive = $true,
   [string] $baseUrl = "",
   [string] $rootUrl = "",
-  [array] $errorStatusCodes = @(400, 404, 11001, 11004),
+  [array] $errorStatusCodes = @(400, 404, 11001, 11004, -131073),
   [string] $branchReplaceRegex = "",
   [string] $branchReplacementName = "",
   [bool] $checkLinkGuidance = $false,


### PR DESCRIPTION
This pull request updates the `Verify-Links.ps1` script to improve detection of broken links by expanding the list of HTTP status codes considered as errors. The main change is the addition of a Linux-specific socket error code to both the documentation and the script's default parameters.

**Broken link detection improvements:**

* Updated the `.PARAMETER errorStatusCodes` documentation to mention that `-131073` (a socket error on Linux) is now included as a default error status code.
* Added `-131073` to the default `$errorStatusCodes` array in the script parameters, ensuring Linux socket errors are treated as broken links during verification.