### PR TITLE
Add presteps support to auto-release template

### DIFF
--- a/eng/common/pipelines/templates/stages/archetype-auto-release-prepare.yml
+++ b/eng/common/pipelines/templates/stages/archetype-auto-release-prepare.yml
@@ -9,6 +9,12 @@ parameters:
   - name: Condition
     type: string
     default: succeeded()
+  # Language-specific steps that run (in the resolve job) before the package-detection script.
+  # Repos whose Get-AllPackageInfoFromRepo needs tooling set up first (e.g. Python installing
+  # azure-sdk-tools from an authenticated feed) pass those steps here. Default is none.
+  - name: PreSteps
+    type: stepList
+    default: []
 
 stages:
   # Post-merge auto-release preparation, shared across language repos (this file lives in the synced
@@ -43,6 +49,10 @@ stages:
             fetchDepth: 1
 
           - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+
+          # Optional language-specific environment setup (e.g. Python: UsePythonVersion + feed auth so
+          # the in-script azure-sdk-tools install resolves from an authenticated, reachable feed).
+          - ${{ parameters.PreSteps }}
 
           - task: PowerShell@2
             name: resolve


### PR DESCRIPTION
## Summary
- Add a `PreSteps` stepList parameter to the shared auto-release prepare stage.
- Run optional language-specific setup steps before package detection resolves auto-release artifacts.
- Keep the default behavior unchanged by defaulting `PreSteps` to an empty list.

## Validation
- Not run; pipeline template-only change.