### PR TITLE
Scope codeowners generate by section and add force overrides to codeowners add commands

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CodeownersGenerateHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CodeownersGenerateHelperTests.cs
@@ -344,22 +344,38 @@ public class CodeownersGenerateHelperTests
     }
 
     [Test]
-    public void BuildCodeownersEntries_ExcludesServiceLevelPathEntryFromDifferentSection()
+    public void BuildCodeownersEntries_IncludesMgmtSectionEntryAndExcludesClientEntry()
     {
-        // Arrange: a service-level (RepoPath) Label Owner in the Client Libraries section
-        var data = new WorkItemDataBuilder()
-            .AddOwner("clientdev", out var ownerId)
-            .AddLabel("Agent Server", out var labelId)
-            .AddPRLabelOwner(out _, repoPath: "sdk/agentserver/", section: "Client Libraries", relatedTo: [ownerId, labelId])
+        // Arrange: service-level entries in both sections, as they exist across the DevOps database
+        var allData = new WorkItemDataBuilder()
+            .AddOwner("clientdev", out var clientOwnerId)
+            .AddLabel("Agent Server", out var clientLabelId)
+            .AddPRLabelOwner(out _, repoPath: "sdk/agentserver/", section: "Client Libraries", relatedTo: [clientOwnerId, clientLabelId])
+            .AddOwner("mgmtdev", out var mgmtOwnerId)
+            .AddLabel("Compute", out var mgmtLabelId)
+            .AddPRLabelOwner(out _, repoPath: "sdk/compute/", section: "Management Libraries", relatedTo: [mgmtOwnerId, mgmtLabelId])
             .Build();
 
         var packageLookup = new Dictionary<string, RepoPackage>(StringComparer.OrdinalIgnoreCase);
 
-        // Act: generate the Management Libraries section
-        var entries = InvokeBuildCodeownersEntries(data, packageLookup, sectionName: "Management Libraries");
+        // Simulate WIQL pre-filter: FetchAllWorkItemsAsync queries by section before calling BuildCodeownersEntries
+        var mgmtData = new WorkItemData(
+            allData.Packages,
+            allData.Owners,
+            allData.Labels,
+            allData.LabelOwners.Where(lo => lo.Section == "Management Libraries").ToList());
 
-        // Assert: the client-section entry does not leak into the mgmt section
-        Assert.That(entries, Has.Count.EqualTo(0));
+        // Act
+        var entries = InvokeBuildCodeownersEntries(mgmtData, packageLookup);
+
+        // Assert: management entry is present; client entry is not
+        Assert.That(entries, Has.Count.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(entries[0].PathExpression, Is.EqualTo("/sdk/compute/"));
+            Assert.That(entries[0].SourceOwners, Does.Contain("mgmtdev"));
+            Assert.That(entries[0].SourceOwners, Does.Not.Contain("clientdev"));
+        });
     }
 
     [Test]
@@ -374,8 +390,8 @@ public class CodeownersGenerateHelperTests
 
         var packageLookup = new Dictionary<string, RepoPackage>(StringComparer.OrdinalIgnoreCase);
 
-        // Act: generate the Management Libraries section (case-insensitive match)
-        var entries = InvokeBuildCodeownersEntries(data, packageLookup, sectionName: "management libraries");
+        // Act: data is already pre-filtered to Management Libraries by the WIQL query
+        var entries = InvokeBuildCodeownersEntries(data, packageLookup);
 
         // Assert
         Assert.That(entries, Has.Count.EqualTo(1));
@@ -387,41 +403,38 @@ public class CodeownersGenerateHelperTests
     }
 
     [Test]
-    public void BuildCodeownersEntries_ExcludesUnsectionedServiceLevelPathEntry()
+    public void BuildCodeownersEntries_IncludesMgmtPathlessEntryAndExcludesClientEntry()
     {
-        // Arrange: a service-level Label Owner with no section set
-        var data = new WorkItemDataBuilder()
-            .AddOwner("orphandev", out var ownerId)
-            .AddLabel("Orphan", out var labelId)
-            .AddPRLabelOwner(out _, repoPath: "sdk/orphan/", section: "", relatedTo: [ownerId, labelId])
+        // Arrange: pathless entries in both sections, as they exist across the DevOps database
+        var allData = new WorkItemDataBuilder()
+            .AddOwner("triagedev", out var clientOwnerId)
+            .AddLabel("TriageService", out var clientLabelId)
+            .AddServiceOwner(out _, section: "Client Libraries", relatedTo: [clientOwnerId, clientLabelId])
+            .AddOwner("mgmttriagedev", out var mgmtOwnerId)
+            .AddLabel("MgmtTriageService", out var mgmtLabelId)
+            .AddServiceOwner(out _, section: "Management Libraries", relatedTo: [mgmtOwnerId, mgmtLabelId])
             .Build();
 
         var packageLookup = new Dictionary<string, RepoPackage>(StringComparer.OrdinalIgnoreCase);
+
+        // Simulate WIQL pre-filter: FetchAllWorkItemsAsync queries by section before calling BuildCodeownersEntries
+        var mgmtData = new WorkItemData(
+            allData.Packages,
+            allData.Owners,
+            allData.Labels,
+            allData.LabelOwners.Where(lo => lo.Section == "Management Libraries").ToList());
 
         // Act
-        var entries = InvokeBuildCodeownersEntries(data, packageLookup, sectionName: "Management Libraries");
+        var entries = InvokeBuildCodeownersEntries(mgmtData, packageLookup);
 
-        // Assert: unsectioned entries are excluded from a specific-section generate
-        Assert.That(entries, Has.Count.EqualTo(0));
-    }
-
-    [Test]
-    public void BuildCodeownersEntries_ExcludesPathlessEntryFromDifferentSection()
-    {
-        // Arrange: a pathless (triage) Label Owner in the Client Libraries section
-        var data = new WorkItemDataBuilder()
-            .AddOwner("triagedev", out var ownerId)
-            .AddLabel("TriageService", out var labelId)
-            .AddServiceOwner(out _, section: "Client Libraries", relatedTo: [ownerId, labelId])
-            .Build();
-
-        var packageLookup = new Dictionary<string, RepoPackage>(StringComparer.OrdinalIgnoreCase);
-
-        // Act: generate the Management Libraries section
-        var entries = InvokeBuildCodeownersEntries(data, packageLookup, sectionName: "Management Libraries");
-
-        // Assert
-        Assert.That(entries, Has.Count.EqualTo(0));
+        // Assert: management entry is present; client entry is not
+        Assert.That(entries, Has.Count.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(entries[0].ServiceLabels, Does.Contain("MgmtTriageService"));
+            Assert.That(entries[0].ServiceOwners, Does.Contain("mgmttriagedev"));
+            Assert.That(entries[0].ServiceLabels, Does.Not.Contain("TriageService"));
+        });
     }
 
     [Test]
