### PR TITLE
Update release pending status and pipeline URL in release plan

### DIFF
--- a/eng/common-tests/scripts/Resolve-AutoReleasePackages.Tests.ps1
+++ b/eng/common-tests/scripts/Resolve-AutoReleasePackages.Tests.ps1
@@ -40,9 +40,44 @@ Describe "Resolve-AutoReleasePackages" -Tag "UnitTest", "Resolve-AutoReleasePack
             return $global:AutoReleaseStubChangedPackages
         }
 
+        function global:Invoke-AzsdkStub {
+            param([Parameter(ValueFromRemainingArguments = $true)][string[]]$CliArgs)
+            $global:AutoReleaseAzsdkCalls += ,$CliArgs
+            $global:LASTEXITCODE = 0
+        }
+
         function Invoke-ResolveScript {
-            param([string]$Artifacts, [string]$CommitSha = 'abc123', [string]$RepoId = 'Azure/azure-sdk-for-net')
-            & $script:scriptPath -CommitSha $CommitSha -RepoId $RepoId -Artifacts $Artifacts -AuthToken 'fake-token' | Out-Null
+            param(
+                [string]$Artifacts,
+                [string]$CommitSha = 'abc123',
+                [string]$RepoId = 'Azure/azure-sdk-for-net',
+                [string]$AutoReleaseLabel,
+                [string]$BaseBranch,
+                [string]$PipelineUrl,
+                [string]$AzsdkExePath
+            )
+
+            $invokeArgs = @{
+                CommitSha = $CommitSha
+                RepoId = $RepoId
+                Artifacts = $Artifacts
+                AuthToken = 'fake-token'
+            }
+
+            if ($PSBoundParameters.ContainsKey('AutoReleaseLabel')) {
+                $invokeArgs['AutoReleaseLabel'] = $AutoReleaseLabel
+            }
+            if ($PSBoundParameters.ContainsKey('BaseBranch')) {
+                $invokeArgs['BaseBranch'] = $BaseBranch
+            }
+            if ($PSBoundParameters.ContainsKey('PipelineUrl')) {
+                $invokeArgs['PipelineUrl'] = $PipelineUrl
+            }
+            if ($PSBoundParameters.ContainsKey('AzsdkExePath')) {
+                $invokeArgs['AzsdkExePath'] = $AzsdkExePath
+            }
+
+            & $script:scriptPath @invokeArgs | Out-Null
             return $global:AutoReleaseEmittedVars
         }
     }
@@ -54,9 +89,11 @@ Describe "Resolve-AutoReleasePackages" -Tag "UnitTest", "Resolve-AutoReleasePack
         Remove-Item function:global:Get-GitHubPullRequestFiles -ErrorAction SilentlyContinue
         Remove-Item function:global:New-GitHubPullRequestDiffObject -ErrorAction SilentlyContinue
         Remove-Item function:global:Get-PrPkgProperties -ErrorAction SilentlyContinue
+        Remove-Item function:global:Invoke-AzsdkStub -ErrorAction SilentlyContinue
         Remove-Variable -Scope Global -ErrorAction SilentlyContinue -Name `
             AutoReleaseEmittedVars, AutoReleaseStubRelease, AutoReleaseStubFiles, AutoReleaseStubChangedPackages, `
