### PR TITLE
Use git ignored relative path for TypeSpec metadata emitter output

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.6.24 (2026-06-30)
+## 0.6.24 (Unreleased)
 
 ### Features Added
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,16 +1,14 @@
 # Release History
 
-## 0.6.24 (Unreleased)
+## 0.6.24 (2026-06-30)
 
 ### Features Added
-
-### Breaking Changes
 
 ### Bugs Fixed
 
 - `azsdk_update_sdk_details_in_release_plan` no longer fails for data-plane release plans when the TypeSpec project emits an optional Go package. Go is now accepted as an optional data-plane language and its package name is written to the release plan (Go remains not required, so it is not flagged as an excluded language when absent). Languages the release plan does not track (e.g. Rust, C++) are now skipped instead of causing the update to fail, and are reported in the result message.
 
-### Other Changes
+- Update SDK details to use explicit output directory param when running TypeSpec emitter.
 
 ## 0.6.23 (2026-06-24)
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TypeSpecHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TypeSpecHelper.cs
@@ -154,7 +154,7 @@ namespace Azure.Sdk.Tools.Cli.Helpers
 
                 var npxOptions = new NpxOptions(
                     package: "@typespec/compiler",
-                    args: ["tsp", "compile", ".", "--emit", "@azure-tools/typespec-metadata"],
+                    args: ["tsp", "compile", ".", "--emit", "@azure-tools/typespec-metadata", "--output-dir", "./tsp-output"],
                     logOutputStream: true,
                     workingDirectory: project.ProjectRootPath,
                     timeout: TimeSpan.FromMinutes(5)


### PR DESCRIPTION
tsp-output is already ignored in .gitignore. This PR passed output-dir for emitter output instead of relying on the tsp compiler to choose the option. Default output-dir config is leading to an issue if a TypeSpec project has global Output-dir config.