### PR TITLE
tsp-client: honor a checked-in eng/common/.npmrc

### DIFF
--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## 2025-11-24 - 0.31.0
 
-- Add support for batch library generation. See [README](./README.md) for more information on how to configure.
+- Add support for batch library generation. See [README](https://github.com/Azure/azure-sdk-tools/blob/main/tools/tsp-client/README.md#batch-library-generation) for more information on how to configure.
 
 ## 2025-11-05 - 0.30.0
 

--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2026-07-16 - 0.34.0
+
+- Copy a repository's checked-in `eng/common/.npmrc` (if present) into the `TempTypeSpecFiles` directory before running npm for the `init`, `sync`, `generate`, `update`, `generate-lock-file`, and `generate-config-files` commands, so those npm operations honor the repository's npm registry configuration.
+
 ## 2026-04-30 - 0.33.1
 
 - Added support for passing flags to underlying npm commands using the `--npm-args` flag with the `generate-config-files` and `generate-lock-file` commands.

--- a/tools/tsp-client/README.md
+++ b/tools/tsp-client/README.md
@@ -12,7 +12,7 @@
 npm install -g @azure-tools/typespec-client-generator-cli
 ```
 
-> NOTE: Repo owners should follow the steps in the [tsp-client repo setup](./repo_setup.md) doc.
+> NOTE: Repo owners should follow the steps in the [tsp-client repo setup](https://github.com/Azure/azure-sdk-tools/blob/main/tools/tsp-client/repo_setup.md) doc.
 
 ## Usage
 

--- a/tools/tsp-client/README.md
+++ b/tools/tsp-client/README.md
@@ -235,6 +235,16 @@ tsp-client install-dependencies [optional install path]
 
 ## Important concepts
 
+### npm registry configuration (eng/common/.npmrc)
+
+If your repository checks in an `.npmrc` file at `<repo root>/eng/common/.npmrc`, tsp-client
+copies it into the `TempTypeSpecFiles` working directory before running npm for the `init`, `update`, `sync`,
+`generate`, `generate-lock-file`, and `generate-config-files` commands. npm
+then picks it up as project-level configuration, so those npm operations honor the
+repository's npm registry settings. Copying it into `TempTypeSpecFiles` also means developers
+debugging directly inside that directory get the same behavior. If the file is not present,
+this is a no-op and npm uses its default configuration.
+
 ### Per project setup
 
 Each project will need to have a configuration file called tsp-location.yaml that will tell the tool where to find the TypeSpec project.

--- a/tools/tsp-client/package-lock.json
+++ b/tools/tsp-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.33.1",
+  "version": "0.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/typespec-client-generator-cli",
-      "version": "0.33.1",
+      "version": "0.34.0",
       "license": "MIT",
       "dependencies": {
         "@azure-tools/typespec-autorest": ">=0.53.0 <1.0.0",

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.33.1",
+  "version": "0.34.0",
   "description": "A tool to generate Azure SDKs from TypeSpec",
   "main": "dist/index.js",
   "homepage": "https://github.com/Azure/azure-sdk-tools/tree/main/tools/tsp-client#readme",

--- a/tools/tsp-client/src/commands.ts
+++ b/tools/tsp-client/src/commands.ts
@@ -12,6 +12,7 @@ import {
   getEmitterFromRepoConfig,
   readTspLocation,
   removeDirectory,
+  copyRepoNpmrcToTemp,
 } from "./fs.js";
 import { cp, mkdir, readFile, stat, unlink, writeFile } from "fs/promises";
 import { npmCommand, npxCommand, npmViewPackageDevDependencies } from "./npm.js";
@@ -416,6 +417,10 @@ export async function syncCommand(argv: any) {
       `Ran into the following error: ${err}\nTo continue using tsp-client, please provide a valid emitter-package.json file in the eng/ directory of the repository.`,
     );
   }
+
+  // Copy the repository's eng/common/.npmrc (if present) into the temp directory so npm
+  // operations run from here honor the repo's npm registry configuration.
+  await copyRepoNpmrcToTemp(repoRoot, tempRoot);
 }
 
 export async function generateCommand(argv: any) {
@@ -469,6 +474,9 @@ export async function generateCommand(argv: any) {
     Logger.info("Skipping installation of dependencies");
   } else {
     Logger.info("Installing dependencies from npm...");
+    // Ensure the repository's eng/common/.npmrc (if present) is in the temp directory so npm
+    // honors the repo's npm registry configuration when installing dependencies.
+    await copyRepoNpmrcToTemp(repoRoot, tempRoot);
     const args: string[] = [];
     try {
       // Check if package-lock.json exists, if it does, we'll install dependencies through `npm ci`
@@ -764,6 +772,9 @@ export async function generateLockFileCommandCore(
   }
   const tempRoot = await createTempDirectory(outputDir);
   await cp(emitterPackageJsonPath, joinPaths(tempRoot, "package.json"));
+  // Copy the repository's eng/common/.npmrc (if present) into the temp directory so npm
+  // honors the repo's npm registry configuration when generating the lock file.
+  await copyRepoNpmrcToTemp(await getRepoRoot(outputDir), tempRoot);
   await npmCommand(tempRoot, args);
   const lockFile = await stat(joinPaths(tempRoot, "package-lock.json"));
   const emitterLockPath = getEmitterLockPath(emitterPackageJsonPath);

--- a/tools/tsp-client/src/fs.ts
+++ b/tools/tsp-client/src/fs.ts
@@ -1,8 +1,14 @@
-import { mkdir, rm, stat, readFile, access } from "node:fs/promises";
+import { cp, mkdir, rm, stat, readFile, access } from "node:fs/promises";
 import { Logger } from "./log.js";
 import { parse as parseYaml } from "yaml";
 import { joinPaths, normalizePath, resolvePath } from "@typespec/compiler";
 import { TspLocation } from "./typespec.js";
+
+/**
+ * Relative path (from the repository root) to the npmrc file that repositories may check in
+ * to configure the npm registry used by tsp-client's npm operations.
+ */
+export const relativeRepoNpmrcPath = joinPaths("eng", "common", ".npmrc");
 
 export async function ensureDirectory(path: string) {
   await mkdir(path, { recursive: true });
@@ -17,6 +23,34 @@ export async function createTempDirectory(outputDir: string): Promise<string> {
   await mkdir(tempRoot, { recursive: true });
   Logger.debug(`Created temporary working directory ${tempRoot}`);
   return tempRoot;
+}
+
+/**
+ * Copies the repository's checked-in npmrc file (eng/common/.npmrc) into the provided
+ * TempTypeSpecFiles directory as .npmrc so that npm operations run from that directory pick
+ * it up as project-level configuration. This also ensures developers debugging inside the
+ * temp directory get the same npm registry behavior. No-op when the repo doesn't ship the file.
+ */
+export async function copyRepoNpmrcToTemp(repoRoot: string, tempRoot: string): Promise<void> {
+  const npmrcPath = joinPaths(repoRoot, relativeRepoNpmrcPath);
+  try {
+    const fileStat = await stat(npmrcPath);
+    if (!fileStat.isFile()) {
+      Logger.debug(
+        `${relativeRepoNpmrcPath} exists but is not a file. Skipping npmrc copy to ${tempRoot}.`,
+      );
+      return;
+    }
+  } catch {
+    // The file doesn't exist; nothing to copy.
+    Logger.debug(
+      `No ${relativeRepoNpmrcPath} found in the repository. Skipping npmrc copy to ${tempRoot}.`,
+    );
+    return;
+  }
+  const destination = joinPaths(tempRoot, ".npmrc");
+  await cp(npmrcPath, destination);
+  Logger.debug(`Copied ${npmrcPath} to ${destination}`);
 }
 
 export async function readTspLocation(rootDir: string): Promise<TspLocation> {

--- a/tools/tsp-client/src/fs.ts
+++ b/tools/tsp-client/src/fs.ts
@@ -41,10 +41,10 @@ export async function copyRepoNpmrcToTemp(repoRoot: string, tempRoot: string): P
       );
       return;
     }
-  } catch {
+  } catch (err) {
     // The file doesn't exist; nothing to copy.
     Logger.debug(
-      `No ${relativeRepoNpmrcPath} found in the repository. Skipping npmrc copy to ${tempRoot}.`,
+      `Unable to read ${npmrcPath}. Skipping npmrc copy to ${tempRoot}. Details: ${err}`,
     );
     return;
   }

--- a/tools/tsp-client/test/commands.spec.ts
+++ b/tools/tsp-client/test/commands.spec.ts
@@ -21,7 +21,7 @@ import { writeTspLocationYaml } from "../src/utils.js";
 import { dirname, resolve } from "node:path";
 
 // The command integration tests below run real `npm` installs. tsp-client copies the
-// repository's eng/common/.npmrc into the temp directory, which in this repo repoints npm to
+// repository's eng/common/.npmrc into the temp directory, which the alternate feed might repoint npm to
 // a feed that can't resolve the test emitter packages. The copy behavior is covered directly
 // by test/npmrc.spec.ts, so neutralize it here to keep these tests on the default registry.
 vi.mock("../src/fs.js", async (importActual) => {

--- a/tools/tsp-client/test/commands.spec.ts
+++ b/tools/tsp-client/test/commands.spec.ts
@@ -9,7 +9,7 @@ import {
   generateConfigFilesCommand,
   parseNpmArgs,
 } from "../src/commands.js";
-import { afterAll, afterEach, beforeAll, describe, it, expect } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, it, expect, vi } from "vitest";
 import { assert } from "chai";
 import { getRepoRoot } from "../src/git.js";
 import { cwd } from "node:process";
@@ -19,6 +19,18 @@ import { doesFileExist } from "../src/network.js";
 import { TspLocation } from "../src/typespec.js";
 import { writeTspLocationYaml } from "../src/utils.js";
 import { dirname, resolve } from "node:path";
+
+// The command integration tests below run real `npm` installs. tsp-client copies the
+// repository's eng/common/.npmrc into the temp directory, which in this repo repoints npm to
+// a feed that can't resolve the test emitter packages. The copy behavior is covered directly
+// by test/npmrc.spec.ts, so neutralize it here to keep these tests on the default registry.
+vi.mock("../src/fs.js", async (importActual) => {
+  const actual = await importActual<typeof import("../src/fs.js")>();
+  return {
+    ...actual,
+    copyRepoNpmrcToTemp: vi.fn().mockResolvedValue(undefined),
+  };
+});
 
 describe.sequential("Verify commands", () => {
   let repoRoot: string;

--- a/tools/tsp-client/test/npmrc.spec.ts
+++ b/tools/tsp-client/test/npmrc.spec.ts
@@ -1,0 +1,45 @@
+import { mkdir, mkdtemp, rm, writeFile, stat, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it, expect } from "vitest";
+import { joinPaths } from "@typespec/compiler";
+import { copyRepoNpmrcToTemp, relativeRepoNpmrcPath } from "../src/fs.js";
+
+describe("eng/common/.npmrc support", () => {
+  let repoRoot: string;
+  let tempRoot: string;
+
+  beforeEach(async () => {
+    repoRoot = await mkdtemp(join(tmpdir(), "tsp-client-npmrc-repo-"));
+    tempRoot = await mkdtemp(join(tmpdir(), "tsp-client-npmrc-temp-"));
+  });
+
+  afterEach(async () => {
+    await rm(repoRoot, { recursive: true, force: true });
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  async function writeRepoNpmrc(contents: string): Promise<string> {
+    const npmrcPath = joinPaths(repoRoot, relativeRepoNpmrcPath);
+    await mkdir(join(repoRoot, "eng", "common"), { recursive: true });
+    await writeFile(npmrcPath, contents);
+    return npmrcPath;
+  }
+
+  it("copyRepoNpmrcToTemp copies the file into the temp directory as .npmrc", async () => {
+    const contents = "registry=https://example.com/\n";
+    await writeRepoNpmrc(contents);
+
+    await copyRepoNpmrcToTemp(repoRoot, tempRoot);
+
+    const destination = joinPaths(tempRoot, ".npmrc");
+    const destStat = await stat(destination);
+    expect(destStat.isFile()).toBe(true);
+    expect(await readFile(destination, "utf8")).toBe(contents);
+  });
+
+  it("copyRepoNpmrcToTemp is a no-op when the repo has no eng/common/.npmrc", async () => {
+    await expect(copyRepoNpmrcToTemp(repoRoot, tempRoot)).resolves.toBeUndefined();
+    await expect(stat(joinPaths(tempRoot, ".npmrc"))).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Adds support for a repository-controlled npm registry configuration in tsp-client. When the target repo checks in an `.npmrc` at `eng/common/.npmrc`, tsp-client copies it into the `TempTypeSpecFiles/` working directory before running npm. npm then picks it up as a project-level `.npmrc` (which merges with, and takes precedence over, the developer's `~/.npmrc`, preserving their auth tokens), so npm operations honor the repo's registry. Copying it into `TempTypeSpecFiles/` also means developers debugging directly in that directory get identical behavior.

If the repo does not ship `eng/common/.npmrc`, this is a graceful no-op.

## Scope

Only the commands that run npm from within `TempTypeSpecFiles/` are covered:

- `sync`
- `generate` / `update`
- `generate-lock-file`
- `generate-config-files`

(`restore`, `convert`, and `generate-config-files --use-npm-pinning` run npm outside `TempTypeSpecFiles` and are intentionally out of scope.)

## Changes

- `src/fs.ts`: new `relativeRepoNpmrcPath` constant and `copyRepoNpmrcToTemp(repoRoot, tempRoot)` helper (copies the file in as `.npmrc`; debug-logs and no-ops when the file is missing or is not a regular file).
- `src/commands.ts`: calls the helper in `syncCommand`, `generateCommand`, and `generateLockFileCommandCore`.
- `test/npmrc.spec.ts`: unit tests (copies when present, no-op when absent).
- `test/commands.spec.ts`: mocks the helper so the real-`npm install` integration tests stay hermetic regardless of a developer's local `eng/common/.npmrc`.
- Docs/version: README section, CHANGELOG entry, version bump `0.33.1` -> `0.34.0`.

## Validation

- `npm run build`, `npm run format:check`, and the new npmrc unit tests all pass.
- Lock-file command integration tests pass.