### PR TITLE
Restrict codeowners enforcement skipping to specified emails

### DIFF
--- a/eng/common/pipelines/templates/steps/verify-codeowners.yml
+++ b/eng/common/pipelines/templates/steps/verify-codeowners.yml
@@ -25,14 +25,34 @@ parameters:
       - data
       - functions
       - datamovement
+  # Comma separated list of emails allowed to skip codeowners validation. User 
+  # must queue the pipeline manually with the 'Skip.VerifyCodeowners' variable 
+  # set to 'true'.
+  - name: AllowSkipEmails
+    type: string
+    default: ''
 
 steps:
   - ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(parameters.EnablePrValidation, true)) }}:
+    - task: PowerShell@2
+      displayName: Evaluate Codeowners Skip
+      condition: succeeded()
+      inputs:
+        pwsh: true
+        filePath: $(Build.SourcesDirectory)/eng/common/scripts/Set-VerifyCodeownersSkip.ps1
+        arguments: >-
+          -RequestedForEmail '$(Build.RequestedForEmail)'
+          -SkipVerifyCodeowners '$(Skip.VerifyCodeowners)'
+          -AdditionalSkipEmails '${{ parameters.AllowSkipEmails }}'
+        workingDirectory: $(Build.SourcesDirectory)
+
     - template: /eng/common/pipelines/templates/steps/install-azsdk-cli.yml
+      parameters:
+        Condition: and(succeeded(), ne(variables['ShouldSkipVerifyCodeowners'], 'true'))
 
     - task: PowerShell@2
       displayName: Generate PR Diff for Codeowners
-      condition: and(succeeded(), ne(variables['Skip.VerifyCodeowners'], 'true'))
+      condition: and(succeeded(), ne(variables['ShouldSkipVerifyCodeowners'], 'true'))
       inputs:
         pwsh: true
         filePath: $(Build.SourcesDirectory)/eng/common/scripts/Generate-PR-Diff.ps1
@@ -43,7 +63,7 @@ steps:
 
     - task: PowerShell@2
       displayName: Verify Codeowners
-      condition: and(succeeded(), ne(variables['Skip.VerifyCodeowners'], 'true'))
+      condition: and(succeeded(), ne(variables['ShouldSkipVerifyCodeowners'], 'true'))
       inputs:
         pwsh: true
         filePath: $(Build.SourcesDirectory)/eng/common/scripts/Test-CodeownersForArtifacts.ps1
@@ -56,13 +76,25 @@ steps:
         workingDirectory: $(Build.SourcesDirectory)
 
   - ${{ elseif eq(variables['Build.Reason'], 'Manual') }}:
+    - task: PowerShell@2
+      displayName: Evaluate Codeowners Skip
+      condition: succeeded()
+      inputs:
+        pwsh: true
+        filePath: $(Build.SourcesDirectory)/eng/common/scripts/Set-VerifyCodeownersSkip.ps1
+        arguments: >-
+          -RequestedForEmail '$(Build.RequestedForEmail)'
+          -SkipVerifyCodeowners '$(Skip.VerifyCodeowners)'
+          -AdditionalSkipEmails '${{ parameters.AllowSkipEmails }}'
+        workingDirectory: $(Build.SourcesDirectory)
+
     - template: /eng/common/pipelines/templates/steps/install-azsdk-cli.yml
       parameters:
-        Condition: and(succeeded(), ne(variables['Skip.VerifyCodeowners'], 'true'))
+        Condition: and(succeeded(), ne(variables['ShouldSkipVerifyCodeowners'], 'true'))
 
     - task: PowerShell@2
       displayName: Verify Codeowners
-      condition: and(succeeded(), ne(variables['Skip.VerifyCodeowners'], 'true'))
+      condition: and(succeeded(), ne(variables['ShouldSkipVerifyCodeowners'], 'true'))
       inputs:
         pwsh: true
         filePath: $(Build.SourcesDirectory)/eng/common/scripts/Test-CodeownersForArtifacts.ps1

--- a/eng/common/scripts/Set-VerifyCodeownersSkip.ps1
+++ b/eng/common/scripts/Set-VerifyCodeownersSkip.ps1
@@ -6,9 +6,8 @@ variable with the result.
 .DESCRIPTION
 Codeowners verification can be skipped when the 'Skip.VerifyCodeowners' variable
 is set to 'true' and the person who requested the build is a member of an allowed
-set of emails. The allowed set is the union of a default list (kept in sync with
-the emails used by create-apireview.yml) and any additional emails passed via
-the AdditionalSkipEmails parameter.
+set of emails. The allowed set is the union of a default list and any additional
+emails passed via the AdditionalSkipEmails parameter.
 
 The result is written to an Azure DevOps pipeline variable (default name
 'ShouldSkipVerifyCodeowners') so that later steps can gate on a single variable.

