### PR TITLE
Update CLI command to add release pipeline URL in release plan

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
@@ -364,3 +364,4 @@ namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
         }
     }
 }
+

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/DevOpsServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/DevOpsServiceTests.cs
@@ -648,4 +648,3 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
     }
 }
 
-

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/DevOpsServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/DevOpsServiceTests.cs
@@ -647,3 +647,5 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
         #endregion
     }
 }
+
+

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/PackageReleaseStatusToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/PackageReleaseStatusToolTests.cs
@@ -29,7 +29,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         public async Task UpdatePackageReleaseStatus_WithNullPackageName_ReturnsError()
         {
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus(null!, "python", "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus(null!, "python", "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Does.Contain("Package name cannot be null or empty"));
@@ -39,7 +39,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         public async Task UpdatePackageReleaseStatus_WithEmptyPackageName_ReturnsError()
         {
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("", "python", "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("", "python", "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Does.Contain("Package name cannot be null or empty"));
@@ -49,7 +49,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         public async Task UpdatePackageReleaseStatus_WithWhitespacePackageName_ReturnsError()
         {
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("   ", "python", "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("   ", "python", "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Does.Contain("Package name cannot be null or empty"));
@@ -59,7 +59,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         public async Task UpdatePackageReleaseStatus_WithNullLanguage_ReturnsError()
         {
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", null!, "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", null!, "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Does.Contain("Language cannot be null or empty"));
@@ -70,7 +70,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         public async Task UpdatePackageReleaseStatus_WithEmptyLanguage_ReturnsError()
         {
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "", "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "", "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Does.Contain("Language cannot be null or empty"));
@@ -81,7 +81,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         public async Task UpdatePackageReleaseStatus_WithWhitespaceLanguage_ReturnsError()
         {
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "   ", "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "   ", "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Does.Contain("Language cannot be null or empty"));
@@ -94,7 +94,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         public async Task UpdatePackageReleaseStatus_WithUnsupportedLanguage_ReturnsError(string language)
         {
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", language, "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", language, "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.Message, Does.Contain($"Language '{language}' is not supported"));
@@ -118,7 +118,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new List<ReleasePlanWorkItem>());
 
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", language, "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", language, "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.Message, Does.Contain("No in-progress release plans found"));
@@ -137,7 +137,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new List<ReleasePlanWorkItem>());
 
             // Act - Java packages no longer require groupName:packageName format
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-resourcemanager-containerservice", language, "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-resourcemanager-containerservice", language, "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.Message, Does.Contain("No in-progress release plans found"));
@@ -175,7 +175,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
 
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Is.Null);
@@ -232,7 +232,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 11111 });
 
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Is.Null);
@@ -288,7 +288,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 11111 });
 
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Is.Null);
@@ -298,6 +298,70 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 x => x.UpdateWorkItemAsync(11111, It.Is<Dictionary<string, string>>(d =>
                     d.ContainsKey("Custom.ReleaseStatusForPython")), It.IsAny<CancellationToken>()),
                 Times.Once);
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_WithMultipleReleasePlans_AndSdkPullRequest_SelectsMatchingReleasePlan()
+        {
+            // Arrange
+            const string sdkPullRequestUrl = "https://github.com/Azure/azure-sdk-for-python/pull/200";
+
+            var nonMatchingReleasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 11111,
+                ReleasePlanId = 101,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo
+                    {
+                        Language = "python",
+                        PackageName = "azure-test-package",
+                        SdkPullRequestUrl = "https://github.com/Azure/azure-sdk-for-python/pull/100",
+                        PullRequestStatus = "Open"
+                    }
+                }
+            };
+
+            var matchingReleasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 22222,
+                ReleasePlanId = 102,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo
+                    {
+                        Language = "python",
+                        PackageName = "azure-test-package",
+                        SdkPullRequestUrl = sdkPullRequestUrl,
+                        PullRequestStatus = "Open"
+                    }
+                }
+            };
+
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync("azure-test-package", "python", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem> { nonMatchingReleasePlan, matchingReleasePlan });
+
+            mockDevOpsService
+                .Setup(x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 22222 });
+
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus(
+                "azure-test-package", "python", "Released", null, 0, null, null, sdkPullRequestUrl, CancellationToken.None);
+
+            // Assert
+            Assert.That(result.ResponseError, Is.Null);
+            Assert.That(result.ReleasePlanId, Is.EqualTo(102));
+
+            // Verify only the matching release plan is updated.
+            mockDevOpsService.Verify(
+                x => x.UpdateWorkItemAsync(22222, It.Is<Dictionary<string, string>>(d =>
+                    d.ContainsKey("Custom.ReleaseStatusForPython") && d["Custom.ReleaseStatusForPython"] == "Released"), It.IsAny<CancellationToken>()),
+                Times.Once);
+            mockDevOpsService.Verify(
+                x => x.UpdateWorkItemAsync(11111, It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()),
+                Times.Never);
         }
 
         [TestCase("python", "Custom.ReleaseStatusForPython", "azure-test-package")]
