### PR TITLE
Check shared skill formatting directly in sync pipeline

### DIFF
--- a/.github/skills/azsdk-common-sdk-release/SKILL.md
+++ b/.github/skills/azsdk-common-sdk-release/SKILL.md
@@ -10,8 +10,6 @@ compatibility: "azure-sdk-mcp server, SDK package merged on release branch. Supp
 
 # SDK Release
 
-<!-- Test comment for validating shared skill formatting checks. -->
-
 This skill checks release readiness and triggers the Azure SDK release pipeline for packages that are already prepared, guiding the user through prerequisite validation, readiness review, and the final pipeline launch with required approval steps.
 
 ## Triggers

--- a/.github/skills/azsdk-common-sdk-release/SKILL.md
+++ b/.github/skills/azsdk-common-sdk-release/SKILL.md
@@ -10,6 +10,8 @@ compatibility: "azure-sdk-mcp server, SDK package merged on release branch. Supp
 
 # SDK Release
 
+<!-- Test comment for validating shared skill formatting checks. -->
+
 This skill checks release readiness and triggers the Azure SDK release pipeline for packages that are already prepared, guiding the user through prerequisite validation, readiness review, and the final pipeline launch with required approval steps.
 
 ## Triggers

--- a/eng/pipelines/sync-.github-skills.yml
+++ b/eng/pipelines/sync-.github-skills.yml
@@ -71,8 +71,8 @@ extends:
         workingDirectory: .github
         displayName: Install Prettier
 
-      - script: npm run format:check
+      - script: npm exec -- prettier --check "skills/azsdk-common-*/**"
         workingDirectory: .github
-        displayName: Check .github/skills formatting with Prettier
+        displayName: Check shared .github/skills formatting with Prettier
     Repos: ${{ parameters.Repos }}
     PRValidationPipelines: ${{ parameters.PRValidationPipelines }}


### PR DESCRIPTION
## Summary
- replace the `.github` npm format script call with a direct Prettier check for shared azsdk-common skill folders
- clarify the pipeline step display name to match the narrower formatting scope

## Testing
- [sync pipeline](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6514847&view=logs&j=dd3c4890-bc65-5b50-07c9-288bb4f89a58&t=042ed502-a7a1-5a71-3b1c-0871a034b4c0)