### PR TITLE
fix(pylint-checker): C4776 relative-import resolution and C4739 ClassDef vararg bugs

### DIFF
--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/CHANGELOG.md
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 0.5.9 (Unreleased)
 - Fix `no-cross-package-private-import` (C4776) to skip relative imports (`from .x import …`); `node.modname` for a relative import is an un-anchored suffix that was incorrectly compared against the fully-qualified current module, causing false positives on legitimate same-package imports
 - Fix `no-cross-package-private-import` (C4776) to skip modules whose first segment is already private (e.g. `_utils.model_base`); previously `_get_private_prefix` returned `""`, making `startswith("")` always `True` and silencing the check
+- Fix `check-docstrings` (C4739) ClassDef branch reading `vararg_name` from the class node instead of `__init__`; `node.args.vararg` → `constructor.args.vararg`
+- Fix `check-docstrings` (C4739) `is_overload_impl` never set for ClassDef path, making the overload-implementation escape hatch unreachable for class constructors
+- Fix `check-docstrings` (C4739) to never require `*args` to be documented; `*args` passthroughs are optional to document — omitting them is not a gap
 
 ## 0.5.8 (2026-07-13)
 - Add `do-not-store-secrets-in-test-variables` check

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/CHANGELOG.md
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 0.5.9 (Unreleased)
-- Fix `no-cross-package-private-import` (C4776) to skip relative imports (`from .x import …`); `node.modname` for a relative import is an un-anchored suffix that was incorrectly compared against the fully-qualified current module, causing false positives on legitimate same-package imports
+- Fix `no-cross-package-private-import` (C4776) to correctly handle relative imports (`from .x import …`); previously `node.modname` for a relative import was an un-anchored suffix that was incorrectly compared against the fully-qualified current module, causing false positives on legitimate same-package imports. Relative imports are now resolved to their absolute module name (accounting for `__init__.py` packages) before running the cross-package check, so genuine cross-package relative imports are still flagged.
 - Fix `no-cross-package-private-import` (C4776) to skip modules whose first segment is already private (e.g. `_utils.model_base`); previously `_get_private_prefix` returned `""`, making `startswith("")` always `True` and silencing the check
 - Fix `check-docstrings` (C4739) ClassDef branch reading `vararg_name` from the class node instead of `__init__`; `node.args.vararg` → `constructor.args.vararg`
 - Fix `check-docstrings` (C4739) `is_overload_impl` never set for ClassDef path, making the overload-implementation escape hatch unreachable for class constructors with overloaded `__init__`

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/CHANGELOG.md
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/CHANGELOG.md
@@ -4,8 +4,7 @@
 - Fix `no-cross-package-private-import` (C4776) to skip relative imports (`from .x import …`); `node.modname` for a relative import is an un-anchored suffix that was incorrectly compared against the fully-qualified current module, causing false positives on legitimate same-package imports
 - Fix `no-cross-package-private-import` (C4776) to skip modules whose first segment is already private (e.g. `_utils.model_base`); previously `_get_private_prefix` returned `""`, making `startswith("")` always `True` and silencing the check
 - Fix `check-docstrings` (C4739) ClassDef branch reading `vararg_name` from the class node instead of `__init__`; `node.args.vararg` → `constructor.args.vararg`
-- Fix `check-docstrings` (C4739) `is_overload_impl` never set for ClassDef path, making the overload-implementation escape hatch unreachable for class constructors
-- Fix `check-docstrings` (C4739) to never require `*args` to be documented; `*args` passthroughs are optional to document — omitting them is not a gap
+- Fix `check-docstrings` (C4739) `is_overload_impl` never set for ClassDef path, making the overload-implementation escape hatch unreachable for class constructors with overloaded `__init__`
 
 ## 0.5.8 (2026-07-13)
 - Add `do-not-store-secrets-in-test-variables` check

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/CHANGELOG.md
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/CHANGELOG.md
@@ -1,9 +1,8 @@
 # Release History
 
 ## 0.5.9 (Unreleased)