@@ -332,7 +396,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
 
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus(packageName, language, "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus(packageName, language, "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Is.Null);
@@ -370,7 +434,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
 
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Pending", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Pending", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Is.Null);
@@ -390,7 +454,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ThrowsAsync(new Exception("DevOps service error"));
 
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Does.Contain("Failed to update release status"));
@@ -426,7 +490,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ThrowsAsync(new Exception("Failed to update work item"));
 
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Does.Contain("Failed to update release status"));
@@ -461,7 +525,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
 
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("com.azure:azure-test", "java", "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("com.azure:azure-test", "java", "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Is.Null);
@@ -480,7 +544,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new List<ReleasePlanWorkItem>());
 
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus(packageName, language, "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus(packageName, language, "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Is.Null);
@@ -562,7 +626,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
 
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", "1.2.3", 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", "1.2.3", 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Is.Null);
@@ -603,7 +667,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
 
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Pending", "1.2.3", 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Pending", "1.2.3", 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Is.Null);
@@ -644,7 +708,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
 
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Is.Null);
@@ -703,7 +767,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
 
             // Act - provide release plan ID 200 to select the second plan
             var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus(
-                "azure-test-package", "python", "Released", null, 200, CancellationToken.None);
+                "azure-test-package", "python", "Released", null, 200, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Is.Null);
@@ -747,7 +811,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
 
             // Act - provide release plan ID 999 that doesn't match any result
             var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus(
-                "azure-test-package", "python", "Released", null, 999, CancellationToken.None);
+                "azure-test-package", "python", "Released", null, 999, null, null, null, CancellationToken.None);
 
             // Assert - returns message, does not update any work item
             Assert.That(result.ResponseError, Is.Null);
@@ -810,7 +874,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
 
             // Act - releasing the last language (Python)
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test", "python", "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test", "python", "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Is.Null);
@@ -852,7 +916,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
 
             // Act - releasing Python (last non-excluded language)
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test", "python", "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test", "python", "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Is.Null);
@@ -893,7 +957,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
 
             // Act - releasing Python but Java, JS, Go still pending
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test", "python", "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test", "python", "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Is.Null);
@@ -935,7 +999,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
 
             // Act - releasing Python (last of the 4 data plane languages)
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test", "python", "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test", "python", "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert - Go is not released but should be ignored for data plane
             Assert.That(result.ResponseError, Is.Null);
@@ -976,7 +1040,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
 
             // Act - releasing Python but Java and JS still pending
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test", "python", "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test", "python", "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Is.Null);
@@ -1017,7 +1081,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
 
             // Act - setting status to "Pending" (not "Released")
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test", "python", "Pending", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test", "python", "Pending", null, 0, null, null, null, CancellationToken.None);
 
             // Assert - finish check should not be triggered
             Assert.That(result.ResponseError, Is.Null);
@@ -1059,7 +1123,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 12345 });
 
             // Act - releasing JavaScript (last of the 4 data plane languages)
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("@azure/test", "javascript", "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("@azure/test", "javascript", "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Is.Null);
@@ -1108,7 +1172,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ThrowsAsync(new Exception("State transition not allowed"));
 
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test", "python", "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test", "python", "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert - release status update succeeded, no ResponseError
             Assert.That(result.ResponseError, Is.Null);