-            AutoReleaseGetPrPkgCalled, AutoReleaseResolveArgs, AutoReleaseThrowOnResolve, AutoReleaseThrowOnGetPrPkg
+            AutoReleaseGetPrPkgCalled, AutoReleaseResolveArgs, AutoReleaseThrowOnResolve, AutoReleaseThrowOnGetPrPkg, `
+            AutoReleaseAzsdkCalls
     }
 
     BeforeEach {
@@ -68,6 +105,7 @@ Describe "Resolve-AutoReleasePackages" -Tag "UnitTest", "Resolve-AutoReleasePack
         $global:AutoReleaseResolveArgs = $null
         $global:AutoReleaseThrowOnResolve = $false
         $global:AutoReleaseThrowOnGetPrPkg = $false
+        $global:AutoReleaseAzsdkCalls = @()
     }
 
     Context "when no eligible pull request is found" {
@@ -100,6 +138,13 @@ Describe "Resolve-AutoReleasePackages" -Tag "UnitTest", "Resolve-AutoReleasePack
             $global:AutoReleaseResolveArgs.RepoId | Should -Be 'Azure/azure-sdk-for-java'
             $global:AutoReleaseResolveArgs.TargetBranch | Should -Be 'main'
             $global:AutoReleaseResolveArgs.RequiredLabel | Should -Be 'auto-release'
+        }
+
+        It "forwards overridden branch and label parameters to the resolver" {
+            Invoke-ResolveScript -Artifacts '[]' -BaseBranch 'release/2026' -AutoReleaseLabel 'ship-it' | Out-Null
+
+            $global:AutoReleaseResolveArgs.TargetBranch | Should -Be 'release/2026'
+            $global:AutoReleaseResolveArgs.RequiredLabel | Should -Be 'ship-it'
         }
     }
 
@@ -173,6 +218,37 @@ Describe "Resolve-AutoReleasePackages" -Tag "UnitTest", "Resolve-AutoReleasePack
             $payload = @($vars['AutoReleaseArtifactsJson'] | ConvertFrom-Json)
             $payload.Count | Should -Be 1
             $payload[0].name | Should -Be 'Pkg.A'
+        }
+
+        It "updates release plan status to approval pending for releasable artifacts" {
+            $global:AutoReleaseStubRelease = [pscustomobject]@{
+                PullRequestNumber = 123
+                IsEligible = $true
+                SkipReason = ''
+                PullRequest = [pscustomobject]@{ number = 123; html_url = 'https://github.com/Azure/azure-sdk-for-net/pull/123' }
+            }
+            $global:AutoReleaseStubChangedPackages = @(
+                [pscustomobject]@{ Name = 'Azure.Storage.Blobs'; ArtifactName = 'Azure.Storage.Blobs'; Group = $null; IncludedForValidation = $false }
+            )
+
+            Invoke-ResolveScript `
+                -Artifacts '[{"name":"Azure.Storage.Blobs","safeName":"AzureStorageBlobs"}]' `
+                -PipelineUrl 'https://dev.azure.com/fabrikam/project/_build/results?buildId=12345' `
+                -AzsdkExePath 'Invoke-AzsdkStub' | Out-Null
+
+            $global:AutoReleaseAzsdkCalls.Count | Should -Be 1
+
+            $callArgs = $global:AutoReleaseAzsdkCalls[0]
+            $callArgs[0] | Should -Be 'release-plan'
+            $callArgs[1] | Should -Be 'update-release-status'
+            $callArgs | Should -Contain '--package-name'
+            $callArgs | Should -Contain 'Azure.Storage.Blobs'
+            $callArgs | Should -Contain '--status'
+            $callArgs | Should -Contain 'Approval Pending'
+            $callArgs | Should -Contain '--sdk-pull-request'
+            $callArgs | Should -Contain 'https://github.com/Azure/azure-sdk-for-net/pull/123'
+            $callArgs | Should -Contain '--release-pipeline'
+            $callArgs | Should -Contain 'https://dev.azure.com/fabrikam/project/_build/results?buildId=12345'
         }
     }
 

--- a/eng/common/pipelines/templates/stages/archetype-auto-release-prepare.yml
+++ b/eng/common/pipelines/templates/stages/archetype-auto-release-prepare.yml
@@ -54,6 +54,8 @@ stages:
           # the in-script azure-sdk-tools install resolves from an authenticated, reachable feed).
           - ${{ parameters.PreSteps }}
 
+          - template: /eng/common/pipelines/templates/steps/install-azsdk-cli.yml
+
           - task: PowerShell@2
             name: resolve
             displayName: Determine releasable packages
@@ -68,3 +70,5 @@ stages:
               arguments: >
                 -CommitSha "$(Build.SourceVersion)"
                 -RepoId "$(Build.Repository.Name)"
+                -PipelineUrl "$(System.CollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)"
+                -AzsdkExePath "$(AZSDK)"

--- a/eng/common/scripts/Mark-ReleasePlanCompletion.ps1
+++ b/eng/common/scripts/Mark-ReleasePlanCompletion.ps1
@@ -49,7 +49,24 @@ function Process-Package([string]$packageInfoPath)
 
     Write-Host "Marking release completion for package, name: $PackageName"
     $PackageVersion = $pkgInfo.Version
