### PR TITLE
[Teams Chatbot] Add APIView Copilot tool for API-design review in PRs

### DIFF
--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/agents/chat_agent/init.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/agents/chat_agent/init.py
@@ -33,6 +33,7 @@ import config.app_config as app_config
 from config.app_config import get as cfg
 from tools.knowledge_tools import KnowledgeTools
 from tools.web_tools import WebTools
+from tools.apiview_copilot_tools import ApiViewCopilotTools
 from tools.ado_mcp_tools import create_ado_mcp_tool
 from tools.github_mcp_tools import create_github_mcp_tool
 from tools.pipeline_tools import PipelineTools
@@ -92,6 +93,7 @@ async def main() -> None:
     knowledge_tools = KnowledgeTools()
     web_tools = WebTools()
     pipeline_tools = PipelineTools()
+    apiview_copilot_tools = ApiViewCopilotTools()
     web_search_tool = agent_client.get_web_search_tool(
         search_context_size="medium",
     )
@@ -100,6 +102,7 @@ async def main() -> None:
         knowledge_tools.search_knowledge_base,
         web_tools.web_fetch,
         pipeline_tools.azsdk_analyze_pipeline,
+        apiview_copilot_tools.ask_apiview_copilot,
         web_search_tool,
     ]
 

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/agents/chat_agent/instruction.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/agents/chat_agent/instruction.md
@@ -36,10 +36,14 @@ Route every message to exactly one of these paths:
 When a message asks you to review a PR and includes a GitHub PR URL or number,
 after reading the PR and its check runs:
 
-1. **Assess merge readiness.** Treat the PR as **ready to merge** only when its
+1. **For PRs that change an API surface (spec TypeSpec, or SDK client
+   code), also call `ask_apiview_copilot`** with the changed content to get
+   API-design guidance, and include its useful findings in your reply. This is
+   in addition to the merge-readiness assessment.
+2. **Assess merge readiness.** Treat the PR as **ready to merge** only when its
    required checks are passing/green **and** there are no unresolved blocking
    review comments or requested changes. Otherwise treat it as **not ready**.
-2. **If ready to merge:** identify the requested reviewers / code owners for the PR,
+3. **If ready to merge:** identify the requested reviewers / code owners for the PR,
    then list them inline as `@github-handle` mentions and tell the author to ping
    them for the approval needed to merge.
    - Prefer the requested reviewers / code owners returned by
@@ -51,7 +55,7 @@ after reading the PR and its check runs:
      the PR's **Reviewers** panel / `CODEOWNERS` instead.
    - If there are too many reviewers, just select 3 from the list to mention
      rather than naming all of them.
-3. **If not ready to merge:** explain the blocking checks or comments and the
+4. **If not ready to merge:** explain the blocking checks or comments and the
    concrete fix steps. Do **not** name approvers in this case.
 
 Stay within the tool-call budget: diagnosing a PR already requires reading the PR and its check runs; only if needed, add a single `get_file_contents` call to read `CODEOWNERS`.
@@ -63,6 +67,10 @@ GitHub MCP is read-only — never request reviewers or merge on the user's behal
 
 **GitHub MCP** — **MANDATORY when the message contains a GitHub URL or PR number.** Use GitHub MCP tools to read the PR, its failing check runs, and their logs before answering. Do not give generic advice about a PR — read it first and provide specific diagnostics. Supports repos, issues, pull requests, and actions (read-only). If results are large, summarize and ask the user to narrow down rather than making more calls.
   - **Spec repo PRs (`azure-rest-api-specs` / `azure-rest-api-specs-pr`): use `pull_request_read` to read the PR's "Next Steps to Merge" comment — it is the single source of truth for merge blockers.** Report only the blockers it lists, each with a fix. A red CI check is a blocker only if named there; if it's not listed, tell the user it does NOT block merge. If the comment is missing, fall back to the failing check runs.
