### PR TITLE
Fix custom-code repair without local TypeSpec path

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Prompts/Templates/FeedbackClassificationTemplateTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Prompts/Templates/FeedbackClassificationTemplateTests.cs
@@ -63,5 +63,7 @@ public class FeedbackClassificationTemplateTests
         Assert.That(prompt, Does.Contain("TypeSpec inspection unavailable"));
         Assert.That(prompt, Does.Not.Contain("**Available Tools:**"));
         Assert.That(prompt, Does.Not.Contain("Always search the TypeSpec files first"));
+        Assert.That(prompt, Does.Not.Contain("reference documentation below"));
+        Assert.That(prompt, Does.Not.Contain("Consult the reference documentation provided"));
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Prompts/Templates/FeedbackClassificationTemplateTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Prompts/Templates/FeedbackClassificationTemplateTests.cs
@@ -14,14 +14,15 @@ public class FeedbackClassificationTemplateTests
         new FeedbackItem { Text = "Rename FooClient to BarClient" }
     ];
 
-    private static FeedbackClassificationTemplate CreateTemplate(EditScope editScope) =>
+    private static FeedbackClassificationTemplate CreateTemplate(EditScope editScope, bool specInspectionAvailable = true) =>
         new(
             serviceName: "Widget",
             language: "csharp",
             referenceDocContent: "reference",
             items: SampleItems(),
             globalContext: "ctx",
-            editScope: editScope);
+            editScope: editScope,
+            specInspectionAvailable: specInspectionAvailable);
 
     [Test]
     public void AllScope_EmitsNoEditScopeBias()
@@ -52,5 +53,15 @@ public class FeedbackClassificationTemplateTests
         Assert.That(prompt, Does.Contain("EDIT SCOPE — SPEC INPUTS ONLY"));
         Assert.That(prompt, Does.Contain("classify it as **TSP_APPLICABLE**"));
         Assert.That(prompt, Does.Not.Contain("EDIT SCOPE — CUSTOM CODE ONLY"));
