### PR TITLE
Remove archived AutoRest Java repo from sync list

### DIFF
--- a/tools/github/data/common-labels.csv
+++ b/tools/github/data/common-labels.csv
@@ -281,7 +281,7 @@ architecture-review-added,Architecture review completed,0e8a16
 architecture-review-in-progress,Architecture review is in progress,fbca04
 architecture-review-needed,Triggers Archie: AI architecture review agent,1d76db
 auto-close-exempt,Prevents the auto-close from closing based on max lifetime,ededed
-auto-release,"When merged to main, the release pipelines for this PR's changed packages are triggered automatically.",1d76db
+auto-release,"When merged to main, release pipelines for this PR's changed packages trigger automatically.",1d76db
 blocking-release,Blocks release,d73a49
 breaking-change,,d73a49
 bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875

--- a/tools/github/data/repositories.txt
+++ b/tools/github/data/repositories.txt
@@ -20,7 +20,6 @@ Azure/azure-sdk-pr
 Azure/azure-sdk-tools
 Azure/azure-sdk-actions
 Azure/autorest
-Azure/autorest.java
 Azure/autorest.go
 Azure/autorest.cpp
 Azure/azure-rest-api-specs


### PR DESCRIPTION
## Description
- Remove the archived Azure/autorest.java repository from the GitHub repository sync list since it's read-only and label update would throw errors.
- Make the `auto-release` label description to be shorter to satisfy the length requirement.