-- Fix `no-cross-package-private-import` (C4776) to correctly handle relative imports (`from .x import …`); previously `node.modname` for a relative import was an un-anchored suffix that was incorrectly compared against the fully-qualified current module, causing false positives on legitimate same-package imports. Relative imports are now resolved to their absolute module name (accounting for `__init__.py` packages) before running the cross-package check, so genuine cross-package relative imports are still flagged.
-- Fix `no-cross-package-private-import` (C4776) to skip modules whose first segment is already private (e.g. `_utils.model_base`); previously `_get_private_prefix` returned `""`, making `startswith("")` always `True` and silencing the check
-- Fix `check-docstrings` (C4739) ClassDef branch reading `vararg_name` from the class node instead of `__init__`; `node.args.vararg` → `constructor.args.vararg`
+- Fix `no-cross-package-private-import` (C4776) to correctly handle relative imports
+- Fix `no-cross-package-private-import` (C4776) to skip modules whose first segment is already private
 - Fix `check-docstrings` (C4739) `is_overload_impl` never set for ClassDef path, making the overload-implementation escape hatch unreachable for class constructors with overloaded `__init__`
 
 ## 0.5.8 (2026-07-13)

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/CHANGELOG.md
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Release History
 
-## 0.5.8 (Unreleased)
+## 0.5.9 (Unreleased)
+- Fix `no-cross-package-private-import` (C4776) to skip relative imports (`from .x import …`); `node.modname` for a relative import is an un-anchored suffix that was incorrectly compared against the fully-qualified current module, causing false positives on legitimate same-package imports
+- Fix `no-cross-package-private-import` (C4776) to skip modules whose first segment is already private (e.g. `_utils.model_base`); previously `_get_private_prefix` returned `""`, making `startswith("")` always `True` and silencing the check
+
+## 0.5.8 (2026-07-13)
 - Add `do-not-store-secrets-in-test-variables` check
 - Add `remove-deprecated-iscoroutinefunction` check
 - Add `do-not-use-logging-directly` check

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
@@ -3774,11 +3774,16 @@ class NoCrossPackagePrivateImport(BaseChecker):
           'azure.storage.blob._generated.models' -> 'azure.storage.blob'
           'azure.core._pipeline_client' -> 'azure.core'
 
