### PR TITLE
Self-evolve: add auth & error-response references (telemetry-driven)

### DIFF
--- a/.github/skills/azure-typespec-author/references/reference-document-links.md
+++ b/.github/skills/azure-typespec-author/references/reference-document-links.md
@@ -12,6 +12,18 @@
 ## Data-Plane Operations
 
 - [Azure.Core reference](https://azure.github.io/typespec-azure/docs/libraries/azure-core/reference): Full reference for Azure.Core decorators, interfaces, operations, and models.
-- [Standard resource operations](https://azure.github.io/typespec-azure/docs/libraries/azure-core/reference/interfaces): Azure.Core operation templates (ResourceRead, ResourceList, ResourceCreateOrUpdate, ResourceDelete, etc.).
+- [Standard resource operations](https://azure.github.io/typespec-azure/docs/libraries/azure-core/reference/interfaces): Azure.Core operation templates (`ResourceRead`, `ResourceList`, `ResourceCreateOrUpdate`, `ResourceDelete`, etc.).
 - [Data-plane getting started](https://azure.github.io/typespec-azure/docs/getstarted/azure-core/step01): Getting started guide for creating data-plane TypeSpec services with Azure.Core.
-- [Deep Dive: Long-running (Asynchronous) Operations](https://azure.github.io/typespec-azure/docs/howtos/azure-core/long-running-operations/): Defining asynchronous (long-running) operations
+- [Deep Dive: Long-running (Asynchronous) Operations](https://azure.github.io/typespec-azure/docs/howtos/azure-core/long-running-operations/): Defining asynchronous (long-running) operations.
+
+## Authentication and Security Definitions
+
+- [Azure TypeSpec style guide — Security Definitions](https://azure.github.io/typespec-azure/docs/reference/azure-style-guide/#security-definitions): Azure-specific requirements. Data-plane services must explicitly apply `@useAuth`; use OAuth2 or a header API key, document every scheme, and define at least one OAuth2 scope. ARM services receive the standard security definitions from Azure.ResourceManager.
+- [TypeSpec HTTP authentication](https://typespec.io/docs/libraries/http/authentication/): Syntax and semantics for `@useAuth`, `BearerAuth`, `ApiKeyAuth`, `OAuth2Auth`, scopes, and auth inheritance. A tuple means all schemes are required; a union means any one scheme is accepted. Child `@useAuth` declarations override the parent unless all desired schemes are restated.
+- [Azure.Core authentication data types](https://azure.github.io/typespec-azure/docs/libraries/azure-core/reference/data-types/#aadoauth2auth): Prefer Azure.Core's `AadOauth2Auth` for Microsoft Entra ID OAuth2 and `AzureApiKeyAuthentication` for the standard `Ocp-Apim-Subscription-Key` header when those standard Azure schemes match the service.
+
+## Error Responses
+
+- [Azure.Core `no-error-status-codes` rule](https://azure.github.io/typespec-azure/docs/libraries/azure-core/rules/no-error-status-codes/): Azure data-plane APIs should normally use one `default` error response instead of defining separate custom 4xx or 5xx responses.
+- [Azure.Core operation templates](https://azure.github.io/typespec-azure/docs/libraries/azure-core/reference/interfaces/): Azure.Core resource-operation templates include a default error response and allow an `ErrorResponse` template argument only when a service-specific error contract is required.
+- [TypeSpec handling errors](https://typespec.io/docs/getting-started/getting-started-rest/03-handling-errors/): General TypeSpec guidance for structured custom error models. Mark custom error models with `@error` and include them in an operation response union. For Azure services, apply the stricter Azure.Core default-error guidance above before modeling individual status-code responses.


### PR DESCRIPTION
## Benchmark Test Report

Self-evolving agent update driven by user telemetry (auth + error-response clusters).

- **Change:** .github/skills/azure-typespec-author/references/reference-document-links.md only (adds authentication/security + custom error-response references).
- **Benchmark:** ADO pipeline 8178 run [6572266](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6572266), run **on this branch**.
- **Code-quality pass rate:** 31/38 = 81.6% (> 75% gate).
