### PR TITLE
Eval CI: authenticate copilot-sdk via login-to-github GH_TOKEN instead of PAT

### DIFF
--- a/eng/common/pipelines/live-eval.yml
+++ b/eng/common/pipelines/live-eval.yml
@@ -16,8 +16,6 @@ schedules:
 variables:
   # Managed-pool image selection (LINUXPOOL/LINUXVMIMAGE). Repo-local.
   - template: /eng/pipelines/templates/variables/image.yml
-  # Provides the secret azuresdk-copilot-github-pat, mapped into GITHUB_TOKEN in the invoke step.
-  - group: AzSDK_Eval_Variable_group
 
 extends:
   template: /eng/common/pipelines/templates/stages/archetype-eval.yml

--- a/eng/common/pipelines/skill-eval.yml
+++ b/eng/common/pipelines/skill-eval.yml
@@ -21,8 +21,6 @@ pr: none
 variables:
   # Managed-pool image selection (LINUXPOOL/LINUXVMIMAGE). Repo-local.
   - template: /eng/pipelines/templates/variables/image.yml
-  # Provides the secret azuresdk-copilot-github-pat, mapped into GITHUB_TOKEN in the invoke step.
-  - group: AzSDK_Eval_Variable_group
 
 extends:
   template: /eng/common/pipelines/templates/stages/archetype-eval.yml

--- a/eng/common/pipelines/templates/jobs/refresh-copilot-token.yml
+++ b/eng/common/pipelines/templates/jobs/refresh-copilot-token.yml
@@ -1,0 +1,39 @@
+# RefreshCopilotToken job: mints a fresh 8h Copilot access token from the stored GitHub App
+# refresh token and writes it into the access-token Key Vault secret that the eval shards
+# already consume. Runs in the Prepare stage so the Eval stage (dependsOn Prepare) resolves
+# the Key-Vault-backed variable group AFTER the secret has been refreshed — no shard wiring
+# changes. Opt-in: only added when the archetype's refreshCopilotToken parameter is true and
+# the one-time Bootstrap-CopilotToken.ps1 has seeded the refresh token.
+
+parameters:
+  - name: keyVaultServiceConnection
+    # Service connection whose identity has get + set on the Key Vault below.
+    type: string
+  - name: keyVaultName
+    type: string
+    default: AzureSDKEngKeyVault
+  - name: githubAppClientId
+    # The GitHub App client id (not a secret); pass via a pipeline variable if you prefer.
+    type: string
+
+jobs:
+  - job: RefreshCopilotToken
+    displayName: 'Refresh Copilot access token'
+    pool:
+      name: $(LINUXPOOL)
+      image: $(LINUXVMIMAGE)
+      os: linux
+    steps:
+      - checkout: self
+        fetchDepth: 1
+
+      - task: AzureCLI@2
+        displayName: 'Rotate refresh token + publish access token'
+        inputs:
+          azureSubscription: ${{ parameters.keyVaultServiceConnection }}
+          scriptType: pscore
+          scriptLocation: scriptPath
+          scriptPath: $(Build.SourcesDirectory)/eng/common/scripts/eval/Refresh-CopilotToken.ps1
+          arguments: >-
+            -KeyVaultName ${{ parameters.keyVaultName }}
+            -ClientId ${{ parameters.githubAppClientId }}

--- a/eng/common/pipelines/templates/stages/archetype-eval.yml
+++ b/eng/common/pipelines/templates/stages/archetype-eval.yml
@@ -62,6 +62,24 @@ parameters:
     # Per-shard job timeout, passed to the shard job's timeoutInMinutes. Live tier raises it.
     type: number
     default: 20
+  - name: refreshCopilotToken
+    # Opt-in: when true, a Prepare-stage job rotates the GitHub App refresh token and republishes
+    # a fresh 8h Copilot access token into the access-token Key Vault secret before the shards run.
+    # Requires the one-time Bootstrap-CopilotToken.ps1 to have seeded the refresh token, plus the
+    # keyVault* parameters below. Default false so existing consumers are unaffected.
+    type: boolean
+    default: false
+  - name: keyVaultServiceConnection
+    # Service connection with get + set on the Key Vault; required only when refreshCopilotToken is true.
+    type: string
+    default: ''
+  - name: keyVaultName
+    type: string
+    default: AzureSDKEngKeyVault
+  - name: githubAppClientId
+    # GitHub App client id (not a secret); required only when refreshCopilotToken is true.
+    type: string
+    default: ''
 
 extends:
   # 1es-redirect picks Official (internal) vs Unofficial; its Use1ESOfficial defaults true.