+    }
+
+    [Test]
+    public void CustomCodeScopeWithoutSpecInspection_DoesNotAdvertiseSpecTools()
+    {
+        var prompt = CreateTemplate(EditScope.CustomCode, specInspectionAvailable: false).BuildPrompt();
+
+        Assert.That(prompt, Does.Contain("TypeSpec inspection unavailable"));
+        Assert.That(prompt, Does.Not.Contain("**Available Tools:**"));
+        Assert.That(prompt, Does.Not.Contain("Always search the TypeSpec files first"));
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/FeedbackClassifierServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/FeedbackClassifierServiceTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Reflection;
 using Azure.Sdk.Tools.Cli.CopilotAgents;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
@@ -10,8 +11,6 @@ using GitHub.Copilot.SDK;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
-using System.Reflection;
-
 using static Azure.Sdk.Tools.Cli.Tests.TestHelpers.TestCategories;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Services;
@@ -254,6 +253,57 @@ public class FeedbackClassifierServiceTests
 
         // Assert
         Assert.That(item1.Status, Is.EqualTo(FeedbackStatus.TSP_APPLICABLE));
+    }
+
+    [Test]
+    public async Task ClassifyAsync_CustomCodeScopeWithoutTspPath_DoesNotAccessSpecRepo()
+    {
+        var service = CreateMockedService();
+        var item = CreateTestItem("error CS0103: The name 'BlobUriForRepairTest' does not exist", "item-1");
+        var items = new List<FeedbackItem> { item };
+        var batchResponse = """
+            [item-1]
+            Classification: CODE_CUSTOMIZATION
+            Reason: The failure is in a custom partial class and can be fixed without changing TypeSpec inputs
+            """;
+
+        _mockAgentRunner
+            .Setup(x => x.RunAsync(It.IsAny<CopilotAgent<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(batchResponse);
+
+        await service.ClassifyItemsAsync(
+            items,
+            globalContext: "Custom-code build repair",
+            tspProjectPath: null,
+            language: "csharp",
+            serviceName: "ContentSafety",
+            editScope: EditScope.CustomCode);
+
+        Assert.That(item.Status, Is.EqualTo(FeedbackStatus.CODE_CUSTOMIZATION));
+        _mockTypeSpecHelper.Verify(
+            x => x.GetSpecRepoRootPath(It.IsAny<string>()),
+            Times.Never);
+        _mockAgentRunner.Verify(
+            x => x.RunAsync(It.IsAny<CopilotAgent<string>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [TestCase(EditScope.SpecInputs)]
+    [TestCase(EditScope.All)]
+    public void ClassifyAsync_SpecInputScopeWithoutTspPath_ThrowsArgumentException(EditScope editScope)
+    {
+        var service = CreateMockedService();
+        var items = new List<FeedbackItem> { CreateTestItem("Rename FooClient", "item-1") };
+
+        Assert.ThrowsAsync<ArgumentException>(() => service.ClassifyItemsAsync(
+            items,
+            globalContext: string.Empty,
+            tspProjectPath: null,
+            editScope: editScope));
+
+        _mockAgentRunner.Verify(
+            x => x.RunAsync(It.IsAny<CopilotAgent<string>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     /// <summary>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/FeedbackClassificationTemplate.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/FeedbackClassificationTemplate.cs
@@ -23,6 +23,7 @@ public class FeedbackClassificationTemplate : BasePromptTemplate
     private readonly List<FeedbackItem> _items;
     private readonly string _globalContext;
     private readonly EditScope _editScope;
+    private readonly bool _specInspectionAvailable;
 
     /// <summary>
     /// Initializes a new batch classification template.
@@ -37,13 +38,15 @@ public class FeedbackClassificationTemplate : BasePromptTemplate
     /// is asked to prefer the in-scope axis for items that could be addressed either way (e.g. a rename
     /// achievable in spec inputs OR custom code), so fixable items are not reported as out of scope.
     /// </param>
+    /// <param name="specInspectionAvailable">Whether tools and reference content for a local TypeSpec project are available.</param>
     public FeedbackClassificationTemplate(
         string? serviceName,
         string language,
         string referenceDocContent,
         List<FeedbackItem> items,
         string globalContext,
-        EditScope editScope = EditScope.All)
+        EditScope editScope = EditScope.All,
+        bool specInspectionAvailable = true)
     {
         _serviceName = serviceName;
         _language = language;
@@ -51,6 +54,7 @@ public class FeedbackClassificationTemplate : BasePromptTemplate
         _items = items;
         _globalContext = globalContext;
         _editScope = editScope;
+        _specInspectionAvailable = specInspectionAvailable;
     }
 
     public override string BuildPrompt()
@@ -59,7 +63,7 @@ public class FeedbackClassificationTemplate : BasePromptTemplate
         var constraints = BuildClassificationConditions();
         var examples = BuildExamples();
         var outputRequirements = BuildOutputRequirements();
-        
+
         return BuildStructuredPrompt(taskInstructions, constraints, examples, outputRequirements);
     }
 
@@ -95,7 +99,7 @@ public class FeedbackClassificationTemplate : BasePromptTemplate
             sb.AppendLine(scopeGuidance);
         }
 
-        sb.AppendLine($"""
+        sb.AppendLine("""
 
         **Task:**
         Classify ALL of the feedback items listed below. For each item, determine the appropriate classification: **TSP_APPLICABLE**, **CODE_CUSTOMIZATION**, **SUCCESS**, or **REQUIRES_MANUAL_INTERVENTION**.
@@ -103,11 +107,28 @@ public class FeedbackClassificationTemplate : BasePromptTemplate
         - If the feedback is actionable AND TypeSpec client customization decorators can address it (based on the reference documentation below), classify as **TSP_APPLICABLE**.
         - If the feedback is actionable, TypeSpec decorators CANNOT address it, but automated code patching could fix it (e.g., compile errors from method signature changes, parameter additions/removals, symbol renames in generated code), classify as **CODE_CUSTOMIZATION**. Include specific repair instructions in the Reason.
         - If the feedback is actionable but requires complex manual work that cannot be automated (e.g., new feature implementation, architectural changes, custom business logic), classify as **REQUIRES_MANUAL_INTERVENTION**.
+        """);
 
-        **IMPORTANT — Check for already-applied customizations:**
-        Before classifying any item as TSP_APPLICABLE, use the available tools to search the TypeSpec project files (e.g., `client.tsp`, `customizations.tsp`) for the decorator or customization that would address the feedback. If the customization is already present in the TypeSpec files, classify the item as **SUCCESS** (the change has already been applied). Use `grep_search` or `read_file` to verify.
+        if (_specInspectionAvailable)
+        {
+            sb.AppendLine("""
 
-        Use the available tools to inspect the TypeSpec project files when needed to determine if decorators are applicable.
+            **IMPORTANT — Check for already-applied customizations:**
+            Before classifying any item as TSP_APPLICABLE, use the available tools to search the TypeSpec project files (e.g., `client.tsp`, `customizations.tsp`) for the decorator or customization that would address the feedback. If the customization is already present in the TypeSpec files, classify the item as **SUCCESS** (the change has already been applied). Use `grep_search` or `read_file` to verify.
+
+            Use the available tools to inspect the TypeSpec project files when needed to determine if decorators are applicable.
+            """);
+        }
+        else
+        {
+            sb.AppendLine("""
+
+            **TypeSpec inspection unavailable:**
+            No local TypeSpec checkout or spec-repo tools are available in this custom-code-only run. Do not attempt to inspect TypeSpec files. Classify using the feedback, build context, and edit-scope guidance.
+            """);
+        }
+
+        sb.AppendLine($"""
 
         **Global Context:**
         {_globalContext}
@@ -129,20 +150,23 @@ public class FeedbackClassificationTemplate : BasePromptTemplate
             """);
         }
 
-        sb.AppendLine($"""
+        if (_specInspectionAvailable)
+        {
+            sb.AppendLine($"""
 
-        ---
+            ---
 
-        **TypeSpec Client Customizations Reference:**
-        <reference_doc>
-        {_referenceDocContent}
-        </reference_doc>
+            **TypeSpec Client Customizations Reference:**
+            <reference_doc>
+            {_referenceDocContent}
+            </reference_doc>
 
-        **Available Tools:**
-        - `read_file`: Read contents of specific files in the spec repo
-        - `list_dir`: List files and directories
-        - `grep_search`: Search for patterns within files
-        """);
+            **Available Tools:**
+            - `read_file`: Read contents of specific files in the spec repo
+            - `list_dir`: List files and directories
+            - `grep_search`: Search for patterns within files
+            """);
+        }
 
         return sb.ToString();
     }
@@ -199,7 +223,24 @@ public class FeedbackClassificationTemplate : BasePromptTemplate
 
     private string BuildClassificationConditions()
     {
-        return """
+        var specInspectionGuidance = _specInspectionAvailable
+            ? """
+              - Actionable AND a TypeSpec decorator from the reference doc could address it → **check the TypeSpec files first** using `grep_search` or `read_file`
+                - If the decorator/customization is already present in the TypeSpec files → **SUCCESS** (already applied)
+                - If not present → **TSP_APPLICABLE**
+              """
+            : """
+              - Actionable AND a TypeSpec decorator could address it → apply the edit-scope guidance without attempting to inspect unavailable TypeSpec files
+              """;
+
+        var tspVerificationGuidance = _specInspectionAvailable
+            ? """
+              **Always search the TypeSpec files first** (using `grep_search` or `read_file`) to confirm the decorator
+              is NOT already present before classifying as TSP_APPLICABLE. If it is already present, classify as SUCCESS.
+              """
+            : "Local TypeSpec files are unavailable in this run; do not attempt to use spec-repo inspection tools.";
+
+        return $$"""
         **Decision Logic (apply to EACH item independently):**
 
         **If Context is NON-EMPTY** (check first):
@@ -209,9 +250,7 @@ public class FeedbackClassificationTemplate : BasePromptTemplate
 
         **If Context is EMPTY** (first attempt):
         - Non-actionable (informational, "keep as is", past tense, build success, discussion, question) → **SUCCESS**
-        - Actionable AND a TypeSpec decorator from the reference doc could address it → **check the TypeSpec files first** using `grep_search` or `read_file`
-          - If the decorator/customization is already present in the TypeSpec files → **SUCCESS** (already applied)
-          - If not present → **TSP_APPLICABLE**
+        {{specInspectionGuidance}}
         - Actionable, no TypeSpec decorator applies, but automated patching can fix (compile errors, signature changes, parameter additions/removals, symbol renames, linting or typing errors) → **CODE_CUSTOMIZATION**
         - Actionable BUT requires complex manual implementation → **REQUIRES_MANUAL_INTERVENTION**
 
@@ -226,8 +265,7 @@ public class FeedbackClassificationTemplate : BasePromptTemplate
         **TypeSpec Decorator Applicability (TSP_APPLICABLE):**
         Consult the reference documentation provided to determine if any supported
         TypeSpec client customization decorator can address the feedback.
-        **Always search the TypeSpec files first** (using `grep_search` or `read_file`) to confirm the decorator
-        is NOT already present before classifying as TSP_APPLICABLE. If it is already present, classify as SUCCESS.
+        {{tspVerificationGuidance}}
 
         **Common feedback patterns that ARE TypeSpec-applicable:**
         - Renaming (client, operation, model, property, enum value) → `@@clientName` or `@clientName`

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/FeedbackClassificationTemplate.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Prompts/Templates/FeedbackClassificationTemplate.cs
@@ -86,6 +86,10 @@ public class FeedbackClassificationTemplate : BasePromptTemplate
     private string BuildTaskInstructions()
     {
         var sb = new StringBuilder();
+        var tspApplicabilityBasis = _specInspectionAvailable
+            ? "based on the reference documentation below"
+            : "based on known TypeSpec capabilities and the available feedback context";
+
         sb.AppendLine($"""
         **Current Context:**
         - Service: {_serviceName ?? "N/A"}
@@ -104,7 +108,7 @@ public class FeedbackClassificationTemplate : BasePromptTemplate
         **Task:**
         Classify ALL of the feedback items listed below. For each item, determine the appropriate classification: **TSP_APPLICABLE**, **CODE_CUSTOMIZATION**, **SUCCESS**, or **REQUIRES_MANUAL_INTERVENTION**.
         - If the feedback is non-actionable (discussion, informational, "keep as is", or about build/generation succeeding), classify as **SUCCESS**.
-        - If the feedback is actionable AND TypeSpec client customization decorators can address it (based on the reference documentation below), classify as **TSP_APPLICABLE**.
+        - If the feedback is actionable AND TypeSpec client customization decorators can address it ({tspApplicabilityBasis}), classify as **TSP_APPLICABLE**.
         - If the feedback is actionable, TypeSpec decorators CANNOT address it, but automated code patching could fix it (e.g., compile errors from method signature changes, parameter additions/removals, symbol renames in generated code), classify as **CODE_CUSTOMIZATION**. Include specific repair instructions in the Reason.
         - If the feedback is actionable but requires complex manual work that cannot be automated (e.g., new feature implementation, architectural changes, custom business logic), classify as **REQUIRES_MANUAL_INTERVENTION**.
         """);
@@ -240,6 +244,16 @@ public class FeedbackClassificationTemplate : BasePromptTemplate
               """
             : "Local TypeSpec files are unavailable in this run; do not attempt to use spec-repo inspection tools.";
 
+        var tspApplicabilityGuidance = _specInspectionAvailable
+            ? """
+              Consult the reference documentation provided to determine if any supported
+              TypeSpec client customization decorator can address the feedback.
+              """
+            : """
+              Use known TypeSpec client customization capabilities and the available feedback context
+              to determine whether the change genuinely requires a spec-input edit.
+              """;
+
         return $$"""
         **Decision Logic (apply to EACH item independently):**
 
@@ -261,10 +275,9 @@ public class FeedbackClassificationTemplate : BasePromptTemplate
         - Informational: Explanations, questions, acknowledgments
         - Build/generation success with no errors
         - Discussion or questions without a clear directive
-
         **TypeSpec Decorator Applicability (TSP_APPLICABLE):**
-        Consult the reference documentation provided to determine if any supported
-        TypeSpec client customization decorator can address the feedback.
+        **TypeSpec Decorator Applicability (TSP_APPLICABLE):**
+        {{tspApplicabilityGuidance}}
         {{tspVerificationGuidance}}
 
         **Common feedback patterns that ARE TypeSpec-applicable:**

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/FeedbackClassifierService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/FeedbackClassifierService.cs
@@ -27,7 +27,7 @@ public interface IFeedbackClassifierService
     Task<FeedbackClassificationResponse> ClassifyItemsAsync(
         List<FeedbackItem> items,
         string globalContext,
-        string tspProjectPath,
+        string? tspProjectPath,
         string? apiViewUrl = null,
         string? plainTextFeedback = null,
         string? language = null,
@@ -77,7 +77,7 @@ public class FeedbackClassifierService : IFeedbackClassifierService
     public async Task<FeedbackClassificationResponse> ClassifyItemsAsync(
         List<FeedbackItem> items,
         string globalContext,
-        string tspProjectPath,
+        string? tspProjectPath,
         string? apiViewUrl = null,
         string? plainTextFeedback = null,
         string? language = null,
@@ -98,19 +98,31 @@ public class FeedbackClassifierService : IFeedbackClassifierService
             throw new ArgumentException("No feedback items to classify. Provide an APIView URL or plain text feedback.");
         }
 
-        var specRepoBasePath = _typeSpecHelper.GetSpecRepoRootPath(tspProjectPath);
-        if (string.IsNullOrEmpty(specRepoBasePath))
+        string? specRepoBasePath = null;
+        var referenceDocContent = string.Empty;
+
+        if (!string.IsNullOrWhiteSpace(tspProjectPath))
+        {
+            specRepoBasePath = _typeSpecHelper.GetSpecRepoRootPath(tspProjectPath);
+            if (string.IsNullOrEmpty(specRepoBasePath))
+            {
+                throw new ArgumentException(
+                    $"Could not determine spec repo root from TypeSpec project path: {tspProjectPath}",
+                    nameof(tspProjectPath));
+            }
+
+            referenceDocContent = await LoadTspCustomizationGuideAsync(specRepoBasePath, ct);
+        }
+        else if (editScope.HasFlag(EditScope.SpecInputs))
         {
             throw new ArgumentException(
-                $"Could not determine spec repo root from TypeSpec project path: {tspProjectPath}",
+                "A TypeSpec project path is required when spec inputs are in scope.",
                 nameof(tspProjectPath));
         }
 
         var effectiveBatchSize = batchSize ?? DefaultBatchSize;
         _logger.LogInformation("Classifying {Count} items in batch(es) of up to {BatchSize} items",
             items.Count, effectiveBatchSize);
-
-        var referenceDocContent = await LoadTspCustomizationGuideAsync(specRepoBasePath, ct);
 
         foreach (var chunk in items.Chunk(effectiveBatchSize))
         {
@@ -192,7 +204,7 @@ public class FeedbackClassifierService : IFeedbackClassifierService
         string? language,
         string? serviceName,
         string referenceDocContent,
-        string specRepoBasePath,
+        string? specRepoBasePath,
         EditScope editScope,
         CancellationToken ct)
     {
@@ -202,18 +214,21 @@ public class FeedbackClassifierService : IFeedbackClassifierService
             referenceDocContent: referenceDocContent,
             items: items,
             globalContext: globalContext,
-            editScope: editScope
+            editScope: editScope,
+            specInspectionAvailable: !string.IsNullOrWhiteSpace(specRepoBasePath)
         );
 
         var prompt = template.BuildPrompt();
 
-        // Tools scoped to spec repo for TypeSpec project inspection
-        var specTools = new List<AIFunction>
+        // Spec inspection is optional for custom-code-only repair, which intentionally
+        // runs without a local azure-rest-api-specs checkout.
+        var specTools = new List<AIFunction>();
+        if (!string.IsNullOrWhiteSpace(specRepoBasePath))
         {
-            FileTools.CreateReadFileTool(specRepoBasePath),
-            FileTools.CreateListFilesTool(specRepoBasePath),
-            FileTools.CreateGrepSearchTool(specRepoBasePath)
-        };
+            specTools.Add(FileTools.CreateReadFileTool(specRepoBasePath));
+            specTools.Add(FileTools.CreateListFilesTool(specRepoBasePath));
+            specTools.Add(FileTools.CreateGrepSearchTool(specRepoBasePath));
+        }
 
         var result = await _agentRunner.RunAsync(new CopilotAgent<string>
         {
@@ -292,7 +307,7 @@ public class FeedbackClassifierService : IFeedbackClassifierService
             item.ClassificationReason = reason;
             item.AppendContext($"Classification: {classification}\nReason: {reason}", leadingNewLines: 2);
         }
-        
+
         _logger.LogInformation("Item {Id} classified as {Status}: {Reason}", item.Id, status, reason);
     }
 

--- a/tools/azsdk-cli/CHANGELOG.md
+++ b/tools/azsdk-cli/CHANGELOG.md
@@ -10,3 +10,4 @@
 ### Bugs Fixed
 
 - Fixed release plan SDK details update to avoid marking a language as missing emitter config when the TypeSpec parser did not detect any package name.
+- Fixed custom-code-only SDK repair to classify feedback without requiring a local TypeSpec project path.


### PR DESCRIPTION
## Summary

- allow FeedbackClassifierService to classify CustomCode repairs without a local TypeSpec checkout
- omit spec-repo tools and their prompt instructions when no spec path is available
- preserve fail-fast validation for SpecInputs and All scopes
- add regression coverage for the production failure from Azure/azure-sdk-for-net#61234

Fixes #16456.

--generated by Copilot