@@ -1127,7 +1191,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new List<ReleasePlanWorkItem>());
 
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", "2.0.0", 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", "2.0.0", 0, null, null, null, CancellationToken.None);
 
             // Assert - The tool should report no in-progress release plans found
             Assert.That(result.ResponseError, Is.Null);
@@ -1171,7 +1235,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 33333 });
 
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", "1.0.0", 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", "1.0.0", 0, null, null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Is.Null);
@@ -1202,7 +1266,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .ReturnsAsync(new List<ReleasePlanWorkItem>());
 
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", language, "Released", null, 0, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", language, "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert - Verify the service was called with the correct language
             mockDevOpsService.Verify(
@@ -1211,3 +1275,6 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         }
     }
 }
+
+
+

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.6.27 (Unreleased)
+
+### Features Added
+
+- Update release status CLI command to take release pipeline URL as a parameter to update it in the release plan. Also updated this tool to accept SDK release type and SDK pull request to lookup the release plan using pull request/release type.
+
 ## 0.6.26 (2026-07-09)
 
 ### Breaking Changes

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ReleasePlan/ReleaseStatusUpdateResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/ReleasePlan/ReleaseStatusUpdateResponse.cs
@@ -26,6 +26,18 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses.ReleasePlan
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? PackageVersion { get; set; }
 
