### PR TITLE
Simplified pipeline variables for auto-release

### DIFF
--- a/eng/common-tests/scripts/Resolve-AutoReleasePackages.Tests.ps1
+++ b/eng/common-tests/scripts/Resolve-AutoReleasePackages.Tests.ps1
@@ -13,6 +13,10 @@ Describe "Resolve-AutoReleasePackages" -Tag "UnitTest", "Resolve-AutoReleasePack
             param([string]$Name, $Value = '', [switch]$IsOutput, [switch]$IsSecret)
             $global:AutoReleaseEmittedVars[$Name] = "$Value"
         }
+        # logging.ps1 is not loaded in the injected-dependency path, so provide the warning helper it exports.
+        function global:LogWarning {
+            Write-Host "##[warning]$args"
+        }
         function global:Get-GitHubAutoReleasePullRequestForCommit {
             param($RepoId, $CommitSha, $TargetBranch, $RequiredLabel, $AuthToken)
             if ($global:AutoReleaseThrowOnResolve) { throw 'boom resolving PR' }
@@ -45,6 +49,7 @@ Describe "Resolve-AutoReleasePackages" -Tag "UnitTest", "Resolve-AutoReleasePack
 
     AfterAll {
         Remove-Item function:global:Set-PipelineVariable -ErrorAction SilentlyContinue
+        Remove-Item function:global:LogWarning -ErrorAction SilentlyContinue
         Remove-Item function:global:Get-GitHubAutoReleasePullRequestForCommit -ErrorAction SilentlyContinue
         Remove-Item function:global:Get-GitHubPullRequestFiles -ErrorAction SilentlyContinue
         Remove-Item function:global:New-GitHubPullRequestDiffObject -ErrorAction SilentlyContinue
@@ -71,20 +76,21 @@ Describe "Resolve-AutoReleasePackages" -Tag "UnitTest", "Resolve-AutoReleasePack
 
             $vars = Invoke-ResolveScript -Artifacts '[{"name":"Azure.Storage.Blobs","safeName":"AzureStorageBlobs"}]'
 
-            $vars['AutoReleaseLabelPresent'] | Should -Be 'false'
             $vars['HasAutoReleaseArtifacts'] | Should -Be 'false'
             $vars['AutoReleaseArtifactsJson'] | Should -Be '[]'
             $vars['ReleaseArtifact_AzureStorageBlobs'] | Should -Be 'false'
             $global:AutoReleaseGetPrPkgCalled | Should -BeFalse
         }
 
-        It "still emits the resolved PR number when the pull request is not eligible" {
-            $global:AutoReleaseStubRelease = [pscustomobject]@{ PullRequestNumber = 321; IsEligible = $false; SkipReason = 'missing label'; PullRequest = $null }
+        It "fails closed when a pull request is resolved but not eligible" {
+            $global:AutoReleaseStubRelease = [pscustomobject]@{ PullRequestNumber = 321; IsEligible = $false; SkipReason = 'missing label'; PullRequest = [pscustomobject]@{ number = 321 } }
 
             $vars = Invoke-ResolveScript -Artifacts '[{"name":"pkg","safeName":"pkg"}]'
 
-            $vars['AutoReleasePrNumber'] | Should -Be '321'
-            $vars['AutoReleaseLabelPresent'] | Should -Be 'false'
+            $vars['HasAutoReleaseArtifacts'] | Should -Be 'false'
+            $vars['AutoReleaseArtifactsJson'] | Should -Be '[]'
+            $vars['ReleaseArtifact_pkg'] | Should -Be 'false'
+            $global:AutoReleaseGetPrPkgCalled | Should -BeFalse
         }
 
         It "forwards commit, repo, branch and label to the resolver with the documented defaults" {
@@ -109,8 +115,6 @@ Describe "Resolve-AutoReleasePackages" -Tag "UnitTest", "Resolve-AutoReleasePack
 
             $vars = Invoke-ResolveScript -Artifacts '[{"name":"Azure.Storage.Blobs","safeName":"AzureStorageBlobs"}]'
 
-            $vars['AutoReleasePrNumber'] | Should -Be '123'
-            $vars['AutoReleaseLabelPresent'] | Should -Be 'true'
             $vars['HasAutoReleaseArtifacts'] | Should -Be 'true'
             $vars['ReleaseArtifact_AzureStorageBlobs'] | Should -Be 'true'
 
@@ -128,7 +132,6 @@ Describe "Resolve-AutoReleasePackages" -Tag "UnitTest", "Resolve-AutoReleasePack
 
             $vars = Invoke-ResolveScript -Artifacts '[{"name":"Azure.Messaging.EventHubs","safeName":"AzureMessagingEventHubs"}]'
 
-            $vars['AutoReleaseLabelPresent'] | Should -Be 'true'
             $vars['HasAutoReleaseArtifacts'] | Should -Be 'false'
             $vars['AutoReleaseArtifactsJson'] | Should -Be '[]'
             $vars['ReleaseArtifact_AzureMessagingEventHubs'] | Should -Be 'false'
@@ -204,13 +207,44 @@ Describe "Resolve-AutoReleasePackages" -Tag "UnitTest", "Resolve-AutoReleasePack
         }
     }
 
+    Context "pull request link logging" {
+        BeforeEach {
+            $global:AutoReleaseStubChangedPackages = @(
+                [pscustomobject]@{ Name = 'Pkg'; ArtifactName = 'Pkg'; Group = $null; IncludedForValidation = $false }
+            )
+        }
+
+        It "logs the pull request's html_url when the payload provides it" {
+            $global:AutoReleaseStubRelease = [pscustomobject]@{
+                PullRequestNumber = 777; IsEligible = $true; SkipReason = ''
+                PullRequest       = [pscustomobject]@{ number = 777; html_url = 'https://github.com/Azure/azure-sdk-for-net/pull/777' }
+            }
+
+            $log = & $script:scriptPath -CommitSha 'abc123' -RepoId 'Azure/azure-sdk-for-net' -Artifacts '[{"name":"Pkg","safeName":"Pkg"}]' -AuthToken 'fake-token' 6>&1 | Out-String
+
+            $log | Should -Match 'https://github\.com/Azure/azure-sdk-for-net/pull/777'
+            # The bare "PR #<number>" form should no longer appear in the log.
+            $log | Should -Not -Match 'PR #777'
+        }
+
+        It "constructs a pull request link from the repo id and number when html_url is absent" {
+            $global:AutoReleaseStubRelease = [pscustomobject]@{
+                PullRequestNumber = 654; IsEligible = $true; SkipReason = ''
+                PullRequest       = [pscustomobject]@{ number = 654 }
+            }
+
+            $log = & $script:scriptPath -CommitSha 'abc123' -RepoId 'Azure/azure-sdk-for-python' -Artifacts '[{"name":"Pkg","safeName":"Pkg"}]' -AuthToken 'fake-token' 6>&1 | Out-String
+
+            $log | Should -Match 'https://github\.com/Azure/azure-sdk-for-python/pull/654'
+        }
+    }
+
     Context "when there is nothing to release" {
-        It "marks the label present but releases nothing when the pipeline declares no artifacts" {
+        It "releases nothing when an eligible pull request's pipeline declares no artifacts" {
             $global:AutoReleaseStubRelease = [pscustomobject]@{ PullRequestNumber = 9; IsEligible = $true; SkipReason = ''; PullRequest = [pscustomobject]@{ number = 9 } }
 
             $vars = Invoke-ResolveScript -Artifacts '[]'
 
-            $vars['AutoReleaseLabelPresent'] | Should -Be 'true'
             $vars['HasAutoReleaseArtifacts'] | Should -Be 'false'
             $vars['AutoReleaseArtifactsJson'] | Should -Be '[]'
             $global:AutoReleaseGetPrPkgCalled | Should -BeFalse
@@ -222,7 +256,6 @@ Describe "Resolve-AutoReleasePackages" -Tag "UnitTest", "Resolve-AutoReleasePack
             { Invoke-ResolveScript -Artifacts 'not-valid-json' } | Should -Not -Throw
 
             $vars = $global:AutoReleaseEmittedVars
-            $vars['AutoReleaseLabelPresent'] | Should -Be 'false'
             $vars['HasAutoReleaseArtifacts'] | Should -Be 'false'
             $vars['AutoReleaseArtifactsJson'] | Should -Be '[]'
         }
@@ -235,28 +268,23 @@ Describe "Resolve-AutoReleasePackages" -Tag "UnitTest", "Resolve-AutoReleasePack
             { Invoke-ResolveScript -Artifacts '[{"name":"pkg","safeName":"pkg"}]' } | Should -Not -Throw
 
             $vars = $global:AutoReleaseEmittedVars
-            $vars['AutoReleaseLabelPresent'] | Should -Be 'false'
             $vars['HasAutoReleaseArtifacts'] | Should -Be 'false'
             $vars['AutoReleaseArtifactsJson'] | Should -Be '[]'
             $vars['ReleaseArtifact_pkg'] | Should -Be 'false'
         }
 
-        It "resets the label-present signal when a failure occurs after the PR is deemed eligible" {
-            # The PR resolves as eligible (AutoReleaseLabelPresent is flipped to 'true') but package
-            # detection then throws. The catch block must re-emit the fail-closed defaults so no partial
-            # release decision leaks downstream.
+        It "fails closed when a failure occurs after the PR is deemed eligible" {
+            # The PR resolves as eligible but package detection then throws. The catch block must re-emit
+            # the fail-closed defaults so no partial release decision leaks downstream.
             $global:AutoReleaseStubRelease = [pscustomobject]@{ PullRequestNumber = 500; IsEligible = $true; SkipReason = ''; PullRequest = [pscustomobject]@{ number = 500 } }
             $global:AutoReleaseThrowOnGetPrPkg = $true
 
             { Invoke-ResolveScript -Artifacts '[{"name":"pkg","safeName":"pkg"}]' } | Should -Not -Throw
 
             $vars = $global:AutoReleaseEmittedVars
-            $vars['AutoReleaseLabelPresent'] | Should -Be 'false'
             $vars['HasAutoReleaseArtifacts'] | Should -Be 'false'
             $vars['AutoReleaseArtifactsJson'] | Should -Be '[]'
             $vars['ReleaseArtifact_pkg'] | Should -Be 'false'
-            # The resolved PR number is informational and is intentionally preserved.
-            $vars['AutoReleasePrNumber'] | Should -Be '500'
         }
     }
 }

--- a/eng/common/pipelines/templates/stages/archetype-auto-release-prepare.yml
+++ b/eng/common/pipelines/templates/stages/archetype-auto-release-prepare.yml
@@ -21,8 +21,8 @@ stages:
   # fixed cross-language output contract. Downstream release stages read outputs as:
   #   condition:  dependencies.AutoReleasePrepare.outputs['ResolveAutoReleasePackages.resolve.<var>']
   #   variables:  stageDependencies.AutoReleasePrepare.ResolveAutoReleasePackages.outputs['resolve.<var>']
-  # Emitted variables: AutoReleasePrNumber, AutoReleaseLabelPresent, HasAutoReleaseArtifacts,
-  # AutoReleaseArtifactsJson, and ReleaseArtifact_<safeName> per declared artifact.
+  # Emitted variables: HasAutoReleaseArtifacts (the single eligibility gate), AutoReleaseArtifactsJson,
+  # and ReleaseArtifact_<safeName> per declared artifact.
   - stage: AutoReleasePrepare
     displayName: Auto-release prepare
     dependsOn: ${{ parameters.DependsOn }}

--- a/eng/common/scripts/Resolve-AutoReleasePackages.ps1
+++ b/eng/common/scripts/Resolve-AutoReleasePackages.ps1
@@ -21,8 +21,8 @@ commit, this script:
          for pipelines that iterate the releasable set at runtime (e.g. Java).
 
 The script FAILS CLOSED: on any error, or if no qualifying labeled PR / changed package is found, it
-emits AutoReleaseLabelPresent=false, HasAutoReleaseArtifacts=false, AutoReleaseArtifactsJson=[] and
-ReleaseArtifact_<safeName>=false for every artifact, and exits 0 so the CI run is not failed.
+emits HasAutoReleaseArtifacts=false, AutoReleaseArtifactsJson=[] and ReleaseArtifact_<safeName>=false
+for every artifact, and exits 0 so the CI run is not failed.
 
 .PARAMETER CommitSha
 The build source version (merge commit) to resolve the pull request from. Typically $(Build.SourceVersion).
@@ -49,11 +49,11 @@ The base branch a PR must have been merged into to qualify. Defaults to 'main'.
 
 .OUTPUTS
 Azure DevOps output variables (reference cross-stage via dependencies.<stage>.outputs['<job>.<step>.<name>']):
-  - AutoReleasePrNumber        : the resolved PR number, or empty
-  - AutoReleaseLabelPresent    : 'true' if the resolved merged PR has the auto-release label
   - HasAutoReleaseArtifacts    : 'true' if at least one declared package is releasable
   - AutoReleaseArtifactsJson   : JSON array of the matched declared-artifact objects (or '[]')
   - ReleaseArtifact_<safeName> : 'true'/'false' per declared artifact
+HasAutoReleaseArtifacts is the single eligibility gate: it is 'true' only when a merged, auto-release-labeled
+PR changed at least one declared package, and it is emitted last so any earlier failure fails closed.
 #>
 #Requires -Version 7.0
 [CmdletBinding()]
@@ -86,12 +86,10 @@ try {
   if ($null -ne $parsed) { $declaredArtifacts = @($parsed) }
 }
 catch {
-  Write-Host "##[warning]Failed to parse -Artifacts JSON; treating as empty. $($_.Exception.Message)"
+  LogWarning "Failed to parse -Artifacts JSON; treating as empty. $($_.Exception.Message)"
 }
 
 # Fail-closed defaults: nothing releases unless we positively determine otherwise below.
-Set-PipelineVariable -Name 'AutoReleasePrNumber' -Value '' -IsOutput
-Set-PipelineVariable -Name 'AutoReleaseLabelPresent' -Value 'false' -IsOutput
 Set-PipelineVariable -Name 'HasAutoReleaseArtifacts' -Value 'false' -IsOutput
 Set-PipelineVariable -Name 'AutoReleaseArtifactsJson' -Value '[]' -IsOutput
 foreach ($artifact in $declaredArtifacts) {
@@ -109,30 +107,28 @@ function Invoke-AutoReleaseResolution {
     -RequiredLabel $AutoReleaseLabel `
     -AuthToken $AuthToken
 
-  if ($release.PullRequestNumber) {
-    Set-PipelineVariable -Name 'AutoReleasePrNumber' -Value "$($release.PullRequestNumber)" -IsOutput
-  }
-
   if (-not $release.IsEligible) {
     Write-Host "Skipping auto-release: $($release.SkipReason)"
     return
   }
 
   $pr = $release.PullRequest
-  Write-Host "PR #$($pr.number) is eligible for auto-release (merged into '$BaseBranch' with the '$AutoReleaseLabel' label)."
-  Set-PipelineVariable -Name 'AutoReleaseLabelPresent' -Value 'true' -IsOutput
+  # Prefer the PR's canonical html_url; fall back to constructing it so the log link stays clickable even
+  # if the field is absent from the payload.
+  $prLink = if ($pr.PSObject.Properties['html_url'] -and $pr.html_url) { "$($pr.html_url)" } else { "https://github.com/$RepoId/pull/$($pr.number)" }
+  Write-Host "PR $prLink is eligible for auto-release (merged into '$BaseBranch' with the '$AutoReleaseLabel' label)."
 
   if ($declaredArtifacts.Count -eq 0) {
-    Write-Host "No declared artifacts for this pipeline. Nothing to auto-release."
+    LogWarning "PR $prLink has the '$AutoReleaseLabel' label but this pipeline declares no artifacts; nothing will be auto-released."
     return
   }
 
   # Turn the PR's changed files into a diff object (Generate-PR-Diff.ps1 shape) and reuse the repo's
   # package-detection logic to identify the changed packages.
-  Write-Host "Fetching changed files for PR #$($pr.number)..."
+  Write-Host "Fetching changed files for PR $prLink..."
   $files = @(Get-GitHubPullRequestFiles -RepoId $RepoId -PullRequestNumber $pr.number -AuthToken $AuthToken)
   $diff = New-GitHubPullRequestDiffObject -PullRequestNumber $pr.number -PullRequestFiles $files
-  Write-Host "PR #$($pr.number) changed $($diff.ChangedFiles.Count) file(s) and deleted $($diff.DeletedFiles.Count) file(s)."
+  Write-Host "PR $prLink changed $($diff.ChangedFiles.Count) file(s) and deleted $($diff.DeletedFiles.Count) file(s)."
 
   $diffPath = Join-Path ([System.IO.Path]::GetTempPath()) ("autorelease-diff-" + [System.Guid]::NewGuid().ToString('N') + ".json")
   $diff | ConvertTo-Json -Depth 10 | Set-Content -Path $diffPath -Encoding utf8
@@ -187,16 +183,16 @@ function Invoke-AutoReleaseResolution {
       }
 
       if ($isMatch) {
-        Write-Host "  [$name] changed by PR #$($pr.number) -> releasable."
+        Write-Host "  [$name] changed by PR $prLink -> releasable."
         Set-PipelineVariable -Name "ReleaseArtifact_$safeName" -Value 'true' -IsOutput
         $matchedArtifacts += $artifact
       }
       else {
-        Write-Host "  [$name] not changed by PR #$($pr.number)."
+        Write-Host "  [$name] not changed by PR $prLink."
       }
     }
     catch {
-      Write-Host "##[warning]Failed to evaluate an artifact; treating as not releasable. $($_.Exception.Message)"
+      LogWarning "Failed to evaluate an artifact; treating as not releasable. $($_.Exception.Message)"
     }
   }
 
@@ -204,11 +200,11 @@ function Invoke-AutoReleaseResolution {
     # Pipe (not -InputObject) with -AsArray so a single match still serializes as a JSON array, '[{...}]'.
     $artifactsJson = $matchedArtifacts | ConvertTo-Json -Depth 100 -Compress -AsArray
     Set-PipelineVariable -Name 'AutoReleaseArtifactsJson' -Value $artifactsJson -IsOutput
-    Write-Host "Auto-release packages from PR #$($pr.number): $((@($matchedArtifacts | ForEach-Object { $_.name })) -join ', ')"
+    Write-Host "Auto-release packages from PR $prLink`: $((@($matchedArtifacts | ForEach-Object { $_.name })) -join ', ')"
     Set-PipelineVariable -Name 'HasAutoReleaseArtifacts' -Value 'true' -IsOutput
   }
   else {
-    Write-Host "PR #$($pr.number) changed no releasable package in this pipeline."
+    LogWarning "PR $prLink has the '$AutoReleaseLabel' label but changed no releasable package in this pipeline; nothing will be auto-released."
   }
 }
 
@@ -216,11 +212,10 @@ try {
   Invoke-AutoReleaseResolution
 }
 catch {
-  # Re-emit the fail-closed defaults so a failure after any positive signal was set (e.g. after
-  # AutoReleaseLabelPresent or a ReleaseArtifact_<safeName> flag was flipped to 'true') cannot leak a
-  # partial "release" decision to downstream stages, regardless of how each consumer gates on the outputs.
-  Write-Host "##[warning]Auto-release resolution failed; skipping auto-release. $($_.Exception.Message)"
-  Set-PipelineVariable -Name 'AutoReleaseLabelPresent' -Value 'false' -IsOutput
+  # Re-emit the fail-closed defaults so a failure after any positive signal was set (e.g. after a
+  # ReleaseArtifact_<safeName> flag was flipped to 'true') cannot leak a partial "release" decision to
+  # downstream stages, regardless of how each consumer gates on the outputs.
+  LogWarning "Auto-release resolution failed; skipping auto-release. $($_.Exception.Message)"
   Set-PipelineVariable -Name 'HasAutoReleaseArtifacts' -Value 'false' -IsOutput
   Set-PipelineVariable -Name 'AutoReleaseArtifactsJson' -Value '[]' -IsOutput
   foreach ($artifact in $declaredArtifacts) {

--- a/eng/common/scripts/Resolve-AutoReleasePackages.ps1
+++ b/eng/common/scripts/Resolve-AutoReleasePackages.ps1
@@ -200,7 +200,7 @@ function Invoke-AutoReleaseResolution {
     # Pipe (not -InputObject) with -AsArray so a single match still serializes as a JSON array, '[{...}]'.
     $artifactsJson = $matchedArtifacts | ConvertTo-Json -Depth 100 -Compress -AsArray
     Set-PipelineVariable -Name 'AutoReleaseArtifactsJson' -Value $artifactsJson -IsOutput
-    Write-Host "Auto-release packages from PR $prLink`: $((@($matchedArtifacts | ForEach-Object { $_.name })) -join ', ')"
+    Write-Host "Auto-release packages from PR ${prLink}: $((@($matchedArtifacts | ForEach-Object { $_.name })) -join ', ')"
     Set-PipelineVariable -Name 'HasAutoReleaseArtifacts' -Value 'true' -IsOutput
   }
   else {


### PR DESCRIPTION
## Description
Simplifies the auto-release package resolution pipeline variables and keeps the downstream output contract focused on `HasAutoReleaseArtifacts`, `AutoReleaseArtifactsJson`, and per-artifact `ReleaseArtifact_<safeName>` flags.

## Changes
- Passes declared artifacts through `AUTORELEASE_ARTIFACTS` instead of command-line arguments.
- Keeps auto-release package resolution fail-closed by default and re-emits safe defaults on failures.
- Updates package matching and tests for declared artifacts, group-scoped artifacts, PR links, invalid artifact JSON, and resolver/package-detection failures.

## Validation
- Not run; PR created from the existing first commit on the branch.