-        Returns None if there is no private segment.
+        Returns None if there is no private segment, or if the first segment itself is
+        private (no meaningful public prefix to compare against).
         """
         parts = module_name.split(".")
         for i, part in enumerate(parts):
             if part.startswith("_"):
+                # If the very first segment is private there is no public prefix,
+                # so we cannot reliably determine the owning package. Skip.
+                if i == 0:
+                    return None
                 return ".".join(parts[:i])
         return None
 
@@ -3804,6 +3809,14 @@ class NoCrossPackagePrivateImport(BaseChecker):
     def visit_importfrom(self, node):
         """Check 'from x.y._z import foo' style imports."""
         if node.modname is None:
+            return
+        # Relative imports (level > 0) are by definition within the same package.
+        # node.modname for a relative import is the *un-anchored* suffix (e.g.
+        # "operations._operations" for "from ...operations._operations import …"),
+        # which cannot be compared against the fully-qualified current_module without
+        # first resolving the anchor — which we don't do here.  Skipping is safe:
+        # a relative import can never be a cross-package import.
+        if node.level and node.level > 0:
             return
         current_module = node.root().name
         if self._is_cross_package_private_import(node.modname, current_module):

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
@@ -3811,21 +3811,27 @@ class NoCrossPackagePrivateImport(BaseChecker):
         """Check 'from x.y._z import foo' style imports."""
         if node.modname is None:
             return
-        current_module = node.root().name
+        root = node.root()
+        current_module = root.name
 
         if node.level and node.level > 0:
             # Relative import: resolve node.modname to an absolute module name before
             # checking.  A level-1 import anchors at the current package; level-2 at
-            # the parent; level-3 at the grandparent; and so on.
+            # the parent; and so on.
             #
-            # Example: from azure.storage.file.datalake._some_module,
+            # Example (regular module): from azure.storage.file.datalake._some_module,
             #   "from ...blob._generated.models import …"  (level=3, modname="blob._generated.models")
-            # resolves to azure.storage.blob._generated.models — a genuine cross-package
-            # private import that must still be flagged.
+            # resolves to azure.storage.blob._generated.models.
+            #
+            # For __init__.py, astroid marks the module as a package and current_module
+            # is already the package name (no leaf module to drop).
             parts = current_module.split(".")
-            package_parts = parts[:-1]  # drop the module name, keep the package
-            ups = node.level - 1        # level=1 → current package (0 ups); level=2 → 1 up; etc.
-            if ups >= len(package_parts):
+            if getattr(root, "package", False):
+                package_parts = parts
+            else:
+                package_parts = parts[:-1]
+            ups = node.level - 1  # level=1 → current package (0 ups); level=2 → 1 up; etc.
+            if ups > len(package_parts):
                 # Import would escape above the top-level package — invalid Python; skip.
                 return
             base_parts = package_parts[:-ups] if ups > 0 else package_parts

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
@@ -1726,10 +1726,8 @@ class CheckDocstringParameters(BaseChecker):
         except AttributeError:
             return
 
-        # Always track the vararg name so that a documented *args (e.g. ":param args:")
-        # is not mistakenly flagged as "should be keyword".  We do NOT require it to be
-        # documented (see missing_params loop below).
-        if vararg_name:
+        # If there is a vararg, treat it as a param (unless this is an overload implementation)
+        if vararg_name and not is_overload_impl:
             arg_names.append(vararg_name)
 
         docparams = {}
@@ -1755,10 +1753,6 @@ class CheckDocstringParameters(BaseChecker):
         missing_params = []
         for param in arg_names:
             if param == "self" or param == "cls":
-                continue
-            if param == vararg_name:
-                # *args passthroughs are never required to be documented; documenting
-                # them is optional and valid, but omitting them is not a gap.
                 continue
             if param not in docparams:
                 missing_params.append(param)

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
@@ -1708,6 +1708,7 @@ class CheckDocstringParameters(BaseChecker):
                     ]
                     vararg_name = constructor.args.vararg
                     kwarg_name = constructor.args.kwarg
+                    is_overload_impl = self._is_overload_implementation(constructor)
                     break
 
         if isinstance(node, astroid.FunctionDef):
@@ -1725,8 +1726,10 @@ class CheckDocstringParameters(BaseChecker):
         except AttributeError:
             return
 
-        # If there is a vararg, treat it as a param (unless this is an overload implementation)
-        if vararg_name and not is_overload_impl:
+        # Always track the vararg name so that a documented *args (e.g. ":param args:")
+        # is not mistakenly flagged as "should be keyword".  We do NOT require it to be
+        # documented (see missing_params loop below).
+        if vararg_name:
             arg_names.append(vararg_name)
 
         docparams = {}
@@ -1752,6 +1755,10 @@ class CheckDocstringParameters(BaseChecker):
         missing_params = []
         for param in arg_names:
             if param == "self" or param == "cls":
+                continue
+            if param == vararg_name:
+                # *args passthroughs are never required to be documented; documenting
+                # them is optional and valid, but omitting them is not a gap.
                 continue
             if param not in docparams:
                 missing_params.append(param)
@@ -3810,16 +3817,29 @@ class NoCrossPackagePrivateImport(BaseChecker):
         """Check 'from x.y._z import foo' style imports."""
         if node.modname is None:
             return
-        # Relative imports (level > 0) are by definition within the same package.
-        # node.modname for a relative import is the *un-anchored* suffix (e.g.
-        # "operations._operations" for "from ...operations._operations import …"),
-        # which cannot be compared against the fully-qualified current_module without
-        # first resolving the anchor — which we don't do here.  Skipping is safe:
-        # a relative import can never be a cross-package import.
-        if node.level and node.level > 0:
-            return
         current_module = node.root().name
-        if self._is_cross_package_private_import(node.modname, current_module):
+
+        if node.level and node.level > 0:
+            # Relative import: resolve node.modname to an absolute module name before
+            # checking.  A level-1 import anchors at the current package; level-2 at
+            # the parent; level-3 at the grandparent; and so on.
+            #
+            # Example: from azure.storage.file.datalake._some_module,
+            #   "from ...blob._generated.models import …"  (level=3, modname="blob._generated.models")
+            # resolves to azure.storage.blob._generated.models — a genuine cross-package
+            # private import that must still be flagged.
+            parts = current_module.split(".")
+            package_parts = parts[:-1]  # drop the module name, keep the package
+            ups = node.level - 1        # level=1 → current package (0 ups); level=2 → 1 up; etc.
+            if ups >= len(package_parts):
+                # Import would escape above the top-level package — invalid Python; skip.
+                return
+            base_parts = package_parts[:-ups] if ups > 0 else package_parts
+            resolved = ".".join(base_parts + [node.modname]) if node.modname else ".".join(base_parts)
+        else:
+            resolved = node.modname
+
+        if self._is_cross_package_private_import(resolved, current_module):
             self.add_message(
                 msgid="no-cross-package-private-import",
                 node=node,

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
@@ -3831,7 +3831,7 @@ class NoCrossPackagePrivateImport(BaseChecker):
             else:
                 package_parts = parts[:-1]
             ups = node.level - 1  # level=1 → current package (0 ups); level=2 → 1 up; etc.
-            if ups > len(package_parts):
+            if ups >= len(package_parts):
                 # Import would escape above the top-level package — invalid Python; skip.
                 return
             base_parts = package_parts[:-ups] if ups > 0 else package_parts

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/setup.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/setup.py
@@ -6,7 +6,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="azure-pylint-guidelines-checker",
-    version="0.5.8",
+    version="0.5.9",
     url="http://github.com/Azure/azure-sdk-for-python",
     license="MIT License",
     description="A pylint plugin which enforces azure sdk guidelines.",

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/docstring_overload_args_kwargs.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/docstring_overload_args_kwargs.py
@@ -78,3 +78,20 @@ class AsyncClient:
         :type x: str or int
         """
         return None
