### PR TITLE
Update verify-lnk trigger for cpp

### DIFF
--- a/.github/workflows/verify-links.yml
+++ b/.github/workflows/verify-links.yml
@@ -28,7 +28,7 @@ jobs:
           (github.repository == 'Azure/azure-sdk-for-java' && contains(github.event.check_run.name, 'Analyze')) ||
           (github.repository == 'Azure/azure-sdk-for-js' && contains(github.event.check_run.name, 'Analyze')) ||
           (github.repository == 'Azure/azure-sdk-for-c' && contains(github.event.check_run.name, 'GenerateReleaseArtifacts')) ||
-          (github.repository == 'Azure/azure-sdk-for-cpp' && contains(github.event.check_run.name, 'Analyze')) ||
+          (github.repository == 'Azure/azure-sdk-for-cpp' && contains(github.event.check_run.name, 'GenerateReleaseArtifacts')) ||
           (github.repository == 'Azure/azure-sdk-for-go' && contains(github.event.check_run.name, 'Analyze')) ||
           (github.repository == 'Azure/azure-sdk-for-ios' && contains(github.event.check_run.name, 'Analyze'))
         )


### PR DESCRIPTION
This pull request makes a small update to the workflow conditions in `.github/workflows/verify-links.yml`. The change ensures that for the `Azure/azure-sdk-for-cpp` repository, the workflow now triggers on the `GenerateReleaseArtifacts` check run instead of `Analyze`.