### PR TITLE
Fix release plan tools to guide users when run from a language repo (#16005)

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
@@ -157,6 +157,43 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             Assert.True(releaseplan.ResponseError.Contains("Invalid spec pull request URL"));
         }
 
+        [Test]
+        public async Task Test_Create_releasePlan_from_language_repo_returns_guidance()
+        {
+            // Simulate running from a language SDK repository (or any non-spec repo): the git remote
+            // is not an azure-rest-api-specs(-pr) repo, so the tool should guide the user to provide an
+            // absolute path or run from the specs repo instead of reporting a private-repo error.
+            var languageRepoGitHelperMock = new Mock<IGitHelper>();
+            languageRepoGitHelperMock.Setup(x => x.GetBranchNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync("testBranch");
+            languageRepoGitHelperMock.Setup(x => x.GetRepoRemoteUriAsync(It.Is<string>(p => !string.IsNullOrEmpty(p) && !Uri.IsWellFormedUriString(p, UriKind.Absolute)), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Uri("https://github.com/Azure/azure-sdk-for-net.git"));
+            languageRepoGitHelperMock.Setup(x => x.DiscoverRepoRootAsync(It.Is<string>(p => !string.IsNullOrEmpty(p) && !Uri.IsWellFormedUriString(p, UriKind.Absolute)), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string path, CancellationToken _) => path.Contains("specification") ? path.Substring(0, path.IndexOf("specification")) : path);
+
+            var processHelper = new ProcessHelper(new TestLogger<ProcessHelper>(), Mock.Of<IRawOutputHelper>());
+            var languageRepoTypeSpecHelper = new TypeSpecHelper(languageRepoGitHelperMock.Object, processHelper);
+
+            var languageRepoReleasePlanTool = new ReleasePlanTool(
+                devOpsService,
+                languageRepoGitHelperMock.Object,
+                languageRepoTypeSpecHelper,
+                logger,
+                userHelper,
+                gitHubService,
+                environmentHelper,
+                inputSanitizer,
+                httpClient,
+                Mock.Of<INpxHelper>(), Mock.Of<IRawOutputHelper>());
+
+            var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
+            var releaseplan = await languageRepoReleasePlanTool.CreateReleasePlan(null, testCodeFilePath, "July 2025", "GA", specPullRequestUrl: "https://github.com/Azure/azure-rest-api-specs/pull/35446", isTestReleasePlan: true);
+
+            Assert.IsNotNull(releaseplan);
+            Assert.IsNotNull(releaseplan.ResponseError);
+            Assert.True(releaseplan.ResponseError.Contains("Could not locate the Azure REST API specs repository"), $"Unexpected error: {releaseplan.ResponseError}");
+            Assert.True(releaseplan.ResponseError.Contains("absolute path"), $"Unexpected error: {releaseplan.ResponseError}");
+        }
+
         [TestCase("TypeSpecTestData/specification/testcontoso/Contoso.Management", "July 2025", "https://github.com/Azure/azure-rest-api-specs/pull/35446", "GA", "", "")]
         [TestCase("TypeSpecTestData/specification/testcontoso/Contoso.Management", "July 2025", "https://github.com/Azure/azure-rest-api-specs/pull/35447", "Public Preview", "", "")]
         [TestCase("TypeSpecTestData/specification/testcontoso/Contoso.Management", "July 2025", "https://github.com/Azure/azure-rest-api-specs-pr/pull/35448", "Private Preview", "", "")]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - The create release plan tool no longer accepts an `--sdk-type` parameter. The SDK release type is now always derived from the API release type (GA maps to a stable SDK release, preview maps to a beta SDK release), preventing a stable SDK release from a preview API version.
 
+- The create and update release plan tools now give clear guidance when run from a language SDK repository (or any directory that is not the `azure-rest-api-specs`/`azure-rest-api-specs-pr` repo). Instead of incorrectly reporting that the spec is in a private repository, they now ask the user to provide the absolute path to the TypeSpec project or to run the command from within the `Azure/azure-rest-api-specs` repository.
+
 ## 0.6.24 (2026-06-30)
 
 ### Features Added

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -644,9 +644,9 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     return new ReleasePlanResponse
                     {
                         ResponseError = $"Could not resolve a TypeSpec project from '{typeSpecProjectPath}'. " +
-                            "If you are running this from a language SDK repository or another directory, provide the absolute path to the TypeSpec project, " +
-                            "or run this command from within a local clone of the Azure/azure-rest-api-specs repository.",
-                        NextSteps = ["Provide the absolute path to the TypeSpec project, or run this command from within the azure-rest-api-specs repository."]
+                            "Provide the absolute path to the TypeSpec project directory, a URL to the TypeSpec project in the azure-rest-api-specs or azure-rest-api-specs-pr repository, " +
+                            "or run this command from within a local clone of one of those repositories.",
+                        NextSteps = ["Provide the absolute path or a valid azure-rest-api-specs / azure-rest-api-specs-pr URL to the TypeSpec project, or run this command from within a local clone of one of those repositories."]
                     };
                 }
                                
@@ -894,6 +894,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     }
                     catch (Exception ex) when (ex is not OperationCanceledException)
                     {
+                        logger.LogDebug(ex, "Failed to determine whether '{RepoRoot}' is an azure-rest-api-specs(-pr) repository; falling back to user guidance.", repoRoot);
                         isSpecRepo = false;
                     }
                 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -643,8 +643,10 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     logger.LogWarning("Failed to identify a TypeSpec project path from {typeSpecProjectPath}", typeSpecProjectPath);
                     return new ReleasePlanResponse
                     {
-                        ResponseError = $"Failed to find the TypeSpec project from {typeSpecProjectPath}",
-                        NextSteps = ["Retry with valid TypeSpec project path"]
+                        ResponseError = $"Could not resolve a TypeSpec project from '{typeSpecProjectPath}'. " +
+                            "If you are running this from a language SDK repository or another directory, provide the absolute path to the TypeSpec project, " +
+                            "or run this command from within a local clone of the Azure/azure-rest-api-specs repository.",
+                        NextSteps = ["Provide the absolute path to the TypeSpec project, or run this command from within the azure-rest-api-specs repository."]
                     };
                 }
                                