@@ -436,8 +449,8 @@ public class CodeownersGenerateHelperTests
 
         var packageLookup = new Dictionary<string, RepoPackage>(StringComparer.OrdinalIgnoreCase);
 
-        // Act
-        var entries = InvokeBuildCodeownersEntries(data, packageLookup, sectionName: "Management Libraries");
+        // Act: data is already pre-filtered to Management Libraries by the WIQL query
+        var entries = InvokeBuildCodeownersEntries(data, packageLookup);
 
         // Assert
         Assert.That(entries, Has.Count.EqualTo(1));
@@ -451,8 +464,7 @@ public class CodeownersGenerateHelperTests
     private List<CodeownersEntry> InvokeBuildCodeownersEntries(
         WorkItemData data,
         Dictionary<string, RepoPackage> packageLookup,
-        DateTime? invalidOwnerCutoff = null,
-        string sectionName = "Client Libraries")
+        DateTime? invalidOwnerCutoff = null)
     {
         var method = typeof(CodeownersGenerateHelper).GetMethod(
             "BuildCodeownersEntries",
@@ -464,7 +476,7 @@ public class CodeownersGenerateHelperTests
             _logger
         );
 
-        return method?.Invoke(helper, [data, packageLookup, _repoRoot, sectionName, invalidOwnerCutoff ?? DateTime.MinValue]) as List<CodeownersEntry> ?? [];
+        return method?.Invoke(helper, [data, packageLookup, _repoRoot, invalidOwnerCutoff ?? DateTime.MinValue]) as List<CodeownersEntry> ?? [];
     }
 
     #endregion

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CodeownersGenerateHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/CodeownersGenerateHelperTests.cs
@@ -343,10 +343,116 @@ public class CodeownersGenerateHelperTests
         });
     }
 
