### PR TITLE
Integrate tool-prompt coverage check with the Vally eval suite

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Azure.Sdk.Tools.Cli.Tests.csproj
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Azure.Sdk.Tools.Cli.Tests.csproj
@@ -40,12 +40,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="../Azure.Sdk.Tools.Cli.Evaluations/TestData/TestPrompts.json" Link="TestData/TestPrompts.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
     <None Update="TypeSpecTestData/specification/testcontoso/Contoso.Management/employee.tsp">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Core/ToolPromptCoverageTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Core/ToolPromptCoverageTests.cs
@@ -2,19 +2,19 @@
 // Licensed under the MIT License.
 
 using System.Reflection;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using ModelContextProtocol.Server;
+using YamlDotNet.RepresentationModel;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Tools.Core;
 
 /// <summary>
-/// Validates that every MCP tool has test prompts in TestPrompts.json.
-/// Runs during PR CI (no MCP server or OpenAI required).
+/// Validates that every MCP tool has at least one "required" tool-calls stimulus under
+/// evals/tools/*.eval.yaml (the Vally prompt-to-tool suite). Runs during PR CI -- no MCP
+/// server, no LLM, and no vally install required, since it only parses the eval YAML.
 /// </summary>
 internal class ToolPromptCoverageTests
 {
-    // Tools that are only available in DEBUG builds or don't need prompts
+    // Tools that are only available in DEBUG builds or don't need eval coverage
     private static readonly HashSet<string> ExemptTools = new(StringComparer.OrdinalIgnoreCase)
     {
         "azsdk_hello_world",
@@ -39,7 +39,7 @@ internal class ToolPromptCoverageTests
     };
 
     [Test]
-    public void AllToolsHaveTestPrompts()
+    public void AllToolsHaveEvalCoverage()
     {
         // Discover all MCP tool names via reflection on the CLI assembly
         var cliAssembly = typeof(Azure.Sdk.Tools.Cli.Program).Assembly;
@@ -54,44 +54,117 @@ internal class ToolPromptCoverageTests
 
         Assert.That(allToolNames, Is.Not.Empty, "No MCP tools found via reflection. Is the CLI assembly loaded?");
 
-        // Load TestPrompts.json
-        var testPromptsPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "TestPrompts.json");
-        Assert.That(File.Exists(testPromptsPath), Is.True, $"TestPrompts.json not found at: {testPromptsPath}");
+        // Discover the repo root by walking up from the test binary's directory, then read
+        // every stimulus's tool-calls.required[].name across evals/tools/*.eval.yaml.
+        var evalsToolsDir = Path.Combine(FindRepoRoot(), "evals", "tools");
+        Assert.That(Directory.Exists(evalsToolsDir), Is.True, $"evals/tools directory not found at: {evalsToolsDir}");
 
-        var json = File.ReadAllText(testPromptsPath);
-        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-        var file = JsonSerializer.Deserialize<TestPromptsFile>(json, options);
-        Assert.That(file?.Prompts, Is.Not.Null, "Failed to deserialize TestPrompts.json");
-
-        var toolsWithPrompts = file!.Prompts
-            .Select(p => p.ToolName)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var toolsWithCoverage = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var evalFile in Directory.GetFiles(evalsToolsDir, "*.eval.yaml"))
+        {
+            foreach (var name in ExtractRequiredToolNames(evalFile))
+            {
+                toolsWithCoverage.Add(name);
+            }
+        }
 
         var missingTools = allToolNames
             .Where(t => !ExemptTools.Contains(t))
-            .Where(t => !toolsWithPrompts.Contains(t))
+            .Where(t => !toolsWithCoverage.Contains(t))
             .OrderBy(t => t)
             .ToList();
 
         if (missingTools.Any())
         {
             Assert.Fail(
-                $"Coverage gap: {missingTools.Count} tool(s) have no test prompts in TestPrompts.json. " +
-                $"Tool owners must add 2-3 prompt variations for each:\n" +
+                $"Coverage gap: {missingTools.Count} tool(s) have no eval coverage under evals/tools/. " +
+                $"Tool owners must add 2-3 prompt variations (as tool-calls.required stimuli) for each:\n" +
                 $"  - {string.Join("\n  - ", missingTools)}\n\n" +
-                $"To add prompts, edit: tools/azsdk-cli/Azure.Sdk.Tools.Cli.Evaluations/TestData/TestPrompts.json");
+                $"To add coverage, edit or add: evals/tools/prompt-to-tool-<area>.eval.yaml");
         }
     }
 
