### PR TITLE
Remove privileged Azure service connection from QA bot agent CI test step

### DIFF
--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/pipelines/server-ci.yml
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/pipelines/server-ci.yml
@@ -83,36 +83,27 @@ extends:
                 displayName: 'Type Check (pyright)'
                 workingDirectory: $(workingDirectory)
 
-              - task: AzureCLI@2
+              - bash: |
+                  set -euo pipefail
+                  echo "Running unit tests..."
+                  python -m pytest tests/ \
+                    --ignore=tests/azsdk_mcp_tools_test.py \
+                    --ignore=tests/github_tools_test.py \
+                    --ignore=tests/knowledge_tools_test.py \
+                    --ignore=tests/intention_service_test.py \
+                    --ignore=tests/conversation_evaluation_test.py \
+                    --ignore=tests/knowledge_retrieve_service_test.py \
+                    --cov=config \
+                    --cov=services \
+                    --cov=tools \
+                    --cov=utils \
+                    --cov-report=term-missing \
+                    --cov-report=xml:$(workingDirectory)/coverage.xml \
+                    -v \
+                    --tb=short \
+                    --junitxml=$(workingDirectory)/test-results.xml
                 displayName: 'Run Unit Tests'
-                inputs:
-                  azureSubscription: 'azuresdkqabot-dev'
-                  addSpnToEnvironment: true
-                  scriptType: bash
-                  scriptLocation: inlineScript
-                  workingDirectory: $(workingDirectory)
-                  inlineScript: |
-                    set -euo pipefail
-                    export AZURESUBSCRIPTION_CLIENT_ID=$servicePrincipalId
-                    export AZURESUBSCRIPTION_TENANT_ID=$tenantId
-                    echo "Running unit tests..."
-                    python -m pytest tests/ \
-                      --ignore=tests/azsdk_mcp_tools_test.py \
-                      --ignore=tests/github_tools_test.py \
-                      --ignore=tests/knowledge_tools_test.py \
-                      --cov=config \
-                      --cov=services \
-                      --cov=tools \
-                      --cov=utils \
-                      --cov-report=term-missing \
-                      --cov-report=xml:$(workingDirectory)/coverage.xml \
-                      -v \
-                      --tb=short \
-                      --junitxml=$(workingDirectory)/test-results.xml
-                env:
-                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-                  AZURESUBSCRIPTION_SERVICE_CONNECTION_ID: $(AZURESUBSCRIPTION_SERVICE_CONNECTION_ID)
-                  AZURE_APPCONFIG_ENDPOINT: $(AZURE_APPCONFIG_ENDPOINT)
+                workingDirectory: $(workingDirectory)
 
               - task: PublishTestResults@2
                 displayName: 'Publish Test Results'


### PR DESCRIPTION
## Summary

The Azure SDK QA Bot **agent** CI pipeline ([`server-ci.yml`](https://github.com/Azure/azure-sdk-tools/blob/main/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/pipelines/server-ci.yml)) is **PR-triggered** and ran its unit tests via an `AzureCLI@2` task under the privileged `azuresdkqabot-dev` Azure service connection, with `addSpnToEnvironment: true` and `SYSTEM_ACCESSTOKEN` / `AZURESUBSCRIPTION_*` exported into the environment.

That means **PR-controlled test code executed under an identity that can reach Key Vault and App Configuration** — an untrusted PR could add/modify a test to exfiltrate secrets using `config` credentials / `SYSTEM_ACCESSTOKEN` (`AzurePipelinesCredential`). This is the same class of issue reported against the (now deprecated) backend pipeline.

## Change

- Replace the `AzureCLI@2` "Run Unit Tests" task with a plain `bash` step — **no service connection, no `SYSTEM_ACCESSTOKEN`, no SPN env**.
- Exclude the tests that require live Azure access so the PR job no longer needs a credential:
  - `intention_service_test.py` — calls `app_config.init()` and exercises the real model
  - `conversation_evaluation_test.py` — calls `app_config.init()`, real model
  - `knowledge_retrieve_service_test.py` — hits AI Search
  
  (in addition to the already-ignored `azsdk_mcp_tools_test.py`, `github_tools_test.py`, `knowledge_tools_test.py`)
- The **PR trigger is kept**. Lint / pyright and all hermetic (mocked) unit tests still run on PRs.

## Impact / follow-ups

- The three excluded tests are integration/eval-style tests against the live model and no longer run in this PR-triggered pipeline. If we want them to keep running, a good follow-up is a separate `main`-only job (gated on `Build.Reason != PullRequest`) that runs them under the service connection safely.
- No test files were deleted.

## Security

Closes the PR → privileged service connection → Key Vault / App Config secret-exfiltration path for the agent CI pipeline.
