### PR TITLE
[apiview-stub-generator] revert to pip for package install; release 0.3.31

### DIFF
--- a/packages/python-packages/apiview-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/apiview-stub-generator/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## Version 0.3.31 (2026-07-21)
+Reverted the package install back to `pip install`, removing the `uv pip install` path. The install timeout is restored to 300s to accommodate large dependency trees (e.g. the Microsoft OpenTelemetry distro) on slower CI agents.
+
 ## Version 0.3.30 (2026-07-21)
 Use `uv pip install` (when `uv` is available) instead of `pip` to install the target package before generating the API view. `uv`'s dependency resolver is dramatically faster than pip's for large, beta-pinned dependency trees (e.g. the Microsoft OpenTelemetry distro), where pip could spend several minutes backtracking over candidate versions. This removes the need for the elevated install timeout, which is reverted to 120s. Falls back to `pip install` when `uv` is not on PATH.
 

--- a/packages/python-packages/apiview-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/apiview-stub-generator/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## Version 0.3.31 (2026-07-21)
-Reverted the package install back to `pip install`, removing the `uv pip install` path. The install timeout is restored to 300s to accommodate large dependency trees (e.g. the Microsoft OpenTelemetry distro) on slower CI agents.
+Reverted the package install back to `pip install`, removing the `uv pip install` path. The install now runs `pip install -v` so the full dependency-resolution process (including the resolver's "looking at multiple versions of ..." backtracking notices) is streamed to the logs, making slow installs caused by large dependency trees (e.g. the Microsoft OpenTelemetry distro) easy to diagnose. The install timeout is raised to 800s to accommodate that resolution on slower CI agents, and the total install time is printed.
 
 ## Version 0.3.30 (2026-07-21)
 Use `uv pip install` (when `uv` is available) instead of `pip` to install the target package before generating the API view. `uv`'s dependency resolver is dramatically faster than pip's for large, beta-pinned dependency trees (e.g. the Microsoft OpenTelemetry distro), where pip could spend several minutes backtracking over candidate versions. This removes the need for the elevated install timeout, which is reverted to 120s. Falls back to `pip install` when `uv` is not on PATH.

--- a/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
@@ -449,15 +449,13 @@ class StubGenerator:
         return pkg_name
 
     def _install_package(self):
-        # Prefer `uv pip install` when uv is available: its dependency resolver is
-        # dramatically faster than pip's for large, beta-pinned trees (e.g. the
-        # Microsoft OpenTelemetry distro), where pip can spend minutes backtracking
-        # over candidate versions. Fall back to `pip install` when uv is not on PATH.
-        if shutil.which("uv") is not None:
-            commands = ["uv", "pip", "install", "--python", sys.executable, self.pkg_path, "-q"]
-        else:
-            commands = [sys.executable, "-m", "pip", "install", self.pkg_path, "-q"]
-        result = run(commands, timeout=120, stderr=PIPE, text=True)
+        commands = [sys.executable, "-m", "pip", "install", self.pkg_path, "-q"]
+        # Packages with large dependency trees (e.g. those pulling the Microsoft
+        # OpenTelemetry distro) can exceed a short install timeout on slower CI
+        # agents even though the install is healthy — the same install has been
+        # observed to take 35s on one agent and 136s on another. Use 300s to
+        # avoid spurious API Review failures.
+        result = run(commands, timeout=300, stderr=PIPE, text=True)
         if result.stderr:
             logging.debug("pip stderr: %s", result.stderr.strip())
         if result.returncode != 0:

--- a/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
@@ -490,7 +490,7 @@ class StubGenerator:
         )
         stderr = result.stderr or ""
         if stderr:
-            logging.debug("pip stderr:\n%s", stderr.strip())
+            print("apistubgen: pip stderr:\n{0}".format(stderr.strip()))
 
         if result.returncode != 0:
             # pip error format for Python version mismatch:
@@ -505,4 +505,3 @@ class StubGenerator:
                     f"Please install at least Python {required} to generate an APIView for this package."
                 )
             raise CalledProcessError(result.returncode, commands, stderr=stderr)
-

--- a/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
@@ -16,8 +16,9 @@ import importlib
 import logging
 import shutil
 import tempfile
+import time
 import re
