### PR TITLE
Exempt net - partner-release from CFSClean enforcement

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -28,7 +28,10 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      networkIsolationPolicy: Permissive, CFSClean
+      ${{ if eq(variables['Build.DefinitionName'], 'net - partner-release') }}:
+        networkIsolationPolicy: Permissive
+      ${{ else }}:
+        networkIsolationPolicy: Permissive, CFSClean
     sdl:
       # Turn off the build warnings caused by disabling some sdl checks
       createAdoIssuesForJustificationsForDisablement: false


### PR DESCRIPTION
This pull request updates the `1es-redirect.yml` pipeline template to adjust the `networkIsolationPolicy` settings based on the build definition name. The main change is to set a more permissive network isolation policy for the `net - partner-release` pipeline, while keeping the previous policy for other pipelines.

Pipeline configuration update:

* [`eng/pipelines/templates/stages/1es-redirect.yml`](diffhunk://#diff-8800a9effcbb25b180d9532721d7d17e592bed1b8777e5336c0de6b5716212f4R31-R33): Updated the `settings` parameter to conditionally set `networkIsolationPolicy` to `Permissive` for the `net - partner-release` pipeline, and to `Permissive, CFSClean` for all other pipelines.