### PR TITLE
remove azure-sdk-for-c from eng/common sync

### DIFF
--- a/eng/pipelines/branch-cleanup.yml
+++ b/eng/pipelines/branch-cleanup.yml
@@ -7,7 +7,6 @@ parameters:
   default:
     - Azure/azure-sdk
     - Azure/azure-sdk-for-android
-    - Azure/azure-sdk-for-c
     - Azure/azure-sdk-for-cpp
     - Azure/azure-sdk-for-go
     - Azure/azure-sdk-for-ios

--- a/eng/pipelines/mirror-repos.yml
+++ b/eng/pipelines/mirror-repos.yml
@@ -123,11 +123,6 @@ jobs:
               Azure/azure-sdk-for-android-pr:
               azure-sdk/azure-sdk-for-android:
 
-          Azure/azure-sdk-for-c:
-            TargetRepos:
-              Azure/azure-sdk-for-c-pr:
-              azure-sdk/azure-sdk-for-c:
-
           Azure/azure-sdk-for-rust:
             TargetRepos:
               Azure/azure-sdk-for-rust-pr:

--- a/eng/pipelines/sync-.github.yml
+++ b/eng/pipelines/sync-.github.yml
@@ -19,7 +19,6 @@ parameters:
   type: object
   default:
     - azure-sdk
-    - azure-sdk-for-c
     - azure-sdk-for-cpp
     - azure-sdk-for-go
     - azure-sdk-for-ios

--- a/eng/pipelines/sync-eng-common.yml
+++ b/eng/pipelines/sync-eng-common.yml
@@ -10,7 +10,6 @@ parameters:
   type: object
   default:
     - azure-sdk
-    - azure-sdk-for-c
     - azure-sdk-for-cpp
     - azure-sdk-for-go
     - azure-sdk-for-ios

--- a/eng/pipelines/tools-repo-versioning.yml
+++ b/eng/pipelines/tools-repo-versioning.yml
@@ -36,7 +36,6 @@ jobs:
         Repos:
           azure-sdk:
           azure-sdk-for-android:
-          azure-sdk-for-c:
           azure-sdk-for-cpp:
           azure-sdk-for-go:
           azure-sdk-for-ios:


### PR DESCRIPTION
This pull request makes a small update to the pipeline configuration files by removing the `azure-sdk-for-c` repository from the list of default repositories to be synchronized.

- Removed `azure-sdk-for-c` from the default repository list in `eng/pipelines/sync-.github.yml`
- Removed `azure-sdk-for-c` from the default repository list in `eng/pipelines/sync-eng-common.yml`