### PR TITLE
[Teams Chatbot] Add knowledge source: ARM docs

### DIFF
--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/config/tenant_config.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/config/tenant_config.py
@@ -267,7 +267,7 @@ _register(
     ),
     KnowledgeSource(
         name=SRC_STATIC_ARM_DOCS,
-        description="Azure Resource Manager (ARM) important documentation.",
+        description="ARM Wiki (RPaaS) documentation for ARM resource modeling, OpenAPI/TypeSpec onboarding, and related RP platform guidance.",
         base_url="https://armwiki.azurewebsites.net/rpaas/",
         trim_format=True,
         suffix=".html",

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/config/tenant_config.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/config/tenant_config.py
@@ -80,6 +80,7 @@ SRC_AZURE_SDK_TOOLS_DOCS = "azure_sdk_tools_docs"
 # -- General Azure & review resources --
 SRC_STATIC_AZURE_DOCS = "static_azure_docs"
 SRC_STATIC_API_SPEC_VIEW_QA = "static_api_spec_view_qa"
+SRC_STATIC_ARM_DOCS = "static_arm_docs"
 
 
 # ---------------------------------------------------------------------------
@@ -264,6 +265,13 @@ _register(
         name=SRC_STATIC_API_SPEC_VIEW_QA,
         description="Historical Q&A for API specification review covering common validation errors and fixes.",
     ),
+    KnowledgeSource(
+        name=SRC_STATIC_ARM_DOCS,
+        description="Azure Resource Manager (ARM) important documentation.",
+        base_url="https://armwiki.azurewebsites.net/rpaas/",
+        trim_format=True,
+        suffix=".html",
+    ),
     # -- SDK tools --
     KnowledgeSource(
         name=SRC_AZURE_SDK_TOOLS_DOCS,
@@ -341,6 +349,7 @@ _TYPESPEC_SOURCES = _sources(
     SRC_STATIC_AZURE_DOCS,
     SRC_STATIC_TYPESPEC_TO_SWAGGER_MAPPING,
     SRC_TYPESPEC_AZURE_PROVIDERHUB_DOCS,
+    SRC_STATIC_ARM_DOCS,
 )
 
 _AZURE_TYPESPEC_AUTHORING_SOURCES = _sources(
@@ -553,6 +562,7 @@ _TENANT_CONFIG_MAP: dict[TenantID, TenantConfig] = {
             SRC_AZURE_REST_API_SPECS_DOCS,
             SRC_AZURE_OPENAPI_DIFF_DOCS,
             SRC_AZURE_SDK_DOCS_ENG,
+            SRC_STATIC_ARM_DOCS,
         ),
         source_filter={
             SRC_AZURE_SDK_DOCS_ENG: "search.ismatch('design*', 'title')",


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-pr/issues/2666
This PR adds  a new  knowledge source configuration for ARM wiki content.

**Documentation Source Details**

- docs: 
    [OpenAPI Specifications SDP Rollout | ARM Wiki](https://armwiki.azurewebsites.net/rpaas/openapispec_sdp_rollout.html)
[Partial manifest in RP Platform | ARM Wiki](https://armwiki.azurewebsites.net/rpaas/partialregistration.html)
[Modeling ARM Resources | ARM Wiki](https://armwiki.azurewebsites.net/rpaas/development_guides/modeling_arm_resources.html)
[Implementing Long-running Operations | ARM Wiki](https://armwiki.azurewebsites.net/rpaas/development_guides/long_running_operations.html)
[REST API specifications (either OpenAPIv2 or TypeSpec) | ARM Wiki](https://armwiki.azurewebsites.net/rpaas/swaggeronboarding.html)
[OpenAPI (Swagger) based validation in Resource Type Registration | ARM Wiki](https://armwiki.azurewebsites.net/rpaas/swagger_based_validation.html)
[Onboarding to Azure Public Environment | ARM Wiki](https://armwiki.azurewebsites.net/rpaas/onboardprod.html)
[Private Resource Provider (RP) | ARM Wiki](https://armwiki.azurewebsites.net/rpaas/prp-onboarding.html)
- Target Channels: TypeSpec Discussion Channel and API Spec Review

**test case:**
<img width="653" height="442" alt="image" src="https://github.com/user-attachments/assets/87b8c9c9-c8a0-42f4-ae07-819c21b633ca" />