@@ -81,6 +99,13 @@ extends:
             parameters:
               vallyRoot: ${{ parameters.vallyRoot }}
               evalGlobs: ${{ parameters.evalGlobs }}
+
+          - ${{ if parameters.refreshCopilotToken }}:
+            - template: /eng/common/pipelines/templates/jobs/refresh-copilot-token.yml
+              parameters:
+                keyVaultServiceConnection: ${{ parameters.keyVaultServiceConnection }}
+                keyVaultName: ${{ parameters.keyVaultName }}
+                githubAppClientId: ${{ parameters.githubAppClientId }}
 
       - stage: Eval
         displayName: 'Run eval shards'

--- a/eng/common/pipelines/templates/steps/eval-invoke.yml
+++ b/eng/common/pipelines/templates/steps/eval-invoke.yml
@@ -1,7 +1,8 @@
 # Invokes `vally eval` for one shard. UseAzSdkAuthentication=false (default) runs the hermetic
 # node script directly. UseAzSdkAuthentication=true wraps the same run in AzureCLI@2 so a live
 # MCP's Azure DevOps calls inherit the service-connection identity.
-# copilot-sdk authenticates the model session via GITHUB_TOKEN (from the linked eval variable group).
+# copilot-sdk authenticates the model session via GH_TOKEN, minted by the login-to-github step
+# (Azure SDK Automation GitHub App installation token) — no PAT or variable group required.
 
 parameters:
   - name: vallyRoot
@@ -18,6 +19,10 @@ parameters:
     default: opensource-api-connection
 
 steps:
+  # Mint GH_TOKEN as the Azure SDK Automation GitHub App (Key Vault-signed JWT -> installation
+  # token). copilot-sdk reads GH_TOKEN for the model session, so no PAT / variable group is needed.
+  - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+
   - ${{ if parameters.UseAzSdkAuthentication }}:
     - task: AzureCLI@2
       displayName: 'vally eval $(shardName) (authenticated)'
@@ -33,7 +38,7 @@ steps:
             --output-dir "$(Build.SourcesDirectory)/artifacts/vally-results/$(shardName)" \
             --threshold ${{ parameters.threshold }}
       env:
-        GITHUB_TOKEN: $(azuresdk-copilot-github-pat)
+        GH_TOKEN: $(GH_TOKEN)
 
   - ${{ else }}:
     - script: |
@@ -45,4 +50,4 @@ steps:
       displayName: 'vally eval $(shardName)'
       workingDirectory: ${{ parameters.vallyRoot }}
       env:
-        GITHUB_TOKEN: $(azuresdk-copilot-github-pat)
+        GH_TOKEN: $(GH_TOKEN)

--- a/eng/common/pipelines/workflow-eval.yml
+++ b/eng/common/pipelines/workflow-eval.yml
@@ -39,8 +39,6 @@ pr:
 variables:
   # Defines LINUXPOOL + LINUXVMIMAGE used by the archetype's jobs.
   - template: /eng/pipelines/templates/variables/image.yml
-  # Provides the secret azuresdk-copilot-github-pat, mapped into GITHUB_TOKEN in the invoke step.
-  - group: AzSDK_Eval_Variable_group
 
 extends:
   template: /eng/common/pipelines/templates/stages/archetype-eval.yml

