### PR TITLE
Remove SDK release type param from create release plan tool

### DIFF
--- a/.github/skills/azsdk-common-prepare-release-plan/SKILL.md
+++ b/.github/skills/azsdk-common-prepare-release-plan/SKILL.md
@@ -57,15 +57,12 @@ DO NOT USE FOR: SDK code generation, pipeline troubleshooting, API review feedba
 3. **Gather Info** — Collect required details from the user. See [details](references/release-plan-details.md):
    - Target release month/year (format: "Month YYYY", e.g. "June 2026"). Do NOT use formats like "2026-06" or "06/2026" — these are invalid.
    - API release type: Value must be one of the following: "Private Preview", "Public Preview", or "GA"
-   - SDK release type: Value must be "beta" or "stable" — always ask the user explicitly
    - Spec PR URL (optional)
    - Service Tree ID (GUID) — optional if previously created
    - Product Tree ID (GUID) — optional if previously created
-4. **Create** — Run `azure-sdk-mcp:azsdk_create_release_plan` with the collected parameters including `sdkReleaseType`. Use `forceCreateReleasePlan: true` only if an existing release plan was found for a different API release type.
+4. **Create** — Run `azure-sdk-mcp:azsdk_create_release_plan` with the collected parameters. Use `forceCreateReleasePlan: true` only if an existing release plan was found for a different API release type.
 5. **Namespace** — For first management plane releases, link namespace approval issue using `azure-sdk-mcp:azsdk_link_namespace_approval_issue`.
 
-> **IMPORTANT**: Do NOT default the API release type value as the SDK release type. These are separate fields — always ask the user explicitly for the SDK release type.
->
 > **IMPORTANT**: Do NOT update an existing release plan to change its API release type. If a release plan exists for a different API release type, force-create a new one instead.
 
 **Tool**: `azure-sdk-mcp:azsdk_create_release_plan`

--- a/.github/skills/azsdk-common-prepare-release-plan/references/release-plan-details.md
+++ b/.github/skills/azsdk-common-prepare-release-plan/references/release-plan-details.md
@@ -23,7 +23,6 @@ Collect these details (do not use temporary values):
 - **Product Service Tree ID**: GUID format - confirm with user
 - **Expected Release Timeline**: "Month YYYY" format
 - **API Release Type** (required): One of "Private Preview", "Public Preview", or "GA"
-- **SDK Release Type** (optional): "beta" or "stable". Defaults to "beta" for Private Preview and Public Preview, "stable" for GA.
 
 ## API Release Type and Spec PR Validation
 


### PR DESCRIPTION
## Summary

Removes the SDK release type (`sdkReleaseType`) parameter from the **Create Release Plan** flow in the `azsdk-common-prepare-release-plan` skill, since the `azsdk_create_release_plan` tool no longer accepts it.

## Changes

- `SKILL.md` (Use Case 1 — Create Release Plan):
  - Removed the "SDK release type" item from the **Gather Info** step.
  - Removed `including sdkReleaseType` from the **Create** step.
  - Removed the IMPORTANT note about not defaulting the SDK release type from the API release type.
- `references/release-plan-details.md`:
  - Removed the **SDK Release Type** entry from the required-information list.

## Notes

- Scoped to the create flow only. The Update Release Plan use case still references `sdkReleaseType` and was intentionally left unchanged.