### PR TITLE
Skip -pr repositories in GitHub scripts

### DIFF
--- a/tools/github/README.md
+++ b/tools/github/README.md
@@ -28,11 +28,11 @@ This area is focused on the management of the Azure SDK GitHub repositories, con
 
 ## Scripts
 
-> Repositories ending in `-pr` are skipped by the scripts below before any querying, progress reporting, delay calculations, or updates occur.
+> When these scripts load repositories from `repositories.txt`, entries ending in `-pr` are skipped before any querying, progress reporting, delay calculations, or updates occur.
 
 ### `Add-AzsdkMilestones.ps1`
 
-_Creates a set of milestones in one or more repositories.  The milestones follow Azure SDK conventions for naming and due dates.  With the default parameter set, milestones will be created for the next 6 months in repositories in the 'repositories.txt' file in the script directory, excluding repositories whose names end in `-pr`._
+_Creates a set of milestones in one or more repositories.  The milestones follow Azure SDK conventions for naming and due dates.  With the default parameter set, milestones will be created for the next 6 months in repositories in the 'repositories.txt' file in the script directory, excluding entries whose names end in `-pr`._
 
 ```powershell
 # Create the default set of milestone and repository data.
@@ -47,7 +47,7 @@ get-help ./Add-AzsdkMilestones.ps1 -full
 
 ### `Add-AzsdkProjectIssues.ps1`
 
-_Adds a set of Azure SDK repository issues tagged with a given set of labels to a GitHub project.  With the default parameter set, the issues with the specified labels will be queried from a set of core language repositories, excluding repositories whose names end in `-pr`._
+_Adds a set of Azure SDK repository issues tagged with a given set of labels to a GitHub project.  With the default parameter set, the issues with the specified labels will be queried from repositories in `repositories.txt`, excluding entries whose names end in `-pr`._
 
 ```powershell
 # Adds issues with the "Client" and "KeyVault" labels to project #150, querying a set
@@ -64,7 +64,7 @@ get-help ./Add-AzsdkProjectIssues.ps1 -full
 
 ### `Sync-AzsdkLabels.ps1`
 
-_Creates or updates the set of labels expected to be common across the Azure SDK repositories, ensuring that names, descriptions, and colors share the common configuration while skipping repositories whose names end in `-pr`._
+_Creates or updates the set of labels expected to be common across the Azure SDK repositories, ensuring that names, descriptions, and colors share the common configuration while skipping `repositories.txt` entries whose names end in `-pr`._
 
 ```powershell
 # Uses the files from the `data` directory to synchronize the common labels to all centrally managed
@@ -83,7 +83,7 @@ get-help ./Sync-AzsdkLabels.ps1 -full
 
 ### `Snapshot-AzsdkLabels.ps1`
 
-_Creates or updates the set of labels expected to be common across the Azure SDK repositories, ensuring that names, descriptions, and colors share the common configuration while skipping repositories whose names end in `-pr`._
+_Creates or updates the set of labels expected to be common across the Azure SDK repositories, ensuring that names, descriptions, and colors share the common configuration while skipping `repositories.txt` entries whose names end in `-pr`._
 
 ```powershell
 # Uses the files from the "data" directory to generate snapshots of non-common labels for each

--- a/tools/github/README.md
+++ b/tools/github/README.md
@@ -28,9 +28,11 @@ This area is focused on the management of the Azure SDK GitHub repositories, con
 
 ## Scripts
 
+> Repositories ending in `-pr` are skipped by the scripts below before any querying, progress reporting, delay calculations, or updates occur.
+
 ### `Add-AzsdkMilestones.ps1`
 