-    private record TestPromptEntry(
-        [property: JsonPropertyName("toolName")] string ToolName,
-        [property: JsonPropertyName("prompt")] string Prompt,
-        [property: JsonPropertyName("category")] string Category);
-
-    private class TestPromptsFile
+    /// <summary>
+    /// Parses one evals/tools/*.eval.yaml file and yields every tool name referenced in a
+    /// tool-calls grader's "required" list, across all stimuli. Uses YamlDotNet's low-level
+    /// representation model rather than a strict typed model, since eval files legitimately
+    /// vary in which grader types/fields they use.
+    /// </summary>
+    private static IEnumerable<string> ExtractRequiredToolNames(string evalFilePath)
     {
-        [JsonPropertyName("prompts")]
-        public List<TestPromptEntry> Prompts { get; set; } = [];
+        using var reader = new StreamReader(evalFilePath);
+        var yaml = new YamlStream();
+        yaml.Load(reader);
+        if (yaml.Documents.Count == 0 || yaml.Documents[0].RootNode is not YamlMappingNode root)
+        {
+            yield break;
+        }
+
+        if (!root.Children.TryGetValue(new YamlScalarNode("stimuli"), out var stimuliNode) || stimuliNode is not YamlSequenceNode stimuli)
+        {
+            yield break;
+        }
+
+        foreach (var stimulusNode in stimuli.Children)
+        {
+            if (stimulusNode is not YamlMappingNode stimulus)
+            {
+                continue;
+            }
+            if (!stimulus.Children.TryGetValue(new YamlScalarNode("graders"), out var gradersNode) || gradersNode is not YamlSequenceNode graders)
+            {
+                continue;
+            }
+
+            foreach (var graderNode in graders.Children)
+            {
+                if (graderNode is not YamlMappingNode grader)
+                {
+                    continue;
+                }
+                if (!grader.Children.TryGetValue(new YamlScalarNode("type"), out var typeNode) ||
+                    typeNode is not YamlScalarNode typeScalar ||
+                    typeScalar.Value != "tool-calls")
+                {
+                    continue;
+                }
+                if (!grader.Children.TryGetValue(new YamlScalarNode("config"), out var configNode) || configNode is not YamlMappingNode config)
+                {
+                    continue;
+                }
+                if (!config.Children.TryGetValue(new YamlScalarNode("required"), out var requiredNode) || requiredNode is not YamlSequenceNode required)
+                {
+                    continue;
+                }
+
+                foreach (var requiredItem in required.Children)
+                {
+                    if (requiredItem is YamlMappingNode requiredMapping &&
+                        requiredMapping.Children.TryGetValue(new YamlScalarNode("name"), out var nameNode) &&
+                        nameNode is YamlScalarNode nameScalar &&
+                        !string.IsNullOrEmpty(nameScalar.Value))
+                    {
+                        yield return nameScalar.Value;
+                    }
+                }
+            }
+        }
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var gitPath = Path.Combine(dir.FullName, ".git");
+            if ((Directory.Exists(gitPath) || File.Exists(gitPath)) && Directory.Exists(Path.Combine(dir.FullName, "evals")))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException($"Could not locate repository root (looked for .git + evals/ upward from {AppContext.BaseDirectory}).");
     }
 }
+

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Core/ToolPromptCoverageTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Core/ToolPromptCoverageTests.cs
@@ -95,60 +95,60 @@ internal class ToolPromptCoverageTests
         using var reader = new StreamReader(evalFilePath);
         var yaml = new YamlStream();
         yaml.Load(reader);