+    [Test]
+    public void BuildCodeownersEntries_ExcludesServiceLevelPathEntryFromDifferentSection()
+    {
+        // Arrange: a service-level (RepoPath) Label Owner in the Client Libraries section
+        var data = new WorkItemDataBuilder()
+            .AddOwner("clientdev", out var ownerId)
+            .AddLabel("Agent Server", out var labelId)
+            .AddPRLabelOwner(out _, repoPath: "sdk/agentserver/", section: "Client Libraries", relatedTo: [ownerId, labelId])
+            .Build();
+
+        var packageLookup = new Dictionary<string, RepoPackage>(StringComparer.OrdinalIgnoreCase);
+
+        // Act: generate the Management Libraries section
+        var entries = InvokeBuildCodeownersEntries(data, packageLookup, sectionName: "Management Libraries");
+
+        // Assert: the client-section entry does not leak into the mgmt section
+        Assert.That(entries, Has.Count.EqualTo(0));
+    }
+
+    [Test]
+    public void BuildCodeownersEntries_IncludesServiceLevelPathEntryFromMatchingSection()
+    {
+        // Arrange: a service-level Label Owner in the Management Libraries section
+        var data = new WorkItemDataBuilder()
+            .AddOwner("mgmtdev", out var ownerId)
+            .AddLabel("Compute", out var labelId)
+            .AddPRLabelOwner(out _, repoPath: "sdk/compute/", section: "Management Libraries", relatedTo: [ownerId, labelId])
+            .Build();
+
+        var packageLookup = new Dictionary<string, RepoPackage>(StringComparer.OrdinalIgnoreCase);
+
+        // Act: generate the Management Libraries section (case-insensitive match)
+        var entries = InvokeBuildCodeownersEntries(data, packageLookup, sectionName: "management libraries");
+
+        // Assert
+        Assert.That(entries, Has.Count.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(entries[0].PathExpression, Is.EqualTo("/sdk/compute/"));
+            Assert.That(entries[0].SourceOwners, Does.Contain("mgmtdev"));
+        });
+    }
+
+    [Test]
+    public void BuildCodeownersEntries_ExcludesUnsectionedServiceLevelPathEntry()
+    {
+        // Arrange: a service-level Label Owner with no section set
+        var data = new WorkItemDataBuilder()
+            .AddOwner("orphandev", out var ownerId)
+            .AddLabel("Orphan", out var labelId)
+            .AddPRLabelOwner(out _, repoPath: "sdk/orphan/", section: "", relatedTo: [ownerId, labelId])
+            .Build();
+
+        var packageLookup = new Dictionary<string, RepoPackage>(StringComparer.OrdinalIgnoreCase);
+
+        // Act
+        var entries = InvokeBuildCodeownersEntries(data, packageLookup, sectionName: "Management Libraries");
+
+        // Assert: unsectioned entries are excluded from a specific-section generate
+        Assert.That(entries, Has.Count.EqualTo(0));
+    }
+
+    [Test]
+    public void BuildCodeownersEntries_ExcludesPathlessEntryFromDifferentSection()
+    {
+        // Arrange: a pathless (triage) Label Owner in the Client Libraries section
+        var data = new WorkItemDataBuilder()
+            .AddOwner("triagedev", out var ownerId)
+            .AddLabel("TriageService", out var labelId)
+            .AddServiceOwner(out _, section: "Client Libraries", relatedTo: [ownerId, labelId])
+            .Build();
+
+        var packageLookup = new Dictionary<string, RepoPackage>(StringComparer.OrdinalIgnoreCase);
+
+        // Act: generate the Management Libraries section
+        var entries = InvokeBuildCodeownersEntries(data, packageLookup, sectionName: "Management Libraries");
+
+        // Assert
+        Assert.That(entries, Has.Count.EqualTo(0));
+    }
+
+    [Test]
+    public void BuildCodeownersEntries_IncludesPathlessEntryFromMatchingSection()
+    {
+        // Arrange: a pathless (triage) Label Owner in the Management Libraries section
+        var data = new WorkItemDataBuilder()
+            .AddOwner("triagedev", out var ownerId)
+            .AddLabel("TriageService", out var labelId)
+            .AddServiceOwner(out _, section: "Management Libraries", relatedTo: [ownerId, labelId])
+            .Build();
+
+        var packageLookup = new Dictionary<string, RepoPackage>(StringComparer.OrdinalIgnoreCase);
+
+        // Act
+        var entries = InvokeBuildCodeownersEntries(data, packageLookup, sectionName: "Management Libraries");
+
+        // Assert
+        Assert.That(entries, Has.Count.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(entries[0].ServiceLabels, Does.Contain("TriageService"));
+            Assert.That(entries[0].ServiceOwners, Does.Contain("triagedev"));
+        });
+    }
+
     private List<CodeownersEntry> InvokeBuildCodeownersEntries(
         WorkItemData data,
         Dictionary<string, RepoPackage> packageLookup,
-        DateTime? invalidOwnerCutoff = null)
+        DateTime? invalidOwnerCutoff = null,
+        string sectionName = "Client Libraries")
     {
         var method = typeof(CodeownersGenerateHelper).GetMethod(
             "BuildCodeownersEntries",
@@ -358,7 +464,7 @@ public class CodeownersGenerateHelperTests
             _logger
         );
 
-        return method?.Invoke(helper, [data, packageLookup, _repoRoot, invalidOwnerCutoff ?? DateTime.MinValue]) as List<CodeownersEntry> ?? [];
+        return method?.Invoke(helper, [data, packageLookup, _repoRoot, sectionName, invalidOwnerCutoff ?? DateTime.MinValue]) as List<CodeownersEntry> ?? [];
     }
 
     #endregion

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/TestHelpers/WorkItemDataBuilder.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/TestHelpers/WorkItemDataBuilder.cs
@@ -30,7 +30,7 @@ public class WorkItemDataBuilder
     private record PackageData(int Id, string Name, string Version, HashSet<int> RelatedIds);
     private record OwnerData(int Id, string GitHubAlias);
     private record LabelData(int Id, string LabelName);
-    private record LabelOwnerData(int Id, string LabelType, string Repository, string RepoPath, HashSet<int> RelatedIds);
+    private record LabelOwnerData(int Id, string LabelType, string Repository, string RepoPath, string Section, HashSet<int> RelatedIds);
 
     /// <summary>
     /// Adds an Owner work item.
@@ -80,32 +80,33 @@ public class WorkItemDataBuilder
     /// <param name="id">Output parameter receiving the auto-generated ID</param>
     /// <param name="repository">Repository name (e.g., "Azure/azure-sdk-for-net")</param>
     /// <param name="repoPath">Optional repo path for service-level entries</param>
+    /// <param name="section">CODEOWNERS section the Label Owner belongs to</param>
     /// <param name="relatedTo">IDs of related work items (owners, labels)</param>
     /// <returns>This builder for chaining</returns>
-    public WorkItemDataBuilder AddLabelOwner(string labelType, out int id, string repository = "Azure/azure-sdk-for-net", string repoPath = "", params int[] relatedTo)
+    public WorkItemDataBuilder AddLabelOwner(string labelType, out int id, string repository = "Azure/azure-sdk-for-net", string repoPath = "", string section = "Client Libraries", params int[] relatedTo)
     {
         id = _nextId++;
-        _labelOwners.Add(new LabelOwnerData(id, labelType, repository, repoPath, [.. relatedTo]));
+        _labelOwners.Add(new LabelOwnerData(id, labelType, repository, repoPath, section, [.. relatedTo]));
         return this;
     }
 
     /// <summary>
     /// Adds a Service Owner type Label Owner.
     /// </summary>