-_Creates a set of milestones in one or more repositories.  The milestones follow Azure SDK conventions for naming and due dates.  With the default parameter set, milestones will be created for the next 6 months in repositories in the 'repositories.txt' file in the script directory._
+_Creates a set of milestones in one or more repositories.  The milestones follow Azure SDK conventions for naming and due dates.  With the default parameter set, milestones will be created for the next 6 months in repositories in the 'repositories.txt' file in the script directory, excluding repositories whose names end in `-pr`._
 
 ```powershell
 # Create the default set of milestone and repository data.
@@ -45,7 +47,7 @@ get-help ./Add-AzsdkMilestones.ps1 -full
 
 ### `Add-AzsdkProjectIssues.ps1`
 
-_Adds a set of Azure SDK repository issues tagged with a given set of labels to a GitHub project.  With the default parameter set, the issues with the specified labels will be queried from a set of core language repositories._
+_Adds a set of Azure SDK repository issues tagged with a given set of labels to a GitHub project.  With the default parameter set, the issues with the specified labels will be queried from a set of core language repositories, excluding repositories whose names end in `-pr`._
 
 ```powershell
 # Adds issues with the "Client" and "KeyVault" labels to project #150, querying a set
@@ -62,7 +64,7 @@ get-help ./Add-AzsdkProjectIssues.ps1 -full
 
 ### `Sync-AzsdkLabels.ps1`
 
-_Creates or updates the set of labels expected to be common across the Azure SDK repositories, ensuring that names, descriptions, and colors share the common configuration._
+_Creates or updates the set of labels expected to be common across the Azure SDK repositories, ensuring that names, descriptions, and colors share the common configuration while skipping repositories whose names end in `-pr`._
 
 ```powershell
 # Uses the files from the `data` directory to synchronize the common labels to all centrally managed
@@ -81,7 +83,7 @@ get-help ./Sync-AzsdkLabels.ps1 -full
 
 ### `Snapshot-AzsdkLabels.ps1`
 
-_Creates or updates the set of labels expected to be common across the Azure SDK repositories, ensuring that names, descriptions, and colors share the common configuration._
+_Creates or updates the set of labels expected to be common across the Azure SDK repositories, ensuring that names, descriptions, and colors share the common configuration while skipping repositories whose names end in `-pr`._
 
 ```powershell
 # Uses the files from the "data" directory to generate snapshots of non-common labels for each

--- a/tools/github/scripts/Add-AzsdkMilestones.ps1
+++ b/tools/github/scripts/Add-AzsdkMilestones.ps1
@@ -31,20 +31,12 @@ if ($PSCmdlet.ParameterSetName -eq 'Languages') {
 }
 
 if ($PSCmdlet.ParameterSetName -eq 'RepositoryFile') {
-    $Repositories = Get-Content $RepositoryFilePath
+    $Repositories = @(
+        Get-Content $RepositoryFilePath |
+            ForEach-Object { ([string]$_).Trim() } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and -not $_.EndsWith('-pr', [StringComparison]::OrdinalIgnoreCase) }
+    )
 }
