### PR TITLE
Add timotheeguerin as a codeowner of tsp-client

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -49,7 +49,7 @@
 /tools/sdk-testgen/                     @lirenhe @tadelesh
 /tools/spec-gen-sdk/                    @raych1 @chidozieononiwu
 /tools/test-proxy/                      @scbedd @mikeharder @benbp
-/tools/tsp-client/                      @catalinaperalta @mikeharder
+/tools/tsp-client/                      @catalinaperalta @mikeharder @timotheeguerin
 /tools/typespec-bump-deps/              @weidongxu-microsoft
 /tools/content-validation/              @xiangyan99 @zedy-wj
 /tools/perf-regression-finder/          @m-redding @jsquire


### PR DESCRIPTION
Adds @timotheeguerin as a codeowner of `/tools/tsp-client/` in `.github/CODEOWNERS`.