### PR TITLE
Fix import of TypeScript in DifferenceDetector to use ts-morph's version

### DIFF
--- a/tools/js-sdk-release-tools/src/changelog/v2/DifferenceDetector.ts
+++ b/tools/js-sdk-release-tools/src/changelog/v2/DifferenceDetector.ts
@@ -17,7 +17,11 @@ import { SDKType } from '../../common/types.js';
 import { join } from 'path';
 import { FunctionDeclaration, ModuleKind, Project, ScriptTarget, SourceFile, SyntaxKind } from 'ts-morph';
 import { logger } from '../../utils/logger.js';
-import ts from 'typescript';
+// Use the `ts` that ts-morph is built against, NOT the standalone `typescript` package.
+// The nodes inspected below come from ts-morph, and a hoisted/mismatched standalone
+// `typescript` (e.g. an old transitive copy) has different `SyntaxKind` numeric values,
+// which silently breaks `ts.SyntaxKind`/`ts.isIdentifier` checks against ts-morph nodes.
+import { ts } from 'ts-morph';
 
 const { JsxEmit } = ts;
 


### PR DESCRIPTION
fixes:https://github.com/Azure/azure-sdk-tools/issues/16231

This pull request makes an important change to the way TypeScript is imported in `tools/js-sdk-release-tools/src/changelog/v2/DifferenceDetector.ts`. Instead of importing the standalone `typescript` package, it now imports `ts` from `ts-morph` to ensure compatibility between `SyntaxKind` values and node checks. This prevents subtle bugs caused by mismatched TypeScript versions.

Dependency management:

* Changed the import to use `ts` from `ts-morph` instead of the standalone `typescript` package, ensuring that `SyntaxKind` values and node checks are consistent and preventing silent failures due to version mismatches.