-    $releaseArgs = @("release-plan", "update-release-status", "--package-name", $PackageName, "--language", $LanguageDisplayName, "--status", "Released")
+    $version = [AzureEngSemanticVersion]::ParseVersionString($PackageVersion)
+    if (!$version)
+    {
+        Write-Host "Failed to parse version string '$($PackageVersion)' for package '$PackageName'. Skipping the release plan status update."
+        return
+    }
+
+    $sdkReleaseType = ""
+    if ($version.IsPrerelease)
+    {
+        $sdkReleaseType = "beta"
+    }
+    else
+    {
+        $sdkReleaseType = "stable"
+    }
+
+    $releaseArgs = @("release-plan", "update-release-status", "--package-name", $PackageName, "--language", $LanguageDisplayName, "--status", "Released", "--sdk-release-type", $sdkReleaseType)
     if ($PackageVersion)
     {
         $releaseArgs += @("--package-version", $PackageVersion)

--- a/eng/common/scripts/Resolve-AutoReleasePackages.ps1
+++ b/eng/common/scripts/Resolve-AutoReleasePackages.ps1
@@ -47,6 +47,12 @@ The GitHub PR label that opts a merged PR into auto-release. Defaults to 'auto-r
 .PARAMETER BaseBranch
 The base branch a PR must have been merged into to qualify. Defaults to 'main'.
 
+.PARAMETER PipelineUrl
+The URL of the pipeline run, used for logging or linking back to the pipeline. Defaults to empty.
+
+.PARAMETER AzsdkExePath
+The path to the azsdk executable used for release operations. Defaults to the AZSDK environment variable.
+
 .OUTPUTS
 Azure DevOps output variables (reference cross-stage via dependencies.<stage>.outputs['<job>.<step>.<name>']):
   - HasAutoReleaseArtifacts    : 'true' if at least one declared package is releasable
@@ -63,7 +69,9 @@ param(
   [string] $Artifacts = $env:AUTORELEASE_ARTIFACTS,
   [string] $AuthToken = $env:GH_TOKEN,
   [string] $AutoReleaseLabel = 'auto-release',
-  [string] $BaseBranch = 'main'
+  [string] $BaseBranch = 'main',
+  [string] $PipelineUrl = '',
+  [string] $AzsdkExePath = $env:AZSDK
 )
 
 $ErrorActionPreference = 'Stop'
@@ -186,6 +194,40 @@ function Invoke-AutoReleaseResolution {
         Write-Host "  [$name] changed by PR $prLink -> releasable."
         Set-PipelineVariable -Name "ReleaseArtifact_$safeName" -Value 'true' -IsOutput
         $matchedArtifacts += $artifact
+
+        # Update release pending status and release pipeline URL in the release plan for this package.
+        # release status is updated as "Released" when the package has been successfully released; here we are marking it as "Approval Pending" to indicate that the release is awaiting approval.
+        try
+        {
+          if($AzsdkExePath)
+          {
+            $sdkPullRequestUrl = $pr.html_url
+            $cliArgs = @("release-plan", "update-release-status", "--package-name", $name, "--language", $LanguageDisplayName, "--status", "Approval Pending", "--sdk-pull-request", $sdkPullRequestUrl)
+            if ($PipelineUrl)
+            {
+                $cliArgs += @("--release-pipeline", $PipelineUrl)
+            }
+            else
+            {
+              LogWarning "Pipeline URL is not set; Not setting release pipeline link for package '$name' in release plan."
+            }
+
+            & $AzsdkExePath @cliArgs
+            if ($LASTEXITCODE -ne 0)
+            {
+                ## Not all releases have a release plan. So we should not fail the script even if a release plan is missing.
+                Write-Host "Failed to update release pending status for package '$name' using azsdk. Exit code: $LASTEXITCODE"
+            }
+          }
+          else
+          {
+            Write-Host "AzsdkExePath is not set; skipping release plan update for package '$name'."
+          }          
+        }
+        catch
+        {
+          Write-Host "Failed to update release pending status in release plan for package '$name'. $($_.Exception.Message)"
+        }
       }
       else {
         Write-Host "  [$name] not changed by PR $prLink."


### PR DESCRIPTION
This PR adds changes in auto triggering the SDK release to add release pipeline URL and approval pending status in release plan work item so that it will be surfaced in dashboard as required action to approve pending release.