### PR TITLE
[apiview-stub-generator] Use uv for package install (revert timeout to 120s)

### DIFF
--- a/packages/python-packages/apiview-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/apiview-stub-generator/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## Version 0.3.30 (2026-07-21)
+Use `uv pip install` (when `uv` is available) instead of `pip` to install the target package before generating the API view. `uv`'s dependency resolver is dramatically faster than pip's for large, beta-pinned dependency trees (e.g. the Microsoft OpenTelemetry distro), where pip could spend several minutes backtracking over candidate versions. This removes the need for the elevated install timeout, which is reverted to 120s. Falls back to `pip install` when `uv` is not on PATH.
+
 ## Version 0.3.29 (2026-07-17)
 Raised the package-install timeout in the API-stub generator from 120s to 300s. Packages with large dependency trees (e.g. those pulling the Microsoft OpenTelemetry distro) could exceed the previous 120s limit on slower CI agents even though the install was healthy, causing spurious API Review failures.
 

--- a/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
@@ -449,13 +449,15 @@ class StubGenerator:
         return pkg_name
 
     def _install_package(self):
-        commands = [sys.executable, "-m", "pip", "install", self.pkg_path, "-q"]
-        # Packages with large dependency trees (e.g. those pulling the Microsoft
-        # OpenTelemetry distro) can exceed a short install timeout on slower CI
-        # agents even though the install is healthy — the same install has been
-        # observed to take 35s on one agent and 136s on another. Use 300s to
-        # avoid spurious API Review failures.
-        result = run(commands, timeout=300, stderr=PIPE, text=True)
+        # Prefer `uv pip install` when uv is available: its dependency resolver is
+        # dramatically faster than pip's for large, beta-pinned trees (e.g. the
+        # Microsoft OpenTelemetry distro), where pip can spend minutes backtracking
+        # over candidate versions. Fall back to `pip install` when uv is not on PATH.
+        if shutil.which("uv") is not None:
+            commands = ["uv", "pip", "install", "--python", sys.executable, self.pkg_path, "-q"]
+        else:
+            commands = [sys.executable, "-m", "pip", "install", self.pkg_path, "-q"]
+        result = run(commands, timeout=120, stderr=PIPE, text=True)
         if result.stderr:
             logging.debug("pip stderr: %s", result.stderr.strip())
         if result.returncode != 0:

--- a/packages/python-packages/apiview-stub-generator/apistub/_version.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-VERSION = "0.3.29"
+VERSION = "0.3.30"


### PR DESCRIPTION
## Summary
Installs the target package with `uv pip install` (when `uv` is on PATH) instead of `pip` before generating the API view, and reverts the package-install timeout from 300s back to the original 120s.

## Why
Follow-up to #16395. That PR raised the timeout to 300s to accommodate `azure-ai-agentserver-core`, whose install pulls the full Microsoft OpenTelemetry instrumentation tree. Verbose diagnostics showed the slowness was **pip's dependency resolver backtracking** over the large, beta-pinned graph (42 packages, 52 downloads, 0 cached, **no** network retries, only a few MB transferred) — a CPU/resolver problem, not network. The install took ~370s under pip and even blew past 300s.

`uv`'s resolver handles the same tree in seconds (the repo's dev-requirement installs already use uv and resolve in ~1-2s). Switching apistub's own package install to uv removes the root cause, so the elevated timeout is no longer necessary.

## Changes
- `_install_package`: prefer `uv pip install --python <interp>` when `uv` is available; fall back to `pip install` otherwise.
- Revert install timeout `300s -> 120s`.
- Bump version `0.3.29 -> 0.3.30` + CHANGELOG entry.

## Notes
- uv is already the default installer across the azure-sdk-for-python tooling (`AZPYSDK_PIP_IMPL=uv`), with `UV_DEFAULT_INDEX` wired to the authenticated feed — so this aligns apistub's last pip holdout with the established pattern.
- Falls back to pip cleanly if uv is absent, so no hard dependency is introduced.