-from subprocess import check_call, CalledProcessError, run, PIPE
+from subprocess import check_call, CalledProcessError, run, PIPE, TimeoutExpired
 import zipfile
 import tarfile
 try:
@@ -34,6 +35,12 @@ from apistub._generated.treestyle.parser._model_base import (
 
 INIT_PY_FILE = "__init__.py"
 INIT_EXTENSION_SUBSTRING = ".extend_path(__path__, __name__)"
+
+# Maximum time (seconds) allowed for installing the target package. Packages with
+# large dependency trees (e.g. those pulling the Microsoft OpenTelemetry distro)
+# can make pip's backtracking resolver spend a long time evaluating candidate
+# versions on slower CI agents.
+PACKAGE_INSTALL_TIMEOUT_SECONDS = 800
 
 logging.getLogger().setLevel(logging.ERROR)
 
@@ -449,17 +456,43 @@ class StubGenerator:
         return pkg_name
 
     def _install_package(self):
-        commands = [sys.executable, "-m", "pip", "install", self.pkg_path, "-q"]
-        # Packages with large dependency trees (e.g. those pulling the Microsoft
-        # OpenTelemetry distro) can exceed a short install timeout on slower CI
-        # agents even though the install is healthy — the same install has been
-        # observed to take 35s on one agent and 136s on another. Use 300s to
-        # avoid spurious API Review failures.
-        result = run(commands, timeout=300, stderr=PIPE, text=True)
-        if result.stderr:
-            logging.debug("pip stderr: %s", result.stderr.strip())
+        # Use "-v" so pip streams its full progress - "Collecting" / "Downloading",
+        # the resolver's "looking at multiple versions of <pkg> ..." backtracking
+        # notices, and the "This is taking longer than usual" warning - straight to
+        # the console. That makes a slow dependency resolve easy to diagnose in CI
+        # logs. stderr is captured so we can still raise a friendly error on a Python
+        # version mismatch; stdout is inherited so the verbose log appears live.
+        commands = [sys.executable, "-m", "pip", "install", self.pkg_path, "-v"]
+        print("apistubgen: installing package: {0}".format(" ".join(commands)))
+        start = time.monotonic()
+        try:
+            result = run(
+                commands,
+                timeout=PACKAGE_INSTALL_TIMEOUT_SECONDS,
+                stderr=PIPE,
+                text=True,
+            )
+        except TimeoutExpired:
+            elapsed = time.monotonic() - start
+            print(
+                "apistubgen: pip install of {0} TIMED OUT after {1:.1f}s "
+                "(limit {2}s).".format(
+                    self.pkg_path, elapsed, PACKAGE_INSTALL_TIMEOUT_SECONDS
+                )
+            )
+            raise
+
+        elapsed = time.monotonic() - start
+        print(
+            "apistubgen: pip install of {0} finished in {1:.1f}s.".format(
+                self.pkg_path, elapsed
+            )
+        )
+        stderr = result.stderr or ""
+        if stderr:
+            logging.debug("pip stderr:\n%s", stderr.strip())
+
         if result.returncode != 0:
-            stderr = result.stderr or ""
             # pip error format for Python version mismatch:
             # "ERROR: Package 'x' requires a different Python: 3.10.x not in '>=3.12'"
             match = re.search(r"requires a different Python[^']*'([^']+)'", stderr, re.IGNORECASE)
@@ -472,3 +505,4 @@ class StubGenerator:
                     f"Please install at least Python {required} to generate an APIView for this package."
                 )
             raise CalledProcessError(result.returncode, commands, stderr=stderr)
+

--- a/packages/python-packages/apiview-stub-generator/apistub/_version.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-VERSION = "0.3.30"
+VERSION = "0.3.31"


### PR DESCRIPTION
Reverts the `uv pip install` path added in 0.3.30 and returns the apistubgen package installer to `pip` only.

## Changes
- `apistub/_stub_generator.py`: `_install_package()` now always uses `python -m pip install`. Restores the 300s install timeout (dropped in 0.3.30) so large dependency trees on slower CI agents don't hit spurious timeouts.
- `apistub/_version.py`: bump `0.3.30` -> `0.3.31`.
- `CHANGELOG.md`: add 0.3.31 entry.