### PR TITLE
docs: harmless Check Enforcer override PoC marker

### DIFF
--- a/.bounty-poc/check-enforcer-override-poc.md
+++ b/.bounty-poc/check-enforcer-override-poc.md
@@ -1,0 +1,9 @@
+# Check Enforcer authorization PoC marker
+
+Harmless documentation-only file.
+
+Purpose: demonstrate that any user who can comment on a PR can run
+`/check-enforcer override` and force commit status
+`https://aka.ms/azsdk/checkenforcer` to **success** without write/admin role.
+
+Safe to close.


### PR DESCRIPTION
Security research PoC (authorization gap in azure-sdk-actions Check Enforcer). Adds a marker file only under `.bounty-poc/`. Please do not merge; will close after evidence capture.