--- a/eng/common/scripts/eval/Bootstrap-CopilotToken.ps1
+++ b/eng/common/scripts/eval/Bootstrap-CopilotToken.ps1
@@ -1,0 +1,157 @@
+<#
+.SYNOPSIS
+    One-time bootstrap for the durable eval Copilot auth flow (Option A): runs
+    the GitHub App device-flow authorization and seeds the first refresh token.
+
+.DESCRIPTION
+    Run this ONCE, interactively, signed in as the Copilot-seated bot account
+    (e.g. the azure-sdk bot). It authorizes the GitHub App and produces the
+    initial user-to-server access token + refresh token. From then on the
+    per-run Refresh-CopilotToken.ps1 keeps the chain alive automatically with
+    no further manual rotation.
+
+    Prerequisites (org admin / bot owner):
+      - A GitHub App registered with "Expire user authorization tokens" and
+        "Enable Device Flow" turned on, approved in the org.
+      - The bot account that owns the token has an active Copilot seat.
+      - The App client secret already stored in Key Vault (for the refresh
+        script) as the ClientSecretName secret.
+
+    When -KeyVaultName is supplied the resulting refresh token is written
+    straight to Key Vault; otherwise the token is printed so you can store it
+    manually. The access token is short-lived (8h) and only useful for a quick
+    smoke test.
+
+.PARAMETER ClientId
+    The GitHub App's client id.
+
+.PARAMETER KeyVaultName
+    Optional. When set, the refresh token is written to this Key Vault (requires
+    an az-authenticated context with set permission).
+
+.PARAMETER RefreshTokenSecretName
+    Key Vault secret name to write the refresh token to.
+
+.PARAMETER AccessTokenSecretName
+    Optional Key Vault secret name to also write the short-lived access token
+    to (handy for an immediate smoke test). Leave blank to skip.
+
+.PARAMETER DeviceCodeUrl
+    GitHub device-code endpoint. Override only for GHES.
+
+.PARAMETER TokenUrl
+    GitHub OAuth token endpoint. Override only for GHES.
+
+.EXAMPLE
+    ./Bootstrap-CopilotToken.ps1 -ClientId Iv1.0123456789abcdef -KeyVaultName AzureSDKEngKeyVault
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $ClientId,
+
+    [Parameter()]
+    [string] $KeyVaultName,
+
+    [Parameter()]
+    [string] $RefreshTokenSecretName = 'azuresdk-copilot-refresh-token',
+
+    [Parameter()]
+    [string] $AccessTokenSecretName,
+
+    [Parameter()]
+    [string] $DeviceCodeUrl = 'https://github.com/login/device/code',
+
+    [Parameter()]
+    [string] $TokenUrl = 'https://github.com/login/oauth/access_token'
+)
+
+Set-StrictMode -Version 4
+$ErrorActionPreference = 'Stop'
+
+Write-Host 'Requesting a device code from GitHub...'
+$device = Invoke-RestMethod -Method Post -Uri $DeviceCodeUrl `
+    -Body @{ client_id = $ClientId } -Headers @{ Accept = 'application/json' }
+
+if ($device.PSObject.Properties.Name -contains 'error') {
+    throw "GitHub device-code request failed: $($device.error). Confirm the App client id and that Device Flow is enabled."
+}
+
+Write-Host ''
+Write-Host '=========================================================='
+Write-Host " 1. Open:  $($device.verification_uri)"
+Write-Host " 2. Enter code:  $($device.user_code)"
+Write-Host ' 3. Sign in as the COPILOT-SEATED BOT account and Authorize.'
+Write-Host '=========================================================='
+Write-Host ''
+
+$interval = [int]$device.interval
+if ($interval -le 0) { $interval = 5 }
+$deadline = (Get-Date).AddSeconds([int]$device.expires_in)
+
+$tokens = $null
+while ((Get-Date) -lt $deadline) {
+    Start-Sleep -Seconds $interval
+
+    $poll = Invoke-RestMethod -Method Post -Uri $TokenUrl -Headers @{ Accept = 'application/json' } -Body @{
+        client_id   = $ClientId
+        device_code = $device.device_code
+        grant_type  = 'urn:ietf:params:oauth:grant-type:device_code'
+    }
+
+    if ($poll.PSObject.Properties.Name -contains 'error') {
+        switch ($poll.error) {
+            'authorization_pending' { continue }
+            'slow_down'             { $interval += 5; continue }
+            default { throw "Device-flow authorization failed: $($poll.error). $($poll.error_description)" }
+        }
+    }
+
+    $tokens = $poll
+    break
+}
+
+if ($null -eq $tokens) {
+    throw 'Timed out waiting for device-flow authorization. Re-run and complete the browser step sooner.'
+}
+
+if ([string]::IsNullOrWhiteSpace($tokens.refresh_token)) {
+    throw "Authorization succeeded but no refresh_token was returned. Enable 'Expire user authorization tokens' on the GitHub App and retry."
+}
+
+Write-Host 'Authorization succeeded.'
+
+if ($KeyVaultName) {
+    if ($PSCmdlet.ShouldProcess($RefreshTokenSecretName, "Write refresh token to Key Vault '$KeyVaultName'")) {
+        $tmp = New-TemporaryFile
+        try {
+            Set-Content -Path $tmp -Value $tokens.refresh_token -NoNewline -Encoding utf8
+            $null = az keyvault secret set --vault-name $KeyVaultName --name $RefreshTokenSecretName --file $tmp -o none
+            if ($LASTEXITCODE -ne 0) { throw "az keyvault secret set failed for '$RefreshTokenSecretName' (exit $LASTEXITCODE)." }
+        }
+        finally {
+            Remove-Item -Path $tmp -Force -ErrorAction SilentlyContinue
+        }
+        Write-Host "Refresh token stored in '$RefreshTokenSecretName'."
+
+        if ($AccessTokenSecretName -and $PSCmdlet.ShouldProcess($AccessTokenSecretName, 'Write access token to Key Vault')) {
+            $tmp2 = New-TemporaryFile
+            try {
+                Set-Content -Path $tmp2 -Value $tokens.access_token -NoNewline -Encoding utf8
+                $null = az keyvault secret set --vault-name $KeyVaultName --name $AccessTokenSecretName --file $tmp2 -o none
+                if ($LASTEXITCODE -ne 0) { throw "az keyvault secret set failed for '$AccessTokenSecretName' (exit $LASTEXITCODE)." }
+            }
+            finally {
+                Remove-Item -Path $tmp2 -Force -ErrorAction SilentlyContinue
+            }
+            Write-Host "Access token stored in '$AccessTokenSecretName'."
+        }
+    }
+}
+else {
+    Write-Host ''
+    Write-Warning "No -KeyVaultName supplied. Store this refresh token in Key Vault secret '$RefreshTokenSecretName' now:"
+    Write-Host $tokens.refresh_token
+}
+
+Write-Host 'Bootstrap complete. Future runs rotate automatically via Refresh-CopilotToken.ps1.'

--- a/eng/common/scripts/eval/Refresh-CopilotToken.ps1
+++ b/eng/common/scripts/eval/Refresh-CopilotToken.ps1
@@ -1,0 +1,187 @@
+<#
+.SYNOPSIS
+    Mints a fresh Copilot-usable GitHub access token from a stored GitHub App
+    refresh token, rotating the refresh token in place.
+
+.DESCRIPTION
+    Implements the per-run half of the durable eval auth flow (Option A). It
+    replaces the weekly-expiring fine-grained PAT with a self-perpetuating
+    GitHub App user-to-server token chain that the org's PAT-lifetime policy
+    does not govern.
+
+    Each invocation:
+      1. Reads the current refresh token + App client secret from Key Vault.
+      2. Exchanges the refresh token for a NEW 8h access token and a NEW
+         ~6-month refresh token (GitHub single-use-invalidates the old one).
+      3. Writes the new refresh token back to Key Vault FIRST (the critical
+         step — if this is lost the chain breaks and a re-bootstrap is needed).
+      4. Publishes the access token into the access-token secret that the eval
+         shards already consume, so no shard wiring changes.
+
+    Intended to run once per pipeline run in the Prepare stage (before the eval
+    shards resolve the Key-Vault-backed variable group). Requires an already
+    az-authenticated context (e.g. an AzureCLI@2 task) whose identity has
+    get + set on the target Key Vault.
+
+.PARAMETER KeyVaultName
+    Name of the Azure Key Vault holding the secrets (e.g. AzureSDKEngKeyVault).
+
+.PARAMETER ClientId
+    The GitHub App's client id (not a secret).
+
+.PARAMETER ClientSecretName
+    Key Vault secret name holding the GitHub App client secret.
+
+.PARAMETER RefreshTokenSecretName
+    Key Vault secret name holding (and receiving) the rotating refresh token.
+
+.PARAMETER AccessTokenSecretName
+    Key Vault secret name the freshly minted access token is written to. This
+    is the same secret the eval pipelines already map into GITHUB_TOKEN /
+    COPILOT_GITHUB_TOKEN, so nothing downstream changes.
+
+.PARAMETER TokenUrl
+    GitHub OAuth token endpoint. Override only for GHES.
+
+.PARAMETER MaxRetries
+    Attempts for each network / Key Vault operation before failing.
+
+.EXAMPLE
+    ./Refresh-CopilotToken.ps1 -KeyVaultName AzureSDKEngKeyVault -ClientId Iv1.0123456789abcdef
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $KeyVaultName,
+
+    [Parameter(Mandatory = $true)]
+    [string] $ClientId,
+
+    [Parameter()]
+    [string] $ClientSecretName = 'azuresdk-copilot-app-client-secret',
+
+    [Parameter()]
+    [string] $RefreshTokenSecretName = 'azuresdk-copilot-refresh-token',
+
+    [Parameter()]
+    [string] $AccessTokenSecretName = 'azuresdk-copilot-github-pat',
+
+    [Parameter()]
+    [string] $TokenUrl = 'https://github.com/login/oauth/access_token',
+
+    [Parameter()]
+    [int] $MaxRetries = 3
+)
+
+Set-StrictMode -Version 4
+$ErrorActionPreference = 'Stop'
+
+function Invoke-WithRetry {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][scriptblock] $Action,
+        [Parameter(Mandatory = $true)][string] $Description,
+        [int] $Retries = 3
+    )
+
+    for ($attempt = 1; $attempt -le $Retries; $attempt++) {
+        try {
+            return & $Action
+        }
+        catch {
+            if ($attempt -eq $Retries) {
+                throw "Failed: $Description (after $Retries attempts). $($_.Exception.Message)"
+            }
+            $delay = [math]::Pow(2, $attempt)
+            Write-Warning "$Description failed (attempt $attempt/$Retries): $($_.Exception.Message). Retrying in ${delay}s."
+            Start-Sleep -Seconds $delay
+        }
+    }
+}
+
+function Get-KeyVaultSecretValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string] $Vault,
+        [Parameter(Mandatory = $true)][string] $Name
+    )
+
+    return Invoke-WithRetry -Description "read secret '$Name'" -Retries $MaxRetries -Action {
+        $value = az keyvault secret show --vault-name $Vault --name $Name --query value -o tsv 2>$null
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($value)) {
+            throw "az keyvault secret show returned exit code $LASTEXITCODE for secret '$Name'."
+        }
+        return $value
+    }
+}
+
+function Set-KeyVaultSecretValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string] $Vault,
+        [Parameter(Mandatory = $true)][string] $Name,
+        [Parameter(Mandatory = $true)][string] $Value
+    )
+
+    Invoke-WithRetry -Description "write secret '$Name'" -Retries $MaxRetries -Action {
+        # --value via stdin file to avoid the secret appearing in the process table.
+        $tmp = New-TemporaryFile
+        try {
+            Set-Content -Path $tmp -Value $Value -NoNewline -Encoding utf8
+            $null = az keyvault secret set --vault-name $Vault --name $Name --file $tmp -o none 2>$null
+            if ($LASTEXITCODE -ne 0) {
+                throw "az keyvault secret set returned exit code $LASTEXITCODE for secret '$Name'."
+            }
+        }
+        finally {
+            Remove-Item -Path $tmp -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+Write-Host "Reading App client secret and refresh token from Key Vault '$KeyVaultName'..."
+$clientSecret = Get-KeyVaultSecretValue -Vault $KeyVaultName -Name $ClientSecretName
+$refreshToken = Get-KeyVaultSecretValue -Vault $KeyVaultName -Name $RefreshTokenSecretName
+
+Write-Host "Exchanging refresh token for a fresh access token..."
+$response = Invoke-WithRetry -Description 'refresh-token exchange' -Retries $MaxRetries -Action {
+    $body = @{
+        client_id     = $ClientId
+        client_secret = $clientSecret
+        grant_type    = 'refresh_token'
+        refresh_token = $refreshToken
+    }
+    Invoke-RestMethod -Method Post -Uri $TokenUrl -Body $body -Headers @{ Accept = 'application/json' }
+}
+
+if ($response.PSObject.Properties.Name -contains 'error') {
+    $desc = if ($response.PSObject.Properties.Name -contains 'error_description') { $response.error_description } else { '' }
+    throw "GitHub rejected the refresh token: $($response.error). $desc`n" +
+          "The refresh-token chain is broken (or the App/secret changed). Re-run Bootstrap-CopilotToken.ps1 " +
+          "signed in as the Copilot-seated bot account to seed a new refresh token."
+}
+
+if ([string]::IsNullOrWhiteSpace($response.access_token) -or [string]::IsNullOrWhiteSpace($response.refresh_token)) {
+    throw "GitHub token response was missing access_token or refresh_token. Cannot continue."
+}
+
+# Persist the NEW refresh token first: GitHub already invalidated the previous one,
+# so losing this value breaks the chain. Do it before publishing the access token.
+if ($PSCmdlet.ShouldProcess($RefreshTokenSecretName, 'Write rotated refresh token to Key Vault')) {
+    Set-KeyVaultSecretValue -Vault $KeyVaultName -Name $RefreshTokenSecretName -Value $response.refresh_token
+    Write-Host "Rotated refresh token written to '$RefreshTokenSecretName'."
+}
+
+if ($PSCmdlet.ShouldProcess($AccessTokenSecretName, 'Write fresh access token to Key Vault')) {
+    Set-KeyVaultSecretValue -Vault $KeyVaultName -Name $AccessTokenSecretName -Value $response.access_token
+    Write-Host "Fresh access token written to '$AccessTokenSecretName'."
+}
+
+$expiresIn = if ($response.PSObject.Properties.Name -contains 'expires_in') { [int]$response.expires_in } else { 0 }
+Write-Host "Done. Access token valid for ~$([math]::Round($expiresIn / 3600, 1))h; refresh token rotated."
+
+return [pscustomobject]@{
+    AccessTokenSecret       = $AccessTokenSecretName
+    RefreshTokenSecret      = $RefreshTokenSecretName
+    AccessTokenExpiresInSec = $expiresIn
+}