-    public WorkItemDataBuilder AddServiceOwner(out int id, string repository = "Azure/azure-sdk-for-net", string repoPath = "", params int[] relatedTo)
-        => AddLabelOwner("Service Owner", out id, repository, repoPath, relatedTo);
+    public WorkItemDataBuilder AddServiceOwner(out int id, string repository = "Azure/azure-sdk-for-net", string repoPath = "", string section = "Client Libraries", params int[] relatedTo)
+        => AddLabelOwner("Service Owner", out id, repository, repoPath, section, relatedTo);
 
     /// <summary>
     /// Adds an Azure SDK Owner type Label Owner.
     /// </summary>
-    public WorkItemDataBuilder AddAzureSdkOwner(out int id, string repository = "Azure/azure-sdk-for-net", string repoPath = "", params int[] relatedTo)
-        => AddLabelOwner("Azure SDK Owner", out id, repository, repoPath, relatedTo);
+    public WorkItemDataBuilder AddAzureSdkOwner(out int id, string repository = "Azure/azure-sdk-for-net", string repoPath = "", string section = "Client Libraries", params int[] relatedTo)
+        => AddLabelOwner("Azure SDK Owner", out id, repository, repoPath, section, relatedTo);
 
     /// <summary>
     /// Adds a PR Label type Label Owner (used for service-level path entries).
     /// </summary>
-    public WorkItemDataBuilder AddPRLabelOwner(out int id, string repoPath, string repository = "Azure/azure-sdk-for-net", params int[] relatedTo)
-        => AddLabelOwner("PR Label", out id, repository, repoPath, relatedTo);
+    public WorkItemDataBuilder AddPRLabelOwner(out int id, string repoPath, string repository = "Azure/azure-sdk-for-net", string section = "Client Libraries", params int[] relatedTo)
+        => AddLabelOwner("PR Label", out id, repository, repoPath, section, relatedTo);
 
     /// <summary>
     /// Builds the WorkItemData with all relationships hydrated.
@@ -126,7 +127,7 @@ public class WorkItemDataBuilder
             l => MapToLabelWorkItem(CreateLabelWorkItem(l.Id, l.LabelName)));
 
         var labelOwners = _labelOwners
-            .Select(lo => MapToLabelOwnerWorkItem(CreateLabelOwnerWorkItem(lo.Id, lo.LabelType, lo.Repository, lo.RepoPath, lo.RelatedIds)))
+            .Select(lo => MapToLabelOwnerWorkItem(CreateLabelOwnerWorkItem(lo.Id, lo.LabelType, lo.Repository, lo.RepoPath, lo.Section, lo.RelatedIds)))
             .ToList();
 
         var data = new WorkItemData(packages, owners, labels, labelOwners);
@@ -178,7 +179,7 @@ public class WorkItemDataBuilder
         };
     }
 