+
+
+# test_docstring_class_overload_init_skips_args - overloaded __init__ impl should NOT flag args
+class ClientWithOverloadedInit:
+    @overload
+    def __init__(self, url: str) -> None: ...
+
+    @overload
+    def __init__(self, credential: object) -> None: ...
+
+    def __init__(self, *args, **kwargs):
+        """Create a new client.
+
+        :param url: The service endpoint URL.
+        :type url: str
+        """
+        pass

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/docstring_parameters.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/docstring_parameters.py
@@ -130,7 +130,7 @@ def function_foo() -> NoReturn:
     raise ValueError("This function never returns")
 
 
-# test_docstring_class_vararg_documented_ok - documenting *args explicitly is also fine
+# test_docstring_class_vararg_documented_ok - documenting *args explicitly is fine
 class ClassWithDocumentedVararg:
     """A class that explicitly documents its vararg.
 

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/docstring_parameters.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/docstring_parameters.py
@@ -130,16 +130,6 @@ def function_foo() -> NoReturn:
     raise ValueError("This function never returns")
 
 
-# test_docstring_class_vararg_required - undocumented *args in non-overloaded __init__ should be flagged
-class ClassWithVararg:
-    """A class whose constructor accepts extra positional args.
-
-    :param str url: The service endpoint.
-    """
-    def __init__(self, url, *args):
-        pass
-
-
 # test_docstring_class_vararg_documented_ok - documenting *args explicitly is also fine
 class ClassWithDocumentedVararg:
     """A class that explicitly documents its vararg.

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/docstring_parameters.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/docstring_parameters.py
@@ -128,3 +128,24 @@ def function_foo() -> NoReturn:
     This function never returns.
     """
     raise ValueError("This function never returns")
+
+
+# test_docstring_class_vararg_not_required - *args in __init__ should NOT be flagged as missing
+class ClassWithVararg:
+    """A class whose constructor accepts extra positional args.
+
+    :param str url: The service endpoint.
+    """
+    def __init__(self, url, *args):
+        pass
+
+
+# test_docstring_class_vararg_documented_ok - documenting *args explicitly is also fine
+class ClassWithDocumentedVararg:
+    """A class that explicitly documents its vararg.
+
+    :param str url: The service endpoint.
+    :param tuple args: Extra positional arguments passed to the base class.
+    """
+    def __init__(self, url, *args):
+        pass

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/docstring_parameters.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/docstring_parameters.py
@@ -130,7 +130,7 @@ def function_foo() -> NoReturn:
     raise ValueError("This function never returns")
 
 
-# test_docstring_class_vararg_not_required - *args in __init__ should NOT be flagged as missing
+# test_docstring_class_vararg_required - undocumented *args in non-overloaded __init__ should be flagged
 class ClassWithVararg:
     """A class whose constructor accepts extra positional args.
 

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/no_cross_package_private_import.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/no_cross_package_private_import.py
@@ -18,3 +18,10 @@ import azure.identity
 # Non-azure imports are fine
 import os
 from collections import OrderedDict
