### PR TITLE
Add CFSClean enforcement

### DIFF
--- a/eng/common/pipelines/templates/steps/auth-dev-feed.yml
+++ b/eng/common/pipelines/templates/steps/auth-dev-feed.yml
@@ -1,0 +1,49 @@
+parameters:
+  DevFeedName: 'public/azure-sdk-for-python'
+  EnableTwineAuth: true
+  EnablePipAuth: true
+  EnableUvAuth: true
+
+steps:
+  - pwsh: |
+      # For safety default to publishing to the private feed.
+      # Publish to https://dev.azure.com/azure-sdk/internal/_packaging?_a=feed&feed=azure-sdk-for-python-pr
+      $devopsFeedName = 'internal/azure-sdk-for-python-pr'
+      if ('$(Build.Repository.Name)' -eq 'Azure/azure-sdk-for-python') {
+        # Publish to https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk-for-python
+        $devopsFeedName = '${{ parameters.DevFeedName }}'
+      }
+      echo "##vso[task.setvariable variable=DevFeedName]$devopsFeedName"
+      echo "Using DevopsFeed = $devopsFeedName"
+    displayName: Setup DevOpsFeedName
+
+  - ${{ if eq(parameters.EnableTwineAuth, true) }}:
+    - task: TwineAuthenticate@0
+      displayName: 'Twine Authenticate to feed'
+      inputs:
+        artifactFeeds: $(DevFeedName)
+
+  - ${{ if eq(parameters.EnablePipAuth, true) }}:
+    - task: PipAuthenticate@1
+      displayName: 'Pip Authenticate to feed'
+      inputs:
+        artifactFeeds: $(DevFeedName)
+        onlyAddExtraIndex: false
+
+  - ${{ if eq(parameters.EnableUvAuth, true) }}:
+    - pwsh: |
+        if ($env:PIP_INDEX_URL) {
+          Write-Host "Found pip index URL: $($env:PIP_INDEX_URL)"
+          # UV_DEFAULT_INDEX is the canonical replacement for the deprecated UV_INDEX_URL (uv 0.4.23+).
+          # PIP_INDEX_URL is set by PipAuthenticate@1 and contains embedded credentials, which uv
+          # will use for Basic auth against the ADO feed (and its PyPI upstream) per astral-sh/uv#12651.
+          Write-Host "##vso[task.setvariable variable=UV_DEFAULT_INDEX]$($env:PIP_INDEX_URL)"
+          # Disable keyring so uv uses the URL-embedded credentials directly.
+          Write-Host "##vso[task.setvariable variable=UV_KEYRING_PROVIDER]disabled"
+        } else {
+          Write-Host "##[warning]PIP_INDEX_URL not set - uv will fall back to public PyPI."
+        }
+        # Force any managed Python downloads to go directly to GitHub releases
+        # rather than the default CDN (releases.astral.sh).
+        Write-Host "##vso[task.setvariable variable=UV_PYTHON_INSTALL_MIRROR]https://github.com/astral-sh/python-build-standalone/releases/download"
+      displayName: 'Configure UV Authentication'

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -28,7 +28,7 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      networkIsolationPolicy: Permissive
+      networkIsolationPolicy: Permissive, CFSClean
     sdl:
       # Turn off the build warnings caused by disabling some sdl checks
       createAdoIssuesForJustificationsForDisablement: false

--- a/packages/python-packages/apiview-copilot/tests.yml
+++ b/packages/python-packages/apiview-copilot/tests.yml
@@ -2,6 +2,9 @@ parameters:
 - name: PythonVersion
   type: string
   default: '3.10'
+- name: DevFeedName
+  type: string
+  default: 'public/azure-sdk-for-python'
 
 trigger: none
 extends:
@@ -21,6 +24,12 @@ extends:
               os: linux
 
             steps:
+              # Authenticate pip to the configured Azure DevOps feed before installs.
+              - template: /eng/common/pipelines/templates/steps/auth-dev-feed.yml
+                parameters:
+                  DevFeedName: ${{ parameters.DevFeedName }}
+                  EnableTwineAuth: false
+                  
               - template: /eng/pipelines/templates/steps/use-python-version.yml
                 parameters:
                   versionSpec: '${{ parameters.PythonVersion }}'


### PR DESCRIPTION
This pull request makes a small update to the pipeline configuration by adjusting the network isolation policy. The change adds `CFSClean` to the existing `Permissive` policy setting.

* Pipeline configuration:
  * Updated the `networkIsolationPolicy` parameter in `eng/pipelines/templates/stages/1es-redirect.yml` to include `CFSClean` along with `Permissive`.
  
[azure-typespec-author-benchmark-without-skill](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6572913&view=results)
[azure-typespec-author-benchmark](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6572919&view=results)
[tools - test-proxy - tests](https://dev.azure.com/azure-sdk/internal/_build?definitionId=5212&_a=summary)
[tools - apiview-copilot - tests](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6573231&view=results)
[tools - azure-mcp-evals - tests](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6572964&view=results)
[azure-sdk-qa-bot-conversation-evaluation](https://dev.azure.com/azure-sdk/internal/_build?definitionId=8267&_a=summary)