### PR TITLE
Fix twine install in Python tool release stage

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tool-python.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-python.yml
@@ -124,6 +124,12 @@ extends:
                 inputs:
                   versionSpec: '${{ parameters.PythonVersion}}'
 
+              - task: PipAuthenticate@1
+                displayName: 'Pip Authenticate to feed'
+                inputs:
+                  artifactFeeds: ${{ parameters.FeedName }}
+                  onlyAddExtraIndex: false
+
               - script: |
                   set -e
                   python -m pip install twine
@@ -133,12 +139,6 @@ extends:
                 displayName: 'Twine Authenticate to feed'
                 inputs:
                   artifactFeeds: ${{ parameters.FeedName }}
-
-              - task: PipAuthenticate@1
-                displayName: 'Pip Authenticate to feed'
-                inputs:
-                  artifactFeeds: ${{ parameters.FeedName }}
-                  onlyAddExtraIndex: false
 
               - pwsh: |
                   twine upload --repository ${{ parameters.FeedName }} --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{ parameters.ArtifactName }}/*.whl


### PR DESCRIPTION
Move `PipAuthenticate@1` before the `Install Twine` step in `archetype-sdk-tool-python.yml` so pip resolves against the internal DevOps feed.

## Why
Internal build [6592632](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6592632) (`tools - apiview-stub-generator`) failed at **Install Twine**:
```
HTTPSConnection(host='pypi.org', port=443): Failed to establish a new connection: [Errno 1] Operation not permitted
ERROR: No matching distribution found for twine
```
Internal builds block pypi.org egress. `pip install twine` ran before `PipAuthenticate@1` set `PIP_INDEX_URL`, so pip had no reachable index.

## Fix
Reorder so `PipAuthenticate@1` runs first; `TwineAuthenticate@0` stays right before `twine upload`.

Affects releases for **apiview-stub-generator**, **azure-pylint-guidelines-checker**, and **doc-warden** (all consume this template).