+        [JsonPropertyName("sdk_release_type")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? SdkReleaseType { get; set; }
+
+        [JsonPropertyName("release_pipeline_url")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? ReleasePipelineUrl { get; set; }
+
+        [JsonPropertyName("sdk_pull_request")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? SdkPullRequest { get; set; }
+
         [JsonPropertyName("message")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Message { get; set; }
@@ -52,6 +64,18 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses.ReleasePlan
             if (!string.IsNullOrEmpty(PackageVersion))
             {
                 result.AppendLine($"Package Version: {PackageVersion}");
+            }
+            if (!string.IsNullOrEmpty(SdkReleaseType))
+            {
+                result.AppendLine($"SDK Release Type: {SdkReleaseType}");
+            }
+            if (!string.IsNullOrEmpty(ReleasePipelineUrl))
+            {
+                result.AppendLine($"Release Pipeline URL: {ReleasePipelineUrl}");
+            }
+            if (!string.IsNullOrEmpty(SdkPullRequest))
+            {
+                result.AppendLine($"SDK Pull Request: {SdkPullRequest}");
             }
             if (Language != SdkLanguage.Unknown)
             {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/PackageReleaseStatusTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/PackageReleaseStatusTool.cs
@@ -44,6 +44,24 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             Required = true,
         };
 
+        private readonly Option<string?> sdkReleaseTypeOpt = new("--sdk-release-type")
+        {
+            Description = "SDK release type (e.g., beta, stable)",
+            Required = false,
+        };
+
+        private readonly Option<string?> sdkPullRequestOpt = new("--sdk-pull-request")
+        {
+            Description = "SDK pull request URL.",
+            Required = false,
+        };
+
+        private readonly Option<string?> releasePipelineOpt = new("--release-pipeline")
+        {
+            Description = "Release pipeline URL.",
+            Required = false,
+        };
+
         private readonly Option<string> releaseStatusOpt = new("--status", "-s")
         {
             Description = "Release status (e.g., Released, Pending)",
@@ -60,7 +78,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
         protected override Command GetCommand() =>
             new McpCommand(updateReleaseStatusCommandName, "Update package release status in the release plan")
             {
-                packageNameOpt, languageOpt, releaseStatusOpt, packageVersionOpt, releasePlanIdOpt
+                packageNameOpt, languageOpt, releaseStatusOpt, packageVersionOpt, releasePlanIdOpt, sdkReleaseTypeOpt, sdkPullRequestOpt, releasePipelineOpt
             };
 
 
@@ -76,7 +94,10 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     var releaseStatus = commandParser.GetValue(releaseStatusOpt);
                     var packageVersion = commandParser.GetValue(packageVersionOpt);
                     var releasePlanId = commandParser.GetValue(releasePlanIdOpt);
-                    return await UpdatePackageReleaseStatus(packageName, language, releaseStatus, packageVersion, releasePlanId, ct);
+                    var sdkReleaseType = commandParser.GetValue(sdkReleaseTypeOpt);
+                    var releasePipelineUrl = commandParser.GetValue(releasePipelineOpt);
+                    var sdkPullRequest = commandParser.GetValue(sdkPullRequestOpt);
+                    return await UpdatePackageReleaseStatus(packageName, language, releaseStatus, packageVersion, releasePlanId, sdkReleaseType, releasePipelineUrl, sdkPullRequest, ct);
 
                 default:
                     logger.LogError("Unknown command: {command}", command);
@@ -84,7 +105,20 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             }
         }
 
-        public async Task<ReleaseStatusUpdateResponse> UpdatePackageReleaseStatus(string packageName, string language, string releaseStatus, string? packageVersion, int releasePlanId = 0, CancellationToken ct = default)
+        /// <summary>
+        /// Updates the release status for a given package in the release plan to either Released or Approval pending
+        /// </summary>
+        /// <param name="packageName">The name of the package.</param>
+        /// <param name="language">The language of the package.</param>
+        /// <param name="releaseStatus">The release status to set (e.g., Released, Pending).</param>
+        /// <param name="packageVersion">The version of the package.</param>
+        /// <param name="releasePlanId">The ID of the release plan work item.</param>
+        /// <param name="sdkReleaseType">The SDK release type (e.g., beta, stable).</param>
+        /// <param name="sdkPullRequest">The URL of the SDK pull request associated with the release.</param>
+        /// <param name="releasePipelineUrl">The URL of the release pipeline.</param>
+        /// <param name="ct">The cancellation token.</param>
+        /// <returns>A task that represents the asynchronous operation, containing the response of the update operation.</returns>
+        public async Task<ReleaseStatusUpdateResponse> UpdatePackageReleaseStatus(string packageName, string language, string releaseStatus, string? packageVersion, int releasePlanId = 0, string? sdkReleaseType = null, string? releasePipelineUrl = null, string? sdkPullRequest = null, CancellationToken ct = default)
         {
             try
             {
@@ -103,7 +137,10 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     PackageName = packageName,
                     Language = SdkLanguageHelpers.GetSdkLanguage(language),
                     ReleaseStatus = releaseStatus,
-                    PackageVersion = packageVersion
+                    PackageVersion = packageVersion,
+                    ReleasePipelineUrl = releasePipelineUrl,
+                    SdkReleaseType = sdkReleaseType,
+                    SdkPullRequest = sdkPullRequest
                 };
 
                 if (!ReleasePlanTool.SUPPORTED_LANGUAGES.Contains(language.ToLower()))
@@ -141,12 +178,12 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 }
                 else
                 {
-                    releasePlan = SelectReleasePlan(releasePlans, packageName);
+                    releasePlan = SelectReleasePlan(releasePlans, packageName, sdkReleaseType, sdkPullRequest);
                 }
 
                 response.ReleasePlanId = releasePlan.ReleasePlanId;
                 response.TypeSpecProject = releasePlan.APISpecProjectPath;
-                logger.LogInformation("Updating release status for package {packageName} in release plan work item {workItemId}", packageName, releasePlan.WorkItemId);
+                logger.LogInformation("Updating release status to {releaseStatus} for package {packageName} in release plan work item {workItemId}", releaseStatus, packageName, releasePlan.WorkItemId);
 
                 // Update the release status for the specific language
                 var languageId = DevOpsService.MapLanguageToId(language);
@@ -160,8 +197,13 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     fieldsToUpdate[$"Custom.ReleasedVersionFor{languageId}"] = packageVersion;
                 }
 
+                if (!string.IsNullOrWhiteSpace(releasePipelineUrl))
+                {
+                    fieldsToUpdate[$"Custom.ReleasePipelineFor{languageId}"] = releasePipelineUrl;
+                }
+
                 await devOpsService.UpdateWorkItemAsync(releasePlan.WorkItemId, fieldsToUpdate, ct);
-                logger.LogInformation("Successfully updated release status for package {packageName} in release plan {workItemId}", packageName, releasePlan.WorkItemId);
+                logger.LogInformation("Successfully updated release status to {releaseStatus} for package {packageName} in release plan {workItemId}", releaseStatus, packageName, releasePlan.WorkItemId);
                 response.ReleaseStatus = releaseStatus;
 
                 // Check if the release plan can be marked as Finished
@@ -203,13 +245,36 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             }
         }
 
