### PR TITLE
Skip updating exclusion status when package detail are not available

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/DevOpsServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/DevOpsServiceTests.cs
@@ -257,6 +257,125 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
 
         #endregion
 
+        #region UpdateReleasePlanSDKDetailsAsync Tests
+
+        [Test]
+        public async Task UpdateReleasePlanSDKDetailsAsync_WhenCurrentStatusIsMissingEmitterConfig_ResetsExclusionStatusToNotApplicable()
+        {
+            // Arrange: the language was previously auto-marked MissingEmitterConfig because the parser did
+            // not detect a package name. Now a package name is detected, so the status must be reset.
+            var plan = CreateReleasePlanWorkItemWithExclusionStatus(35000, "Python", "MissingEmitterConfig");
+            _connection.AddWorkItem(plan);
+            var sdkLanguages = new List<SDKInfo>
+            {
+                new() { Language = "Python", PackageName = "azure-mgmt-contoso" }
+            };
+
+            // Act
+            var result = await _devOpsService.UpdateReleasePlanSDKDetailsAsync(35000, sdkLanguages, CancellationToken.None);
+
+            // Assert
+            Assert.That(result, Is.True);
+            var patch = _connection.LastCapturedPatchDocument;
+            Assert.IsNotNull(patch, "UpdateWorkItemAsync should have been called with a patch document");
+            var resetOp = patch!.FirstOrDefault(op => op.Path == "/fields/Custom.ReleaseExclusionStatusForPython");
+            Assert.IsNotNull(resetOp, "Exclusion status should be reset when the current status is MissingEmitterConfig");
+            Assert.That(resetOp!.Value, Is.EqualTo("Not applicable"));
+        }
+
+        [Test]
+        public async Task UpdateReleasePlanSDKDetailsAsync_WhenCurrentStatusIsRequested_DoesNotResetExclusionStatus()
+        {
+            // Arrange: an intentional exclusion (Requested) must be preserved even when a package name is detected.
+            var plan = CreateReleasePlanWorkItemWithExclusionStatus(35000, "Java", "Requested");
+            _connection.AddWorkItem(plan);
+            var sdkLanguages = new List<SDKInfo>
+            {
+                new() { Language = "Java", PackageName = "com.azure.contoso" }
+            };
+
+            // Act
+            var result = await _devOpsService.UpdateReleasePlanSDKDetailsAsync(35000, sdkLanguages, CancellationToken.None);
+
+            // Assert
+            Assert.That(result, Is.True);
+            var patch = _connection.LastCapturedPatchDocument;
+            Assert.IsNotNull(patch);
+            // The package name is still updated, but an intentional exclusion must not be reset.
+            Assert.That(patch!.Any(op => op.Path == "/fields/Custom.JavaPackageName"), Is.True);
+            Assert.That(patch.Any(op => op.Path == "/fields/Custom.ReleaseExclusionStatusForJava"), Is.False,
+                "Requested exclusion status must not be reset");
+        }
+
+        [Test]
+        public async Task UpdateReleasePlanSDKDetailsAsync_WhenCurrentStatusIsApproved_DoesNotResetExclusionStatus()
+        {
+            // Arrange: an approved exclusion must be preserved.
+            var plan = CreateReleasePlanWorkItemWithExclusionStatus(35000, "Go", "Approved");
+            _connection.AddWorkItem(plan);
+            var sdkLanguages = new List<SDKInfo>
+            {
+                new() { Language = "Go", PackageName = "sdk/contoso/armcontoso" }
+            };
+
+            // Act
+            var result = await _devOpsService.UpdateReleasePlanSDKDetailsAsync(35000, sdkLanguages, CancellationToken.None);
+
+            // Assert
+            Assert.That(result, Is.True);
+            var patch = _connection.LastCapturedPatchDocument;
+            Assert.IsNotNull(patch);
+            Assert.That(patch!.Any(op => op.Path == "/fields/Custom.ReleaseExclusionStatusForGo"), Is.False,
+                "Approved exclusion status must not be reset");
+        }
+
+        [Test]
+        public async Task UpdateReleasePlanSDKDetailsAsync_WhenCurrentStatusIsEmpty_DoesNotResetExclusionStatus()
+        {
+            // Arrange: no prior exclusion status, so there is nothing to reset.
+            var plan = CreateReleasePlanWorkItem(35000, "In Progress");
+            _connection.AddWorkItem(plan);
+            var sdkLanguages = new List<SDKInfo>
+            {
+                new() { Language = "Python", PackageName = "azure-mgmt-contoso" }
+            };
+
+            // Act
+            var result = await _devOpsService.UpdateReleasePlanSDKDetailsAsync(35000, sdkLanguages, CancellationToken.None);
+
+            // Assert
+            Assert.That(result, Is.True);
+            var patch = _connection.LastCapturedPatchDocument;
+            Assert.IsNotNull(patch);
+            Assert.That(patch!.Any(op => op.Path == "/fields/Custom.ReleaseExclusionStatusForPython"), Is.False,
+                "An empty exclusion status must not be reset");
+        }
+
+        [Test]
+        public async Task UpdateReleasePlanSDKDetailsAsync_MissingEmitterConfigComparisonIsCaseInsensitive()
+        {
+            // Arrange: the current status comparison must be case-insensitive.
+            var plan = CreateReleasePlanWorkItemWithExclusionStatus(35000, "Python", "missingemitterconfig");
+            _connection.AddWorkItem(plan);
+            var sdkLanguages = new List<SDKInfo>
+            {
+                new() { Language = "Python", PackageName = "azure-mgmt-contoso" }
+            };
+
+            // Act
+            var result = await _devOpsService.UpdateReleasePlanSDKDetailsAsync(35000, sdkLanguages, CancellationToken.None);
+
+            // Assert
+            Assert.That(result, Is.True);
+            var patch = _connection.LastCapturedPatchDocument;
+            Assert.IsNotNull(patch);
+            var resetOp = patch!.FirstOrDefault(op => op.Path == "/fields/Custom.ReleaseExclusionStatusForPython");
+            Assert.IsNotNull(resetOp, "MissingEmitterConfig comparison must be case-insensitive");
+            Assert.That(resetOp!.Value, Is.EqualTo("Not applicable"));
+        }
+
+        #endregion
+
         #region Helper Methods
 
         private WorkItem CreateReleasePlanWorkItemWithReleasePlanId(int workItemId, int releasePlanId, string state)