### PR DESCRIPTION
## What

Switch the Vally eval pipelines' copilot-sdk model authentication from a personal access token (PAT) to a GitHub App token minted by the shared `login-to-github` step.

- **`eval-invoke.yml`**: run `login-to-github.yml` before the shard invoke; both invoke branches (hermetic + `UseAzSdkAuthentication`) now map `GH_TOKEN: $(GH_TOKEN)` instead of `GITHUB_TOKEN: $(azuresdk-copilot-github-pat)`.
- **`workflow-eval.yml` / `skill-eval.yml` / `live-eval.yml`**: drop the `AzSDK_Eval_Variable_group` binding (it only supplied the PAT secret).

## Why

`login-to-github` mints a `GH_TOKEN` from the **Azure SDK Automation** GitHub App (App ID `1086291`) via a Key Vault-signed JWT. copilot-sdk reads it automatically — its auth priority is `COPILOT_GITHUB_TOKEN` → `GH_TOKEN` → `GITHUB_TOKEN`. This removes the weekly-expiring PAT (the `azuresdk-copilot-github-pat` secret) and its variable group.

Verified locally that copilot-sdk authenticates with **no PAT** — a minimal auth-only eval passed using only the signed-in `gh` user (a `gho_` OAuth token), `GITHUB_TOKEN`/`GH_TOKEN` unset.

## ⚠️ Validation still required (blocking before merge)

The local test used a `gho_` **user** token. `login-to-github` produces a `ghs_` **App installation** token, which the [copilot-sdk auth doc](https://github.com/github/copilot-sdk/blob/main/docs/auth/authenticate.md) does **not** list among supported types (`gho_` / `ghu_` / `github_pat_`). We must confirm a real `ghs_` token has Copilot entitlement via a **manual pipeline run** before merging.

## Follow-ups (owner: pipeline admin)

- Authorize the eval pipeline(s) for the `AzureSDKEngKeyVault Secrets` service connection used by `login-to-github`.
- After a green manual run, unbind `AzSDK_Eval_Variable_group` on the ADO pipeline definitions.
- If the `ghs_` token lacks Copilot entitlement: fall back to a bot user with a Copilot seat, or copilot-sdk BYOK (Azure OpenAI).