+
+**APIView Copilot (`ask_apiview_copilot`)** — Delegate **API-design guideline Q&A** and **API/spec review** to the APIView Copilot agent, which is grounded in the Azure SDK API design guidelines, curated examples, and past review memories. Use it when the user wants (a) a **review of an API surface** (TypeSpec / Swagger / SDK client listing) or a breaking-change diff, or (b) a **language-specific design-guideline ruling** (naming, async, pagination, LRO, `Response<T>`, etc.).
+  - **You must supply the API surface** — AVC **cannot** fetch `apiview.dev` content. For a spec PR, fetch the changed `.tsp`/`.json` files via GitHub MCP first, then pass their text as `spec_content`. Never pass a bare `apiview.dev` URL expecting a review.
+  - **Always pass `language`** when known — answers are language-specific.
 
 **Azure DevOps Pipeline Analysis** — `azsdk_analyze_pipeline` for failure diagnosis. Parse `project` and `buildId` from ADO URLs. Set `analyzeWithAgent` to `false` by default.
 

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tools/apiview_copilot_tools.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tools/apiview_copilot_tools.py
@@ -1,0 +1,180 @@
+"""APIView Copilot tool — delegates API-design review to the AVC agent.
+
+Forwards a question (optionally with raw TypeSpec/Swagger content) to AVC's
+``/agent/chat`` endpoint. AVC cannot fetch ``apiview.dev`` content, so we pass
+the API surface inline and AVC returns the guideline-grounded review.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Annotated
+
+import httpx
+from pydantic import BaseModel
+
+from config.app_config import get as cfg
+from tools import tool
+from utils.azure_credential import get_credential
+
+logger = logging.getLogger(__name__)
+
+# Endpoint and token scope come from Azure App Configuration.
+_ENDPOINT_KEY = "APIVIEW_COPILOT_ENDPOINT"
+_SCOPE_KEY = "APIVIEW_COPILOT_SCOPE"
+
+_HTTP_TIMEOUT_SECONDS = 120.0
+_MAX_SPEC_CHARS = 60000
+_TOKEN_REFRESH_BUFFER_SECS = 300
+
+_token_cache: tuple[str, float] | None = None
+_token_cache_lock = asyncio.Lock()
+
+
+class ApiViewCopilotResult(BaseModel):
+    """Result for ``ask_apiview_copilot``."""
+
+    success: bool
+    response: str = ""
+    thread_id: str = ""
+    error: str | None = None
+
+
+async def _get_token() -> str:
+    """Mint (and cache) an AAD token for the AVC application."""
+    global _token_cache
+    now = time.monotonic()
+    if _token_cache is not None and _token_cache[1] > now:
+        return _token_cache[0]
+
+    async with _token_cache_lock:
+        if _token_cache is not None and _token_cache[1] > time.monotonic():
+            return _token_cache[0]
+
+        scope = cfg(_SCOPE_KEY, "")
+        if not scope:
+            raise RuntimeError(
+                f"{_SCOPE_KEY} is not configured. Set it in Azure App Configuration."
+            )
+        credential = get_credential()
+        access_token = await credential.get_token(scope)
+        ttl = max(access_token.expires_on - int(time.time()) - _TOKEN_REFRESH_BUFFER_SECS, 0)
+        _token_cache = (access_token.token, time.monotonic() + ttl)
+        return access_token.token
+
+
+def _build_user_input(
+    question: str, spec_content: str | None, language: str | None
+) -> str:
+    """Compose the AVC ``userInput`` from the question and optional spec."""
+    parts: list[str] = [question.strip()]
+    if language:
+        parts.append(f"\nLanguage: {language.strip()}")
+    if spec_content:
+        surface = spec_content.strip()
+        if len(surface) > _MAX_SPEC_CHARS:
+            surface = surface[:_MAX_SPEC_CHARS] + "\n... [truncated]"
+        parts.append("\nAPI surface to review:\n" + surface)
+    return "\n".join(parts)
+
+
+class ApiViewCopilotTools:
+    """Tools that delegate API-design questions to the APIView Copilot agent."""
+
+    @tool
+    async def ask_apiview_copilot(
+        self,
+        *,
+        question: Annotated[
+            str,
+            "The API-design question or review instruction, e.g. 'Review this "
+            "TypeSpec against Azure API guidelines' or 'What is the guideline "
+            "for naming async methods in Python?'.",
+        ],
+        spec_content: Annotated[
+            str | None,
+            "The raw API surface to review (TypeSpec/Swagger/SDK listing). Fetch "
+            "it yourself and pass inline; do NOT pass an apiview.dev URL. Omit "
+            "for pure guideline questions.",
+        ] = None,
+        language: Annotated[
+            str | None,
+            "API language, e.g. 'typespec', 'python', 'dotnet', 'java', 'typescript'," \
+            "'go'. Provide it when known.",
+        ] = None,
+        thread_id: Annotated[
+            str | None,
+            "An AVC thread id from a previous call to continue the conversation.",
+        ] = None,
+    ) -> ApiViewCopilotResult:
+        """Ask APIView Copilot an Azure SDK API-design question or request a review.
+
+        Use for API design guideline Q&A and API/spec review. Prefer over
+        ``search_knowledge_base`` when the user wants a review of an API surface
+        or a language-specific guideline ruling; it complements knowledge search.
+        """
+        endpoint = cfg(_ENDPOINT_KEY, "")
+        if not endpoint:
+            return ApiViewCopilotResult(
+                success=False,
+                error=(
+                    f"{_ENDPOINT_KEY} is not configured. "
+                    "Set it in Azure App Configuration."
+                ),
+            )
+        user_input = _build_user_input(question, spec_content, language)
+
+        payload: dict[str, str] = {"userInput": user_input}
+        if thread_id:
+            payload["threadId"] = thread_id
+
+        try:
+            token = await _get_token()
+        except Exception as e:  # noqa: BLE001 — surface auth failures to the agent
+            logger.exception("Failed to acquire APIView Copilot token")
+            return ApiViewCopilotResult(
+                success=False,
+                error=f"Could not authenticate to APIView Copilot: {e}",
+            )
+
+        try:
+            async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS) as client:
+                resp = await client.post(
+                    endpoint,
+                    headers={"Authorization": f"Bearer {token}"},
+                    json=payload,
+                )
+        except httpx.HTTPError as e:
+            logger.exception("APIView Copilot request failed")
+            return ApiViewCopilotResult(
+                success=False, error=f"APIView Copilot request failed: {e}"
+            )
+
+        if resp.status_code == httpx.codes.FORBIDDEN:
+            return ApiViewCopilotResult(
+                success=False,
+                error=(
+                    "APIView Copilot returned 403 (Unauthorized). The agent "
+                    "identity likely lacks the required app role (Read/App.Read) "
+                    "on the APIView Copilot application."
+                ),
+            )
+        if resp.status_code == httpx.codes.TOO_MANY_REQUESTS:
+            return ApiViewCopilotResult(
+                success=False,
+                error="APIView Copilot is rate limited (429). Try again shortly.",
+            )
+        if resp.is_error:
+            return ApiViewCopilotResult(
+                success=False,
+                error=f"APIView Copilot returned {resp.status_code}: {resp.text[:500]}",
+            )
+
+        data = resp.json()
+        return ApiViewCopilotResult(
+            success=True,
+            response=data.get("response", ""),
+            thread_id=data.get("threadId", ""),
+        )


### PR DESCRIPTION
## Summary

Adds an `ask_apiview_copilot` tool to the Azure SDK QA Bot agent that delegates **API-design review** and **guideline Q&A** to the APIView Copilot (AVC) service. During PR reviews (spec or SDK), the agent can now supply the changed API surface to AVC and surface its guideline-grounded findings.

## Why

AVC runs an agentic API-review pipeline grounded in the Azure SDK API design guidelines, curated examples, and past review memories. However, AVC **cannot fetch `apiview.dev` content** (the backend returns `403 IP Forbidden` to the AVC host). The reliable contract is: **our agent supplies the API surface (via GitHub MCP), and AVC supplies the review.** This PR implements that integration.

## Changes

- **New `tools/apiview_copilot_tools.py`** — `ApiViewCopilotTools.ask_apiview_copilot`:
  - Composes `question` + optional `language` + optional `spec_content` into AVC's `userInput` and POSTs to the `/agent/chat` endpoint.
  - Mints an AAD token via the shared agent credential (cached, lock-guarded refresh).
  - Endpoint and token scope are read **only** from Azure App Configuration (`APIVIEW_COPILOT_ENDPOINT` / `APIVIEW_COPILOT_SCOPE`) — no hardcoded values.
  - Returns a pydantic `ApiViewCopilotResult` (`success`, `response`, `thread_id`, `error`); handles 403 / 429 / other errors gracefully via `httpx.codes`.
- **`agents/chat_agent/init.py`** — instantiate and register the tool.
- **`agents/chat_agent/instruction.md`** — instruct the agent to call AVC during PR review for PRs that change an API surface (spec TypeSpec/Swagger or SDK client code), always passing the fetched content and `language`; never pass a bare `apiview.dev` URL.

## Configuration required

Set these keys in Azure App Configuration before enabling in an environment:
- `APIVIEW_COPILOT_ENDPOINT` — the AVC `/agent/chat` URL
- `APIVIEW_COPILOT_SCOPE` — the AVC app-id token scope (e.g. `<app-id>/.default`)

The hosted agent's managed identity needs the `Read`/`App.Read` app role on the AVC application.

## Testing

- Validated `/agent/chat` end-to-end against the AVC staging endpoint (200 OK, thread continuity works).
- Confirmed AVC produces accurate ARM/API-design findings when passed real TypeSpec content inline.
- No lint/type errors in the changed files.
