### PR TITLE
Refine the swagger-to-typespec knowledge

### DIFF
--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/common-types.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/common-types.md
@@ -1,0 +1,65 @@
+# ARM Common Types Reference
+
+Standard ARM models from common-types and their Swagger schemas.
+
+## What fields does TrackedResource include in Swagger
+
+`TrackedResource` extends `Resource` and adds `location` (required) and `tags` (optional dictionary). All ARM resources get `id`, `name`, `type` (readOnly) and `systemData` (readOnly) from the base `Resource`.
+
+## What the ManagedServiceIdentity schema looks like in Swagger
+
+TypeSpec: `...ManagedServiceIdentityProperty`
+
+Swagger `identity` object: `type` (enum: None, SystemAssigned, UserAssigned, SystemAssigned,UserAssigned), `principalId` (uuid, readOnly), `tenantId` (uuid, readOnly), `userAssignedIdentities` (dictionary of `UserAssignedIdentity` with `principalId` and `clientId`, both readOnly).
+
+## What the SystemAssignedServiceIdentity schema looks like
+
+TypeSpec: `...ManagedSystemAssignedIdentityProperty`
+
+Same as ManagedServiceIdentity but `type` enum only has `None` and `SystemAssigned`, no userAssignedIdentities.
+
+## What the Sku schema looks like in Swagger
+
+TypeSpec: `...ResourceSkuProperty`
+
+Swagger: `name` (string, required), `tier` (enum: Free, Basic, Standard, Premium), `size` (string), `family` (string), `capacity` (int32).
+
+## What the Plan schema looks like in Swagger
+
+TypeSpec: `...ResourcePlanProperty`
+
+Swagger: `name` (required), `publisher` (required), `product` (required), `promotionCode` (optional), `version` (optional).
+
+## What the ExtendedLocation schema looks like in Swagger
+
+TypeSpec: `...ExtendedLocationProperty`
+
+Swagger: `name` (string), `type` (enum: EdgeZone, CustomLocation).
+
+## What the SystemData schema looks like in Swagger
+
+Automatically added to all ARM resources. Contains `createdBy`, `createdByType` (User/Application/ManagedIdentity/Key), `createdAt` (date-time), `lastModifiedBy`, `lastModifiedByType`, `lastModifiedAt`. All readOnly.
+
+## What the ErrorResponse schema looks like in Swagger
+
+All ARM operations include a `default` response with `ErrorResponse`. Contains `error` → `ErrorDetail` with `code`, `message`, `target`, `details[]` (recursive), `additionalInfo[]`.
+
+## What the CheckNameAvailability request and response look like
+
+Request: `name` (string), `type` (string).
+Response: `nameAvailable` (boolean), `reason` (enum: Invalid, AlreadyExists), `message` (string).
+
+## What standard parameter $ref paths are used in Swagger
+
+| Parameter | Common-types $ref path |
+|-----------|----------------------|
+| api-version | `common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter` |
+| subscriptionId | `common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter` |
+| resourceGroupName | `common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter` |
+| location | `common-types/resource-management/v5/types.json#/parameters/LocationParameter` |
+| privateEndpointConnectionName | `common-types/resource-management/v5/privatelinks.json#/parameters/PrivateEndpointConnectionName` |
+
+## What Encryption and CustomerManagedKeyEncryption schemas look like
+
+`Encryption`: `keyVaultProperties` ($ref), `status` (enum: enabled, disabled).
+`CustomerManagedKeyEncryption`: `keyEncryptionKeyIdentity` ($ref), `keyVaultProperties` ($ref).

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/composite-interfaces.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/composite-interfaces.md
@@ -1,0 +1,78 @@
+# ARM Composite Interfaces (CRUD Shortcuts)
+
+How to use composite interfaces to generate full CRUD operations with minimal code in TypeSpec.
+
+## How TrackedResourceOperations generates all standard operations
+
+One line generates GET, PUT (async), PATCH, DELETE (async), ListByResourceGroup, and ListBySubscription.
+
+```typespec
+model Employee is TrackedResource<EmployeeProperties> {
+  ...ResourceNameParameter<Employee>;
+}
+
+@armResourceOperations
+interface Employees
+  extends TrackedResourceOperations<Employee, EmployeeProperties> {}
+```
+
+## How ProxyResourceOperations works for child resources
+
+Generates GET, PUT (async), DELETE (async), and ListByParent. No PATCH or ListBySubscription.
+
+```typespec
+@parentResource(Employee)
+model EmployeeRole is ProxyResource<RoleProperties> {
+  ...ResourceNameParameter<EmployeeRole>;
+}
+
+@armResourceOperations
+interface EmployeeRoles extends ProxyResourceOperations<EmployeeRole> {}
+```
+
+## How ExtensionResourceOperations works for multi-scope resources
+
+Generates full CRUD at all scopes (tenant, subscription, resource group, parent resource).
+
+```typespec
+@armResourceOperations
+interface Locks
+  extends ExtensionResourceOperations<MyLock, LockProperties> {}
+```
+
+## Which composite interface generates which operations
+
+| Interface | GET | PUT | PATCH | DELETE | ListByParent | ListBySub |
+|-----------|-----|-----|-------|--------|-------------|-----------|
+| `TrackedResourceOperations` | ✅ | ✅ async | ✅ | ✅ async | ✅ (by RG) | ✅ |
+| `ProxyResourceOperations` | ✅ | ✅ async | — | ✅ async | ✅ | — |
+| `ExtensionResourceOperations` | ✅ | ✅ async | ✅ | ✅ async | ✅ multi-scope | — |
+| `ResourceInstanceOperations` | ✅ | ✅ async | ✅ | ✅ async | — | — |
+| `ResourceCollectionOperations` | — | — | — | — | ✅ | — |
+| `ResourceOperations` | ✅ | ✅ async | ✅ | ✅ async | ✅ | — |
+
+## How to combine composite interfaces with custom operations
+
+```typespec
+@armResourceOperations
+interface Employees
+  extends TrackedResourceOperations<Employee, EmployeeProperties> {
+  // Add custom actions on top of standard CRUD
+  restart is ArmResourceActionSync<Employee, void, void>;
+}
+```
+
+## How to build operations individually when composites don't fit
+
+```typespec
+@armResourceOperations
+interface Employees {
+  get is ArmResourceRead<Employee>;
+  create is ArmResourceCreateOrReplaceAsync<Employee>;
+  update is ArmCustomPatchSync<Employee, EmployeePatch>;
+  delete is ArmResourceDeleteSync<Employee>;
+  list is ArmResourceListByParent<Employee>;
+}
+```
+
+This gives you full control over which operations to include and whether each is sync/async.

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/crud-operations.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/crud-operations.md
@@ -1,0 +1,169 @@
+# ARM CRUD Operations
+
+How to define create, read, update, and delete operations for ARM resources in TypeSpec.
+
+## How to define an async create (PUT) operation with LRO
+
+Use `ArmResourceCreateOrReplaceAsync` for the most common create pattern. Client gets 201 with polling headers.
+
+```typespec
+@armResourceOperations
+interface Employees {
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<Employee>;
+}
+```
+
+Swagger: PUT with `200` (updated) and `201` (created) responses, both returning the resource. Includes `x-ms-long-running-operation: true` with `final-state-via: azure-async-operation`.
+
+## How to define a sync create (PUT) operation without LRO
+
+Use `ArmResourceCreateOrReplaceSync` when creation completes immediately.
+
+```typespec
+@armResourceOperations
+interface Employees {
+  createOrUpdate is ArmResourceCreateOrReplaceSync<Employee>;
+}
+```
+
+Swagger: Same as async but without `x-ms-long-running-operation`. Returns `200`/`201` with the resource body.
+
+## How to define a create operation with Location header polling
+
+Use `ArmLroLocationHeader` instead of the default Azure-AsyncOperation header.
+
+```typespec
+@armResourceOperations
+interface Employees {
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<
+    Employee,
+    Response = ArmResponse<Employee> | ArmResourceCreatedResponse<
+      Employee,
+      LroHeaders = ArmLroLocationHeader<FinalResult = Employee>
+    >
+  >;
+}
+```
+
+Swagger: `201` response includes `Location` and `Retry-After` headers, with `final-state-via: location`.
+
+## How to define a GET operation to read a single resource
+
+Use `ArmResourceRead` for a standard GET by resource name.
+
+```typespec
+@armResourceOperations
+interface Employees {
+  get is ArmResourceRead<Employee>;
+}
+```
+
+Swagger: GET at `.../employees/{employeeName}` with `200` response returning the resource and `default` error response.
+
+## How to define a HEAD operation to check resource existence
+
+Use `ArmResourceCheckExistence` for a lightweight existence check.
+
+```typespec
+@armResourceOperations
+interface Employees {
+  checkExistence is ArmResourceCheckExistence<Employee>;
+}
+```
+
+Swagger: HEAD with `200` (exists) and `404` (not found) responses, no response body.
+
+## How to define a standard update (PATCH) with auto-generated patch model
+
+Use `ArmResourcePatchAsync` — the patch body is auto-derived from properties (all fields optional).
+
+```typespec
+@armResourceOperations
+interface Employees {
+  update is ArmResourcePatchAsync<Employee, EmployeeProperties>;
+}
+```
+
+Swagger: PATCH with auto-generated `EmployeeUpdate` model (all properties optional), `200` + `202` responses, LRO enabled.
+
+## How to define a tags-only update (PATCH)
+
+Use `ArmTagsPatchSync` or `ArmTagsPatchAsync` to update only the `tags` field.
+
+```typespec
+@armResourceOperations
+interface Employees {
+  update is ArmTagsPatchSync<Employee>;
+}
+```
+
+Swagger: PATCH body is `TagsUpdateModel` with only `tags` property.
+
+## How to define an update (PATCH) with a custom patch body
+
+Use `ArmCustomPatchAsync` or `ArmCustomPatchSync` with your own patch model.
+
+```typespec
+model MyCustomPatch {
+  city?: string;
+  priority?: int32;
+}
+
+@armResourceOperations
+interface Employees {
+  update is ArmCustomPatchAsync<Employee, MyCustomPatch>;
+}
+```
+
+Swagger: PATCH with your custom model as the body, `200`/`202` responses, LRO with `azure-async-operation`.
+
+## How to define an async delete operation (recommended pattern)
+
+Use `ArmResourceDeleteWithoutOkAsync`. Returns `202` (accepted, use polling) and `204` (not found).
+
+```typespec
+@armResourceOperations
+interface Employees {
+  delete is ArmResourceDeleteWithoutOkAsync<Employee>;
+}
+```
+
+Swagger: DELETE with `202` (LRO headers: `Azure-AsyncOperation`, `Location`, `Retry-After`) and `204`. Includes `x-ms-long-running-operation: true`.
+
+## How to define a sync delete operation
+
+Use `ArmResourceDeleteSync` when deletion completes immediately.
+
+```typespec
+@armResourceOperations
+interface Employees {
+  delete is ArmResourceDeleteSync<Employee>;
+}
+```
+
+Swagger: DELETE with `200` (deleted) and `204` (not found), no LRO.
+
+## Which create operation template to choose
+
+| Scenario | Template | LRO? |
+|----------|----------|-------|
+| Standard async create/replace | `ArmResourceCreateOrReplaceAsync` | Yes |
+| Sync create/replace | `ArmResourceCreateOrReplaceSync` | No |
+| Async create/update (deprecated) | `ArmResourceCreateOrUpdateAsync` | Yes |
+
+## Which update operation template to choose
+
+| Scenario | Template | LRO? |
+|----------|----------|-------|
+| Auto-generated patch (async) | `ArmResourcePatchAsync` | Yes |
+| Auto-generated patch (sync) | `ArmResourcePatchSync` | No |
+| Tags-only (async/sync) | `ArmTagsPatchAsync` / `ArmTagsPatchSync` | Yes/No |
+| Custom patch body (async/sync) | `ArmCustomPatchAsync` / `ArmCustomPatchSync` | Yes/No |
+
+## Which delete operation template to choose
+
+| Scenario | Template | LRO? | Status Codes |
+|----------|----------|-------|-------------|
+| Async delete (recommended) | `ArmResourceDeleteWithoutOkAsync` | Yes | 202, 204 |
+| Sync delete | `ArmResourceDeleteSync` | No | 200, 204 |
+| Async delete (deprecated) | `ArmResourceDeleteAsync` | Yes | 200, 202, 204 |

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/custom-actions.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/custom-actions.md
@@ -1,0 +1,114 @@
+# ARM Custom Actions (POST Operations)
+
+How to define custom POST actions on ARM resources in TypeSpec.
+
+## How to define a sync resource action with request and response body
+
+Use `ArmResourceActionSync` for actions that complete immediately (e.g., move, validate, restart).
+
+```typespec
+model MoveRequest {
+  from: string;
+  to: string;
+}
+model MoveResponse {
+  status: string;
+}
+
+@armResourceOperations
+interface Employees {
+  move is ArmResourceActionSync<Employee, MoveRequest, MoveResponse>;
+}
+```
+
+Swagger: POST at `.../employees/{employeeName}/move` with request body and `200` response containing `MoveResponse`.
+
+## How to define an async resource action with LRO
+
+Use `ArmResourceActionAsync` for actions that take time to complete.
+
+```typespec
+@armResourceOperations
+interface Employees {
+  startMigration is ArmResourceActionAsync<
+    Employee, MigrationRequest, MigrationResponse
+  >;
+}
+```
+
+Swagger: POST with `200` (response body) + `202` (accepted), `x-ms-long-running-operation: true`.
+
+## How to define a resource action that returns no content (204)
+
+Use `ArmResourceActionNoContentSync` for actions that return empty body.
+
+```typespec
+@armResourceOperations
+interface Employees {
+  reset is ArmResourceActionNoContentSync<Employee, ResetRequest>;
+}
+```
+
+Swagger: POST with `204` (No Content) response only.
+
+## How to define a provider-level action (not scoped to a resource instance)
+
+Use `ArmProviderActionSync` or `ArmProviderActionAsync` with a scope parameter.
+
+```typespec
+interface ProviderActions {
+  validateConfig is ArmProviderActionSync<
+    ValidateRequest, ValidateResponse, SubscriptionActionScope
+  >;
+}
+```
+
+Swagger: POST at `/subscriptions/{sub}/providers/Microsoft.Provider/validateConfig`.
+
+Scope options:
+- `SubscriptionActionScope` → `/subscriptions/{sub}/providers/...`
+- `TenantActionScope` → `/providers/...`
+- `ExtensionActionScope` → `/{resourceUri}/providers/...`
+
+## How to define a check name availability operation
+
+Use the built-in `checkGlobalNameAvailability` or `checkLocalNameAvailability`.
+
+```typespec
+@armResourceOperations
+interface Operations {
+  checkGlobal is checkGlobalNameAvailability;
+  // or location-scoped:
+  checkLocal is checkLocalNameAvailability;
+}
+```
+
+Swagger: POST to `.../checkNameAvailability` with `CheckNameAvailabilityRequest` body (`name`, `type`) and `CheckNameAvailabilityResponse` response (`nameAvailable`, `reason`, `message`).
+
+## How to define a custom action using the @armResourceAction decorator
+
+For full control over a POST operation while keeping ARM-compliant routing:
+
+```typespec
+@autoRoute
+@armResourceAction(Employee)
+@post
+op moveEmployee(
+  ...ResourceInstanceParameters<Employee>,
+  @body request: MoveRequest,
+): MoveResponse | ErrorResponse;
+```
+
+Swagger: POST at `.../employees/{employeeName}/moveEmployee` with the specified body and response.
+
+## Which action template to choose
+
+| Scenario | Template | LRO? | Response |
+|----------|----------|-------|---------|
+| Sync with response | `ArmResourceActionSync` | No | 200 + body |
+| Async with response | `ArmResourceActionAsync` | Yes | 200 + body, 202 |
+| Sync no content | `ArmResourceActionNoContentSync` | No | 204 |
+| Async no content | `ArmResourceActionNoContentAsync` | Yes | 202, 204 |
+| Async no response body | `ArmResourceActionNoResponseContentAsync` | Yes | 200 (empty), 202 |
+| Provider-level sync | `ArmProviderActionSync` | No | 200 + body |
+| Provider-level async | `ArmProviderActionAsync` | Yes | 200, 202 |

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/extension-resources.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/extension-resources.md
@@ -1,0 +1,79 @@
+# ARM Extension Resources
+
+How to define extension resources with multi-scope operations in TypeSpec.
+
+## What is an extension resource and when to use it
+
+An extension resource attaches to any existing ARM resource via `{resourceUri}`. Use it for cross-cutting concerns (locks, policies, diagnostics). Path: `/{resourceUri}/providers/Microsoft.Provider/extensionType/{name}`.
+
+## How to define an extension resource model
+
+```typespec
+@extensionResource
+model MyDiagnosticSetting is ExtensionResource<DiagnosticProperties> {
+  @key("settingName")
+  @path
+  @segment("diagnosticSettings")
+  name: string;
+}
+```
+
+## How to generate full CRUD for an extension resource at all scopes
+
+Use `ExtensionResourceOperations` to generate GET, PUT, PATCH, DELETE, and List at all scopes (tenant, subscription, resource group, parent resource).
+
+```typespec
+@armResourceOperations
+interface DiagnosticSettings
+  extends ExtensionResourceOperations<MyDiagnosticSetting, DiagnosticProperties> {}
+```
+
+Swagger generates paths for each scope:
+- `/providers/Microsoft.P/diagnosticSettings/{name}` (tenant)
+- `/subscriptions/{sub}/providers/Microsoft.P/diagnosticSettings/{name}` (subscription)
+- `/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.P/diagnosticSettings/{name}` (resource group)
+- `/{resourceUri}/providers/Microsoft.P/diagnosticSettings/{name}` (parent resource)
+
+Plus corresponding list paths at each scope with pagination.
+
+## How to define individual extension operations with a specific scope
+
+```typespec
+@armResourceOperations
+interface DiagnosticSettings {
+  get is Azure.ResourceManager.Extension.Read<
+    Azure.ResourceManager.Extension.ResourceGroup, MyDiagnosticSetting
+  >;
+  create is Azure.ResourceManager.Extension.CreateOrReplaceAsync<
+    Azure.ResourceManager.Extension.ResourceGroup, MyDiagnosticSetting
+  >;
+  delete is Azure.ResourceManager.Extension.DeleteAsync<
+    Azure.ResourceManager.Extension.ResourceGroup, MyDiagnosticSetting
+  >;
+  list is Azure.ResourceManager.Extension.ListByTarget<
+    Azure.ResourceManager.Extension.ResourceGroup, MyDiagnosticSetting
+  >;
+}
+```
+
+## What extension resource scope targets are available
+
+| Target | TypeSpec Model | Path Prefix |
+|--------|---------------|-------------|
+| Resource Group | `Azure.ResourceManager.Extension.ResourceGroup` | `/subscriptions/{sub}/resourceGroups/{rg}` |
+| Subscription | `Azure.ResourceManager.Extension.Subscription` | `/subscriptions/{sub}` |
+| Tenant | `Azure.ResourceManager.Extension.Tenant` | `/` |
+| Management Group | `Azure.ResourceManager.Extension.ManagementGroup` | `/providers/Microsoft.Management/managementGroups/{mgName}` |
+
+## How to define an action on an extension resource
+
+```typespec
+op analyzeAsync is Azure.ResourceManager.Extension.ActionAsync<
+  Azure.ResourceManager.Extension.ResourceGroup,
+  MyDiagnosticSetting,
+  AnalyzeRequest,
+  AnalyzeResponse
+>;
+```
+
+Swagger: POST at scope path + `/diagnosticSettings/{name}/analyzeAsync` with request body and LRO.

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/legacy-patterns.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/legacy-patterns.md
@@ -1,0 +1,105 @@
+# ARM Legacy Patterns
+
+Legacy/deprecated TypeSpec patterns for backward compatibility with non-standard ARM resources.
+
+## When to use legacy patterns instead of standard ones
+
+Use legacy patterns for:
+- Pre-existing Swagger specs that don't conform to standard ARM patterns
+- Custom routing that doesn't follow ARM auto-route conventions
+- Polymorphic/discriminated resources with non-standard discriminators
+- Optional location on tracked resources
+- Single-page lists without pagination
+- External type references to types defined in other Swagger files
+
+## How to define a discriminated (polymorphic) resource
+
+```typespec
+model MyBaseResource
+  is Azure.ResourceManager.Legacy.DiscriminatedTrackedResource<
+    MyBaseProperties, "kind"
+  > {
+  ...ResourceNameParameter<MyBaseResource>;
+}
+```
+
+Also available: `DiscriminatedProxyResource` and `DiscriminatedExtensionResource` for proxy and extension resource variants.
+
+## How to define a tracked resource with optional location
+
+Standard tracked resources require `location`. Use legacy for optional:
+
+```typespec
+model MyResource
+  is Azure.ResourceManager.Legacy.TrackedResourceWithOptionalLocation<MyProperties> {
+  ...ResourceNameParameter<MyResource>;
+}
+```
+
+## How to define single-page list operations (no pagination)
+
+```typespec
+@armResourceOperations
+interface Employees {
+  list is Azure.ResourceManager.Legacy.ArmListSinglePageByParent<Employee>;
+  listBySub is Azure.ResourceManager.Legacy.ArmListSinglePageBySubscription<Employee>;
+}
+```
+
+Returns results without `nextLink` pagination.
+
+## How to use @armExternalType and @externalTypeRef for external Swagger types
+
+Reference types defined in external Swagger files:
+
+```typespec
+@externalTypeRef("../external/types.json#/definitions/ExternalModel")
+model ExternalModel {}
+```
+
+## How to use @armOperationRoute for custom routing
+
+```typespec
+@armOperationRoute("/custom/path/{param}")
+op customOp(@path param: string): Response;
+```
+
+## How to rename a path parameter with @renamePathParameter
+
+```typespec
+@renamePathParameter("employeeName", "workerName")
+model Employee is TrackedResource<EmployeeProperties> {
+  ...ResourceNameParameter<Employee>;
+}
+```
+
+## How to use @customAzureResource for non-standard ARM resources
+
+Marks a model as an ARM resource that doesn't follow standard patterns (no id/name/type from common-types):
+
+```typespec
+@customAzureResource
+model MyLegacyResource {
+  id: string;
+  name: string;
+  customProperty: string;
+}
+```
+
+## How to use legacy extension and private endpoint operations
+
+```typespec
+// Legacy extension operations
+@armResourceOperations
+interface MyExtensions {
+  create is Azure.ResourceManager.Legacy.Extension.CreateOrReplaceAsync<MyExtension>;
+  update is Azure.ResourceManager.Legacy.Extension.CustomPatchAsync<MyExtension, PatchModel>;
+}
+
+// Legacy private endpoint operations
+@armResourceOperations
+interface MyPEConnections {
+  create is Azure.ResourceManager.Legacy.PrivateEndpoints.CreateOrReplaceAsync<MyPEC, Parent>;
+  list is Azure.ResourceManager.Legacy.PrivateEndpoints.ListSinglePageByParent<MyPEC, Parent>;
+}
+```

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/list-operations.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/list-operations.md
@@ -1,0 +1,90 @@
+# ARM List Operations
+
+How to define list/collection operations for ARM resources in TypeSpec.
+
+## How to list resources by resource group
+
+Use `ArmResourceListByParent` for the most common list pattern. Returns paginated results with `nextLink`.
+
+```typespec
+@armResourceOperations
+interface Employees {
+  listByResourceGroup is ArmResourceListByParent<Employee>;
+}
+```
+
+Swagger: GET at `.../providers/Microsoft.Provider/employees` with `x-ms-pageable: { nextLinkName: "nextLink" }`. Response schema is `EmployeeListResult` with `value` array and optional `nextLink`.
+
+## How to list resources by subscription
+
+Use `ArmListBySubscription` to list across all resource groups.
+
+```typespec
+@armResourceOperations
+interface Employees {
+  listBySubscription is ArmListBySubscription<Employee>;
+}
+```
+
+Swagger: GET at `/subscriptions/{sub}/providers/Microsoft.Provider/employees` with pagination.
+
+## How to list child resources by parent
+
+For nested/proxy resources, `ArmResourceListByParent` automatically scopes to the parent.
+
+```typespec
+@parentResource(Employee)
+model EmployeeRole is ProxyResource<RoleProperties> {
+  ...ResourceNameParameter<EmployeeRole>;
+}
+
+@armResourceOperations
+interface EmployeeRoles {
+  list is ArmResourceListByParent<EmployeeRole>;
+}
+```
+
+Swagger: GET at `.../employees/{employeeName}/employeeRoles` with pagination.
+
+## How to define the required operations list endpoint
+
+Every ARM service must expose `GET /providers/Microsoft.Provider/operations`:
+
+```typespec
+interface Operations extends Azure.ResourceManager.Operations {}
+```
+
+Swagger: GET returning `OperationListResult` with `value` array of `Operation` objects (name, isDataAction, display) and `nextLink`.
+
+## How pagination works in ARM list operations
+
+All list operations generate the standard ARM pagination pattern:
+- Response includes `value` array and optional `nextLink` URI
+- Swagger includes `x-ms-pageable` with `"nextLinkName": "nextLink"`
+- Client follows `nextLink` to fetch the next page
+
+The auto-generated list result model:
+
+```json
+{
+  "EmployeeListResult": {
+    "properties": {
+      "value": { "type": "array", "items": { "$ref": "#/definitions/Employee" } },
+      "nextLink": { "type": "string", "format": "uri" }
+    },
+    "required": ["value"]
+  }
+}
+```
+
+## How to list extension resources at multiple scopes
+
+Use `ExtensionResourceCollectionOperations` to generate list operations at all scopes (tenant, subscription, resource group, parent resource).
+
+```typespec
+@armResourceOperations
+interface MyExtensions
+  extends ExtensionResourceCollectionOperations<MyExtension> {}
+```
+
+Swagger generates separate list paths for each scope, all with pagination.

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/model-properties.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/model-properties.md
@@ -1,0 +1,99 @@
+# ARM Model Properties and Schemas
+
+How to define model properties, types, and constraints in TypeSpec and their Swagger mapping.
+
+## How TypeSpec types map to Swagger types
+
+| TypeSpec | Swagger `type` | Swagger `format` |
+|----------|---------------|-----------------|
+| `string` | `string` | — |
+| `int32` | `integer` | `int32` |
+| `int64` | `integer` | `int64` |
+| `float32` | `number` | `float` |
+| `float64` | `number` | `double` |
+| `boolean` | `boolean` | — |
+| `utcDateTime` | `string` | `date-time` |
+| `plainDate` | `string` | `date` |
+| `url` | `string` | `uri` |
+| `bytes` | `string` | `byte` |
+
+## How to define required vs optional and read-only properties
+
+- Required field: `displayName: string;` → appears in `required` array
+- Optional field: `age?: int32;` → not in `required`
+- Read-only: `@visibility(Lifecycle.Read) createdAt?: utcDateTime;` → `"readOnly": true`
+- Array: `emails: string[];` → `"type": "array", "items": { "type": "string" }`
+- Dictionary: `metadata?: Record<string>;` → `"type": "object", "additionalProperties": { "type": "string" }`
+
+## How to add property constraints (pattern, length, range)
+
+```typespec
+model EmployeeProperties {
+  @pattern("^[a-zA-Z0-9-]+$")
+  @minLength(3)
+  @maxLength(24)
+  name: string;
+
+  @minValue(18)
+  @maxValue(65)
+  age: int32;
+}
+```
+
+Swagger adds `pattern`, `minLength`, `maxLength`, `minimum`, `maximum` directly on the property.
+
+## How to define an enum property
+
+```typespec
+union EmployeeStatus {
+  string,
+  Active: "Active",
+  Inactive: "Inactive",
+  OnLeave: "OnLeave",
+}
+
+model EmployeeProperties {
+  status: EmployeeStatus;
+}
+```
+
+Swagger: `"enum": ["Active", "Inactive", "OnLeave"]` with `"x-ms-enum": { "name": "EmployeeStatus", "modelAsString": true }`.
+
+## How to define nested object properties
+
+```typespec
+model Address {
+  street: string;
+  city: string;
+}
+model EmployeeProperties {
+  homeAddress: Address;
+  workAddress?: Address;
+}
+```
+
+Swagger: `homeAddress` references `$ref: "#/definitions/Address"` and appears in `required`. `workAddress` also references `Address` but is not in `required`.
+
+## How to define provisioning state (standard ARM pattern)
+
+Every ARM resource should include a provisioning state:
+
+```typespec
+model EmployeeProperties {
+  @visibility(Lifecycle.Read)
+  provisioningState?: ResourceProvisioningState;
+}
+```
+
+Swagger: `"provisioningState"` with `readOnly: true`, enum `["Succeeded", "Failed", "Canceled"]`, `x-ms-enum` with `modelAsString: true`.
+
+For custom states, extend the union:
+
+```typespec
+union MyProvisioningState {
+  string,
+  ResourceProvisioningState,
+  Provisioning: "Provisioning",
+  Updating: "Updating",
+}
+```

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/parameters-and-scoping.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/parameters-and-scoping.md
@@ -1,0 +1,81 @@
+# ARM Parameters and Resource Scoping
+
+How to define parameters and scope ARM resources in TypeSpec.
+
+## What standard ARM parameters are auto-included
+
+These parameters are automatically added by ARM operation templates — you don't define them manually:
+
+| Parameter | Type | Location | Swagger $ref |
+|-----------|------|----------|-------------|
+| `api-version` | string | query | `ApiVersionParameter` |
+| `subscriptionId` | uuid | path | `SubscriptionIdParameter` |
+| `resourceGroupName` | string | path | `ResourceGroupNameParameter` |
+| `location` | string | path | `LocationParameter` |
+
+## How ResourceInstanceParameters provides all path parameters for a resource
+
+`ResourceInstanceParameters<T>` includes subscriptionId, resourceGroupName, api-version, and the resource name parameter.
+
+```typespec
+op get(...ResourceInstanceParameters<Employee>): Employee | ErrorResponse;
+```
+
+Swagger generates all standard path parameters plus `employeeName` in the `parameters` array.
+
+## What base parameter models exist for different scopes
+
+| Scope | Base Parameters | Path Prefix |
+|-------|----------------|-------------|
+| Resource Group | `ResourceGroupBaseParameters` | `/subscriptions/{sub}/resourceGroups/{rg}` |
+| Subscription | `SubscriptionBaseParameters` | `/subscriptions/{sub}` |
+| Tenant | `TenantBaseParameters` | `/` |
+| Location | `LocationBaseParameters` | `.../locations/{location}` |
+| Extension | `ExtensionBaseParameters` | `/{resourceUri}` |
+
+## What scope templates exist for provider-level actions
+
+| Scope | Template | Path |
+|-------|----------|------|
+| Subscription | `SubscriptionActionScope` | `/subscriptions/{sub}/providers/Microsoft.P/action` |
+| Tenant | `TenantActionScope` | `/providers/Microsoft.P/action` |
+| Extension | `ExtensionActionScope` | `/{resourceUri}/providers/Microsoft.P/action` |
+| Resource Group | `ResourceGroupScope` | `/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.P/action` |
+| Location | `LocationScope` | `.../locations/{location}/action` |
+
+## How to define a custom resource name path parameter with constraints
+
+```typespec
+model Employee is TrackedResource<EmployeeProperties> {
+  @pattern("^[a-zA-Z0-9-]{3,24}$")
+  @key("employeeName")
+  @path
+  @segment("employees")
+  name: string;
+}
+```
+
+Swagger: `{ "name": "employeeName", "in": "path", "required": true, "type": "string", "pattern": "^[a-zA-Z0-9-]{3,24}$" }`
+
+## How to add custom query parameters to a list operation
+
+```typespec
+@armResourceOperations
+interface Employees {
+  list is ArmResourceListByParent<
+    Employee,
+    Parameters = {
+      @query("$filter") filter?: string;
+      @query("$top") top?: int32;
+    }
+  >;
+}
+```
+
+Swagger adds `$filter` (string) and `$top` (integer) as query parameters.
+
+## How extension resources use the resourceUri parameter
+
+Extension resources use `{resourceUri}` with `x-ms-skip-url-encoding: true` to attach to any ARM resource.
+
+Swagger: `{ "name": "resourceUri", "in": "path", "required": true, "type": "string", "x-ms-skip-url-encoding": true }`

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/private-endpoints.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/private-endpoints.md
@@ -1,0 +1,59 @@
+# ARM Private Endpoints
+
+How to add private endpoint and private link support to an ARM resource in TypeSpec.
+
+## How to add private endpoint connection CRUD operations
+
+Define a private endpoint connection resource and create an operations interface using the built-in templates.
+
+```typespec
+model MyPrivateEndpointConnection is PrivateEndpointConnectionResource {}
+
+alias PrivateEndpointOps = Azure.ResourceManager.Private.PrivateEndpoints<
+  MyPrivateEndpointConnection
+>;
+
+@armResourceOperations
+interface PrivateEndpointConnections {
+  list is PrivateEndpointOps.ListByParent<ParentResource>;
+  get is PrivateEndpointOps.Read<ParentResource>;
+  createOrUpdate is PrivateEndpointOps.CreateOrUpdateAsync<ParentResource>;
+  delete is PrivateEndpointOps.DeleteAsyncBase<
+    ParentResource,
+    ArmAcceptedLroResponse | ArmDeletedResponse | ArmDeletedNoContentResponse
+  >;
+}
+```
+
+Swagger generates:
+- `GET .../parentResources/{name}/privateEndpointConnections` — list
+- `GET .../privateEndpointConnections/{connectionName}` — get
+- `PUT .../privateEndpointConnections/{connectionName}` — create (LRO)
+- `DELETE .../privateEndpointConnections/{connectionName}` — delete (LRO)
+
+All definitions reference `common-types/privatelinks.json#/definitions/PrivateEndpointConnection`.
+
+## How to add private link resource operations
+
+```typespec
+@armResourceOperations
+interface PrivateLinkResources {
+  list is Azure.ResourceManager.PrivateLinks<MyPrivateLinkResource>
+    .ListByParent<ParentResource>;
+  get is Azure.ResourceManager.PrivateLinks<MyPrivateLinkResource>
+    .Read<ParentResource>;
+}
+```
+
+Swagger: GET at `.../privateLinkResources` (list) and `.../privateLinkResources/{name}` (get).
+
+## How to use the composite PrivateEndpoints interface shortcut
+
+```typespec
+interface MyPEConnections
+  extends Azure.ResourceManager.PrivateEndpoints<MyPrivateEndpointConnection> {}
+interface MyPLResources
+  extends Azure.ResourceManager.PrivateLinks<MyPrivateLinkResource> {}
+```
+
+This generates all standard private endpoint and private link operations in one line.

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/resource-types.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/resource-types.md
@@ -1,0 +1,145 @@
+# ARM Resource Types
+
+How to define ARM resource models in TypeSpec and their Swagger output.
+
+## How to define a tracked resource (top-level resource with location and tags)
+
+A `TrackedResource` is a top-level ARM resource in a resource group with `location` and `tags`. Use it for primary resources (VMs, databases, storage accounts).
+
+```typespec
+model Employee is TrackedResource<EmployeeProperties> {
+  ...ResourceNameParameter<Employee>;
+}
+
+model EmployeeProperties {
+  age?: int32;
+  city?: string;
+  @visibility(Lifecycle.Read)
+  provisioningState?: ResourceProvisioningState;
+}
+```
+
+Swagger generates a definition with `allOf` referencing `TrackedResource`, containing read-only `id`, `name`, `type`, `systemData`, plus a `properties` object. Path: `/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Provider/employees/{employeeName}`.
+
+## How to define a proxy resource (child or nested resource without location)
+
+A `ProxyResource` has no `location` or `tags`. Use it for child/nested resources under a parent, e.g., a "FirewallRule" under a "Server".
+
+```typespec
+@parentResource(Employee)
+model EmployeeRole is ProxyResource<RoleProperties> {
+  ...ResourceNameParameter<EmployeeRole>;
+}
+```
+
+Path: `.../employees/{employeeName}/employeeRoles/{employeeRoleName}`.
+
+## How to define an extension resource (attaches to any ARM resource)
+
+An `ExtensionResource` attaches to any existing ARM resource via `{resourceUri}`. Use it for cross-cutting concerns like locks, policies, diagnostics.
+
+```typespec
+@extensionResource
+model DiagnosticSetting is ExtensionResource<DiagnosticProperties> {
+  @key("diagnosticName")
+  @path
+  @segment("diagnosticSettings")
+  name: string;
+}
+```
+
+Swagger generates paths for multiple scopes (tenant, subscription, resourceGroup, parent resource) using `{resourceUri}` parameter.
+
+## How to define a singleton resource (only one instance exists)
+
+A singleton resource has exactly one instance under its parent, with no name parameter in the URL (uses a fixed value like "default").
+
+```typespec
+@singleton
+@parentResource(Employee)
+model EmployeeSettings is ProxyResource<SettingsProperties> {
+  ...ResourceNameParameter<EmployeeSettings, "default">;
+}
+```
+
+Path: `.../employees/{employeeName}/settings/default`.
+
+## How to define a tenant-scoped resource
+
+Use `@tenantResource` for resources at tenant scope. Path: `/providers/Microsoft.Provider/resourceType/{name}`.
+
+```typespec
+@tenantResource
+model TenantConfig is ProxyResource<TenantConfigProperties> {
+  ...ResourceNameParameter<TenantConfig>;
+}
+```
+
+## How to define a subscription-scoped resource
+
+Use `@subscriptionResource`. Path: `/subscriptions/{sub}/providers/Microsoft.Provider/resourceType/{name}`.
+
+```typespec
+@subscriptionResource
+model SubscriptionQuota is ProxyResource<QuotaProperties> {
+  ...ResourceNameParameter<SubscriptionQuota>;
+}
+```
+
+## How to define a location-scoped resource
+
+Path: `.../providers/Microsoft.Provider/locations/{location}/resourceType/{name}`.
+
+```typespec
+@parentResource(ArmLocationResource<"ResourceGroup">)
+model RegionalConfig is TrackedResource<RegionalConfigProperties> {
+  ...ResourceNameParameter<RegionalConfig>;
+}
+```
+
+## How to add standard envelope properties (identity, SKU, plan, encryption, etc.)
+
+Spread these into your resource model to add standard ARM properties:
+
+- `...ManagedServiceIdentityProperty` → `identity` with SystemAssigned + UserAssigned
+- `...ManagedSystemAssignedIdentityProperty` → `identity` with SystemAssigned only
+- `...ResourceSkuProperty` → `sku` with name, tier, size, family, capacity
+- `...ResourcePlanProperty` → `plan` with name, publisher, product
+- `...ResourceKindProperty` → `kind` string
+- `...EntityTagProperty` → `etag` (readOnly)
+- `...ExtendedLocationProperty` → `extendedLocation` with name and type
+- `...ManagedByProperty` → `managedBy` string
+- `...AvailabilityZonesProperty` → `zones` array of strings
+- `...DefaultProvisioningStateProperty` → `provisioningState` (readOnly)
+
+Example with identity and SKU:
+
+```typespec
+model MyVm is TrackedResource<VmProperties> {
+  ...ResourceNameParameter<MyVm>;
+  ...ManagedServiceIdentityProperty;
+  ...ResourceSkuProperty;
+}
+```
+
+## How ResourceNameParameter generates the name path parameter
+
+`ResourceNameParameter<T>` generates the `@key`, `@path`, and `@segment` for a resource name.
+
+```typespec
+model Employee is TrackedResource<EmployeeProperties> {
+  ...ResourceNameParameter<Employee>;
+}
+```
+
+Swagger output:
+
+```json
+{
+  "name": "employeeName",
+  "in": "path",
+  "required": true,
+  "type": "string",
+  "pattern": "^[a-zA-Z0-9-]{3,24}$"
+}
+```

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/response-types-and-lro.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/response-types-and-lro.md
@@ -1,0 +1,94 @@
+# ARM Response Types and Long-Running Operations (LRO)
+
+How to configure response status codes, LRO headers, and polling patterns in TypeSpec.
+
+## What ARM response types are available and their status codes
+
+| TypeSpec Model | Code | Has Body? | Use Case |
+|---------------|------|-----------|----------|
+| `ArmResponse<T>` | 200 | Yes | Successful sync operation |
+| `ArmResourceCreatedResponse<T>` | 201 | Yes + LRO headers | Async resource creation |
+| `ArmResourceCreatedSyncResponse<T>` | 201 | Yes | Sync resource creation |
+| `ArmResourceUpdatedResponse<T>` | 200 | Yes | Resource updated |
+| `ArmAcceptedLroResponse` | 202 | No, LRO headers | Async operation accepted |
+| `ArmAcceptedResponse` | 202 | No | Sync accepted (no LRO) |
+| `ArmDeletedResponse` | 200 | No | Resource deleted |
+| `ArmDeleteAcceptedLroResponse` | 202 | No, LRO headers | Async delete accepted |
+| `ArmDeletedNoContentResponse` | 204 | No | Resource doesn't exist |
+| `ArmNoContentResponse` | 204 | No | No content |
+| `ArmResourceExistsResponse` | 200 | No | HEAD - exists |
+
+## How Azure-AsyncOperation header polling works (default LRO pattern)
+
+Most ARM async operations use `Azure-AsyncOperation` header by default.
+
+```typespec
+op create is ArmResourceCreateOrReplaceAsync<Employee>;
+```
+
+Swagger includes `x-ms-long-running-operation: true` with `final-state-via: azure-async-operation`. The `201` response has `Azure-AsyncOperation` and `Retry-After` headers.
+
+## How to use Location header polling instead of Azure-AsyncOperation
+
+Use `ArmLroLocationHeader` for Location-based polling.
+
+```typespec
+op create is ArmResourceCreateOrReplaceAsync<
+  Employee,
+  Response = ArmResponse<Employee> | ArmResourceCreatedResponse<
+    Employee,
+    LroHeaders = ArmLroLocationHeader<FinalResult = Employee>
+  >
+>;
+```
+
+Swagger: `final-state-via: location` with `Location` and `Retry-After` headers.
+
+## How to use both Azure-AsyncOperation and Location headers (combined)
+
+Use `ArmCombinedLroHeaders` for dual-header support.
+
+```typespec
+op delete is ArmResourceDeleteWithoutOkAsync<
+  Employee,
+  LroHeaders = ArmCombinedLroHeaders<ArmOperationStatus, Employee>
+>;
+```
+
+Swagger: `202` response includes both `Azure-AsyncOperation` and `Location` headers.
+
+## Which LRO header type to choose
+
+| TypeSpec LRO Header | Headers Generated | `final-state-via` |
+|---------------------|-------------------|-------------------|
+| (default) | `Azure-AsyncOperation` | `azure-async-operation` |
+| `ArmLroLocationHeader` | `Location` + `Retry-After` | `location` |
+| `ArmCombinedLroHeaders` | Both | `azure-async-operation` |
+
+## How to add custom headers to a response
+
+```typespec
+@post
+op create(...ResourceInstanceParameters<Employee>): ArmCreatedResponse<
+  Employee,
+  ExtraHeaders = {
+    @header("x-ms-client-request-id") clientRequestId: string;
+  }
+>;
+```
+
+Swagger: `201` response includes the custom header in the `headers` section.
+
+## How the ArmOperationStatus model works for polling endpoints
+
+```typespec
+model MyOperationStatus extends ArmOperationStatus {
+  properties: Record<string>;
+}
+```
+
+Swagger generates a model with `id`, `name`, `status`, `percentComplete`, `startTime`, `endTime`, `error` (all readOnly), plus your custom `properties`.
+
+## How error responses work in ARM operations
+
+All ARM operations include a `default` error response referencing `ErrorResponse` from common-types. The `ErrorResponse` contains `ErrorDetail` with `code`, `message`, `target`, `details[]`, and `additionalInfo[]`.

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/service-setup.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/knowledge/typespec/management-plane/service-setup.md
@@ -1,0 +1,94 @@
+# ARM Service Setup and Decorators
+
+How to set up an ARM TypeSpec project, configure namespaces, versioning, and key decorators.
+
+## How to set up a minimal ARM TypeSpec service
+
+Every ARM TypeSpec project needs a namespace with `@armProviderNamespace`, `@service`, versioning, and an Operations interface.
+
+```typespec
+import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/versioning";
+
+using Azure.ResourceManager;
+using TypeSpec.Versioning;
+
+@armProviderNamespace
+@service(#{ title: "ContosoProviderHubClient" })
+@versioned(Versions)
+namespace Microsoft.ContosoProviderHub;
+
+enum Versions {
+  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
+  `2024-01-01`,
+}
+
+interface Operations extends Azure.ResourceManager.Operations {}
+```
+
+Swagger generates: `swagger: "2.0"`, `host: "management.azure.com"`, OAuth2 security, and the operations list endpoint.
+
+## How @armProviderNamespace sets the provider name
+
+Defaults to the namespace name. Can be overridden:
+
+```typespec
+@armProviderNamespace
+namespace Microsoft.Contoso;  // provider = Microsoft.Contoso
+
+@armProviderNamespace("Microsoft.CustomName")
+namespace Microsoft.Contoso;  // provider = Microsoft.CustomName
+```
+
+## How @armCommonTypesVersion controls common-types $ref version
+
+This sets which version of ARM common-types is used in Swagger `$ref` paths (e.g., `v3`, `v5`).
+
+```typespec
+enum Versions {
+  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
+  `2024-01-01`,
+}
+```
+
+Affects all `$ref` paths: `common-types/resource-management/v5/types.json`.
+
+## How @armLibraryNamespace creates reusable type libraries
+
+Marks a namespace as a shared library. Use with `@useLibraryNamespace` in consuming services.
+
+```typespec
+@armLibraryNamespace
+namespace Microsoft.MyServiceLibrary {
+  model SharedConfig { name: string; value: string; }
+}
+
+// In consuming service:
+@useLibraryNamespace(Microsoft.MyServiceLibrary)
+namespace Microsoft.ConsumingService;
+```
+
+## What resource type decorators are available
+
+| Decorator | Purpose | Path Scope |
+|-----------|---------|-----------|
+| `@tenantResource` | Tenant-scoped | `/providers/Microsoft.P/...` |
+| `@subscriptionResource` | Subscription-scoped | `/subscriptions/{sub}/providers/Microsoft.P/...` |
+| `@locationResource` | Location-scoped | `.../locations/{location}/...` |
+| `@extensionResource` | Any parent (uses resourceUri) | `/{resourceUri}/providers/Microsoft.P/...` |
+| `@singleton` | Single instance | `.../resourceType/default` |
+| `@parentResource(Parent)` | Nested under parent | `.../parentType/{name}/childType/{name}` |
+
+## How @armResourceOperations works on interfaces
+
+Required on interfaces containing resource operations. Automatically adds `@autoRoute` and `@tag`.
+
+```typespec
+@armResourceOperations
+interface Employees {
+  get is ArmResourceRead<Employee>;
+  create is ArmResourceCreateOrReplaceAsync<Employee>;
+}
+```
+
+Options: `allowStaticRoutes` (allow `@route` on operations), `resourceType` (explicit resource), `omitTags` (disable auto-tagging).


### PR DESCRIPTION
fixes: https://github.com/Azure/azure-sdk-pr/issues/2497

- Introduced composite interfaces for CRUD shortcuts in TypeSpec.
- Documented standard CRUD operations for ARM resources.
- Added guidance on defining custom actions for ARM resources.
- Explained extension resources and their multi-scope operations.
- Included legacy patterns for backward compatibility with non-standard ARM resources.
- Detailed list operations for ARM resources and pagination handling.
- Defined model properties, types, and constraints in TypeSpec.
- Explained parameters and resource scoping for ARM resources.
- Documented private endpoint and private link support in TypeSpec.
- Provided guidelines for defining various ARM resource types.
- Configured response types and long-running operations (LRO) in TypeSpec.
- Set up ARM TypeSpec project structure and key decorators.