@@ -315,6 +434,13 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
                 },
                 Relations = new List<WorkItemRelation>()
             };
+            return workItem;
+        }
+
+        private WorkItem CreateReleasePlanWorkItemWithExclusionStatus(int id, string languageId, string exclusionStatus)
+        {
+            var workItem = CreateReleasePlanWorkItem(id, "In Progress");
+            workItem.Fields[$"Custom.ReleaseExclusionStatusFor{languageId}"] = exclusionStatus;
             return workItem;
         }
 
@@ -528,6 +654,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
 
             public string? LastCapturedQuery => _workItemClient.LastCapturedQuery;
 
+            public Microsoft.VisualStudio.Services.WebApi.Patch.Json.JsonPatchDocument? LastCapturedPatchDocument => _workItemClient.LastCapturedPatchDocument;
+
             public BuildHttpClient GetBuildClient(CancellationToken ct = default)
             {
                 throw new NotImplementedException();
@@ -560,6 +688,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
             private readonly Dictionary<int, WorkItem> _workItems = new();
 
             public string? LastCapturedQuery { get; private set; }
+
+            public Microsoft.VisualStudio.Services.WebApi.Patch.Json.JsonPatchDocument? LastCapturedPatchDocument { get; private set; }
 
             public TestWorkItemClient() : base(new Uri("https://dev.azure.com/test"), null)
             {
@@ -640,6 +770,21 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
                     return Task.FromResult(workItem);
                 }
                 throw new InvalidOperationException($"Work item {id} not found");
+            }
+
+            public override Task<WorkItem> UpdateWorkItemAsync(
+                Microsoft.VisualStudio.Services.WebApi.Patch.Json.JsonPatchDocument document,
+                int id,
+                bool? validateOnly = null,
+                bool? bypassRules = null,
+                bool? suppressNotifications = null,
+                WorkItemExpand? expand = null,
+                object? userState = null,
+                CancellationToken cancellationToken = default)
+            {
+                LastCapturedPatchDocument = document;
+                _workItems.TryGetValue(id, out var workItem);
+                return Task.FromResult(workItem ?? new WorkItem { Id = id });
             }
 
         }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