-
-$Repositories = @(
-    foreach ($repository in $Repositories) {
-        $repository = ([string]$repository).Trim()
-
-        if ([string]::IsNullOrWhiteSpace($repository) -or $repository.EndsWith('-pr', [StringComparison]::OrdinalIgnoreCase)) {
-            continue
-        }
-
-        $repository
-    }
-)
 
 $date = $StartDate
 [pscustomobject[]] $milestones = do {
@@ -102,16 +94,16 @@ Write-Progress -Activity $activity -Completed
 Creates Azure SDK milestones in the form of "yyyy-MM".
 
 .DESCRIPTION
-Creates Azure SDK milestones in the form of "yyyy-MM" with the due date set to the first Friday of the following month at 11:59 PM UTC. Repositories ending in "-pr" are skipped before any milestones are created or reported.
+Creates Azure SDK milestones in the form of "yyyy-MM" with the due date set to the first Friday of the following month at 11:59 PM UTC. When repositories are loaded from RepositoryFilePath, entries ending in "-pr" are skipped before any milestones are created or reported.
 
 .PARAMETER Repositories
-The GitHub repositories to update. Repositories ending in "-pr" are skipped.
+The GitHub repositories to update.
 
 .PARAMETER Languages
-The Azure SDK languages to query for milestones e.g., "net" for "Azure/azure-sdk-for-net". Repositories ending in "-pr" are skipped.
+The Azure SDK languages to query for milestones e.g., "net" for "Azure/azure-sdk-for-net".
 
 .PARAMETER RepositoryFilePath
-The fully-qualified path (including filename) to a new line-delmited file of respositories to update. Repositories ending in "-pr" are skipped.
+The fully-qualified path (including filename) to a new line-delmited file of respositories to update. Entries ending in "-pr" are skipped.
 
 .PARAMETER StartDate
 The starting date for new milestones.

--- a/tools/github/scripts/Add-AzsdkMilestones.ps1
+++ b/tools/github/scripts/Add-AzsdkMilestones.ps1
@@ -34,6 +34,18 @@ if ($PSCmdlet.ParameterSetName -eq 'RepositoryFile') {
     $Repositories = Get-Content $RepositoryFilePath
 }
 
+$Repositories = @(
+    foreach ($repository in $Repositories) {
+        $repository = ([string]$repository).Trim()
+
+        if ([string]::IsNullOrWhiteSpace($repository) -or $repository.EndsWith('-pr', [StringComparison]::OrdinalIgnoreCase)) {
+            continue
+        }
+
+        $repository
+    }
+)
+
 $date = $StartDate
 [pscustomobject[]] $milestones = do {
     # Start with the first of the month at 23:59 UTC.
@@ -90,16 +102,16 @@ Write-Progress -Activity $activity -Completed
 Creates Azure SDK milestones in the form of "yyyy-MM".
 
 .DESCRIPTION
-Creates Azure SDK milestones in the form of "yyyy-MM" with the due date set to the first Friday of the following month at 11:59 PM UTC.
+Creates Azure SDK milestones in the form of "yyyy-MM" with the due date set to the first Friday of the following month at 11:59 PM UTC. Repositories ending in "-pr" are skipped before any milestones are created or reported.
 
 .PARAMETER Repositories
-The GitHub repositories to update.
+The GitHub repositories to update. Repositories ending in "-pr" are skipped.
 
 .PARAMETER Languages
-The Azure SDK languages to query for milestones e.g., "net" for "Azure/azure-sdk-for-net".
+The Azure SDK languages to query for milestones e.g., "net" for "Azure/azure-sdk-for-net". Repositories ending in "-pr" are skipped.
 
 .PARAMETER RepositoryFilePath
-The fully-qualified path (including filename) to a new line-delmited file of respositories to update.
+The fully-qualified path (including filename) to a new line-delmited file of respositories to update. Repositories ending in "-pr" are skipped.
 
 .PARAMETER StartDate
 The starting date for new milestones.

--- a/tools/github/scripts/Add-AzsdkProjectIssues.ps1
+++ b/tools/github/scripts/Add-AzsdkProjectIssues.ps1
@@ -52,6 +52,18 @@ if ($PSCmdlet.ParameterSetName -eq 'RepositoryFile') {
     $Repositories = Get-Content $RepositoryFilePath
 }
 
+$Repositories = @(
+    foreach ($repository in $Repositories) {
+        $repository = ([string]$repository).Trim()
+
+        if ([string]::IsNullOrWhiteSpace($repository) -or $repository.EndsWith('-pr', [StringComparison]::OrdinalIgnoreCase)) {
+            continue
+        }
+
+        $repository
+    }
+)
+
 if ($Fields) {
     $fieldArgs = @()
     foreach ($key in $Fields.Keys) {
@@ -93,6 +105,9 @@ foreach ($repo in $Repositories) {
 .SYNOPSIS
 Adds issues from Azure SDK language repositories to a project given labels.
 
+.DESCRIPTION
+Adds issues from Azure SDK repositories to a project given labels. Repositories ending in "-pr" are skipped before any issues are queried or reported.
+
 .PARAMETER ProjectNumber
 The project (beta) number in the Azure organization. This project (beta) should be referenced within the language repository.
 
@@ -100,13 +115,13 @@ The project (beta) number in the Azure organization. This project (beta) should 
 The required labels used to select issues from each lanuage repository.
 
 .PARAMETER Repositories
-The GitHub repositories to query for issues e.g., "Azure/azure-sdk-for-net".
+The GitHub repositories to query for issues e.g., "Azure/azure-sdk-for-net". Repositories ending in "-pr" are skipped.
 
 .PARAMETER Languages
-The Azure SDK languages to query for issues e.g., "net" for "Azure/azure-sdk-for-net".
+The Azure SDK languages to query for issues e.g., "net" for "Azure/azure-sdk-for-net". Repositories ending in "-pr" are skipped.
 
 .PARAMETER RepositoryFilePath
-The fully-qualified path (including filename) to a new line-delmited file of respositories to update.
+The fully-qualified path (including filename) to a new line-delmited file of respositories to update. Repositories ending in "-pr" are skipped.
 
 .PARAMETER Fields
 Custom fields defined by the project to set when adding issues.

--- a/tools/github/scripts/Add-AzsdkProjectIssues.ps1
+++ b/tools/github/scripts/Add-AzsdkProjectIssues.ps1
@@ -49,20 +49,12 @@ if ($PSCmdlet.ParameterSetName -eq 'Languages') {
 }
 
 if ($PSCmdlet.ParameterSetName -eq 'RepositoryFile') {
-    $Repositories = Get-Content $RepositoryFilePath
+    $Repositories = @(
+        Get-Content $RepositoryFilePath |
+            ForEach-Object { ([string]$_).Trim() } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and -not $_.EndsWith('-pr', [StringComparison]::OrdinalIgnoreCase) }
+    )
 }
-
-$Repositories = @(
-    foreach ($repository in $Repositories) {
-        $repository = ([string]$repository).Trim()
-
-        if ([string]::IsNullOrWhiteSpace($repository) -or $repository.EndsWith('-pr', [StringComparison]::OrdinalIgnoreCase)) {
-            continue
-        }
-
-        $repository
-    }
-)
 
 if ($Fields) {
     $fieldArgs = @()
@@ -106,7 +98,7 @@ foreach ($repo in $Repositories) {
 Adds issues from Azure SDK language repositories to a project given labels.
 
 .DESCRIPTION
-Adds issues from Azure SDK repositories to a project given labels. Repositories ending in "-pr" are skipped before any issues are queried or reported.
+Adds issues from Azure SDK repositories to a project given labels. When repositories are loaded from RepositoryFilePath, entries ending in "-pr" are skipped before any issues are queried or reported.
 
 .PARAMETER ProjectNumber
 The project (beta) number in the Azure organization. This project (beta) should be referenced within the language repository.
@@ -115,13 +107,13 @@ The project (beta) number in the Azure organization. This project (beta) should 
 The required labels used to select issues from each lanuage repository.
 
 .PARAMETER Repositories
-The GitHub repositories to query for issues e.g., "Azure/azure-sdk-for-net". Repositories ending in "-pr" are skipped.
+The GitHub repositories to query for issues e.g., "Azure/azure-sdk-for-net".
 
 .PARAMETER Languages
-The Azure SDK languages to query for issues e.g., "net" for "Azure/azure-sdk-for-net". Repositories ending in "-pr" are skipped.
+The Azure SDK languages to query for issues e.g., "net" for "Azure/azure-sdk-for-net".
 
 .PARAMETER RepositoryFilePath
-The fully-qualified path (including filename) to a new line-delmited file of respositories to update. Repositories ending in "-pr" are skipped.
+The fully-qualified path (including filename) to a new line-delmited file of respositories to update. Entries ending in "-pr" are skipped.
 
 .PARAMETER Fields
 Custom fields defined by the project to set when adding issues.

--- a/tools/github/scripts/Snapshot-AzsdkLabels.ps1
+++ b/tools/github/scripts/Snapshot-AzsdkLabels.ps1
@@ -40,20 +40,12 @@ if ($PSCmdlet.ParameterSetName -eq 'Languages') {
 }
 
 if ($PSCmdlet.ParameterSetName -eq 'RepositoryFile') {
-    $Repositories = Get-Content $RepositoryFilePath
+    $Repositories = @(
+        Get-Content $RepositoryFilePath |
+            ForEach-Object { ([string]$_).Trim() } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and -not $_.EndsWith('-pr', [StringComparison]::OrdinalIgnoreCase) }
+    )
 }
-
-$Repositories = @(
-    foreach ($repository in $Repositories) {
-        $repository = ([string]$repository).Trim()
-
-        if ([string]::IsNullOrWhiteSpace($repository) -or $repository.EndsWith('-pr', [StringComparison]::OrdinalIgnoreCase)) {
-            continue
-        }
-
-        $repository
-    }
-)
 
 # If the output path does not exist, create it.
 if (-not (Test-Path $SnapshotDirectory -PathType Container)) {
@@ -119,7 +111,7 @@ foreach ($repo in $Repositories) {
 Inspects labels for a set of repositories and creates a snapshot of those not part of the common set.
 
 .DESCRIPTION
-Inspects labels for a set of repositories and creates a snapshot of those labels not part of the common set.  The snapshot is written as a line-delimited list of label names in the specified directory named after the source repository. Repositories ending in "-pr" are skipped before any snapshots or reporting are generated.
+Inspects labels for a set of repositories and creates a snapshot of those labels not part of the common set.  The snapshot is written as a line-delimited list of label names in the specified directory named after the source repository. When repositories are loaded from RepositoryFilePath, entries ending in "-pr" are skipped before any snapshots or reporting are generated.
 
 .PARAMETER SnapshotDirectory
 The fully-qualifeid path to the directory in which repository shapshot files should be written.
@@ -128,13 +120,13 @@ The fully-qualifeid path to the directory in which repository shapshot files sho
 The fully-qualifeid path (including filename) to a CSV file of the common Azure SDK labels that will filtered from snapshots.  Columns have no headers and are in the form of "Name,Description,Color".
 
 .PARAMETER Repositories
-The GitHub repositories to inspect and build snapshots for. Repositories ending in "-pr" are skipped.
+The GitHub repositories to inspect and build snapshots for.
 
 .PARAMETER Languages
-The Azure SDK languages whose repositories should be inspected and snapshots built for.   e.g., "net" for "Azure/azure-sdk-for-net". Repositories ending in "-pr" are skipped.
+The Azure SDK languages whose repositories should be inspected and snapshots built for.   e.g., "net" for "Azure/azure-sdk-for-net".
 
 .PARAMETER RepositoryFilePath
-The fully-qualified path (including filename) to a new line-delmited file of respositories to inspect and build snapshots for. Repositories ending in "-pr" are skipped.
+The fully-qualified path (including filename) to a new line-delmited file of respositories to inspect and build snapshots for. Entries ending in "-pr" are skipped.
 
 .PARAMETER Force
 Build snapshots for each repository without prompting.

--- a/tools/github/scripts/Snapshot-AzsdkLabels.ps1
+++ b/tools/github/scripts/Snapshot-AzsdkLabels.ps1
@@ -43,6 +43,18 @@ if ($PSCmdlet.ParameterSetName -eq 'RepositoryFile') {
     $Repositories = Get-Content $RepositoryFilePath
 }
 
+$Repositories = @(
+    foreach ($repository in $Repositories) {
+        $repository = ([string]$repository).Trim()
+
+        if ([string]::IsNullOrWhiteSpace($repository) -or $repository.EndsWith('-pr', [StringComparison]::OrdinalIgnoreCase)) {
+            continue
+        }
+
+        $repository
+    }
+)
+
 # If the output path does not exist, create it.
 if (-not (Test-Path $SnapshotDirectory -PathType Container)) {
     New-Item -Path $SnapshotDirectory -ItemType Directory | Out-Null
@@ -107,7 +119,7 @@ foreach ($repo in $Repositories) {
 Inspects labels for a set of repositories and creates a snapshot of those not part of the common set.
 
 .DESCRIPTION
-Inspects labels for a set of repositories and creates a snapshot of those labels not part of the common set.  The snapshot is written as a line-delimited list of label names in the specified directory named after the source repository.
+Inspects labels for a set of repositories and creates a snapshot of those labels not part of the common set.  The snapshot is written as a line-delimited list of label names in the specified directory named after the source repository. Repositories ending in "-pr" are skipped before any snapshots or reporting are generated.
 
 .PARAMETER SnapshotDirectory
 The fully-qualifeid path to the directory in which repository shapshot files should be written.
@@ -116,13 +128,13 @@ The fully-qualifeid path to the directory in which repository shapshot files sho
 The fully-qualifeid path (including filename) to a CSV file of the common Azure SDK labels that will filtered from snapshots.  Columns have no headers and are in the form of "Name,Description,Color".
 
 .PARAMETER Repositories
-The GitHub repositories to inspect and build snapshots for.
+The GitHub repositories to inspect and build snapshots for. Repositories ending in "-pr" are skipped.
 
 .PARAMETER Languages
-The Azure SDK languages whose repositories should be inspected and snapshots built for.   e.g., "net" for "Azure/azure-sdk-for-net".
+The Azure SDK languages whose repositories should be inspected and snapshots built for.   e.g., "net" for "Azure/azure-sdk-for-net". Repositories ending in "-pr" are skipped.
 
 .PARAMETER RepositoryFilePath
-The fully-qualified path (including filename) to a new line-delmited file of respositories to inspect and build snapshots for.
+The fully-qualified path (including filename) to a new line-delmited file of respositories to inspect and build snapshots for. Repositories ending in "-pr" are skipped.
 
 .PARAMETER Force
 Build snapshots for each repository without prompting.

--- a/tools/github/scripts/Sync-AzsdkLabels.ps1
+++ b/tools/github/scripts/Sync-AzsdkLabels.ps1
@@ -207,6 +207,18 @@ if ($PSCmdlet.ParameterSetName -eq 'RepositoryFile') {
     $Repositories = Get-Content $RepositoryFilePath
 }
 
+$Repositories = @(
+    foreach ($repository in $Repositories) {
+        $repository = ([string]$repository).Trim()
+
+        if ([string]::IsNullOrWhiteSpace($repository) -or $repository.EndsWith('-pr', [StringComparison]::OrdinalIgnoreCase)) {
+            continue
+        }
+
+        $repository
+    }
+)
+
 # Extract the label content to be sync'd.
 $labels = Get-LabelDefinitionsFromFile -Path $LabelsFilePath
 $changedLabels = @()
@@ -261,19 +273,19 @@ Write-Progress -Activity $activity -Completed
 Synchonizes the common set of Azure SDK labels to one or more repository.
 
 .DESCRIPTION
-Creates or updates labels - without deleting any - ensuring the common Azure SDK label set exists in all listed repositories.
+Creates or updates labels - without deleting any - ensuring the common Azure SDK label set exists in all listed repositories. Repositories ending in "-pr" are skipped before any synchronization, progress reporting, or delay calculations occur.
 
 .PARAMETER LabelsFilePath
 The fully-qualifeid path (including filename) to a CSV file of the common Azure SDK labels that will be created or updated in each repository.  Columns have no headers and are in the form of "Name,Description,Color".
 
 .PARAMETER Repositories
-The GitHub repositories to update with the common label set.
+The GitHub repositories to update with the common label set. Repositories ending in "-pr" are skipped.
 
 .PARAMETER Languages
-The Azure SDK languages whose repositories should be updated with the common label set.  e.g., "net" for "Azure/azure-sdk-for-net".
+The Azure SDK languages whose repositories should be updated with the common label set.  e.g., "net" for "Azure/azure-sdk-for-net". Repositories ending in "-pr" are skipped.
 
 .PARAMETER RepositoryFilePath
-The fully-qualified path (including filename) to a new line-delmited file of respositories to update with the common label set.
+The fully-qualified path (including filename) to a new line-delmited file of respositories to update with the common label set. Repositories ending in "-pr" are skipped.
 
 .PARAMETER Incremental
 Determines whether each repository should be synchronized based only on labels added or updated in the labels CSV. When local staged or unstaged changes exist for the labels file, those pending changes are evaluated; otherwise, the last commit that changed the file is evaluated.

--- a/tools/github/scripts/Sync-AzsdkLabels.ps1
+++ b/tools/github/scripts/Sync-AzsdkLabels.ps1
@@ -204,20 +204,12 @@ if ($PSCmdlet.ParameterSetName -eq 'Languages') {
 }
 
 if ($PSCmdlet.ParameterSetName -eq 'RepositoryFile') {
-    $Repositories = Get-Content $RepositoryFilePath
+    $Repositories = @(
+        Get-Content $RepositoryFilePath |
+            ForEach-Object { ([string]$_).Trim() } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and -not $_.EndsWith('-pr', [StringComparison]::OrdinalIgnoreCase) }
+    )
 }
-
-$Repositories = @(
-    foreach ($repository in $Repositories) {
-        $repository = ([string]$repository).Trim()
-
-        if ([string]::IsNullOrWhiteSpace($repository) -or $repository.EndsWith('-pr', [StringComparison]::OrdinalIgnoreCase)) {
-            continue
-        }
-
-        $repository
-    }
-)
 
 # Extract the label content to be sync'd.
 $labels = Get-LabelDefinitionsFromFile -Path $LabelsFilePath
@@ -273,19 +265,19 @@ Write-Progress -Activity $activity -Completed
 Synchonizes the common set of Azure SDK labels to one or more repository.
 
 .DESCRIPTION
-Creates or updates labels - without deleting any - ensuring the common Azure SDK label set exists in all listed repositories. Repositories ending in "-pr" are skipped before any synchronization, progress reporting, or delay calculations occur.
+Creates or updates labels - without deleting any - ensuring the common Azure SDK label set exists in all listed repositories. When repositories are loaded from RepositoryFilePath, entries ending in "-pr" are skipped before any synchronization, progress reporting, or delay calculations occur.
 
 .PARAMETER LabelsFilePath
 The fully-qualifeid path (including filename) to a CSV file of the common Azure SDK labels that will be created or updated in each repository.  Columns have no headers and are in the form of "Name,Description,Color".
 
 .PARAMETER Repositories
-The GitHub repositories to update with the common label set. Repositories ending in "-pr" are skipped.
+The GitHub repositories to update with the common label set.
 
 .PARAMETER Languages
-The Azure SDK languages whose repositories should be updated with the common label set.  e.g., "net" for "Azure/azure-sdk-for-net". Repositories ending in "-pr" are skipped.
+The Azure SDK languages whose repositories should be updated with the common label set.  e.g., "net" for "Azure/azure-sdk-for-net".
 
 .PARAMETER RepositoryFilePath
-The fully-qualified path (including filename) to a new line-delmited file of respositories to update with the common label set. Repositories ending in "-pr" are skipped.
+The fully-qualified path (including filename) to a new line-delmited file of respositories to update with the common label set. Entries ending in "-pr" are skipped.
 
 .PARAMETER Incremental
 Determines whether each repository should be synchronized based only on labels added or updated in the labels CSV. When local staged or unstaged changes exist for the labels file, those pending changes are evaluated; otherwise, the last commit that changed the file is evaluated.


### PR DESCRIPTION
## Summary
- pre-filter repositories ending in `-pr` in the GitHub repo management scripts
- ensure skipped repos do not affect progress, delays, or other reporting
- document the skip behavior in script help and the tools/github README