### PR TITLE
Add CODEOWNERS entry for typespec-author eval step templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -76,7 +76,7 @@
 /eng/pipelines/azure-typespec-author-eval/                      @azure/azsdk-cli @haolingdong-msft @catalinaperalta
 /eng/pipelines/azure-typespec-author-benchmark.yml              @azure/azsdk-cli @haolingdong-msft @catalinaperalta
 /eng/pipelines/azure-typespec-author-benchmark-no-skill.yml     @azure/azsdk-cli @haolingdong-msft @catalinaperalta
-/eng/pipelines/templates/steps/typespec-author-eval-*.yml  @azure/azsdk-cli @haolingdong-msft @catalinaperalta
+/eng/pipelines/templates/steps/typespec-author-eval-*.yml              @azure/azsdk-cli @haolingdong-msft @catalinaperalta
 
 
 ###########

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -76,6 +76,7 @@
 /eng/pipelines/azure-typespec-author-eval/                      @azure/azsdk-cli @haolingdong-msft @catalinaperalta
 /eng/pipelines/azure-typespec-author-benchmark.yml              @azure/azsdk-cli @haolingdong-msft @catalinaperalta
 /eng/pipelines/azure-typespec-author-benchmark-no-skill.yml     @azure/azsdk-cli @haolingdong-msft @catalinaperalta
+/eng/pipelines/templates/steps/typespec-author-eval-*.yml  @azure/azsdk-cli @haolingdong-msft @catalinaperalta
 
 
 ###########


### PR DESCRIPTION
Miss adding CODEOWNER for files under template folder.

```
/eng/pipelines/templates/steps/typespec-author-eval-*.yml  @azure/azsdk-cli @haolingdong-msft @catalinaperalta
```

