### PR TITLE
[Teams Chatbot] Fix a filter bug for knowledge sync

### DIFF
--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/src/DailySyncKnowledge.ts
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/src/DailySyncKnowledge.ts
@@ -455,8 +455,8 @@ async function processSourceDirectory(
                     }
                 }
 
-                // Skip reference files and release notes
-                if (relativePath.startsWith('reference') || entry.name.startsWith('release-')) {
+                // Skip reference files and dated release notes (release-YYYY-MM-DD)
+                if (relativePath.startsWith('reference') || /^release-\d{4}-\d{2}-\d{2}\.(md|mdx)$/.test(entry.name)) {
                     continue;
                 }
                 


### PR DESCRIPTION
## Summary
The daily knowledge sync was silently skipping `docs/plan/release-xxx.md` from the `azure-sdk-docs-eng.ms` source, so it never got uploaded to blob storage or indexed by AI Search.

Resolve this issue: https://github.com/Azure/azure-sdk-pr/issues/2678#issuecomment-5101289021

## Root cause
The directory walker in `processSourceDirectory` (`azure-sdk-qa-bot-knowledge-sync/src/DailySyncKnowledge.ts`) filters out release notes using an overly broad prefix check:

```typescript
if (relativePath.startsWith('reference') || entry.name.startsWith('release-')) {
    continue;
}
```

The `entry.name.startsWith('release-')` condition was intended to exclude dated release-note files (e.g. `release-2024-01-01.md`), but it also matches `release-plan.md`, dropping a legitimate doc.

## Fix
Tighten the filter to only skip the dated release-note pattern, consistent with the regex already used in `createReleaseNotesIndex` (`/release-\d{4}-\d{2}-\d{2}\.(md|mdx)$/`):

```typescript
if (relativePath.startsWith('reference') || /^release-\d{4}-\d{2}-\d{2}\.(md|mdx)$/.test(entry.name)) {
    continue;
}
```

## Impact
- `release-plan.md` (and any similarly named non-dated docs) will now be synced and indexed.
- Actual dated release notes (`release-YYYY-MM-DD.md/.mdx`) remain excluded — no behavior change for them.

## Testing
- `npm run build` passes with no type errors.
- [ ] Manual sync run verified `release-plan.md` is uploaded.