### PR TITLE
self-evolve: dry-run wording tweak

### DIFF
--- a/.github/skills/azure-typespec-author/SKILL.md
+++ b/.github/skills/azure-typespec-author/SKILL.md
@@ -42,7 +42,7 @@ This includes but is not limited to:
 - **Always follow the full workflow** — even seemingly simple changes (e.g. adding a default value) can require complex versioning decorator changes. Never skip steps.
 - **Mandatory for ALL `.tsp` edits** — even a single `?` change can be breaking.
 - **Minimal, scoped edits** — only change what the request requires.
-- **Always validate** — run every steps in [validation](references/validation.md) after every edit.
+- **Always validate** — run every step in [validation](references/validation.md) after every edit.
 - **Always cite references** — provide links that justify the approach.
 - **Follow the authoring plan exactly** — code changes in Step 4 MUST follow the authoring plan generated in Step 3. Do not deviate by referring to existing code patterns in the TypeSpec project; the authoring plan is the single source of truth for what to change.
 


### PR DESCRIPTION
This is an automated dry run. It makes one tiny, semantics-preserving wording correction in SKILL.md: changing “run every steps” to “run every step.”