@@ -977,6 +977,33 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             var updateStatus = await tool.UpdateSDKDetailsInReleasePlan(100, testCodeFilePath, CancellationToken.None);
             Assert.That(updateStatus.ResponseError, Does.Contain("Failed to parse TypeSpec project"));
         }
+
+        [Test]
+        public async Task Test_Update_SDK_Details_skips_update_when_no_packages_resolved()
+        {
+            // When the TypeSpec project resolves zero packages, the tool must skip the update entirely
+            // to avoid incorrectly marking languages as having missing emitter configuration. It should
+            // return an informational message and never touch the release plan work item.
+            var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
+            var project = TypeSpecProject.ParseTypeSpecConfig(testCodeFilePath);
+            project.Packages = new List<PackageInfo>();
+
+            var mockDevOps = new Mock<IDevOpsService>();
+            var mockTypeSpecHelper = new Mock<ITypeSpecHelper>();
+            mockTypeSpecHelper.Setup(x => x.IsValidTypeSpecProjectPath(testCodeFilePath)).Returns(true);
+            mockTypeSpecHelper.Setup(x => x.ParseTypeSpecProjectAsync(testCodeFilePath, It.IsAny<INpxHelper>(), It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(project);
+
+            var tool = new ReleasePlanTool(mockDevOps.Object, gitHelper, mockTypeSpecHelper.Object, logger, userHelper, gitHubService, environmentHelper, inputSanitizer, httpClient, Mock.Of<INpxHelper>(), Mock.Of<IRawOutputHelper>(), Mock.Of<INotificationService>());
+            var updateStatus = await tool.UpdateSDKDetailsInReleasePlan(100, testCodeFilePath, CancellationToken.None);
+
+            Assert.That(updateStatus.ResponseError, Is.Null);
+            Assert.That(updateStatus.Message, Does.Contain("No package details were identified"));
+            // No release plan reads or writes should happen when there are no packages to update.
+            mockDevOps.Verify(x => x.ResolveReleasePlanByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+            mockDevOps.Verify(x => x.UpdateReleasePlanSDKDetailsAsync(It.IsAny<int>(), It.IsAny<List<SDKInfo>>(), It.IsAny<CancellationToken>()), Times.Never);
+            mockDevOps.Verify(x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
         
         [Test]
         public async Task Test_update_language_exclusion_justification()

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -151,6 +151,8 @@ namespace Azure.Sdk.Tools.Cli.Services
     {
         private static readonly string RELEASE_PLANNER_APP_TEST = "Release Planner App Test";
         private static readonly string MISSING_EMITTER_CONFIG = "MissingEmitterConfig";
+        private static readonly string NOT_APPLICABLE = "Not applicable";
+
         private List<WorkItemRelationType>? _cachedRelationTypes;
 
         private static readonly string[] SUPPORTED_SDK_LANGUAGES = { "Dotnet", "JavaScript", "Python", "Java", "Go" };
@@ -1128,7 +1130,7 @@ namespace Azure.Sdk.Tools.Cli.Services
                                 {
                                     Operation = Microsoft.VisualStudio.Services.WebApi.Patch.Operation.Add,
                                     Path = $"/fields/Custom.ReleaseExclusionStatusFor{MapLanguageToId(sdk.Language)}",
-                                    Value = "Not applicable"
+                                    Value = NOT_APPLICABLE
                                 }
                             );
                         }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -150,6 +150,7 @@ namespace Azure.Sdk.Tools.Cli.Services
     public partial class DevOpsService(ILogger<DevOpsService> logger, IDevOpsConnection connection) : IDevOpsService
     {
         private static readonly string RELEASE_PLANNER_APP_TEST = "Release Planner App Test";
+        private static readonly string MISSING_EMITTER_CONFIG = "MissingEmitterConfig";
         private List<WorkItemRelationType>? _cachedRelationTypes;
 
         private static readonly string[] SUPPORTED_SDK_LANGUAGES = { "Dotnet", "JavaScript", "Python", "Java", "Go" };
@@ -1109,6 +1110,28 @@ namespace Azure.Sdk.Tools.Cli.Services
                                 Value = sdk.PackageName
                             }
                         );
+
+                        // A package name is now detected for this language, so only reset the exclusion
+                        // status if it was previously auto-set to MissingEmitterConfig. This avoids leaving a
+                        // language marked as missing emitter config when the TypeSpec parser did not detect a
+                        // package name in an earlier run, while preserving intentional exclusions
+                        // (e.g. Requested/Approved).
+                        var normalizedLanguage = MapLanguageIdToName(MapLanguageToId(sdk.Language));
+                        var currentExclusionStatus = releasePlan?.SDKInfo?
+                            .FirstOrDefault(s => string.Equals(s.Language, normalizedLanguage, StringComparison.OrdinalIgnoreCase))?
+                            .ReleaseExclusionStatus;
+                        if (string.Equals(currentExclusionStatus, MISSING_EMITTER_CONFIG, StringComparison.OrdinalIgnoreCase))
+                        {
+                            // Reset exclusion status as not applicable
+                            jsonLinkDocument.Add(
+                                new JsonPatchOperation
+                                {
+                                    Operation = Microsoft.VisualStudio.Services.WebApi.Patch.Operation.Add,
+                                    Path = $"/fields/Custom.ReleaseExclusionStatusFor{MapLanguageToId(sdk.Language)}",
+                                    Value = "Not applicable"
+                                }
+                            );
+                        }
                     }
                 }
                 await connection.GetWorkItemClient(ct).UpdateWorkItemAsync(jsonLinkDocument, workItemId, cancellationToken: ct);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -1265,6 +1265,13 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     return new DefaultCommandResponse { ResponseError = $"Failed to parse TypeSpec project at {typeSpecProjectPath}." };
                 }
 
