### PR TITLE
Add api-version optional parameter in create release plan tool

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
@@ -170,6 +170,16 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         }
 
         [Test]
+        public async Task Test_Create_releasePlan_with_invalid_api_version()
+        {
+            var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
+            var releaseplan = await releasePlanTool.CreateReleasePlan(null, testCodeFilePath, "July 2025", "GA", specPullRequestUrl: "https://github.com/Azure/azure-rest-api-specs/pull/35446", isTestReleasePlan: true, apiVersion: "2025/01/01");
+            Assert.IsNotNull(releaseplan);
+            Assert.IsNotNull(releaseplan.ResponseError);
+            Assert.True(releaseplan.ResponseError.Contains("Invalid API version"));
+        }
+
+        [Test]
         public async Task Test_Create_releasePlan_with_invalid_service_tree_id()
         {
             var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
@@ -557,7 +567,144 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             Assert.That(releaseplan.ReleasePlanDetails?.WorkItemId, Is.EqualTo(42));
         }
 
-        
+        [Test]
+        public async Task Test_Create_releasePlan_allows_different_api_version_for_same_spec_pr()
+        {
+            // Arrange: existing GA release plan for the spec PR with a specific API version
+            var mockDevOpsService = new MockDevOpsService
+            {
+                ConfiguredReleasePlanForSpecPrUrl = new ReleasePlanWorkItem
+                {
+                    WorkItemId = 42,
+                    ReleasePlanId = 10,
+                    Title = "Existing GA Release Plan",
+                    ReleasePlanType = "GA",
+                    SpecAPIVersion = "2025-01-01"
+                }
+            };
+
+            var tool = new ReleasePlanTool(
+                mockDevOpsService,
+                gitHelper,
+                typeSpecHelper,
+                logger,
+                userHelper,
+                gitHubService,
+                environmentHelper,
+                inputSanitizer,
+                httpClient,
+                Mock.Of<INpxHelper>(), Mock.Of<IRawOutputHelper>(), Mock.Of<INotificationService>());
+
+            var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
+            var specPrUrl = "https://github.com/Azure/azure-rest-api-specs/pull/35446";
+
+            // Act: create a GA plan for the same spec PR but with a different API version (should succeed)
+            var releaseplan = await tool.CreateReleasePlan(null,
+                testCodeFilePath,
+                "July 2025",
+                "GA",
+                specPullRequestUrl: specPrUrl,
+                isTestReleasePlan: true,
+                apiVersion: "2025-06-01");
+
+            Assert.IsNotNull(releaseplan);
+            Assert.IsNull(releaseplan.ResponseError, $"Unexpected error: {releaseplan.ResponseError}");
+            Assert.IsNotNull(releaseplan.ReleasePlanDetails);
+            Assert.Greater(releaseplan.ReleasePlanDetails.WorkItemId, 0);
+        }
+
+        [Test]
+        public async Task Test_Create_releasePlan_blocks_same_api_version_for_same_spec_pr()
+        {
+            // Arrange: existing GA release plan for the spec PR with a specific API version
+            var mockDevOpsService = new MockDevOpsService
+            {
+                ConfiguredReleasePlanForSpecPrUrl = new ReleasePlanWorkItem
+                {
+                    WorkItemId = 42,
+                    ReleasePlanId = 10,
+                    Title = "Existing GA Release Plan",
+                    ReleasePlanType = "GA",
+                    SpecAPIVersion = "2025-01-01"
+                }
+            };
+
+            var tool = new ReleasePlanTool(
+                mockDevOpsService,
+                gitHelper,
+                typeSpecHelper,
+                logger,
+                userHelper,
+                gitHubService,
+                environmentHelper,
+                inputSanitizer,
+                httpClient,
+                Mock.Of<INpxHelper>(), Mock.Of<IRawOutputHelper>(), Mock.Of<INotificationService>());
+
+            var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
+            var specPrUrl = "https://github.com/Azure/azure-rest-api-specs/pull/35446";
+
+            // Act: create a GA plan for the same spec PR with the same API version (should be blocked)
+            var releaseplan = await tool.CreateReleasePlan(null,
+                testCodeFilePath,
+                "July 2025",
+                "GA",
+                specPullRequestUrl: specPrUrl,
+                isTestReleasePlan: true,
+                apiVersion: "2025-01-01");
+
+            Assert.IsNotNull(releaseplan);
+            Assert.IsNull(releaseplan.ResponseError);
+            Assert.That(releaseplan.Message, Does.Contain("release plan already exists"));
+            Assert.That(releaseplan.ReleasePlanDetails?.WorkItemId, Is.EqualTo(42));
+        }
+
+        [Test]
+        public async Task Test_Create_releasePlan_blocks_when_existing_plan_has_no_api_version()
+        {
+            // Arrange: existing GA release plan for the spec PR with no API version available
+            var mockDevOpsService = new MockDevOpsService
+            {
+                ConfiguredReleasePlanForSpecPrUrl = new ReleasePlanWorkItem
+                {
+                    WorkItemId = 42,
+                    ReleasePlanId = 10,
+                    Title = "Existing GA Release Plan",
+                    ReleasePlanType = "GA"
+                    // SpecAPIVersion intentionally not set (not available)
+                }
+            };
+
+            var tool = new ReleasePlanTool(
+                mockDevOpsService,
+                gitHelper,
+                typeSpecHelper,
+                logger,
+                userHelper,
+                gitHubService,
+                environmentHelper,
+                inputSanitizer,
+                httpClient,
+                Mock.Of<INpxHelper>(), Mock.Of<IRawOutputHelper>(), Mock.Of<INotificationService>());
+
+            var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
+            var specPrUrl = "https://github.com/Azure/azure-rest-api-specs/pull/35446";
+
+            // Act: create a GA plan with an API version, but existing plan has none (should be blocked by release type)
+            var releaseplan = await tool.CreateReleasePlan(null,
+                testCodeFilePath,
+                "July 2025",
+                "GA",
+                specPullRequestUrl: specPrUrl,
+                isTestReleasePlan: true,
+                apiVersion: "2025-06-01");
+
+            Assert.IsNotNull(releaseplan);
+            Assert.IsNull(releaseplan.ResponseError);
+            Assert.That(releaseplan.Message, Does.Contain("release plan already exists"));
+            Assert.That(releaseplan.ReleasePlanDetails?.WorkItemId, Is.EqualTo(42));
+        }
+
         [Test]
         public async Task Test_Get_Release_Plan_by_spec_pull_request_url()
         {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
@@ -13,7 +13,7 @@
     <WarningsAsErrors>CA2254</WarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AssemblyName>azsdk</AssemblyName>
-    <VersionPrefix>0.6.29</VersionPrefix>
+    <VersionPrefix>0.6.30</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <!-- Package metadata -->

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.6.30 (Unreleased)
+## 0.6.30 (2026-07-23)
 
 ### Features Added
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+## 0.6.30 (Unreleased)
+
+### Features Added
+
+- Added an optional `apiVersion` parameter to the create release plan tool (`--api-version` CLI option). When provided, the value is validated to follow the `YYYY-MM-DD` or `YYYY-MM-DD-preview` format and is stored on the release plan.
+- Allowed creating a new release plan for the same TypeSpec project or spec PR when the requested API version differs from an existing release plan's API version. When the existing release plan has no API version, creation is still blocked based on a matching API release type.
+
 ## 0.6.29 (2026-07-22)
 
 ### Features Added

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -985,7 +985,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 // Validate API version format if provided
                 if (!string.IsNullOrEmpty(apiVersion) && !ApiVersionRegex().IsMatch(apiVersion))
                 {
-                    return new ReleasePlanResponse { ResponseError = $"Invalid API version '{apiVersion}'. API version must be in YYYY-MM-DD or YYYY-MM-DD-preview format." };
+                    return new ReleasePlanResponse { ResponseError = $"Invalid API version '{apiVersion}'. API version must be an existing API version in YYYY-MM-DD or YYYY-MM-DD-preview format." };
                 }
 
                 // SDK release type is always derived from the API release type to prevent

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -134,6 +134,13 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             DefaultValueFactory = _ => false,
         };
 