+
+# ---- relative imports are always same-package — must not be flagged ----
+# Simulates: from ...operations._operations import FooMixin
+# (level=3, modname="operations._operations")
+from ...operations._operations import FooMixin  # noqa: F401, E402
+# Simulates: from ._utils import helper
+from ._utils import helper  # noqa: F401, E402

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/no_cross_package_private_import.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/no_cross_package_private_import.py
@@ -19,9 +19,16 @@ import azure.identity
 import os
 from collections import OrderedDict
 
-# ---- relative imports are always same-package — must not be flagged ----
-# Simulates: from ...operations._operations import FooMixin
-# (level=3, modname="operations._operations")
-from ...operations._operations import FooMixin  # noqa: F401, E402
-# Simulates: from ._utils import helper
+# ---- relative imports ----
+# Same-package level-1 relative import: resolves to azure.storage.file.datalake._operations — NOT flagged
+from ._operations import SomeMixin  # noqa: F401, E402
+# Same-package level-1 with leading-private modname: resolves to azure.storage.file.datalake._utils — NOT flagged
 from ._utils import helper  # noqa: F401, E402
+
+# Cross-package level-3 relative import: from azure.storage.file.datalake._some_module,
+# "from ...blob._generated.models import …" resolves to azure.storage.blob._generated.models — FLAGGED
+from ...blob._generated.models import BlobItem  # noqa: F401, E402
+
+# Absolute import whose modname starts with '_': _get_private_prefix returns None (i==0) — NOT flagged
+from _utils import something_absolute  # noqa: F401, E402
+

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
@@ -3186,9 +3186,10 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
 
     def test_docstring_class_vararg_documented_ok(self):
         """Class __init__ that documents *args in the docstring should NOT be flagged."""
-        file = open(os.path.join(TEST_FOLDER, "test_files", "docstring_parameters.py"))
-        node = astroid.parse(file.read())
-        file.close()
+        with open(
+            os.path.join(TEST_FOLDER, "test_files", "docstring_parameters.py")
+        ) as file:
+            node = astroid.parse(file.read())
         # ClassWithDocumentedVararg is body[14]
         class_node = node.body[14]
         with self.assertNoMessages():
@@ -3196,15 +3197,14 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
 
     def test_docstring_class_overload_init_skips_args(self):
         """Class with overloaded __init__ implementation should not flag *args/**kwargs."""
-        file = open(
+        with open(
             os.path.join(
                 TEST_FOLDER,
                 "test_files",
                 "docstring_overload_args_kwargs.py",
             )
-        )
-        node = astroid.parse(file.read())
-        file.close()
+        ) as file:
+            node = astroid.parse(file.read())
         # ClientWithOverloadedInit is body[5]
         class_node = node.body[5]
         with self.assertNoMessages():
@@ -4951,4 +4951,19 @@ class TestNoCrossPackagePrivateImport(pylint.testutils.CheckerTestCase):
             ),
             ignore_position=True,
         ):
+            self.checker.visit_importfrom(importfrom_node)
+
+    def test_relative_import_escaping_top_level_package_is_skipped(self):
+        """A relative import that escapes above the top-level package is invalid Python.
+
+        For the top-level "azure" package __init__.py, "from .. import x" (level=2)
+        would resolve above "azure"; ups == len(package_parts), so it must be skipped
+        rather than resolved to a bare module name.
+        """
+        source = "from .. import something\n"
+        module = astroid.parse(source)
+        module.name = "azure"
+        module.package = True
+        importfrom_node = module.body[0]
+        with self.assertNoMessages():
             self.checker.visit_importfrom(importfrom_node)

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
@@ -4845,3 +4845,23 @@ class TestNoCrossPackagePrivateImport(pylint.testutils.CheckerTestCase):
         importfrom_node = setup.body[10]
         with self.assertNoMessages():
             self.checker.visit_importfrom(importfrom_node)
+
+    def test_allows_relative_import_with_private_segment(self, setup):
+        """from ...operations._operations import FooMixin should NOT be flagged.
+
+        Relative imports are always within the same package; node.modname is an
+        un-anchored suffix that must not be compared against current_module.
+        """
+        importfrom_node = setup.body[11]
+        with self.assertNoMessages():
+            self.checker.visit_importfrom(importfrom_node)
+
+    def test_allows_relative_import_leading_private(self, setup):
+        """from ._utils import helper should NOT be flagged.
+
+        The module name starts with '_'; _get_private_prefix returns None (no
+        public prefix), so the check is skipped entirely.
+        """
+        importfrom_node = setup.body[12]
+        with self.assertNoMessages():
+            self.checker.visit_importfrom(importfrom_node)

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
@@ -3184,30 +3184,13 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
         ):
             self.checker.check_parameters(regular_node)
 