+                // Skip updating SDK details to avoid marking packages as missing emitter config when no SDK details are available.
+                if (resolvedPackages.Count == 0)
+                {
+                    logger.LogDebug("No package details were identified in the TypeSpec project path {typeSpecProjectPath}", typeSpecProjectPath);
+                    return new DefaultCommandResponse { Message = $"No package details were identified in the TypeSpec project path {typeSpecProjectPath}" };
+                }
+
                 // Get release plan. The resolver accepts either a Release Plan ID or a work item ID.
                 var releasePlan = await devOpsService.ResolveReleasePlanByIdAsync(releasePlanWorkItemId, ct);
                 if (releasePlan == null)

--- a/tools/azsdk-cli/CHANGELOG.md
+++ b/tools/azsdk-cli/CHANGELOG.md
@@ -6,3 +6,7 @@
 
 - Added `request-copilot-review` CLI command and `azsdk_apiview_request_copilot_review` MCP tool to submit API surface text for automated Copilot review. Accepts text directly via `--api-text` (raw or markdown-fenced) or fetches it automatically from an APIView URL via `--url`. Optional parameters: `--language`, `--base-api-text`, `--outline`, `--existing-comments`.
 - Added `get-copilot-review` CLI command and `azsdk_apiview_get_copilot_review` MCP tool to retrieve the status and results of a Copilot review job by `--job-id`.
+
+### Bugs Fixed
+
+- Fixed release plan SDK details update to avoid marking a language as missing emitter config when the TypeSpec parser did not detect any package name.


### PR DESCRIPTION
Skip updating release exclusion status when no sdk details are available to avoid false negative exclusion.
Also resent the exclusion status when package name is identified.