### PR TITLE
Make prefix check optional for remove storage sync services method

### DIFF
--- a/eng/common/scripts/Helpers/Resource-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Resource-Helpers.ps1
@@ -336,13 +336,18 @@ function Remove-StorageSyncServices() {
   [CmdletBinding(SupportsShouldProcess = $True)]
   param(
     [string]$GroupPrefix,
-    [switch]$CI
+    [switch]$CI,
+    [bool]$CheckPrefix = $true
   )
 
   $ErrorActionPreference = 'Stop'
 
-  if (!$groupPrefix -or ($CI -and (!$GroupPrefix.StartsWith('rg-') -and !$GroupPrefix.StartsWith('SSS3PT_rg-')))) {
-    throw "The -GroupPrefix parameter must not be empty, or must start with 'rg-' or 'SSS3PT_rg-' in CI contexts"
+  if (!$GroupPrefix) {
+    throw "The -GroupPrefix parameter must not be empty"
+  }
+
+  if ($CheckPrefix -and $CI -and (!$GroupPrefix.StartsWith('rg-') -and !$GroupPrefix.StartsWith('SSS3PT_rg-'))) {
+    throw "In CI contexts with -CheckPrefix enabled, -GroupPrefix must start with 'rg-' or 'SSS3PT_rg-'"
   }
 
   $groups = Get-AzResourceGroup | Where-Object { $_.ResourceGroupName.StartsWith($GroupPrefix) } | Where-Object { $_.ProvisioningState -ne 'Deleting' }

--- a/eng/scripts/live-test-resource-cleanup.ps1
+++ b/eng/scripts/live-test-resource-cleanup.ps1
@@ -471,7 +471,7 @@ function DeleteAndPurgeGroups([array]$toDelete) {
           SetStorageNetworkAccessRules -ResourceGroupName $rg.ResourceGroupName -SetFirewall -CI:($null -ne $env:SYSTEM_TEAMPROJECTID) 
           Remove-WormStorageAccounts -GroupPrefix $rg.ResourceGroupName -CI:($null -ne $env:SYSTEM_TEAMPROJECTID) -CheckPrefix $CheckPrefix
         }
-        Remove-StorageSyncServices -GroupPrefix $rg.ResourceGroupName -CI:($null -ne $env:SYSTEM_TEAMPROJECTID)
+        Remove-StorageSyncServices -GroupPrefix $rg.ResourceGroupName -CI:($null -ne $env:SYSTEM_TEAMPROJECTID) -CheckPrefix $CheckPrefix
 
         Write-Host ($rg | Remove-AzResourceGroup -Force -AsJob).Name
       }


### PR DESCRIPTION
Followup PR to this change https://github.com/Azure/azure-sdk-tools/pull/16342, want to make prefix check optional for remove storage sync services as well. This change will only apply to our team's test resource subscription