-    private static WorkItem CreateLabelOwnerWorkItem(int id, string labelType, string repository, string repoPath, HashSet<int> relatedIds)
+    private static WorkItem CreateLabelOwnerWorkItem(int id, string labelType, string repository, string repoPath, string section, HashSet<int> relatedIds)
     {
         return new WorkItem
         {
@@ -187,7 +188,8 @@ public class WorkItemDataBuilder
             {
                 { "Custom.LabelType", labelType },
                 { "Custom.Repository", repository },
-                { "Custom.RepoPath", repoPath }
+                { "Custom.RepoPath", repoPath },
+                { "Custom.Section", section }
             },
             Relations = relatedIds.Select(relId => new WorkItemRelation
             {
@@ -238,6 +240,7 @@ public class WorkItemDataBuilder
             LabelType = GetFieldValue(wi, "Custom.LabelType"),
             Repository = GetFieldValue(wi, "Custom.Repository"),
             RepoPath = GetFieldValue(wi, "Custom.RepoPath"),
+            Section = GetFieldValue(wi, "Custom.Section"),
             RelatedIds = wi.ExtractRelatedIds()
         };
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Config/CodeownersToolsTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Config/CodeownersToolsTests.cs
@@ -92,6 +92,90 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.Config
         }
 
         [Test]
+        public async Task AddLabelOwner_WithPackageDirectoryPath_ReturnsErrorAndDoesNotCallHelper()
+        {
+            var result = await _tool.AddLabelOwner(
+                githubUsers: [],
+                labels: [],
+                ownerType: OwnerType.ServiceOwner,
+                path: "/sdk/storage/Azure.Storage.Blobs",
+                repo: "Azure/azure-sdk-for-net");
+
+            Assert.That(result, Is.TypeOf<DefaultCommandResponse>());
+            var response = (DefaultCommandResponse)result;
+            Assert.Multiple(() =>
+            {
+                Assert.That(response.ResponseError, Does.Contain("Azure.Storage.Blobs"));
+                Assert.That(response.ResponseError, Does.Contain("--force"));
+            });
+
+            _mockCodeownersManagement.Verify(
+                m => m.AddOwnersAndLabelsToPath(It.IsAny<OwnerWorkItem[]>(), It.IsAny<LabelWorkItem[]>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<OwnerType>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Test]
+        public async Task AddLabelOwner_WithPackageDirectoryPath_AndForce_CallsHelper()
+        {
+            _mockCodeownersManagement
+                .Setup(m => m.AddOwnersAndLabelsToPath(It.IsAny<OwnerWorkItem[]>(), It.IsAny<LabelWorkItem[]>(), "Azure/azure-sdk-for-net", It.IsAny<string>(), It.IsAny<OwnerType>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new CodeownersModifyResponse { View = new CodeownersViewResponse() });
+
+            var result = await _tool.AddLabelOwner(
+                githubUsers: [],
+                labels: [],
+                ownerType: OwnerType.ServiceOwner,
+                path: "/sdk/storage/Azure.Storage.Blobs",
+                repo: "Azure/azure-sdk-for-net",
+                force: true);
+
+            Assert.That(result, Is.Not.Null);
+            _mockCodeownersManagement.Verify(
+                m => m.AddOwnersAndLabelsToPath(It.IsAny<OwnerWorkItem[]>(), It.IsAny<LabelWorkItem[]>(), "Azure/azure-sdk-for-net", "/sdk/storage/Azure.Storage.Blobs", OwnerType.ServiceOwner, It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task AddLabelOwner_WithServiceLevelPath_CallsHelper()
+        {
+            _mockCodeownersManagement
+                .Setup(m => m.AddOwnersAndLabelsToPath(It.IsAny<OwnerWorkItem[]>(), It.IsAny<LabelWorkItem[]>(), "Azure/azure-sdk-for-net", It.IsAny<string>(), It.IsAny<OwnerType>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new CodeownersModifyResponse { View = new CodeownersViewResponse() });
+
+            var result = await _tool.AddLabelOwner(
+                githubUsers: [],
+                labels: [],
+                ownerType: OwnerType.ServiceOwner,
+                path: "sdk/storage/",
+                repo: "Azure/azure-sdk-for-net");
+
+            Assert.That(result, Is.Not.Null);
+            _mockCodeownersManagement.Verify(
+                m => m.AddOwnersAndLabelsToPath(It.IsAny<OwnerWorkItem[]>(), It.IsAny<LabelWorkItem[]>(), "Azure/azure-sdk-for-net", "sdk/storage/", OwnerType.ServiceOwner, It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [TestCase("/sdk/storage/Azure.Storage.Blobs", "Azure.Storage.Blobs")]
+        [TestCase("sdk/storage/Azure.Storage.Blobs", "Azure.Storage.Blobs")]
+        [TestCase("sdk/storage/Azure.Storage.Blobs/", "Azure.Storage.Blobs")]
+        [TestCase("/sdk/storage/Azure.Storage.Blobs/", "Azure.Storage.Blobs")]
+        public void LooksLikePackageDirectory_ThreeSegments_ReturnsTrue(string path, string expected)
+        {
+            Assert.That(CodeownersTool.LooksLikePackageDirectory(path, out var packageName), Is.True);
+            Assert.That(packageName, Is.EqualTo(expected));
+        }
+
+        [TestCase("")]
+        [TestCase(null)]
+        [TestCase("sdk/storage/")]
+        [TestCase("/sdk/storage")]
+        [TestCase("sdk/storage/Azure.Storage.Blobs/extra")]
+        public void LooksLikePackageDirectory_NonPackageDirectory_ReturnsFalse(string? path)
+        {
+            Assert.That(CodeownersTool.LooksLikePackageDirectory(path, out _), Is.False);
+        }
+
+        [Test]
         public async Task RemovePackageLabel_CallsRemoveLabelsFromPackage()
         {
             _mockCodeownersManagement

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Config/CodeownersToolsTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Config/CodeownersToolsTests.cs
@@ -170,6 +170,9 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.Config
         [TestCase("sdk/storage/")]
         [TestCase("/sdk/storage")]
         [TestCase("sdk/storage/Azure.Storage.Blobs/extra")]
+        [TestCase("sdk/storage/*")]
+        [TestCase("sdk/*/Azure.Storage.Blobs")]
+        [TestCase("/sdk/storage/Azure.Storage.*")]
         public void LooksLikePackageDirectory_NonPackageDirectory_ReturnsFalse(string? path)
         {
             Assert.That(CodeownersTool.LooksLikePackageDirectory(path, out _), Is.False);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Config/CodeownersToolsTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Config/CodeownersToolsTests.cs
@@ -91,14 +91,17 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.Config
             _mockCodeownersManagement.Verify(m => m.AddOwnersToPackage(It.IsAny<OwnerWorkItem[]>(), "pkg1", "Azure/azure-sdk-for-net", It.IsAny<CancellationToken>()), Times.Once);
         }
 
-        [Test]
-        public async Task AddLabelOwner_WithPackageDirectoryPath_ReturnsErrorAndDoesNotCallHelper()
+        [TestCase("/sdk/storage/Azure.Storage.Blobs")]
+        [TestCase("/sdk/storage/Azure.Storage.Blobs/")]
+        [TestCase("sdk/storage/Azure.Storage.Blobs")]
+        [TestCase("sdk/storage/Azure.Storage.Blobs/")]
+        public async Task AddLabelOwner_WithPackageDirectoryPath_ReturnsErrorAndDoesNotCallHelper(string path)
         {
             var result = await _tool.AddLabelOwner(
                 githubUsers: [],
                 labels: [],
                 ownerType: OwnerType.ServiceOwner,
-                path: "/sdk/storage/Azure.Storage.Blobs",
+                path: path,
                 repo: "Azure/azure-sdk-for-net");
 
             Assert.That(result, Is.TypeOf<DefaultCommandResponse>());

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -5,9 +5,11 @@
 ### Features Added
 
 - Added `detect-breaking-change` CLI command and `azsdk_package_detect_breaking_change` MCP tool to detect SDK breaking changes for a package. Accepts the sdk package via `--package-path`. Optional parameters: `--tsp-config-path`, `--changes-only`.
+- `codeowners add-label-owner` rejects a package-directory path (e.g. `sdk/<service>/<package>`) in favor of the package name; use `--force` to override, and wildcard (`*`) paths are always allowed.
 
 ### Bugs Fixed
 
+- `codeowners generate --section` now scopes Label Owner entries to the requested section, so entries from other sections no longer leak into the generated block.
 - Updated `GitHub.Copilot.SDK` to 1.0.8 so Copilot-backed commands accept ISO-8601 `ping` timestamps returned by current Copilot CLI versions.
 
 ## 0.6.30 (2026-07-23)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Codeowners/CodeownersGenerateHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Codeowners/CodeownersGenerateHelper.cs
@@ -62,11 +62,11 @@ public class CodeownersGenerateHelper(
         var packageLookup = repoPackages.ToDictionary(p => p.Name, p => p, StringComparer.OrdinalIgnoreCase);
 
         logger.LogInformation("Fetching work items from Azure DevOps...");
-        var workItemData = await FetchAllWorkItemsAsync(repoName, language, packageTypes, ct);
+        var workItemData = await FetchAllWorkItemsAsync(repoName, language, packageTypes, sectionName, ct);
 
         logger.LogInformation("Building CODEOWNERS entries...");
         var invalidOwnerCutoff = DateTime.UtcNow.AddDays(-invalidOwnerLookbackDays);
-        var entries = BuildCodeownersEntries(workItemData, packageLookup, repoRoot, invalidOwnerCutoff);
+        var entries = BuildCodeownersEntries(workItemData, packageLookup, repoRoot, sectionName, invalidOwnerCutoff);
         logger.LogInformation("Total entries: {Count}", entries.Count);
 
         logger.LogInformation("Sorting entries...");
@@ -125,7 +125,7 @@ public class CodeownersGenerateHelper(
         }
     }
 
-    private async Task<WorkItemData> FetchAllWorkItemsAsync(string repoName, SdkLanguage language, string[] packageTypes, CancellationToken ct)
+    private async Task<WorkItemData> FetchAllWorkItemsAsync(string repoName, SdkLanguage language, string[] packageTypes, string sectionName, CancellationToken ct)
     {
         // Build package type filter using IN clause
         var packageTypeList = string.Join(", ", packageTypes.Select(pt => $"'{pt}'"));
@@ -156,9 +156,12 @@ public class CodeownersGenerateHelper(
             ct);
         logger.LogInformation("Labels: {Count}", labels.Count);
 
-        // Fetch Label Owners by repository
+        // Fetch Label Owners by repository and section.
+        // Scoping by section prevents Label Owner entries from other sections
+        // (e.g. client/data-plane services) from leaking into the section being generated.
+        var escapedSection = sectionName.Replace("'", "''");
         var labelOwners = await FetchWorkItemsAsync<LabelOwnerWorkItem>(
-            $"[System.WorkItemType] = 'Label Owner' AND [Custom.Repository] = '{repoName}'",
+            $"[System.WorkItemType] = 'Label Owner' AND [Custom.Repository] = '{repoName}' AND [Custom.Section] = '{escapedSection}'",
             WorkItemMappers.MapToLabelOwnerWorkItem,
             ct);
         logger.LogInformation("Label Owners: {Count}", labelOwners.Count);
@@ -189,6 +192,7 @@ public class CodeownersGenerateHelper(
         WorkItemData data,
         Dictionary<string, RepoPackage> packageLookup,
         string repoRoot,
+        string sectionName,
         DateTime invalidOwnerCutoff)
     {
         var entries = new List<CodeownersEntry>();
@@ -240,7 +244,7 @@ public class CodeownersGenerateHelper(
 
         // Service-level path entries: Label Owners with RepoPath
         var serviceLevelPathEntries = new Dictionary<string, CodeownersEntry>(StringComparer.OrdinalIgnoreCase);
-        foreach (var lo in unlinkedLabelOwners.Where(lo => !string.IsNullOrEmpty(lo.RepoPath)))
+        foreach (var lo in unlinkedLabelOwners.Where(lo => !string.IsNullOrEmpty(lo.RepoPath) && MatchesSection(lo, sectionName)))
         {
             string pathExpression = "/" + lo.RepoPath.TrimStart('/');
 
@@ -286,7 +290,7 @@ public class CodeownersGenerateHelper(
 
         // Pathless entries: Label Owners without RepoPath (Service Owner / Azure SDK Owner types for triage)
         var pathlessEntriesByLabel = new Dictionary<string, CodeownersEntry>(StringComparer.OrdinalIgnoreCase);
-        foreach (var lo in unlinkedLabelOwners.Where(lo => string.IsNullOrEmpty(lo.RepoPath)))
+        foreach (var lo in unlinkedLabelOwners.Where(lo => string.IsNullOrEmpty(lo.RepoPath) && MatchesSection(lo, sectionName)))
         {
             var labels = lo.Labels
                 .Select(l => l.LabelName)
@@ -316,6 +320,17 @@ public class CodeownersGenerateHelper(
         }
 
         return entries;
+    }
+
+    /// <summary>
+    /// Returns true if the Label Owner belongs to the requested section (case-insensitive, trimmed).
+    /// Label Owners with an empty/missing section are excluded from a specific-section generate to
+    /// prevent cross-section bleed. This mirrors the WIQL section filter in <see cref="FetchAllWorkItemsAsync"/>
+    /// and keeps generation correct even if that query is later changed.
+    /// </summary>
+    private static bool MatchesSection(LabelOwnerWorkItem lo, string sectionName)
+    {
+        return string.Equals(lo.Section?.Trim(), sectionName?.Trim(), StringComparison.OrdinalIgnoreCase);
     }
 
     private static void AddLabelOwnerMetadata(CodeownersEntry entry, LabelOwnerWorkItem lo, DateTime invalidOwnerCutoff)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Codeowners/CodeownersGenerateHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Codeowners/CodeownersGenerateHelper.cs
@@ -66,7 +66,7 @@ public class CodeownersGenerateHelper(
 
         logger.LogInformation("Building CODEOWNERS entries...");
         var invalidOwnerCutoff = DateTime.UtcNow.AddDays(-invalidOwnerLookbackDays);
-        var entries = BuildCodeownersEntries(workItemData, packageLookup, repoRoot, sectionName, invalidOwnerCutoff);
+        var entries = BuildCodeownersEntries(workItemData, packageLookup, repoRoot, invalidOwnerCutoff);
         logger.LogInformation("Total entries: {Count}", entries.Count);
 
         logger.LogInformation("Sorting entries...");
@@ -188,11 +188,12 @@ public class CodeownersGenerateHelper(
         return workItems.Select(factory).ToList();
     }
 
+    // Assumes the data passed in has already been filtered to the target section
+    // by the WIQL query in FetchAllWorkItemsAsync. No additional section filtering is applied here.
     private List<CodeownersEntry> BuildCodeownersEntries(
         WorkItemData data,
         Dictionary<string, RepoPackage> packageLookup,
         string repoRoot,
-        string sectionName,
         DateTime invalidOwnerCutoff)
     {
         var entries = new List<CodeownersEntry>();
@@ -244,7 +245,7 @@ public class CodeownersGenerateHelper(
 
         // Service-level path entries: Label Owners with RepoPath
         var serviceLevelPathEntries = new Dictionary<string, CodeownersEntry>(StringComparer.OrdinalIgnoreCase);
-        foreach (var lo in unlinkedLabelOwners.Where(lo => !string.IsNullOrEmpty(lo.RepoPath) && MatchesSection(lo, sectionName)))
+        foreach (var lo in unlinkedLabelOwners.Where(lo => !string.IsNullOrEmpty(lo.RepoPath)))
         {
             string pathExpression = "/" + lo.RepoPath.TrimStart('/');
 
@@ -290,7 +291,7 @@ public class CodeownersGenerateHelper(
 
         // Pathless entries: Label Owners without RepoPath (Service Owner / Azure SDK Owner types for triage)
         var pathlessEntriesByLabel = new Dictionary<string, CodeownersEntry>(StringComparer.OrdinalIgnoreCase);
-        foreach (var lo in unlinkedLabelOwners.Where(lo => string.IsNullOrEmpty(lo.RepoPath) && MatchesSection(lo, sectionName)))
+        foreach (var lo in unlinkedLabelOwners.Where(lo => string.IsNullOrEmpty(lo.RepoPath)))
         {
             var labels = lo.Labels
                 .Select(l => l.LabelName)
@@ -320,17 +321,6 @@ public class CodeownersGenerateHelper(
         }
 
         return entries;
-    }
-
-    /// <summary>
-    /// Returns true if the Label Owner belongs to the requested section (case-insensitive, trimmed).
-    /// Label Owners with an empty/missing section are excluded from a specific-section generate to
-    /// prevent cross-section bleed. This mirrors the WIQL section filter in <see cref="FetchAllWorkItemsAsync"/>
-    /// and keeps generation correct even if that query is later changed.
-    /// </summary>
-    private static bool MatchesSection(LabelOwnerWorkItem lo, string sectionName)
-    {
-        return string.Equals(lo.Section?.Trim(), sectionName?.Trim(), StringComparison.OrdinalIgnoreCase);
     }
 
     private static void AddLabelOwnerMetadata(CodeownersEntry entry, LabelOwnerWorkItem lo, DateTime invalidOwnerCutoff)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
@@ -686,11 +686,12 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
         /// (exactly three segments, e.g. sdk/&lt;service&gt;/&lt;package&gt;), as opposed to a
         /// service-level path. Such entries should be attached to the package by name rather
         /// than a raw path. The final path segment is returned as the suggested package name.
+        /// Paths containing a wildcard ('*') are never treated as package directories.
         /// </summary>
         public static bool LooksLikePackageDirectory(string? path, out string packageName)
         {
             packageName = string.Empty;
-            if (string.IsNullOrWhiteSpace(path))
+            if (string.IsNullOrWhiteSpace(path) || path.Contains('*'))
             {
                 return false;
             }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
@@ -157,6 +157,15 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
             DefaultValueFactory = _ => false,
         };
 
+        // Add-label-owner command options
+        private readonly Option<bool> forceLabelOwnerPathOption = new("--force")
+        {
+            Description = "Create the CODEOWNERS entry even when the path looks like a package directory. "
+                + "By default a 3-segment path (e.g. sdk/<service>/<package>) is rejected in favor of using the package name.",
+            Required = false,
+            DefaultValueFactory = _ => false,
+        };
+
         // Command names
         private const string generateCodeownersCommandName = "generate";
         private const string viewCodeownersCommandName = "view";
@@ -227,7 +236,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
             },
             new(addLabelOwnerCommandName, "Add owner(s) to a label and optional path")
             {
-                multipleGithubUserOption, labelsOption, pathOption, ownerTypeOption, repoOption, sectionOption,
+                multipleGithubUserOption, labelsOption, pathOption, ownerTypeOption, repoOption, sectionOption, forceLabelOwnerPathOption,
             },
             new(removeCodeownersToPackageCommandName, "Remove source owner(s) from a package")
             {
@@ -306,7 +315,8 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
                 var path = parseResult.GetValue(pathOption);
                 var repo = parseResult.GetValue(repoOption);
                 var section = parseResult.GetValue(sectionOption);
-                return await AddLabelOwner(users!, labels!, ownerType!, path, repo, section, ct);
+                var force = parseResult.GetValue(forceLabelOwnerPathOption);
+                return await AddLabelOwner(users!, labels!, ownerType!, path, repo, section, force, ct);
             }
 
             if (command == removeCodeownersToPackageCommandName)
@@ -628,7 +638,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
             }
         }
 
-        [McpServerTool(Name = CodeownerAddLabelOwnerToolName), Description("Add owner(s) to a label with an optional path in CODEOWNERS work items. Valid ownerType values: service-owner, azsdk-owner, pr-label.")]
+        [McpServerTool(Name = CodeownerAddLabelOwnerToolName), Description("Add owner(s) to a label with an optional path in CODEOWNERS work items. Valid ownerType values: service-owner, azsdk-owner, pr-label. A 3-segment path (e.g. sdk/<service>/<package>) is rejected because it targets a package directory; add owners to the package by name instead, or set force=true to create the path anyway.")]
         public async Task<CommandResponse> AddLabelOwner(
             string[] githubUsers,
             string[] labels,
@@ -636,6 +646,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
             string? path = null,
             string? repo = null,
             string section = "Client Libraries",
+            bool force = false,
             CancellationToken ct = default
         )
         {
@@ -644,6 +655,13 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
                 if (string.IsNullOrEmpty(section))
                 {
                     throw new ArgumentException("Section name must be provided", nameof(section));
+                }
+                if (!force && LooksLikePackageDirectory(path, out var packageName))
+                {
+                    throw new ArgumentException(
+                        $"The path '{path}' looks like a package directory. Use the package name '{packageName}' instead of a full path, "
+                        + "or pass --force to create a CODEOWNERS entry for this path anyway.",
+                        nameof(path));
                 }
                 repo = await ResolveRepo(repo, ct);
                 return await codeownersManagementHelper.AddOwnersAndLabelsToPath(
@@ -661,6 +679,33 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
                 logger.LogError(ex, "Error adding label owner(s)");
                 return new DefaultCommandResponse { ResponseError = ex.Message };
             }
+        }
+
+        /// <summary>
+        /// Returns true when a CODEOWNERS path targets a specific package directory
+        /// (exactly three segments, e.g. sdk/&lt;service&gt;/&lt;package&gt;), as opposed to a
+        /// service-level path. Such entries should be attached to the package by name rather
+        /// than a raw path. The final path segment is returned as the suggested package name.
+        /// </summary>
+        public static bool LooksLikePackageDirectory(string? path, out string packageName)
+        {
+            packageName = string.Empty;
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return false;
+            }
+
+            var segments = path
+                .Replace('\\', '/')
+                .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            if (segments.Length != 3)
+            {
+                return false;
+            }
+
+            packageName = segments[^1];
+            return true;
         }
 
         [McpServerTool(Name = CodeownerRemovePackageOwnerToolName), Description("Remove source owner(s) from a package in CODEOWNERS work items.")]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Config/CodeownersTool.cs
@@ -683,7 +683,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Config
 
         /// <summary>
         /// Returns true when a CODEOWNERS path targets a specific package directory
-        /// (exactly three segments, e.g. sdk/&lt;service&gt;/&lt;package&gt;), as opposed to a
+        /// (exactly three segments, e.g. sdk/<service>/<package>), as opposed to a
         /// service-level path. Such entries should be attached to the package by name rather
         /// than a raw path. The final path segment is returned as the suggested package name.
         /// Paths containing a wildcard ('*') are never treated as package directories.


### PR DESCRIPTION
## Summary

Improvements to the `azsdk config codeowners` tooling in `tools/azsdk-cli`:

### 1. `generate` now scopes Label Owner entries by `--section`
Previously `--section` only chose which CODEOWNERS block to overwrite and was used for logging; Label Owner work items were fetched by repository alone, so every service-level and pathless (triage) Label Owner leaked into the targeted block regardless of its real `Custom.Section` (e.g. ~38 client/data-plane services leaking into a mgmt generate).

- Added `AND [Custom.Section] = '<section>'` to the Label Owner WIQL in `FetchAllWorkItemsAsync` (apostrophes escaped), so the section filter happens at query time.
- `BuildCodeownersEntries` assumes the data is already section-filtered by the WIQL query (documented with a comment); no additional in-code section filtering is applied.
- Label Owners with an empty/missing section are naturally excluded from a specific-section generate, since an empty section never equals the requested section.
- Package (source-path) selection and `--package-types` behavior are unchanged.

### 2. `add-label-owner` rejects package-directory paths
A `--path` with exactly three segments (e.g. `sdk/<service>/<package>`) targets a specific package directory and should be attached to the package by name instead.

- Rejected by default with a message suggesting the package name (final segment); pass `--force` to create the path anyway.
- Paths containing a `*` wildcard are treated as glob patterns and allowed through without `--force`.

## Tests
- Generate helper tests exercise section behavior by simulating the WIQL pre-filter (constructing `WorkItemData` with only the target-section Label Owners) and asserting the management entry is present while the client-section entry is excluded, for both service-level path and pathless (triage) entries.
- Tool tests cover package-directory path rejection (data-driven across leading/trailing-slash variations), the `--force` bypass, wildcard pass-through, and the `LooksLikePackageDirectory` helper.
- `WorkItemDataBuilder` test helper gained `Section` support.

## Decisions
- Section filtering is enforced at the WIQL layer; unsectioned Label Owners are excluded from a specific-section generate.
- Wildcard paths bypass the package-directory heuristic.