-    def test_docstring_class_vararg_required(self):
-        """Class __init__ with undocumented *args (no overloading) should be flagged."""
-        file = open(os.path.join(TEST_FOLDER, "test_files", "docstring_parameters.py"))
-        node = astroid.parse(file.read())
-        file.close()
-        # ClassWithVararg is body[14]
-        class_node = node.body[14]
-        with self.assertAddsMessages(
-            pylint.testutils.MessageTest(
-                msg_id="docstring-missing-param",
-                node=class_node,
-                args="args",
-            ),
-            ignore_position=True,
-        ):
-            self.checker.visit_classdef(class_node)
-
     def test_docstring_class_vararg_documented_ok(self):
         """Class __init__ that documents *args in the docstring should NOT be flagged."""
         file = open(os.path.join(TEST_FOLDER, "test_files", "docstring_parameters.py"))
         node = astroid.parse(file.read())
         file.close()
-        # ClassWithDocumentedVararg is body[15]
-        class_node = node.body[15]
+        # ClassWithDocumentedVararg is body[14]
+        class_node = node.body[14]
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
 

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
@@ -3202,7 +3202,7 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
             self.checker.visit_classdef(class_node)
 
     def test_docstring_class_vararg_documented_ok(self):
-        """Class __init__ that explicitly documents *args should NOT fire should-be-keyword."""
+        """Class __init__ that documents *args in the docstring should NOT be flagged."""
         file = open(os.path.join(TEST_FOLDER, "test_files", "docstring_parameters.py"))
         node = astroid.parse(file.read())
         file.close()
