### PR TITLE
Fix rust parser CI npm registry redirect

### DIFF
--- a/tools/apiview/parsers/rust-api-parser/ci.yml
+++ b/tools/apiview/parsers/rust-api-parser/ci.yml
@@ -36,6 +36,8 @@ extends:
             value: 'tools/apiview/parsers/rust-api-parser'
         jobs:
           - job: 'Build'
+            variables:
+              npmrcPath: $(Agent.TempDirectory)/.npmrc
 
             pool:
               name: $(LINUXPOOL)
@@ -48,14 +50,20 @@ extends:
                   versionSpec: '$(NodeVersion)'
                 displayName: 'Use NodeJS $(NodeVersion)'
 
+              - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+                parameters:
+                  npmrcPath: $(npmrcPath)
+
               - script: |
-                        npm install -g npm@latest
+                  npm install -g npm@latest --userconfig $(npmrcPath)
                 displayName: "Install latest npm"
 
               - script: |
                   npm install
                 workingDirectory: $(RustGeneratorDirectory)
                 displayName: "Install npm packages Rust generator"
+                env:
+                  npm_config_userconfig: $(npmrcPath)
 
               - script: |
                   npm run-script build

--- a/tools/apiview/parsers/rust-api-parser/ci.yml
+++ b/tools/apiview/parsers/rust-api-parser/ci.yml
@@ -38,6 +38,7 @@ extends:
           - job: 'Build'
             variables:
               npmrcPath: $(Agent.TempDirectory)/.npmrc
+              NPM_CONFIG_USERCONFIG: $(npmrcPath)
 
             pool:
               name: $(LINUXPOOL)
@@ -55,15 +56,13 @@ extends:
                   npmrcPath: $(npmrcPath)
 
               - script: |
-                  npm install -g npm@latest --userconfig $(npmrcPath)
+                  npm install -g npm@latest
                 displayName: "Install latest npm"
 
               - script: |
                   npm install
                 workingDirectory: $(RustGeneratorDirectory)
                 displayName: "Install npm packages Rust generator"
-                env:
-                  npm_config_userconfig: $(npmrcPath)
 
               - script: |
                   npm run-script build

--- a/tools/apiview/parsers/rust-api-parser/ci.yml
+++ b/tools/apiview/parsers/rust-api-parser/ci.yml
@@ -36,10 +36,6 @@ extends:
             value: 'tools/apiview/parsers/rust-api-parser'
         jobs:
           - job: 'Build'
-            variables:
-              npmrcPath: $(Agent.TempDirectory)/.npmrc
-              NPM_CONFIG_USERCONFIG: $(npmrcPath)
-
             pool:
               name: $(LINUXPOOL)
               image: $(LINUXVMIMAGE)
@@ -52,8 +48,6 @@ extends:
                 displayName: 'Use NodeJS $(NodeVersion)'
 
               - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
-                parameters:
-                  npmrcPath: $(npmrcPath)
 
               - script: |
                   npm install -g npm@latest


### PR DESCRIPTION
Use authenticated .npmrc in the rust-api-parser build job so npm install commands resolve through the Azure Artifacts feed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Copilot-Session: de13c0a7-b615-4083-9d4c-43e3028e2804