+        private readonly Option<string> apiVersionOpt = new("--api-version")
+        {
+            Description = "API version in YYYY-MM-DD or YYYY-MM-DD-preview format",
+            Required = false,
+            DefaultValueFactory = _ => string.Empty,
+        };
+
         private readonly Option<string> namespaceApprovalIssueOpt = new("--namespace-approval-issue")
         {
             Description = "Namespace approval issue URL",
@@ -302,6 +309,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 optionalPullRequestOpt,
                 isTestReleasePlanOpt,
                 forceCreateReleasePlanOpt,
+                apiVersionOpt,
             },
             new McpCommand(linkNamespaceApprovalIssueCommandName, "Link namespace approval issue to release plan", LinkNamespaceApprovalToolName) { workItemIdOpt, namespaceApprovalIssueOpt, },
             new McpCommand(checkApiReadinessCommandName, "Check if API spec is ready to generate SDK", CheckApiSpecReadyToolName) { typeSpecProjectPathOpt, pullRequestNumberOpt, workItemIdOpt, },
@@ -347,6 +355,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     var apiReleaseType = commandParser.GetValue(apiReleaseTypeOpt);
                     var isTestReleasePlan = commandParser.GetValue(isTestReleasePlanOpt);
                     var forceCreateReleasePlan = commandParser.GetValue(forceCreateReleasePlanOpt);
