### PR TITLE
Authenticate to npm and maven deOps feed

### DIFF
--- a/tools/js-sdk-release-tools/ci.yml
+++ b/tools/js-sdk-release-tools/ci.yml
@@ -46,6 +46,8 @@ extends:
               image: $(LINUXVMIMAGE)
               os: linux
             steps:
+            - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+            
             - task: NodeTool@0
               inputs:
                 versionSpec: '$(NodeVersion)'

--- a/tools/js-sdk-release-tools/src/test/npm/npm.test.ts
+++ b/tools/js-sdk-release-tools/src/test/npm/npm.test.ts
@@ -1,8 +1,20 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { updatePackageVersion } from '../../mlc/clientGenerator/utils/typeSpecUtils.js';
 import { join } from 'path';
 import { load } from '@npmcli/package-json';
 import { tryGetNpmView } from '../../common/npmUtils.js';
+
+vi.mock('npm-registry-fetch', () => ({
+  json: vi.fn((url: string) => {
+    if (url === '/connect') {
+      return Promise.resolve({ name: 'connect', version: '3.7.0' });
+    }
+    if (url === '/non-exist') {
+      return Promise.reject(new Error('404 Not Found'));
+    }
+    return Promise.reject(new Error('Not found'));
+  }),
+}));
 
 describe('Npm package json', () => {
   test('Replace package version', async () => {

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/ci.yml
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/ci.yml
@@ -34,6 +34,8 @@ extends:
               os: linux
 
             steps:
+              - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+              
               - task: NodeTool@0
                 displayName: "Use Node.js 24.x"
                 inputs:

--- a/tools/spec-gen-sdk/ci.yml
+++ b/tools/spec-gen-sdk/ci.yml
@@ -38,6 +38,8 @@ extends:
               image: $(LINUXVMIMAGE)
               os: linux
             steps:
+              - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+              
               - task: NodeTool@0
                 inputs:
                   versionSpec: '$(NodeVersion)'

--- a/tools/typespec-bump-deps/build-typespec-bump-deps.yml
+++ b/tools/typespec-bump-deps/build-typespec-bump-deps.yml
@@ -9,6 +9,8 @@ steps:
       versionSpec: '$(NodeVersion)'
     displayName: 'Install Node.js'
 
+  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+
   - bash: |
       npm ci
     displayName: 'npm ci'


### PR DESCRIPTION
This pull request updates several CI pipeline YAML files to improve authentication for package management tools. The main changes involve adding shared templates to handle authenticated access to npm and Maven registries, ensuring builds can reliably fetch dependencies in all environments.

**Pipeline authentication improvements:**

* Added the `create-authenticated-npmrc.yml` template to the `tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/ci.yml` and `tools/spec-gen-sdk/ci.yml` pipelines to set up authenticated npm access. [[1]](diffhunk://#diff-e5c0159044dc290ddd5430d5b687ea8da9d7eaf84748580521f99cb0f8999c06R37-R38) [[2]](diffhunk://#diff-6e73986b6a75d2a001e2def9aeaff628fc99c438e549823be385ebe3b2f0f1d9R41-R42)
* Updated the `tools/typespec-bump-deps/build-typespec-bump-deps.yml` pipeline to include both `create-authenticated-npmrc.yml` and `maven-authenticate.yml` templates, ensuring authentication for both npm and Maven package managers.


[tools - typespec-bump-deps](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6623395&view=results)
[azure-sdk-qa-bot-knowledge-sync-ci](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6623018&view=logs&si=9b7fc79e-6aca-5ace-3213-4f43c256f98e)
[tools - spec-gen-sdk](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6623034&view=results)
[tools - js-sdk-release-tools - ci](https://dev.azure.com/azure-sdk/public/_build/results?buildId=6624489&view=logs&s=350b01e2-de84-5372-bbb4-a44018ebc28b&j=0eb38c80-da20-5d5c-746d-f7b17bb6b11e)