### PR TITLE
Add DigitalAssets service label

### DIFF
--- a/tools/github/data/common-labels.csv
+++ b/tools/github/data/common-labels.csv
@@ -133,6 +133,7 @@ DevOps,,e99695
 DevOps - Infrastructure,,e99695
 Device Update,,e99695
 Devtestlab,,e99695
+DigitalAssets,,e99695
 Digital Twins,,e99695
 Do Not Merge,,b60205
 Docs,,e99695


### PR DESCRIPTION
Adds the missing DigitalAssets service label for Azure SDK onboarding.\n\nBrand / service reference: https://msazure.visualstudio.com/One/_git/Compute-CPlat-DigitalAssets