@@ -879,6 +881,30 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             if (!typeSpecHelper.IsUrl(typeSpecProjectPath) && apiReleaseType != ApiReleaseType.PrivatePreview)
             {
                 var repoRoot = typeSpecHelper.GetSpecRepoRootPath(typeSpecProjectPath);
+
+                // When this command is run from a language SDK repository (or any other directory) with a
+                // relative path, the path does not resolve within the azure-rest-api-specs(-pr) repository.
+                // In that case, guide the user instead of incorrectly reporting a private-repo error.
+                bool isSpecRepo = false;
+                if (!string.IsNullOrEmpty(repoRoot))
+                {
+                    try
+                    {
+                        isSpecRepo = await typeSpecHelper.IsRepoPathForSpecRepoAsync(repoRoot, ct);
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        isSpecRepo = false;
+                    }
+                }
+
+                if (!isSpecRepo)
+                {
+                    throw new Exception(
+                        $"Could not locate the Azure REST API specs repository (azure-rest-api-specs or azure-rest-api-specs-pr) from the TypeSpec project path '{typeSpecProjectPath}'. " +
+                        "If you are running this from a language SDK repository or another directory, provide the absolute path to the TypeSpec project, " +
+                        "or run this command from within a local clone of the Azure/azure-rest-api-specs repository.");
+                }
 
                 // Ensure a release plan is created only if the API specs pull request is in a public repository.
                 if (!await typeSpecHelper.IsRepoPathForPublicSpecRepoAsync(repoRoot, ct))


### PR DESCRIPTION
## Summary

Fixes #16005.

The create and update release plan tools failed with misleading errors when invoked from a language SDK repository (e.g. `azure-sdk-for-net`) or any directory that is not a local clone of `azure-rest-api-specs` / `azure-rest-api-specs-pr`. In that situation the create tool reported that the spec was in a *private* repo (and suggested Private Preview), and the update tool returned a generic "Failed to find the TypeSpec project" message. Neither told the user what to actually do.

## Changes

- `ValidateCreateReleasePlanInputAsync`: before checking whether the spec repo is public, the tool now verifies the resolved path actually lives inside an `azure-rest-api-specs(-pr)` repository (via `IsRepoPathForSpecRepoAsync`). If it does not, it throws a clear message asking the user to provide the **absolute path** to the TypeSpec project, or to run the command from within the `Azure/azure-rest-api-specs` repo. The existing public/private-repo behavior is preserved for paths that do resolve inside a specs repo.
- `UpdateReleasePlan`: when the TypeSpec project path cannot be resolved, the error and next step now provide the same guidance instead of a generic failure message.
- Added a unit test (`Test_Create_releasePlan_from_language_repo_returns_guidance`) that simulates a non-specs git remote and asserts the new guidance is returned.
- CHANGELOG entry under `0.6.25` Bugs Fixed.

## Testing

`dotnet test --filter "FullyQualifiedName~ReleasePlanToolTests"` — 104 passed, 0 failed.
