### PR TITLE
[Teams Chatbot] Refine intention classifier for human-assistance and add License-CLA-check doc

### DIFF
--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/config/tenant_config.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/config/tenant_config.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
+from urllib.parse import quote
 
 from models.knowledge import KnowledgeSource, _trim_file_format
 
@@ -248,7 +249,7 @@ _register(
         link_fn=lambda title: (
             "https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki"
             "?wikiVersion=GBwikiMaster&pagePath=/"
-            + _trim_file_format(title.replace("#", "/"))
+            + quote(_trim_file_format(title.replace("#", "/")), safe="/")
         ),
     ),
     # -- General Azure & review resources --

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/config/tenant_config.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/config/tenant_config.py
@@ -563,6 +563,7 @@ _TENANT_CONFIG_MAP: dict[TenantID, TenantConfig] = {
             SRC_AZURE_OPENAPI_DIFF_DOCS,
             SRC_AZURE_SDK_DOCS_ENG,
             SRC_STATIC_ARM_DOCS,
+            SRC_AZURE_SDK_INTERNAL_WIKI,
         ),
         source_filter={
             SRC_AZURE_SDK_DOCS_ENG: "search.ismatch('design*', 'title')",

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/prompts/intention_classify.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/prompts/intention_classify.md
@@ -27,7 +27,7 @@ The bot should NOT respond when the message is:
 
 How to handle `@-mentions`:
 
-- Treat `@-mentions` as routing hints, not as a hard block. Decide based on the substance of the message.
+- Treat `@-mentions` as routing hints, not as a hard block. Decide based on the substance of the message. A mention's text is only a name, never question content — if a message is nothing but one or more mentions plus routing/filler words (cc, fyi, ping, adding, looping in, thanks, etc.), it asks nothing and the bot should not reply.
 - If the message contains a domain question that anyone (including the bot) could answer, classify as should_respond=true even when other people are @-mentioned.
 - Only classify as should_respond=false when the message is plainly a private/personal ask to the named person and providing a bot answer would not add value.
 - **Exception (takes priority):** if the message is about the bot's own behavior — asking a human to approve/confirm/review the bot's prior answer, or noting the bot did not reply, replied wrong, or is broken — classify as should_respond=false even when it @-mentions that human and restates the underlying technical question. The user is escalating to or talking *about* the bot to a human, not asking it something.

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/prompts/intention_classify.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/prompts/intention_classify.md
@@ -9,7 +9,7 @@ The bot SHOULD respond when the message is:
 - A technical question about Azure SDK, TypeSpec, API design, onboarding, CI/CD, or release processes
 - A request for help, troubleshooting, or guidance in the bot's domain
 - A direct ask that expects an answer
-- A follow-up to the bot's previous reply, even if it is not phrased as a question
+- A substantive follow-up to the bot's previous reply that adds a new question, correction, or technical detail — even if it is not phrased as a question
 - A clarification, confirmation, correction, or extra context that continues the current technical thread
 - A review request for a PR or spec in the bot's domain, even if it @-mentions specific people or teams
 - A domain question that includes an `@-mention` of a person or team but is still phrased as an open question to the channel (e.g., "@John any idea why my TypeSpec build fails?"). The presence of an `@-mention` alone is NOT a reason to skip — only skip if the message is clearly addressed to that specific person and would not benefit from a bot answer.
@@ -23,19 +23,19 @@ The bot should NOT respond when the message is:
 - A greeting or thank-you that doesn't need a bot answer
 - A pure routing addendum that only loops in a person or team without adding a new question of its own — e.g., "cc @Alice", "/cc @team", "fyi @Bob" (the mention may render as `<at id="0">Name</at>` or plain text). Treat these as continuations that ping a human, not as questions for the bot.
 - A message about the bot's own behavior rather than a technical question for it — e.g., asking a human to approve, confirm, verify, or review the bot's prior answer ("can some human approve the above AI-generated response"), or commentary to a human that the bot did not reply, replied incorrectly, or seems broken. This holds even when it references an earlier unanswered question. (This does not apply to ordinary PR or spec review requests.)
-- A generic plea for a human to step in or a thread-bump that adds no new technical detail — e.g., "Can someone please assist on this request?", "Any update on this?", "Bumping this thread". Treat these as escalations to a human, not new questions for the bot, even after the bot has already answered.
+- A generic plea for a human to step in or a thread-bump that adds no new technical detail — e.g., "Can someone please assist on this request?", "Any update on this?", "Bumping this thread". These hand the thread off to a human, so the bot stays silent even right after it has answered or when the plea trails a cc/routing ping. (Because they add no new technical detail, they are not a substantive follow-up.)
 
 How to handle `@-mentions`:
 
 - Treat `@-mentions` as routing hints, not as a hard block. Decide based on the substance of the message. A mention's text is only a name, never question content — if a message is nothing but one or more mentions plus routing/filler words (cc, fyi, ping, adding, looping in, thanks, etc.), it asks nothing and the bot should not reply.
 - If the message contains a domain question that anyone (including the bot) could answer, classify as should_respond=true even when other people are @-mentioned.
 - Only classify as should_respond=false when the message is plainly a private/personal ask to the named person and providing a bot answer would not add value.
-- **Exception (takes priority):** if the message is about the bot's own behavior — asking a human to approve/confirm/review the bot's prior answer, or noting the bot did not reply, replied wrong, or is broken — classify as should_respond=false even when it @-mentions that human and restates the underlying technical question. The user is escalating to or talking *about* the bot to a human, not asking it something.
+- If the message is about the bot's own behavior — asking a human to approve/confirm/review the bot's prior answer, or noting the bot did not reply, replied wrong, or is broken — classify as should_respond=false even when it @-mentions that human and restates the underlying technical question. The user is talking *to a human about the bot*, not asking the bot something.
 
 When prior conversation history is provided:
 
 - Treat prior bot messages as the bot's own replies, not as other human participants
-- If the current message is replying to, clarifying, or pushing back on the bot's earlier answer, classify it as should_respond=true unless it is only a thank-you or clear closure
+- A substantive reply, clarification, or push-back on the bot's earlier answer is should_respond=true; a thank-you, closure, plea for a human, or comment about the bot's behavior is should_respond=false.
 
 Reply with a JSON object containing exactly two fields:
 

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/prompts/intention_classify.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/prompts/intention_classify.md
@@ -21,7 +21,9 @@ The bot should NOT respond when the message is:
 - A rhetorical question or thinking-aloud comment
 - A message clearly directed at specific people instead of the bot or the ongoing bot exchange (for example, a private/individual ask such as "@Alice can you take a look at my PR when you have time?" with no general technical question the bot could usefully answer)
 - A greeting or thank-you that doesn't need a bot answer
+- A pure routing addendum that only loops in a person or team without adding a new question of its own — e.g., "cc @Alice", "/cc @team", "fyi @Bob" (the mention may render as `<at id="0">Name</at>` or plain text). Treat these as continuations that ping a human, not as questions for the bot.
 - A message about the bot's own behavior rather than a technical question for it — e.g., asking a human to approve, confirm, verify, or review the bot's prior answer ("can some human approve the above AI-generated response"), or commentary to a human that the bot did not reply, replied incorrectly, or seems broken. This holds even when it references an earlier unanswered question. (This does not apply to ordinary PR or spec review requests.)
+- A generic plea for a human to step in or a thread-bump that adds no new technical detail — e.g., "Can someone please assist on this request?", "Any update on this?", "Bumping this thread". Treat these as escalations to a human, not new questions for the bot, even after the bot has already answered.
 
 How to handle `@-mentions`:
 
@@ -49,4 +51,6 @@ Example responses:
 {"should_respond": true, "reason": "The message is a PR review request in the bot's domain, which should still be classified as a response-worthy ask."}
 {"should_respond": true, "reason": "The user @-mentions a teammate but is asking an open TypeSpec question that the bot can answer."}
 {"should_respond": false, "reason": "The message is a private ask directed at a specific person with no general technical question the bot could usefully answer."}
+{"should_respond": false, "reason": "The message only loops a teammate in (cc/fyi) and adds no new question of its own."}
 {"should_respond": false, "reason": "The message is commentary to a human noting the bot did not reply, not a technical question for the bot to answer."}
+{"should_respond": false, "reason": "The message is a generic plea for a human to assist that adds no new question, so the bot should not answer again."}

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/intention_service_test.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/intention_service_test.py
@@ -554,3 +554,139 @@ async def test_pre_deployment_thread_reply_should_not_respond(
     assert resp.reason == "no_history_and_not_root_message"
 
 
+@pytest.mark.asyncio(loop_scope="module")
+async def test_human_assistance_plea_after_bot_reply_should_not_respond(
+    service: IntentionService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A generic plea for a human to assist after the bot already answered should not trigger another reply.
+
+    Real case: the bot answered the technical question, then the asker posted a
+    generic "Can someone please assist on this request?" to escalate to a human.
+    That is a thread-bump directed at people, not a new question for the bot.
+    """
+    user_id = "user-333"
+    conversation_id = "conv-plea"
+    conversation_type = ConversationType.teams_channel
+
+    prior_user_msg = ConversationMessageItem(
+        id="msg-1",
+        sender_role=Role.User,
+        sender_id=user_id,
+        sender_name="Frank",
+        content="Why are my PRs stuck on the license/cla check and how do I unblock them?",
+        created_at=datetime.now(timezone.utc),
+        conversation_id=conversation_id,
+        conversation_type=conversation_type,
+        conversation_partition=f"channel:{conversation_id}",
+    )
+    prior_bot_reply = ConversationMessageItem(
+        id="msg-2",
+        sender_role=Role.Assistant,
+        sender_id="bot",
+        sender_name="Azure SDK QA Bot",
+        content=(
+            "The license/cla check blocks PRs until the CLA is signed. Ask the PR "
+            "author to sign the CLA, then re-run the check to unblock the PR."
+        ),
+        created_at=datetime.now(timezone.utc),
+        conversation_id=conversation_id,
+        conversation_type=conversation_type,
+        conversation_partition=f"channel:{conversation_id}",
+    )
+
+    async def fake_has_expert_reply(*_args, **_kwargs):
+        return False
+
+    async def fake_get_messages_by_conversation(*_args, **_kwargs):
+        return [prior_user_msg, prior_bot_reply]
+
+    monkeypatch.setattr(
+        service._conversation_service, "has_expert_reply", fake_has_expert_reply
+    )
+    monkeypatch.setattr(
+        service._conversation_service,
+        "get_messages_by_conversation",
+        fake_get_messages_by_conversation,
+    )
+
+    req = IntentionRequest(
+        message=Message(
+            role=Role.User,
+            user_id=user_id,
+            content="Can someone please assist on this request? Thanks!",
+        ),
+        conversation_id=conversation_id,
+        conversation_type=conversation_type,
+    )
+    resp = await service.classify(req)
+    assert resp.should_respond is False
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_cc_routing_addendum_should_not_respond(
+    service: IntentionService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pure cc/fyi routing addendum that only loops in a teammate should not be answered.
+
+    Real case: the bot already answered the technical question, then the asker
+    posts a "cc @Alice fyi" addendum to loop in a teammate. That is a routing
+    ping directed at people, not a new question for the bot.
+    """
+    user_id = "user-444"
+    conversation_id = "conv-cc"
+    conversation_type = ConversationType.teams_channel
+
+    prior_user_msg = ConversationMessageItem(
+        id="msg-1",
+        sender_role=Role.User,
+        sender_id=user_id,
+        sender_name="Grace",
+        content="How do I add a suppression for a breaking change in my spec PR?",
+        created_at=datetime.now(timezone.utc),
+        conversation_id=conversation_id,
+        conversation_type=conversation_type,
+        conversation_partition=f"channel:{conversation_id}",
+    )
+    prior_bot_reply = ConversationMessageItem(
+        id="msg-2",
+        sender_role=Role.Assistant,
+        sender_id="bot",
+        sender_name="Azure SDK QA Bot",
+        content=(
+            "Add a suppression entry under the `suppressions` section of your PR and "
+            "have an approver apply the breaking-change label."
+        ),
+        created_at=datetime.now(timezone.utc),
+        conversation_id=conversation_id,
+        conversation_type=conversation_type,
+        conversation_partition=f"channel:{conversation_id}",
+    )
+
+    async def fake_has_expert_reply(*_args, **_kwargs):
+        return False
+
+    async def fake_get_messages_by_conversation(*_args, **_kwargs):
+        return [prior_user_msg, prior_bot_reply]
+
+    monkeypatch.setattr(
+        service._conversation_service, "has_expert_reply", fake_has_expert_reply
+    )
+    monkeypatch.setattr(
+        service._conversation_service,
+        "get_messages_by_conversation",
+        fake_get_messages_by_conversation,
+    )
+
+    req = IntentionRequest(
+        message=Message(
+            role=Role.User,
+            user_id=user_id,
+            content="cc <at>Alice</at> /cc <at>SDK Team</at> fyi",
+        ),
+        conversation_id=conversation_id,
+        conversation_type=conversation_type,
+    )
+    resp = await service.classify(req)
+    assert resp.should_respond is False
+
+

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/intention_service_test.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/intention_service_test.py
@@ -690,3 +690,86 @@ async def test_cc_routing_addendum_should_not_respond(
     assert resp.should_respond is False
 
 
+@pytest.mark.asyncio(loop_scope="module")
+async def test_assistance_plea_after_cc_ping_should_not_respond(
+    service: IntentionService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A human-assistance plea that trails a cc routing ping should not be answered.
+
+    Real case (screenshot): the bot answered the PR merge-readiness question, the
+    asker then posted a ``cc @<account>`` ping followed by "Can someone please
+    assist on this request? Thanks!". The plea is a hand-off to a human, not a
+    follow-up for the bot, even though it trails the cc ping and the technical
+    thread. The bot must stay silent instead of offering to draft a nudge.
+    """
+    user_id = "user-555"
+    conversation_id = "conv-plea-cc"
+    conversation_type = ConversationType.teams_channel
+
+    prior_user_msg = ConversationMessageItem(
+        id="msg-1",
+        sender_role=Role.User,
+        sender_id=user_id,
+        sender_name="Heidi",
+        content="Is this PR ready to merge, or is something still blocking it?",
+        created_at=datetime.now(timezone.utc),
+        conversation_id=conversation_id,
+        conversation_type=conversation_type,
+        conversation_partition=f"channel:{conversation_id}",
+    )
+    prior_bot_reply = ConversationMessageItem(
+        id="msg-2",
+        sender_role=Role.Assistant,
+        sender_id="bot",
+        sender_name="Azure SDK QA Bot",
+        content=(
+            "This PR is not ready to merge yet: checks are green, but it is still "
+            "missing human approval (branch protection / CODEOWNERS). Get an "
+            "approving review from a requested reviewer to unblock the merge.\n\n"
+            "Not resolved? Please re-post in the Language - Python channel."
+        ),
+        created_at=datetime.now(timezone.utc),
+        conversation_id=conversation_id,
+        conversation_type=conversation_type,
+        conversation_partition=f"channel:{conversation_id}",
+    )
+    cc_ping_msg = ConversationMessageItem(
+        id="msg-3",
+        sender_role=Role.User,
+        sender_id=user_id,
+        sender_name="Heidi",
+        content="cc <at>non-people-account-for-chatbot</at>",
+        created_at=datetime.now(timezone.utc),
+        conversation_id=conversation_id,
+        conversation_type=conversation_type,
+        conversation_partition=f"channel:{conversation_id}",
+    )
+
+    async def fake_has_expert_reply(*_args, **_kwargs):
+        return False
+
+    async def fake_get_messages_by_conversation(*_args, **_kwargs):
+        return [prior_user_msg, prior_bot_reply, cc_ping_msg]
+
+    monkeypatch.setattr(
+        service._conversation_service, "has_expert_reply", fake_has_expert_reply
+    )
+    monkeypatch.setattr(
+        service._conversation_service,
+        "get_messages_by_conversation",
+        fake_get_messages_by_conversation,
+    )
+
+    req = IntentionRequest(
+        message=Message(
+            role=Role.User,
+            user_id=user_id,
+            content="Can someone please assist on this request? Thanks!",
+        ),
+        conversation_id=conversation_id,
+        conversation_type=conversation_type,
+    )
+    resp = await service.classify(req)
+    assert resp.should_respond is False
+
+

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-function/package-lock.json
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-function/package-lock.json
@@ -1140,9 +1140,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.7",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha1-Gw5GlltHna1lr3N7SgJ5CgVJgzc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-function/package.json
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-function/package.json
@@ -46,6 +46,7 @@
     },
     "botframework-schema": {
       "uuid": "^11.1.1"
-    }
+    },
+    "brace-expansion": "^5.0.5"
   }
 }

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/config/knowledge-config.json
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/config/knowledge-config.json
@@ -227,7 +227,7 @@
         },
         {
           "description": "My License-CLA check hung",
-          "path": "/Engineering-System/Pipelines/My-License-CLA-check-hung",
+          "path": "/Engineering-System/Pipelines/My-License-CLA-check-hung.md",
           "folder": "azure-sdk-internal-wiki",
           "relativeByRepoPath": true
         }

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/config/knowledge-config.json
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/config/knowledge-config.json
@@ -224,6 +224,12 @@
           "path": "/Engineering-System/Pipelines/Azure-DevOps-Pipeline-Guidance.md",
           "folder": "azure-sdk-internal-wiki",
           "relativeByRepoPath": true
+        },
+        {
+          "description": "My License-CLA check hung",
+          "path": "/Engineering-System/Pipelines/My-License-CLA-check-hung",
+          "folder": "azure-sdk-internal-wiki",
+          "relativeByRepoPath": true
         }
       ]
     },

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/config/knowledge-config.json
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/config/knowledge-config.json
@@ -227,7 +227,7 @@
         },
         {
           "description": "My License-CLA check hung",
-          "path": "/Engineering-System/Pipelines/My-License-CLA-check-hung.md",
+          "path": "/Engineering-System/Pipelines/My-License%2DCLA-check-hung.md",
           "folder": "azure-sdk-internal-wiki",
           "relativeByRepoPath": true
         }

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/package-lock.json
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/package-lock.json
@@ -17,6 +17,7 @@
         "@azure/search-documents": "^12.1.0",
         "@azure/storage-blob": "^12.21.0",
         "dotenv": "^16.4.5",
+        "http-status-codes": "^2.3.0",
         "js-yaml": "^4.1.1",
         "minimatch": "^10.2.4",
         "openai": "^5.20.0",
@@ -1517,6 +1518,12 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.3.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/http-status-codes/-/http-status-codes-2.3.0.tgz",
+      "integrity": "sha1-mH/vsoxp+SpDrsx3/uwoZjSai/w=",
+      "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/package.json
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/package.json
@@ -26,6 +26,7 @@
     "@azure/search-documents": "^12.1.0",
     "@azure/storage-blob": "^12.21.0",
     "dotenv": "^16.4.5",
+    "http-status-codes": "^2.3.0",
     "js-yaml": "^4.1.1",
     "minimatch": "^10.2.4",
     "openai": "^5.20.0",

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/src/DailySyncKnowledge.ts
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/src/DailySyncKnowledge.ts
@@ -150,6 +150,10 @@ export async function processDailySyncKnowledge(): Promise<void> {
         
         // Clean up expired blobs
         await cleanupExpiredBlobs(allChangedFiles.concat(allUnchangedFiles).concat(allMetadataChangedFiles));
+
+        // Trigger AI Search to reindex the knowledge base so the updated blobs are picked up
+        await searchService.runIndexer();
+
         console.log('Daily sync knowledge processing completed');
 
     } finally {

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/src/services/AppSecret.ts
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/src/services/AppSecret.ts
@@ -25,15 +25,6 @@ export async function initSecrets(): Promise<void> {
         // Establish a connection to the Key Vault client
         const client = new SecretClient(keyVaultEndpoint, credential);
 
-        // Get AI Search API Key
-        const aiSearchSecretResponse = await client.getSecret('AI-SEARCH-APIKEY');
-        if (!aiSearchSecretResponse.value) {
-            throw new Error('Failed to get AI-SEARCH-APIKEY secret value');
-        }
-
-        process.env.AI_SEARCH_API_KEY = aiSearchSecretResponse.value;
-        console.log('Set AI_SEARCH_API_KEY from Key Vault');
-
         // Get AOAI Chat Completions API Key
         const aoaiSecretResponse = await client.getSecret('AOAI-CHAT-COMPLETIONS-API-KEY');
         if (!aoaiSecretResponse.value) {

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/src/services/SearchService.ts
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/src/services/SearchService.ts
@@ -1,6 +1,8 @@
 import { InvocationContext } from '@azure/functions';
-import { SearchClient, AzureKeyCredential } from '@azure/search-documents';
+import { SearchClient, SearchIndexerClient } from '@azure/search-documents';
+import { RestError } from '@azure/core-rest-pipeline';
 import { ChainedTokenCredential, AzureCliCredential, ManagedIdentityCredential, WorkloadIdentityCredential} from '@azure/identity';
+import { StatusCodes } from 'http-status-codes';
 
 /**
  * Document interface for AI Search operations
@@ -15,11 +17,13 @@ export interface SearchDocument {
  */
 export class SearchService {
     private searchClient: SearchClient<SearchDocument>;
+    private indexerClient: SearchIndexerClient;
+    private readonly indexerName?: string;
     
     constructor() {
         const searchServiceName = process.env.AI_SEARCH_SERVICE_NAME;
         const searchIndexName = process.env.AI_SEARCH_INDEX;
-        const searchApiKey = process.env.AI_SEARCH_API_KEY;
+        this.indexerName = process.env.AI_SEARCH_INDEXER;
         
         if (!searchServiceName || !searchIndexName) {
             throw new Error('AI_SEARCH_SERVICE_NAME and AI_SEARCH_INDEX environment variables are required');
@@ -27,27 +31,19 @@ export class SearchService {
 
         const endpoint = `https://${searchServiceName}.search.windows.net`;
 
-        if (searchApiKey) {
-            // Use API key authentication
-            this.searchClient = new SearchClient(
-                endpoint,
-                searchIndexName,
-                new AzureKeyCredential(searchApiKey)
-            );
-        } else {
-            // Use managed identity authentication
-            const credential = new ChainedTokenCredential(
-                new ManagedIdentityCredential(),
-                new AzureCliCredential(),
-                new WorkloadIdentityCredential()
-            );
-            
-            this.searchClient = new SearchClient(
-                endpoint,
-                searchIndexName,
-                credential
-            );
-        }
+        // Use managed identity authentication
+        const credential = new ChainedTokenCredential(
+            new ManagedIdentityCredential(),
+            new AzureCliCredential(),
+            new WorkloadIdentityCredential()
+        );
+
+        this.searchClient = new SearchClient(
+            endpoint,
+            searchIndexName,
+            credential
+        );
+        this.indexerClient = new SearchIndexerClient(endpoint, credential);
     }
 
     /**
@@ -148,6 +144,32 @@ export class SearchService {
         } catch (error) {
             console.error(`Error deleting chunks for "${fileName}":`, error);
             throw error;
+        }
+    }
+
+    /**
+     * Trigger the Azure AI Search indexer to reindex the knowledge base.
+     * This should be called after blob storage has been updated so that the
+     * indexer picks up newly added/changed documents and refreshes the index.
+     */
+    async runIndexer(): Promise<void> {
+        if (!this.indexerName) {
+            console.warn('AI_SEARCH_INDEXER environment variable is not set; skipping reindex trigger');
+            return;
+        }
+
+        try {
+            console.log(`Triggering AI Search indexer to reindex the knowledge base: ${this.indexerName}`);
+            await this.indexerClient.runIndexer(this.indexerName);
+            console.log(`Successfully triggered AI Search indexer: ${this.indexerName}`);
+        } catch (error) {
+            // A conflict means the indexer is already running; treat as non-fatal.
+            if (error instanceof RestError && error.statusCode === StatusCodes.CONFLICT) {
+                console.warn(`AI Search indexer "${this.indexerName}" is already running; a new run will pick up the latest changes`);
+                return;
+            }
+            console.error(`Error triggering AI Search indexer "${this.indexerName}":`, error);
+            throw new Error(`Failed to trigger AI Search indexer: ${error instanceof Error ? error.message : 'Unknown error'}`);
         }
     }
 }


### PR DESCRIPTION
## Summary

Two changes to the Azure SDK Q&A bot:

1. **Refine the intention classifier** so the bot stays silent on generic pleas for human help / thread-bumps.
2. **Add the License-CLA-check knowledge doc** as a source for the relevant tenant.

### 1. Intention classifier Issues

After the bot already answered a question, a follow-up like *"Can someone please assist on this request? Thanks!"* or just *"cc @xxx"* was being re-classified as a "follow-up help request" and the bot answered again. That message is an escalation directed at humans, not a new question for the bot.


### 2. License-CLA-check knowledge doc
- Register the `License-CLA-check` doc in `knowledge-config.json` and add `SRC_AZURE_SDK_INTERNAL_WIKI` to the tenant's sources in [`config/tenant_config.py`](tools/sdk-ai-bots/azure-sdk-qa-bot-agent/config/tenant_config.py).


### 3. Auto trigger AI Search reindex after knowledge sync to storage
- After knowledge sync succeed, we usually reply on Azure AI Search scheduled task to sync reindex the documents in KB, actually we could let knowledge sync pipeline automatically triggers the AI Search indexer.

## Tests

### 1. Intention Test
Added two tests in [`tests/intention_service_test.py`](tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/intention_service_test.py) (both exercise the real LLM classifier):
- `test_human_assistance_plea_after_bot_reply_should_not_respond` — bot answered, then a plea for a human → `should_respond=false`.
- `test_cc_routing_addendum_should_not_respond` — a `cc @Alice fyi` routing addendum after the bot answered → `should_respond=false`.

Live test: 
<img width="1275" height="681" alt="image" src="https://github.com/user-attachments/assets/00281e13-331d-4f48-b86e-2e5b84562ef9" />

### 2. License Doc Test
<img width="1307" height="1083" alt="image" src="https://github.com/user-attachments/assets/312ff4a1-5adc-4ff0-952a-7072c36c663a" />

### 3. Knowledge Sync Pipeline Test
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6558418&view=logs&j=eb5be400-3fc3-547d-15aa-3c791611746f&t=92da56e7-f878-5692-bd8d-2243966cfd5c
<img width="572" height="111" alt="image" src="https://github.com/user-attachments/assets/9cf72590-d749-4d82-88a4-c1cf973e75d9" />