--- a/eng/common/scripts/Set-VerifyCodeownersSkip.ps1
+++ b/eng/common/scripts/Set-VerifyCodeownersSkip.ps1
@@ -1,0 +1,74 @@
+<#
+.SYNOPSIS
+Evaluates whether codeowners verification should be skipped and sets a pipeline
+variable with the result.
+
+.DESCRIPTION
+Codeowners verification can be skipped when the 'Skip.VerifyCodeowners' variable
+is set to 'true' and the person who requested the build is a member of an allowed
+set of emails. The allowed set is the union of a default list (kept in sync with
+the emails used by create-apireview.yml) and any additional emails passed via
+the AdditionalSkipEmails parameter.
+
+The result is written to an Azure DevOps pipeline variable (default name
+'ShouldSkipVerifyCodeowners') so that later steps can gate on a single variable.
+
+.PARAMETER RequestedForEmail
+The email of the person who requested the build (e.g. Build.RequestedForEmail).
+
+.PARAMETER SkipVerifyCodeowners
+The value of the 'Skip.VerifyCodeowners' pipeline variable. Verification is only
+eligible to be skipped when this is 'true'.
+
+.PARAMETER AdditionalSkipEmails
+Additional emails allowed to skip verification, in addition to the
+default set. Accepts a comma-, semicolon-, or whitespace-separated list.
+
+.PARAMETER OutputVariableName
+The name of the pipeline variable to set with the boolean result.
+#>
+[CmdletBinding()]
+param (
+    [string] $RequestedForEmail = '',
+    [string] $SkipVerifyCodeowners = $env:SKIP_VERIFYCODEOWNERS,
+    [string] $AdditionalSkipEmails = '',
+    [string] $OutputVariableName = 'ShouldSkipVerifyCodeowners'
+)
+
+Set-StrictMode -Version 4
+$ErrorActionPreference = 'Stop'
+
+if ($SkipVerifyCodeowners -ne 'true') {
+    Write-Host "Skip.VerifyCodeowners is not set. Verification will run."
+    Write-Host "##vso[task.setvariable variable=$OutputVariableName]false"
+    return
+}
+
+$defaultSkipEmails = @(
+    'bebroder@microsoft.com',
+    'mharder@microsoft.com',
+    'djurek@microsoft.com',
+    'chononiw@microsoft.com',
+    'raychen@microsoft.com'
+)
+
+$extraSkipEmails = @($AdditionalSkipEmails -split '[,;\s]+' | Where-Object { $_ })
+
+$allowedSkipEmails = @($defaultSkipEmails + $extraSkipEmails) |
+    ForEach-Object { $_.Trim().ToLowerInvariant() } |
+    Where-Object { $_ } |
+    Select-Object -Unique
+
+$normalizedEmail = $RequestedForEmail.Trim().ToLowerInvariant()
+
+$shouldSkip = $allowedSkipEmails -contains $normalizedEmail
+
+if ($shouldSkip) {
+    Write-Host "Skipping codeowners verification. Skip.VerifyCodeowners is set and '$normalizedEmail' is an allowed email."
+} else {
+    Write-Host "Skip.VerifyCodeowners is set but '$normalizedEmail' is not an allowed email. Verification will run."
+}
+
+Write-Host "##vso[task.setvariable variable=$OutputVariableName]$($shouldSkip.ToString().ToLowerInvariant())"
+
+return

--- a/eng/common/scripts/Set-VerifyCodeownersSkip.ps1
+++ b/eng/common/scripts/Set-VerifyCodeownersSkip.ps1
@@ -39,7 +39,7 @@ Set-StrictMode -Version 4
 $ErrorActionPreference = 'Stop'
 
 if ($SkipVerifyCodeowners -ne 'true') {
-    Write-Host "Skip.VerifyCodeowners is not set. Verification will run."
+    Write-Host "Skip.VerifyCodeowners is not set to 'true' (value: '$SkipVerifyCodeowners'). Verification will run."
     Write-Host "##vso[task.setvariable variable=$OutputVariableName]false"
     return
 }


### PR DESCRIPTION
## Summary

Updates `eng/common/pipelines/templates/steps/verify-codeowners.yml` to allow skipping codeowners verification for the same set of reasons as `create-apireview.yml`, restricted to an approved set of email addresses.

## Changes

- Added a new **Evaluate Codeowners Skip** PowerShell task (`eng/common/scripts/Set-VerifyCodeownersSkip.ps1`) that runs first in both the PR and Manual branches. It sets the `ShouldSkipVerifyCodeowners` pipeline variable, which later steps (install-azsdk-cli, Generate PR Diff, Verify Codeowners) gate on.
- Verification is only skipped when `Skip.VerifyCodeowners` is `true` **and** the requesting email (`Build.RequestedForEmail`) is in the allowed set.
- The allowed set is a default list (kept in sync with the emails in `create-apireview.yml`) plus any additional emails passed via the new `AllowSkipEmails` template parameter.
- `$SkipVerifyCodeowners` defaults to `$env:SKIP_VERIFYCODEOWNERS`, and the script exits early (logging the reason) when the skip flag is not set.