-        if (yaml.Documents.Count == 0 || yaml.Documents[0].RootNode is not YamlMappingNode root)
+
+        if (yaml.Documents.Count == 0 ||
+            yaml.Documents[0].RootNode is not YamlMappingNode root ||
+            !TryGetSequence(root, "stimuli", out var stimuli))
         {
             yield break;
         }
 
-        if (!root.Children.TryGetValue(new YamlScalarNode("stimuli"), out var stimuliNode) || stimuliNode is not YamlSequenceNode stimuli)
+        foreach (var stimulusNode in stimuli!.Children)
         {
-            yield break;
-        }
-
-        foreach (var stimulusNode in stimuli.Children)
-        {
-            if (stimulusNode is not YamlMappingNode stimulus)
-            {
-                continue;
-            }
-            if (!stimulus.Children.TryGetValue(new YamlScalarNode("graders"), out var gradersNode) || gradersNode is not YamlSequenceNode graders)
+            if (stimulusNode is not YamlMappingNode stimulus || !TryGetSequence(stimulus, "graders", out var graders))
             {
                 continue;
             }
 
-            foreach (var graderNode in graders.Children)
+            foreach (var graderNode in graders!.Children)
             {
-                if (graderNode is not YamlMappingNode grader)
-                {
-                    continue;
-                }
-                if (!grader.Children.TryGetValue(new YamlScalarNode("type"), out var typeNode) ||
-                    typeNode is not YamlScalarNode typeScalar ||
-                    typeScalar.Value != "tool-calls")
-                {
-                    continue;
-                }
-                if (!grader.Children.TryGetValue(new YamlScalarNode("config"), out var configNode) || configNode is not YamlMappingNode config)
-                {
-                    continue;
-                }
-                if (!config.Children.TryGetValue(new YamlScalarNode("required"), out var requiredNode) || requiredNode is not YamlSequenceNode required)
+                if (graderNode is not YamlMappingNode grader ||
+                    !TryGetScalar(grader, "type", out var type) || type != "tool-calls" ||
+                    !TryGetMapping(grader, "config", out var config) ||
+                    !TryGetSequence(config!, "required", out var required))
                 {
                     continue;
                 }
 
-                foreach (var requiredItem in required.Children)
+                foreach (var requiredItem in required!.Children)
                 {
-                    if (requiredItem is YamlMappingNode requiredMapping &&
-                        requiredMapping.Children.TryGetValue(new YamlScalarNode("name"), out var nameNode) &&
-                        nameNode is YamlScalarNode nameScalar &&
-                        !string.IsNullOrEmpty(nameScalar.Value))
+                    if (requiredItem is YamlMappingNode requiredMapping && TryGetScalar(requiredMapping, "name", out var name))
                     {
-                        yield return nameScalar.Value;
+                        yield return name!;
                     }
                 }
             }
         }
+    }
+
+    private static bool TryGetMapping(YamlMappingNode parent, string key, out YamlMappingNode? value)
+    {
+        value = parent.Children.TryGetValue(new YamlScalarNode(key), out var node) ? node as YamlMappingNode : null;
+        return value is not null;
+    }
+
+    private static bool TryGetSequence(YamlMappingNode parent, string key, out YamlSequenceNode? value)
+    {
+        value = parent.Children.TryGetValue(new YamlScalarNode(key), out var node) ? node as YamlSequenceNode : null;
+        return value is not null;
+    }
+
+    private static bool TryGetScalar(YamlMappingNode parent, string key, out string? value)
+    {
+        value = parent.Children.TryGetValue(new YamlScalarNode(key), out var node) && node is YamlScalarNode scalar
+            ? scalar.Value
+            : null;
+        return !string.IsNullOrEmpty(value);
     }
 
     private static string FindRepoRoot()


### PR DESCRIPTION
Reads AllToolsHaveEvalCoverage (renamed from AllToolsHaveTestPrompts) from evals/tools/*.eval.yaml's tool-calls.required[].name instead of the Gen-1 harness's TestData/TestPrompts.json, and removes the resulting now-unused linked-file reference from Azure.Sdk.Tools.Cli.Tests.csproj. TestPrompts.json itself is untouched (still used elsewhere).