-        private ReleasePlanWorkItem SelectReleasePlan(List<ReleasePlanWorkItem> releasePlans, string packageName)
+        private ReleasePlanWorkItem SelectReleasePlan(List<ReleasePlanWorkItem> releasePlans, string packageName, string? sdkReleaseType, string? sdkPullRequest)
         {
             var releasePlan = releasePlans[0];
             if (releasePlans.Count > 1)
             {
                 logger.LogInformation("Multiple active release plans are found for '{packageName}'", packageName);
-                var releasePlanWithPrMerged = releasePlans.FirstOrDefault(rp => rp.SDKInfo.Any(s => s.PackageName.Equals(packageName) && s.PullRequestStatus.Equals("Merged")));
+                // If an SDK pull request URL is provided, try to select the release plan that matches it.
+                if (!string.IsNullOrWhiteSpace(sdkPullRequest))
+                {
+                    var releasePlanWithSdkPullRequest = releasePlans.FirstOrDefault(rp => rp.SDKInfo.Any(s => !string.IsNullOrEmpty(s.SdkPullRequestUrl) && s.SdkPullRequestUrl.Equals(sdkPullRequest, StringComparison.OrdinalIgnoreCase)));
+                    if (releasePlanWithSdkPullRequest != null)
+                    {
+                        logger.LogInformation("Selected first release plan {releasePlanId} with SDK pull request {sdkPullRequest}.", releasePlanWithSdkPullRequest.ReleasePlanId, sdkPullRequest);
+                        releasePlan = releasePlanWithSdkPullRequest;
+                        return releasePlan;
+                    }
+                }
+                // If an SDK release type is provided, try to select the release plan that matches it.
+                if (!string.IsNullOrWhiteSpace(sdkReleaseType))
+                {
+                    var releasePlanWithSdkReleaseType = releasePlans.FirstOrDefault(rp => string.Equals(rp.SDKReleaseType, sdkReleaseType, StringComparison.OrdinalIgnoreCase));
+                    if (releasePlanWithSdkReleaseType != null)
+                    {
+                        logger.LogInformation("Selected first release plan {releasePlanId} with SDK release type {sdkReleaseType}.", releasePlanWithSdkReleaseType.ReleasePlanId, sdkReleaseType);
+                        releasePlan = releasePlanWithSdkReleaseType;
+                        return releasePlan;
+                    }
+                }
+                // If no release plan was selected by SDK pull request or SDK release type, try to select the release plan with a merged pull request.
+                var releasePlanWithPrMerged = releasePlans.FirstOrDefault(rp => rp.SDKInfo.Any(s => s.PullRequestStatus.Equals("Merged")));
                 if (releasePlanWithPrMerged != null)
                 {
                     logger.LogInformation("Selected first release plan {releasePlanId} with pull request as merged.", releasePlanWithPrMerged.ReleasePlanId);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/PackageReleaseStatusTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/PackageReleaseStatusTool.cs
@@ -254,7 +254,11 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 // If an SDK pull request URL is provided, try to select the release plan that matches it.
                 if (!string.IsNullOrWhiteSpace(sdkPullRequest))
                 {
-                    var releasePlanWithSdkPullRequest = releasePlans.FirstOrDefault(rp => rp.SDKInfo.Any(s => !string.IsNullOrEmpty(s.SdkPullRequestUrl) && s.SdkPullRequestUrl.Equals(sdkPullRequest, StringComparison.OrdinalIgnoreCase)));
+                    var releasePlanWithSdkPullRequest = releasePlans.FirstOrDefault(rp =>
+                        rp.SDKInfo.Any(s =>
+                            string.Equals(s.PackageName, packageName, StringComparison.OrdinalIgnoreCase)
+                            && !string.IsNullOrWhiteSpace(s.SdkPullRequestUrl)
+                            && string.Equals(s.SdkPullRequestUrl, sdkPullRequest, StringComparison.OrdinalIgnoreCase)));
                     if (releasePlanWithSdkPullRequest != null)
                     {
                         logger.LogInformation("Selected release plan {releasePlanId} with SDK pull request {sdkPullRequest}.", releasePlanWithSdkPullRequest.ReleasePlanId, sdkPullRequest);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/PackageReleaseStatusTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/PackageReleaseStatusTool.cs
@@ -257,10 +257,11 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     var releasePlanWithSdkPullRequest = releasePlans.FirstOrDefault(rp => rp.SDKInfo.Any(s => !string.IsNullOrEmpty(s.SdkPullRequestUrl) && s.SdkPullRequestUrl.Equals(sdkPullRequest, StringComparison.OrdinalIgnoreCase)));
                     if (releasePlanWithSdkPullRequest != null)
                     {
-                        logger.LogInformation("Selected first release plan {releasePlanId} with SDK pull request {sdkPullRequest}.", releasePlanWithSdkPullRequest.ReleasePlanId, sdkPullRequest);
+                        logger.LogInformation("Selected release plan {releasePlanId} with SDK pull request {sdkPullRequest}.", releasePlanWithSdkPullRequest.ReleasePlanId, sdkPullRequest);
                         releasePlan = releasePlanWithSdkPullRequest;
                         return releasePlan;
                     }
+                    logger.LogInformation("No release plan matched the SDK pull request {sdkPullRequest}.", sdkPullRequest);
                 }
                 // If an SDK release type is provided, try to select the release plan that matches it.
                 if (!string.IsNullOrWhiteSpace(sdkReleaseType))
@@ -268,10 +269,11 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     var releasePlanWithSdkReleaseType = releasePlans.FirstOrDefault(rp => string.Equals(rp.SDKReleaseType, sdkReleaseType, StringComparison.OrdinalIgnoreCase));
                     if (releasePlanWithSdkReleaseType != null)
                     {
-                        logger.LogInformation("Selected first release plan {releasePlanId} with SDK release type {sdkReleaseType}.", releasePlanWithSdkReleaseType.ReleasePlanId, sdkReleaseType);
+                        logger.LogInformation("Selected release plan {releasePlanId} with SDK release type {sdkReleaseType}.", releasePlanWithSdkReleaseType.ReleasePlanId, sdkReleaseType);
                         releasePlan = releasePlanWithSdkReleaseType;
                         return releasePlan;
                     }
+                    logger.LogInformation("No release plan matched the SDK release type {sdkReleaseType}.", sdkReleaseType);
                 }
                 // If no release plan was selected by SDK pull request or SDK release type, try to select the release plan with a merged pull request.
                 var releasePlanWithPrMerged = releasePlans.FirstOrDefault(rp => rp.SDKInfo.Any(s => s.PullRequestStatus.Equals("Merged")));

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/PackageReleaseStatusTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/PackageReleaseStatusTool.cs
@@ -280,7 +280,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     logger.LogInformation("No release plan matched the SDK release type {sdkReleaseType}.", sdkReleaseType);
                 }
                 // If no release plan was selected by SDK pull request or SDK release type, try to select the release plan with a merged pull request.
-                var releasePlanWithPrMerged = releasePlans.FirstOrDefault(rp => rp.SDKInfo.Any(s => s.PullRequestStatus.Equals("Merged")));
+                var releasePlanWithPrMerged = releasePlans.FirstOrDefault(rp => rp.SDKInfo.Any(s => string.Equals(s.PackageName, packageName, StringComparison.OrdinalIgnoreCase) && s.PullRequestStatus.Equals("Merged")));
                 if (releasePlanWithPrMerged != null)
                 {
                     logger.LogInformation("Selected first release plan {releasePlanId} with pull request as merged.", releasePlanWithPrMerged.ReleasePlanId);


### PR DESCRIPTION
- Update release pipeline URL in release plan.
- Filter a release plan using SDK pull request when pull request URL is provided.
- Filter a release plan using SDK release type when SDK release type is provided.