@@ -4933,4 +4933,39 @@ class TestNoCrossPackagePrivateImport(pylint.testutils.CheckerTestCase):
         """
         importfrom_node = setup.body[14]
         with self.assertNoMessages():
+            self.checker.visit_importfrom(importfrom_node)
+
+    def test_allows_relative_import_in_package_init(self):
+        """Relative imports in __init__.py resolve against the package itself.
+
+        For azure.storage.file.datalake/__init__.py, "from ._models import X" resolves
+        to azure.storage.file.datalake._models — same-package, not flagged.
+        """
+        source = "from ._models import DataLakeFileClient\n"
+        module = astroid.parse(source)
+        # Simulate this being __init__.py for the azure.storage.file.datalake package.
+        module.name = "azure.storage.file.datalake"
+        module.package = True
+        importfrom_node = module.body[0]
+        with self.assertNoMessages():
+            self.checker.visit_importfrom(importfrom_node)
+
+    def test_flags_cross_package_relative_import_in_package_init(self):
+        """Cross-package relative imports in __init__.py should still be flagged.
+
+        For azure.storage.file.datalake/__init__.py, "from ..blob._generated.models import X"
+        resolves to azure.storage.blob._generated.models — cross-package, must be flagged.
+        """
+        source = "from ..blob._generated.models import BlobItem\n"
+        module = astroid.parse(source)
+        module.name = "azure.storage.file.datalake"
+        module.package = True
+        importfrom_node = module.body[0]
+        with self.assertAddsMessages(
+            pylint.testutils.MessageTest(
+                msg_id="no-cross-package-private-import",
+                node=importfrom_node,
+            ),
+            ignore_position=True,
+        ):
             self.checker.visit_importfrom(importfrom_node)

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
@@ -3158,11 +3158,8 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_functiondef(impl_node)
 
-    def test_docstring_no_overload_args_not_required(self):
-        """Regular function with undocumented *args should NOT be flagged.
-
-        *args passthroughs are never required to be documented.
-        """
+    def test_docstring_no_overload_still_checks_args(self):
+        """Regular function with undocumented *args (not an overload impl) should be flagged."""
         file = open(
             os.path.join(
                 TEST_FOLDER,
@@ -3174,17 +3171,34 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
         file.close()
         # regular_function is body[3]
         regular_node = node.body[3]
-        with self.assertNoMessages():
+        with self.assertAddsMessages(
+            pylint.testutils.MessageTest(
+                msg_id="docstring-missing-param",
+                line=59,
+                node=regular_node,
+                args="args",
+                col_offset=0,
+                end_line=59,
+                end_col_offset=20,
+            ),
+        ):
             self.checker.check_parameters(regular_node)
 
-    def test_docstring_class_vararg_not_required(self):
-        """Class __init__ with undocumented *args should NOT be flagged."""
+    def test_docstring_class_vararg_required(self):
+        """Class __init__ with undocumented *args (no overloading) should be flagged."""
         file = open(os.path.join(TEST_FOLDER, "test_files", "docstring_parameters.py"))
         node = astroid.parse(file.read())
         file.close()
         # ClassWithVararg is body[14]
         class_node = node.body[14]
-        with self.assertNoMessages():
+        with self.assertAddsMessages(
+            pylint.testutils.MessageTest(
+                msg_id="docstring-missing-param",
+                node=class_node,
+                args="args",
+            ),
+            ignore_position=True,
+        ):
             self.checker.visit_classdef(class_node)
 
     def test_docstring_class_vararg_documented_ok(self):

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
@@ -3158,8 +3158,11 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_functiondef(impl_node)
 
-    def test_docstring_no_overload_still_checks_args(self):
-        """Regular function with undocumented *args (not an overload impl) should still be flagged."""
+    def test_docstring_no_overload_args_not_required(self):
+        """Regular function with undocumented *args should NOT be flagged.
+
+        *args passthroughs are never required to be documented.
+        """
         file = open(
             os.path.join(
                 TEST_FOLDER,
@@ -3169,20 +3172,46 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
         )
         node = astroid.parse(file.read())
         file.close()
-        # regular_function is the last function in the module (body[3])
+        # regular_function is body[3]
         regular_node = node.body[3]
-        with self.assertAddsMessages(
-            pylint.testutils.MessageTest(
-                msg_id="docstring-missing-param",
-                line=59,
-                node=regular_node,
-                args="args",
-                col_offset=0,
-                end_line=59,
-                end_col_offset=20,
-            ),
-        ):
+        with self.assertNoMessages():
             self.checker.check_parameters(regular_node)
+
+    def test_docstring_class_vararg_not_required(self):
+        """Class __init__ with undocumented *args should NOT be flagged."""
+        file = open(os.path.join(TEST_FOLDER, "test_files", "docstring_parameters.py"))
+        node = astroid.parse(file.read())
+        file.close()
+        # ClassWithVararg is body[14]
+        class_node = node.body[14]
+        with self.assertNoMessages():
+            self.checker.visit_classdef(class_node)
+
+    def test_docstring_class_vararg_documented_ok(self):
+        """Class __init__ that explicitly documents *args should NOT fire should-be-keyword."""
+        file = open(os.path.join(TEST_FOLDER, "test_files", "docstring_parameters.py"))
+        node = astroid.parse(file.read())
+        file.close()
+        # ClassWithDocumentedVararg is body[15]
+        class_node = node.body[15]
+        with self.assertNoMessages():
+            self.checker.visit_classdef(class_node)
+
+    def test_docstring_class_overload_init_skips_args(self):
+        """Class with overloaded __init__ implementation should not flag *args/**kwargs."""
+        file = open(
+            os.path.join(
+                TEST_FOLDER,
+                "test_files",
+                "docstring_overload_args_kwargs.py",
+            )
+        )
+        node = astroid.parse(file.read())
+        file.close()
+        # ClientWithOverloadedInit is body[5]
+        class_node = node.body[5]
+        with self.assertNoMessages():
+            self.checker.visit_classdef(class_node)
 
     def test_docstring_overload_implementation_async_skips_args_kwargs(self):
         """Async overload implementation with *args/**kwargs should not report missing param errors."""
@@ -4847,10 +4876,10 @@ class TestNoCrossPackagePrivateImport(pylint.testutils.CheckerTestCase):
             self.checker.visit_importfrom(importfrom_node)
 
     def test_allows_relative_import_with_private_segment(self, setup):
-        """from ...operations._operations import FooMixin should NOT be flagged.
+        """from ._operations import SomeMixin should NOT be flagged.
 
-        Relative imports are always within the same package; node.modname is an
-        un-anchored suffix that must not be compared against current_module.
+        level=1 resolves to azure.storage.file.datalake._operations — same package
+        as the current module, so the check correctly passes.
         """
         importfrom_node = setup.body[11]
         with self.assertNoMessages():
@@ -4859,9 +4888,35 @@ class TestNoCrossPackagePrivateImport(pylint.testutils.CheckerTestCase):
     def test_allows_relative_import_leading_private(self, setup):
         """from ._utils import helper should NOT be flagged.
 
-        The module name starts with '_'; _get_private_prefix returns None (no
-        public prefix), so the check is skipped entirely.
+        level=1 resolves to azure.storage.file.datalake._utils — the public prefix
+        is azure.storage.file.datalake, which matches the current module.
         """
         importfrom_node = setup.body[12]
+        with self.assertNoMessages():
+            self.checker.visit_importfrom(importfrom_node)
+
+    def test_flags_cross_package_relative_importfrom(self, setup):
+        """from ...blob._generated.models import BlobItem should be flagged.
+
+        level=3 from azure.storage.file.datalake._some_module resolves to
+        azure.storage.blob._generated.models — a genuine cross-package private import.
+        """
+        importfrom_node = setup.body[13]
+        with self.assertAddsMessages(
+            pylint.testutils.MessageTest(
+                msg_id="no-cross-package-private-import",
+                node=importfrom_node,
+            ),
+            ignore_position=True,
+        ):
+            self.checker.visit_importfrom(importfrom_node)
+
+    def test_allows_absolute_leading_private_importfrom(self, setup):
+        """from _utils import something_absolute should NOT be flagged.
+
+        The modname starts with '_' at position 0; _get_private_prefix returns None
+        because there is no public prefix to compare against, so the check is skipped.
+        """
+        importfrom_node = setup.body[14]
         with self.assertNoMessages():
             self.checker.visit_importfrom(importfrom_node)


### PR DESCRIPTION
## Summary

Fixes bugs in `pylint_guidelines_checker.py` found while running 0.5.8 against the TypeSpec Python emitter. Bumps to 0.5.9.

---

## C4776 — `no-cross-package-private-import`

**Bug 1: false-positive on same-package relative imports**
- For `from ._operations import SomeMixin`, astroid sets `node.modname = "_operations"` and `node.level = 1`
- `node.level` was never consulted — the checker compared the un-anchored suffix against the fully-qualified `current_module`
- **Fix:** resolve the relative import to its absolute module name first, then run the existing check on the result
- Same-package relative imports (e.g. `from ._operations import …`) correctly pass; cross-package ones (e.g. `from ...blob._generated.models import …`) are still flagged

**Bug 2: silent miss when first segment is private**
- For a module like `_utils.model_base`, `_get_private_prefix` returned `""` (empty string)
- `current_module.startswith("")` is always `True` → `_is_cross_package_private_import` always returned `False` → check silently disabled
- **Fix:** return `None` (not `""`) when `i == 0` in `_get_private_prefix`

---

## C4739 — `check-docstrings` / `docstring-missing-param`

**Bug 3: `is_overload_impl` unreachable for class constructors (root cause of TypeSpec false positives)**
- `is_overload_impl` was only ever set in the `FunctionDef` branch
- ClassDef branch left it `False` unconditionally — class constructors with overloaded `__init__` could never benefit from the overload-impl exemption
- The TypeSpec Python emitter generates constructors that *are* overload implementations; because this flag was always `False` for classes, their `*args` was always flagged as undocumented
- **Fix:** add `is_overload_impl = self._is_overload_implementation(constructor)` to the ClassDef branch

**Scope note:** This PR does *not* change the existing policy on whether `*args` must be documented — that behavior is unchanged and left as-is (no team decision has been made either way). The only C4739 change here is fixing the overload-impl detection bug for class constructors.

---

## Files changed
- `pylint_guidelines_checker.py` — all three fixes above
- `tests/test_files/no_cross_package_private_import.py` — add relative import cases (same-package and cross-package)
- `tests/test_files/docstring_overload_args_kwargs.py` — add class with overloaded `__init__` (proves the Bug 3 fix)
- `tests/test_files/docstring_parameters.py` — add class that documents `*args` in its `__init__`
- `tests/test_pylint_custom_plugins.py` — new/updated tests for all fixed cases
- `CHANGELOG.md` / `setup.py` — 0.5.8 dated 2026-07-13; new 0.5.9 (Unreleased) section; version bumped to 0.5.9