+                    var apiVersion = commandParser.GetValue(apiVersionOpt);
                     return await CreateReleasePlan(
                         null,
                         typeSpecProjectPath,
@@ -357,6 +366,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                         productTreeId: productTreeId,
                         isTestReleasePlan: isTestReleasePlan,
                         forceCreateReleasePlan: forceCreateReleasePlan,
+                        apiVersion: apiVersion,
                         ct: ct
                     );
 
@@ -961,8 +971,8 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             }
         }
 
-        [McpServerTool(Name = CreateReleasePlanToolName), Description("Create Release Plan for a TypeSpec project and API release type. API release types support Private Preview, Public Preview, and GA. Service ID and product ID are optional and will be resolved from existing release plans when available.")]
-        public async Task<ReleasePlanResponse> CreateReleasePlan(IProgress<ProgressNotificationValue>? progress, string typeSpecProjectPath, string targetReleaseMonthYear, string apiReleaseType, string specPullRequestUrl = "", string serviceTreeId = "", string productTreeId = "", bool isTestReleasePlan = false, bool forceCreateReleasePlan = false, CancellationToken ct = default)
+        [McpServerTool(Name = CreateReleasePlanToolName), Description("Create Release Plan for a TypeSpec project and API release type. API release types support Private Preview, Public Preview, and GA. Service ID and product ID are optional and will be resolved from existing release plans when available. API version is optional and must be in YYYY-MM-DD or YYYY-MM-DD-preview format when provided.")]
+        public async Task<ReleasePlanResponse> CreateReleasePlan(IProgress<ProgressNotificationValue>? progress, string typeSpecProjectPath, string targetReleaseMonthYear, string apiReleaseType, string specPullRequestUrl = "", string serviceTreeId = "", string productTreeId = "", bool isTestReleasePlan = false, bool forceCreateReleasePlan = false, string apiVersion = "", CancellationToken ct = default)
         {
             try
             {         
@@ -970,6 +980,12 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 if (!ApiReleaseTypeExtensions.TryParseFromUserInput(apiReleaseType, out var parsedApiReleaseType))
                 {
                     return new ReleasePlanResponse { ResponseError = $"Invalid API release type '{apiReleaseType}'. Supported values are: Private Preview, Public Preview, GA" };
+                }
+
+                // Validate API version format if provided
+                if (!string.IsNullOrEmpty(apiVersion) && !ApiVersionRegex().IsMatch(apiVersion))
+                {
+                    return new ReleasePlanResponse { ResponseError = $"Invalid API version '{apiVersion}'. API version must be in YYYY-MM-DD or YYYY-MM-DD-preview format." };
                 }
 
                 // SDK release type is always derived from the API release type to prevent
@@ -1046,13 +1062,27 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                         var existingReleasePlan = await devOpsService.GetReleasePlanByTypeSpecProjectPathAsync(specProject, apiReleaseType: parsedApiReleaseType, ct: ct);
                         if (existingReleasePlan != null)
                         {
-                            return new ReleasePlanResponse
+                            // Allow creating a new release plan for the same TypeSpec project only when both the requested
+                            // and existing API versions are available and differ. If the existing release plan has no API
+                            // version, fall back to blocking based on the matching API release type.
+                            var isDifferentApiVersion = !string.IsNullOrEmpty(apiVersion)
+                                && !string.IsNullOrEmpty(existingReleasePlan.SpecAPIVersion)
+                                && !string.Equals(apiVersion, existingReleasePlan.SpecAPIVersion, StringComparison.OrdinalIgnoreCase);
+                            if (isDifferentApiVersion)
                             {
-                                Message = $"An active release plan already exists for the TypeSpec project: {specProject}. "
-                                +  $"Release plan link: {existingReleasePlan.ReleasePlanLink}",
-                                ReleasePlanDetails = existingReleasePlan,
-                                NextSteps = ["Prompt user to confirm whether to use existing release plan or force create a new release plan."]
-                            };
+                                logger.LogInformation("An existing release plan was found for TypeSpec project {specProject} with API version '{existingApiVersion}', but the requested API version '{apiVersion}' is different. Proceeding to create a new release plan.",
+                                    specProject, existingReleasePlan.SpecAPIVersion, apiVersion);
+                            }
+                            else
+                            {
+                                return new ReleasePlanResponse
+                                {
+                                    Message = $"An active release plan already exists for the TypeSpec project: {specProject}. "
+                                    +  $"Release plan link: {existingReleasePlan.ReleasePlanLink}",
+                                    ReleasePlanDetails = existingReleasePlan,
+                                    NextSteps = ["Prompt user to confirm whether to use existing release plan or force create a new release plan."]
+                                };
+                            }
                         }
                     }
 
