### PR TITLE
[Teams Chatbot] Add knowledge source: CPEX related docs

### DIFF
--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/config/tenant_config.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/config/tenant_config.py
@@ -59,6 +59,7 @@ SRC_AZURE_RESOURCE_MANAGER_RPC = "azure_resource_manager_rpc"
 SRC_AZURE_REST_API_SPECS_WIKI = "azure_rest_api_specs_wiki"
 SRC_AZURE_REST_API_SPECS_DOCS = "azure_rest_api_specs_docs"
 SRC_AZURE_OPENAPI_DIFF_DOCS = "azure_openapi_diff_docs"
+SRC_STATIC_CPEX_DOCS = "static_cpex_docs"
 
 # -- SDK language docs --
 SRC_AZURE_SDK_FOR_PYTHON_DOCS = "azure_sdk_for_python_docs"
@@ -183,6 +184,12 @@ _register(
         name=SRC_AZURE_OPENAPI_DIFF_DOCS,
         description="OpenAPI diff documentation for detecting and managing breaking changes in API specifications.",
         base_url="https://github.com/Azure/openapi-diff/blob/main/",
+    ),
+    KnowledgeSource(
+        name=SRC_STATIC_CPEX_DOCS,
+        description="Cloud Product Excellence (CPEX) documentation covering Azure-branded product lifecycle management, S360 KPI requirements, preview/GA readiness, and retirement guidance.",
+        base_url="https://eng.ms/docs/cloud-ai-platform/azure-core/azure-core-product/azure-product-lifecycle-management-plm/azure-product-lifecycle-management/cpex/media/",
+        trim_format=True,
     ),
     # -- SDK language docs --
     KnowledgeSource(
@@ -526,7 +533,10 @@ _TENANT_CONFIG_MAP: dict[TenantID, TenantConfig] = {
             "AzSDK agent, Azure MCP tool usage guidance",
             "Creating new service based on TypeSpec or OpenAPI (Swagger)",
         ],
-        sources=_sources(SRC_AZURE_SDK_DOCS_ENG),
+        sources=_sources(
+            SRC_AZURE_SDK_DOCS_ENG,
+            SRC_STATIC_CPEX_DOCS,
+        ),
         qa_guideline_file="tenants/azure_sdk_onboarding.md",
     ),
     TenantID.AZURE_TYPESPEC_AUTHORING: TenantConfig(

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/config/tenant_config.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/config/tenant_config.py
@@ -187,7 +187,7 @@ _register(
     ),
     KnowledgeSource(
         name=SRC_STATIC_CPEX_DOCS,
-        description="Cloud Product Excellence (CPEX) documentation covering Azure-branded product lifecycle management, S360 KPI requirements, preview/GA readiness, and retirement guidance.",
+        description="Cloud Product Excellence (CPEX) documentation covering Azure-branded product lifecycle management, breaking change policy and process guidance, API breaking changes, S360 KPI requirements, preview/GA readiness, and retirement guidance.",
         base_url="https://eng.ms/docs/cloud-ai-platform/azure-core/azure-core-product/azure-product-lifecycle-management-plm/azure-product-lifecycle-management/cpex/media/",
         trim_format=True,
     ),
@@ -263,11 +263,6 @@ _register(
     KnowledgeSource(
         name=SRC_STATIC_AZURE_DOCS,
         description="Static Azure documentation and reference materials for general Azure services.",
-        link_fn=lambda title: (
-            "http://aka.ms/azbreakingchangespolicy"
-            if title == "Azure Versioning and Breaking Changes Policy V1.3.2"
-            else ""
-        ),
     ),
     KnowledgeSource(
         name=SRC_STATIC_API_SPEC_VIEW_QA,
@@ -513,9 +508,10 @@ _TENANT_CONFIG_MAP: dict[TenantID, TenantConfig] = {
             "Client customization for SDKs (even if a specific language is mentioned, if the core topic is TypeSpec authoring)",
             "API design guidelines and best practices",
         ],
-        sources=[*_TYPESPEC_SOURCES, *_sources(SRC_AZURE_SDK_DOCS_ENG)],
+        sources=[*_TYPESPEC_SOURCES, *_sources(SRC_AZURE_SDK_DOCS_ENG, SRC_STATIC_CPEX_DOCS)],
         source_filter={
             SRC_AZURE_SDK_DOCS_ENG: "search.ismatch('design*', 'title')",
+            SRC_STATIC_CPEX_DOCS: "search.in(title, 'introducing_a_breaking_change.md,faq_breaking_changes.md,apibreakingchanges.md,azurebreakingchangeplaybook.md', ',')",
         },
         qa_guideline_file="tenants/typespec.md",
         enable_routing=True,
@@ -574,10 +570,12 @@ _TENANT_CONFIG_MAP: dict[TenantID, TenantConfig] = {
             SRC_AZURE_OPENAPI_DIFF_DOCS,
             SRC_AZURE_SDK_DOCS_ENG,
             SRC_STATIC_ARM_DOCS,
+            SRC_STATIC_CPEX_DOCS,
             SRC_AZURE_SDK_INTERNAL_WIKI,
         ),
         source_filter={
             SRC_AZURE_SDK_DOCS_ENG: "search.ismatch('design*', 'title')",
+            SRC_STATIC_CPEX_DOCS: "search.in(title, 'introducing_a_breaking_change.md,faq_breaking_changes.md,apibreakingchanges.md,azurebreakingchangeplaybook.md', ',')",
         },
         qa_guideline_file="tenants/api_spec_review.md",
         enable_routing=True,

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/config/tenant_config.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/config/tenant_config.py
@@ -511,7 +511,7 @@ _TENANT_CONFIG_MAP: dict[TenantID, TenantConfig] = {
         sources=[*_TYPESPEC_SOURCES, *_sources(SRC_AZURE_SDK_DOCS_ENG, SRC_STATIC_CPEX_DOCS)],
         source_filter={
             SRC_AZURE_SDK_DOCS_ENG: "search.ismatch('design*', 'title')",
-            SRC_STATIC_CPEX_DOCS: "search.in(title, 'introducing_a_breaking_change.md,faq_breaking_changes.md,apibreakingchanges.md,azurebreakingchangeplaybook.md', ',')",
+            SRC_STATIC_CPEX_DOCS: "search.ismatch('/.*breaking.*/', 'title', 'full', 'any')",
         },
         qa_guideline_file="tenants/typespec.md",
         enable_routing=True,
@@ -575,7 +575,7 @@ _TENANT_CONFIG_MAP: dict[TenantID, TenantConfig] = {
         ),
         source_filter={
             SRC_AZURE_SDK_DOCS_ENG: "search.ismatch('design*', 'title')",
-            SRC_STATIC_CPEX_DOCS: "search.in(title, 'introducing_a_breaking_change.md,faq_breaking_changes.md,apibreakingchanges.md,azurebreakingchangeplaybook.md', ',')",
+            SRC_STATIC_CPEX_DOCS: "search.ismatch('/.*breaking.*/', 'title', 'full', 'any')",
         },
         qa_guideline_file="tenants/api_spec_review.md",
         enable_routing=True,


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-pr/issues/2677
This PR adds a new knowledge source configuration for CPEX related docs

**Documentation Source Details**

- docs:
<img width="600" height="399" alt="image" src="https://github.com/user-attachments/assets/f95edcdd-5204-4862-a1e9-5c596068a04d" />

- Target Channels: azure_sdk_onboarding

- test case:

<img width="1193" height="731" alt="image" src="https://github.com/user-attachments/assets/21cbc0ce-f68d-458c-ac30-d87185593110" />

