### PR TITLE
Update Rust APIView parser version

### DIFF
--- a/eng/common/pipelines/templates/steps/maven-authenticate.yml
+++ b/eng/common/pipelines/templates/steps/maven-authenticate.yml
@@ -1,0 +1,17 @@
+parameters:
+  SourceDirectory: $(Build.SourcesDirectory)
+
+steps:
+  # Copy mirror settings to default Maven location so all requests go through CFS
+  - pwsh: |
+      $m2Dir = if ($env:USERPROFILE) { "$env:USERPROFILE\.m2" } else { "$HOME/.m2" }
+      New-Item -ItemType Directory -Force -Path $m2Dir | Out-Null
+      Copy-Item -Path "${{ parameters.SourceDirectory }}/eng/settings.xml" -Destination "$m2Dir/settings.xml"
+    displayName: "Setup Maven mirror settings"
+
+  # Authenticate with Azure Artifacts feeds
+  # MavenAuthenticate adds <server> entries to ~/.m2/settings.xml matching mirror id 'azure-sdk-for-java'
+  - task: MavenAuthenticate@0
+    displayName: "Maven Authenticate"
+    inputs:
+      artifactsFeeds: "azure-sdk-for-java"

--- a/eng/settings.xml
+++ b/eng/settings.xml
@@ -1,0 +1,13 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                        https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>azure-sdk-for-java</id>
+      <name>Azure Artifacts Maven Mirror</name>
+      <url>https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-java/maven/v1</url>
+      <mirrorOf>external:*</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>

--- a/src/dotnet/APIView/apiview.yml
+++ b/src/dotnet/APIView/apiview.yml
@@ -89,6 +89,8 @@ extends:
                   enabled: true # Enable CG only on the build job
 
             steps:
+              - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+
               - task: NodeTool@0
                 inputs:
                   versionSpec: '$(NodeVersion)'

--- a/src/dotnet/APIView/apiview.yml
+++ b/src/dotnet/APIView/apiview.yml
@@ -10,7 +10,7 @@ parameters:
     default: '@azure-tools/ts-genapi@2.0.11'
   - name: RustAPIParser
     type: string
-    default: '@azure-tools/rust-genapi@1.3.0'
+    default: '@azure-tools/rust-genapi@1.4.0'
   - name: JavaScriptArtifactRegistry
     type: string
     default: 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js@local/npm/registry/'

--- a/src/dotnet/APIView/apiview.yml
+++ b/src/dotnet/APIView/apiview.yml
@@ -91,6 +91,8 @@ extends:
             steps:
               - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
 
+              - template: /eng/common/pipelines/templates/steps/maven-authenticate.yml
+
               - task: NodeTool@0
                 inputs:
                   versionSpec: '$(NodeVersion)'
@@ -184,6 +186,8 @@ extends:
               os: linux
 
             steps:
+              - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+
               - task: NodeTool@0
                 inputs:
                   versionSpec: '$(NodeVersion)'


### PR DESCRIPTION
This pull request updates the default version of the Rust API parser used in the APIView configuration. This ensures that the latest features and fixes from the Rust API parser are available for API analysis.

Dependency updates:

* Updated the `RustAPIParser` parameter in `apiview.yml` to use `@azure-tools/rust-genapi@1.4.0` instead of `1.3.0`, ensuring the latest version is used.