@@ -1063,12 +1093,26 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                         var existingReleasePlan = await devOpsService.GetReleasePlanAsync(specPullRequestUrl, parsedApiReleaseType, ct);
                         if (existingReleasePlan != null && existingReleasePlan.WorkItemId > 0)
                         {
-                            return new ReleasePlanResponse
+                            // Allow creating a new release plan for the same spec PR only when both the requested and
+                            // existing API versions are available and differ. If the existing release plan has no API
+                            // version, fall back to blocking based on the matching API release type.
+                            var isDifferentApiVersion = !string.IsNullOrEmpty(apiVersion)
+                                && !string.IsNullOrEmpty(existingReleasePlan.SpecAPIVersion)
+                                && !string.Equals(apiVersion, existingReleasePlan.SpecAPIVersion, StringComparison.OrdinalIgnoreCase);
+                            if (isDifferentApiVersion)
                             {
-                                Message = $"A {parsedApiReleaseType.ToDisplayLabel()} release plan already exists for the pull request: {specPullRequestUrl}. Release plan link: {existingReleasePlan.ReleasePlanLink}",
-                                ReleasePlanDetails = existingReleasePlan,
-                                NextSteps = ["Prompt user to confirm whether to use existing release plan or force create a new release plan."]
-                            };
+                                logger.LogInformation("An existing {apiReleaseType} release plan was found for pull request {specPullRequestUrl} with API version '{existingApiVersion}', but the requested API version '{apiVersion}' is different. Proceeding to create a new release plan.",
+                                    parsedApiReleaseType.ToDisplayLabel(), specPullRequestUrl, existingReleasePlan.SpecAPIVersion, apiVersion);
+                            }
+                            else
+                            {
+                                return new ReleasePlanResponse
+                                {
+                                    Message = $"A {parsedApiReleaseType.ToDisplayLabel()} release plan already exists for the pull request: {specPullRequestUrl}. Release plan link: {existingReleasePlan.ReleasePlanLink}",
+                                    ReleasePlanDetails = existingReleasePlan,
+                                    NextSteps = ["Prompt user to confirm whether to use existing release plan or force create a new release plan."]
+                                };
+                            }
                         }
                     }
                 }
@@ -1126,7 +1170,8 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     ProductName = productDisplayName,
                     ProductType = productType,
                     ProductLifecycle = productLifecycle,
-                    ApiReleaseType = parsedApiReleaseType
+                    ApiReleaseType = parsedApiReleaseType,
+                    SpecAPIVersion = apiVersion
                 };
 
                 var reporter = new ProgressReporter(progress, logger, totalSteps: 2, outputHelper);

--- a/tools/azsdk-cli/docs/mcp-tools.md
+++ b/tools/azsdk-cli/docs/mcp-tools.md
@@ -17,7 +17,7 @@ This document provides a comprehensive list of all MCP (Model Context Protocol) 
 | azsdk_check_service_label |  | Checks if a service label exists and returns its details |
 | azsdk_convert_swagger_to_typespec | `azsdk tsp convert` | Converts an existing Azure service swagger definition to a TypeSpec project. Returns path to the created project. |
 | azsdk_create_pull_request |  | Create pull request for repository changes. Provide title, description and path to repository root. Creates a pull request for committed changes in the current branch. |
-| azsdk_create_release_plan | `azsdk release-plan create` | Create Release Plan for a TypeSpec project and API release type. API release types support Private Preview, Public Preview, and GA. Service ID and product ID are optional and will be resolved from existing release plans when available. |
+| azsdk_create_release_plan | `azsdk release-plan create` | Create Release Plan for a TypeSpec project and API release type. API release types support Private Preview, Public Preview, and GA. Service ID and product ID are optional and will be resolved from existing release plans when available. API version is optional and must be in YYYY-MM-DD or YYYY-MM-DD-preview format when provided. |
 | azsdk_create_service_label |  | Creates a pull request to add a new service label |
 | azsdk_customized_code_update | `azsdk tsp client customized-update` | Applies patches to customization files based on build errors, regenerates code if needed (Java), builds, and returns success/failure with build result. |
 | azsdk_engsys_codeowner_add_label_owner |  | Add owner(s) to a label with an optional path in CODEOWNERS work items. Valid ownerType values: service-owner, azsdk-owner, pr-label. |


### PR DESCRIPTION
Add API-version parameter in create release plan tool that will be supplied by automated release plan creation. This is required to avoid confusion on which API-version is a release plan tied to. API version can be made as mandatory field in the MCP tool in a future PR once automation is updated to pass this new param.