### PR TITLE
Refactoring pipeline analysis tool and adding GitHub workflows to analyze tool.

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/OutputHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/OutputHelperTests.cs
@@ -1,5 +1,5 @@
 using Azure.Sdk.Tools.Cli.Helpers;
-using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.Responses;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Helpers;
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/GitHubWorkflowAnalysisHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/GitHubWorkflowAnalysisHelperTests.cs
@@ -43,6 +43,12 @@ public class GitHubWorkflowAnalysisHelperTests
             gitHubService.Object,
             logAnalysisHelper.Object,
             new TestLogger<GitHubWorkflowAnalysisHelper>());
+
+        // A run that published no logs is the common case in these tests, and a loose mock would otherwise
+        // hand back a null list where the service contract promises an empty one.
+        gitHubService
+            .Setup(g => g.GetFailedWorkflowRunLogsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<(string Name, string Content)>());
     }
 
     #region AnalyzeWorkflowsAsync
@@ -112,7 +118,7 @@ public class GitHubWorkflowAnalysisHelperTests
     public async Task AnalyzeWorkflowsAsync_RunWithLogs_ReturnsExtractedErrorLines()
     {
         GivenWorkflowRuns(WorkflowRunFor(12345678, "analyze"));
-        GivenLogs(12345678, "##[error]Process completed with exit code 1.");
+        GivenLogs(12345678, ("analyze/3_Build.txt", "##[error]Process completed with exit code 1."));
         logAnalysisHelper
             .Setup(l => l.AnalyzeLogContent(It.IsAny<TextReader>(), It.IsAny<List<string>?>(), null, null, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([new LogEntry { Message = "Process completed with exit code 1." }]);
@@ -122,12 +128,31 @@ public class GitHubWorkflowAnalysisHelperTests
         Assert.That(analysis.Logs.Select(l => l.Message), Is.EqualTo(new[] { "Process completed with exit code 1." }));
     }
 
-    [TestCase(null)]
-    [TestCase("")]
-    public async Task AnalyzeWorkflowsAsync_RunWithoutLogContent_SkipsLogAnalysis(string? logs)
+    // Each log file is analyzed on its own, so the name of the file an error came from is available to the
+    // analysis rather than being folded into one concatenated blob.
+    [Test]
+    public async Task AnalyzeWorkflowsAsync_ManyLogFiles_AnalyzesEachOneByName()
     {
         GivenWorkflowRuns(WorkflowRunFor(12345678, "analyze"));
-        GivenLogs(12345678, logs);
+        GivenLogs(
+            12345678,
+            ("analyze/3_Build.txt", "##[error]build failed"),
+            ("analyze/4_Test.txt", "##[error]test failed"));
+        logAnalysisHelper
+            .Setup(l => l.AnalyzeLogContent(It.IsAny<TextReader>(), It.IsAny<List<string>?>(), null, null, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TextReader _, List<string>? _, int? _, int? _, string _, string filePath, CancellationToken _) =>
+                [new LogEntry { File = filePath }]);
+
+        var analysis = (await helper.AnalyzeWorkflowsAsync(PrCommitRef, CancellationToken.None)).Single();
+
+        Assert.That(analysis.Logs.Select(l => l.File), Is.EqualTo(new[] { "analyze/3_Build.txt", "analyze/4_Test.txt" }));
+    }
+
+    [Test]
+    public async Task AnalyzeWorkflowsAsync_RunWithoutLogContent_SkipsLogAnalysis()
+    {
+        GivenWorkflowRuns(WorkflowRunFor(12345678, "analyze"));
+        GivenLogs(12345678);
 
         var analysis = (await helper.AnalyzeWorkflowsAsync(PrCommitRef, CancellationToken.None)).Single();
 
@@ -159,7 +184,7 @@ public class GitHubWorkflowAnalysisHelperTests
     public async Task AnalyzeWorkflowsAsync_RunWithLogs_DoesNotListJobs()
     {
         GivenWorkflowRuns(WorkflowRunFor(12345678, "analyze"));
-        GivenLogs(12345678, "##[error]boom");
+        GivenLogs(12345678, ("analyze/3_Build.txt", "##[error]boom"));
         logAnalysisHelper
             .Setup(l => l.AnalyzeLogContent(It.IsAny<TextReader>(), It.IsAny<List<string>?>(), null, null, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([new LogEntry { Message = "boom" }]);
@@ -180,7 +205,7 @@ public class GitHubWorkflowAnalysisHelperTests
     public async Task AnalyzeWorkflowsAsync_JobReadFailsWithoutLogs_ReportsError()
     {
         GivenWorkflowRuns(WorkflowRunFor(12345678, "analyze"));
-        GivenLogs(12345678, null);
+        GivenLogs(12345678);
         gitHubService
             .Setup(g => g.GetWorkflowRunJobsAsync(Owner, Repo, 12345678, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new ApiException("jobs unavailable", System.Net.HttpStatusCode.ServiceUnavailable));
@@ -253,7 +278,7 @@ public class GitHubWorkflowAnalysisHelperTests
             .Setup(g => g.GetFailedWorkflowRunsForCommitAsync(Owner, Repo, HeadSha, It.IsAny<CancellationToken>()))
             .ReturnsAsync(runs);
 
-    private void GivenLogs(long runId, string? logs) =>
+    private void GivenLogs(long runId, params (string Name, string Content)[] logs) =>
         gitHubService
             .Setup(g => g.GetFailedWorkflowRunLogsAsync(Owner, Repo, runId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(logs);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/GitHubWorkflowAnalysisHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/GitHubWorkflowAnalysisHelperTests.cs
@@ -1,0 +1,269 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Helpers.Pipeline;
+using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.Pipeline;
+using Azure.Sdk.Tools.Cli.Models.Responses;
+using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
+using Moq;
+using Octokit;
+
+namespace Azure.Sdk.Tools.Cli.Tests.Helpers.Pipeline;
+
+/// <summary>
+/// Seam: <see cref="GitHubWorkflowAnalysisHelper"/> turns a resolved <see cref="BuildGitHubSource"/> into
+/// workflow-run analyses and failing PR checks, given <see cref="IGitHubService"/> and
+/// <see cref="ILogAnalysisHelper"/>.
+/// </summary>
+[TestFixture]
+public class GitHubWorkflowAnalysisHelperTests
+{
+    // Shapes taken from a real azure-sdk-for-net pull request run.
+    private const string Owner = "Azure";
+    private const string Repo = "azure-sdk-for-net";
+    private const string HeadSha = "0f1a2b3c4d5e6f708192a3b4c5d6e7f809a1b2c3";
+    private const int PrNumber = 44941;
+
+    private static readonly BuildGitHubSource PrSource = new(Owner, Repo, HeadSha, PrNumber);
+    private static readonly BuildGitHubSource BranchSource = new(Owner, Repo, HeadSha, null);
+
+    private Mock<IGitHubService> gitHubService;
+    private Mock<ILogAnalysisHelper> logAnalysisHelper;
+    private GitHubWorkflowAnalysisHelper helper;
+
+    [SetUp]
+    public void SetUp()
+    {
+        gitHubService = new Mock<IGitHubService>(MockBehavior.Loose);
+        logAnalysisHelper = new Mock<ILogAnalysisHelper>(MockBehavior.Loose);
+        helper = new GitHubWorkflowAnalysisHelper(
+            gitHubService.Object,
+            logAnalysisHelper.Object,
+            new TestLogger<GitHubWorkflowAnalysisHelper>());
+    }
+
+    #region AnalyzeWorkflowsAsync
+
+    [Test]
+    public async Task AnalyzeWorkflowsAsync_Always_RequestsFailedRunsForTheSourceCommit()
+    {
+        gitHubService
+            .Setup(g => g.GetFailedWorkflowRunsForCommitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<WorkflowRun>());
+
+        await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None);
+
+        gitHubService.Verify(
+            g => g.GetFailedWorkflowRunsForCommitAsync(Owner, Repo, HeadSha, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task AnalyzeWorkflowsAsync_FailedRun_ReportsRunIdentity()
+    {
+        GivenWorkflowRuns(WorkflowRunFor(
+            id: 12345678,
+            name: "analyze",
+            status: WorkflowRunStatus.Completed,
+            conclusion: WorkflowRunConclusion.Failure));
+
+        var analysis = (await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None)).Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(analysis.Name, Is.EqualTo("analyze"));
+            Assert.That(analysis.Status, Is.EqualTo("completed"));
+            Assert.That(analysis.Conclusion, Is.EqualTo("failure"));
+            Assert.That(analysis.Url, Is.EqualTo(HtmlUrlFor(12345678)));
+        });
+    }
+
+    [Test]
+    public async Task AnalyzeWorkflowsAsync_ManyFailedRuns_ReturnsOneAnalysisPerRun()
+    {
+        GivenWorkflowRuns(
+            WorkflowRunFor(1, "analyze"),
+            WorkflowRunFor(2, "prepare-pipelines"),
+            WorkflowRunFor(3, "event-processor"));
+
+        var analyses = await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None);
+
+        Assert.That(analyses.Select(a => a.Name), Is.EqualTo(new[] { "analyze", "prepare-pipelines", "event-processor" }));
+    }
+
+    [Test]
+    public async Task AnalyzeWorkflowsAsync_RunWithLogs_ReturnsExtractedErrorLines()
+    {
+        GivenWorkflowRuns(WorkflowRunFor(12345678, "analyze"));
+        GivenLogs(12345678, "##[error]Process completed with exit code 1.");
+        logAnalysisHelper
+            .Setup(l => l.AnalyzeLogContent(It.IsAny<TextReader>(), null, null, null, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new LogEntry { Message = "Process completed with exit code 1." }]);
+
+        var analysis = (await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None)).Single();
+
+        Assert.That(analysis.Logs.Select(l => l.Message), Is.EqualTo(new[] { "Process completed with exit code 1." }));
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    public async Task AnalyzeWorkflowsAsync_RunWithoutLogContent_SkipsLogAnalysis(string? logs)
+    {
+        GivenWorkflowRuns(WorkflowRunFor(12345678, "analyze"));
+        GivenLogs(12345678, logs);
+
+        var analysis = (await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None)).Single();
+
+        Assert.That(analysis.Logs, Is.Empty);
+        logAnalysisHelper.Verify(
+            l => l.AnalyzeLogContent(It.IsAny<TextReader>(), It.IsAny<List<string>?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task AnalyzeWorkflowsAsync_LogReadFails_ReportsErrorAndStillReportsJobs()
+    {
+        GivenWorkflowRuns(WorkflowRunFor(12345678, "analyze"));
+        gitHubService
+            .Setup(g => g.GetWorkflowRunLogsAsync(Owner, Repo, 12345678, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new NotFoundException("log archive expired", System.Net.HttpStatusCode.Gone));
+        GivenJobs(12345678, WorkflowJobFor("build", WorkflowJobConclusion.Failure));
+
+        var analysis = (await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None)).Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(analysis.Errors, Has.Exactly(1).Contains("Failed to read workflow run logs"));
+            Assert.That(analysis.Jobs, Is.EqualTo(new[] { "build: failure" }));
+        });
+    }
+
+    [Test]
+    public async Task AnalyzeWorkflowsAsync_JobReadFails_ReportsErrorAndStillReportsLogs()
+    {
+        GivenWorkflowRuns(WorkflowRunFor(12345678, "analyze"));
+        GivenLogs(12345678, "##[error]boom");
+        logAnalysisHelper
+            .Setup(l => l.AnalyzeLogContent(It.IsAny<TextReader>(), null, null, null, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new LogEntry { Message = "boom" }]);
+        gitHubService
+            .Setup(g => g.GetWorkflowRunJobsAsync(Owner, Repo, 12345678, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ApiException("jobs unavailable", System.Net.HttpStatusCode.ServiceUnavailable));
+
+        var analysis = (await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None)).Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(analysis.Errors, Has.Exactly(1).Contains("Failed to read workflow run jobs"));
+            Assert.That(analysis.Logs.Select(l => l.Message), Is.EqualTo(new[] { "boom" }));
+        });
+    }
+
+    [Test]
+    public async Task AnalyzeWorkflowsAsync_JobWithoutConclusion_SummarizesJobByStatus()
+    {
+        GivenWorkflowRuns(WorkflowRunFor(12345678, "analyze"));
+        GivenJobs(12345678, WorkflowJobFor("build", conclusion: null, status: WorkflowJobStatus.InProgress));
+
+        var analysis = (await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None)).Single();
+
+        Assert.That(analysis.Jobs, Is.EqualTo(new[] { "build: in_progress" }));
+    }
+
+    #endregion
+
+    #region GetFailingChecksAsync
+
+    [Test]
+    public async Task GetFailingChecksAsync_SourceWithoutPullRequest_ReturnsEmptyWithoutQueryingChecks()
+    {
+        var checks = await helper.GetFailingChecksAsync(BranchSource, CancellationToken.None);
+
+        Assert.That(checks, Is.Empty);
+        gitHubService.Verify(
+            g => g.GetPrCheckRunsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // The full set of non-passing conclusions lives in the helper; enumerating it here would only restate
+    // data the helper already declares. One representative value per branch, plus the lower-case case that
+    // proves the comparison ignores casing, is what actually has to hold.
+    [TestCase("FAILURE")]
+    [TestCase("failure", Description = "GitHub's REST API reports conclusions in lower case")]
+    public async Task GetFailingChecksAsync_NonPassingConclusion_IncludesCheck(string conclusion)
+    {
+        GivenChecks(CheckRun("net - core - ci", conclusion));
+
+        var checks = await helper.GetFailingChecksAsync(PrSource, CancellationToken.None);
+
+        Assert.That(checks.Select(c => c.Name), Is.EqualTo(new[] { "net - core - ci" }));
+    }
+
+    [Test]
+    public async Task GetFailingChecksAsync_MixedChecks_ReturnsOnlyTheFailingOnes()
+    {
+        GivenChecks(
+            CheckRun("license/cla", "SUCCESS"),
+            CheckRun("net - core - ci", "FAILURE"),
+            CheckRun("net - template - ci", null),
+            CheckRun("Publish Artifacts", "TIMED_OUT"));
+
+        var checks = await helper.GetFailingChecksAsync(PrSource, CancellationToken.None);
+
+        Assert.That(checks.Select(c => c.Name), Is.EqualTo(new[] { "net - core - ci", "Publish Artifacts" }));
+    }
+
+    #endregion
+
+    #region Arrange helpers
+
+    private void GivenWorkflowRuns(params WorkflowRun[] runs) =>
+        gitHubService
+            .Setup(g => g.GetFailedWorkflowRunsForCommitAsync(Owner, Repo, HeadSha, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(runs);
+
+    private void GivenLogs(long runId, string? logs) =>
+        gitHubService
+            .Setup(g => g.GetWorkflowRunLogsAsync(Owner, Repo, runId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(logs);
+
+    private void GivenJobs(long runId, params WorkflowJob[] jobs) =>
+        gitHubService
+            .Setup(g => g.GetWorkflowRunJobsAsync(Owner, Repo, runId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(jobs);
+
+    private void GivenChecks(params PrCheckRun[] checks) =>
+        gitHubService
+            .Setup(g => g.GetPrCheckRunsAsync(Owner, Repo, PrNumber, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(checks.ToList());
+
+    private static PrCheckRun CheckRun(string name, string? conclusion) =>
+        new() { Name = name, Conclusion = conclusion, Type = "CheckRun" };
+
+    private static string HtmlUrlFor(long runId) => $"https://github.com/{Owner}/{Repo}/actions/runs/{runId}";
+
+    /// <summary>
+    /// Octokit response models only expose an all-argument constructor, so the fields under test are named
+    /// and everything else is left at its default.
+    /// </summary>
+    private static WorkflowRun WorkflowRunFor(
+        long id,
+        string name,
+        WorkflowRunStatus status = WorkflowRunStatus.Completed,
+        WorkflowRunConclusion? conclusion = WorkflowRunConclusion.Failure) =>
+        new(id, name, null!, 0, null!, "main", HeadSha, ".github/workflows/analyze.yml", 1, "pull_request",
+            name, status, conclusion, 0, null!, HtmlUrlFor(id), null!, default, default, null!, 1, null!,
+            default, null!, null!, null!, null!, null!, null!, null!, null!, null!, null!, null!, null!, 0);
+
+    private static WorkflowJob WorkflowJobFor(
+        string name,
+        WorkflowJobConclusion? conclusion,
+        WorkflowJobStatus status = WorkflowJobStatus.Completed) =>
+        new(0, 0, null!, null!, HeadSha, null!, null!, status, conclusion, default, default, default,
+            name, null!, null!, null!);
+
+    #endregion
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/GitHubWorkflowAnalysisHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/GitHubWorkflowAnalysisHelperTests.cs
@@ -14,7 +14,7 @@ using Octokit;
 namespace Azure.Sdk.Tools.Cli.Tests.Helpers.Pipeline;
 
 /// <summary>
-/// Seam: <see cref="GitHubWorkflowAnalysisHelper"/> turns a resolved <see cref="BuildGitHubSource"/> into
+/// Seam: <see cref="GitHubWorkflowAnalysisHelper"/> turns a resolved <see cref="GitHubCommitRef"/> into
 /// workflow-run analyses and failing PR checks, given <see cref="IGitHubService"/> and
 /// <see cref="ILogAnalysisHelper"/>.
 /// </summary>
@@ -27,8 +27,8 @@ public class GitHubWorkflowAnalysisHelperTests
     private const string HeadSha = "0f1a2b3c4d5e6f708192a3b4c5d6e7f809a1b2c3";
     private const int PrNumber = 44941;
 
-    private static readonly BuildGitHubSource PrSource = new(Owner, Repo, HeadSha, PrNumber);
-    private static readonly BuildGitHubSource BranchSource = new(Owner, Repo, HeadSha, null);
+    private static readonly GitHubCommitRef PrCommitRef = new(Owner, Repo, HeadSha, PrNumber);
+    private static readonly GitHubCommitRef BranchCommitRef = new(Owner, Repo, HeadSha, null);
 
     private Mock<IGitHubService> gitHubService;
     private Mock<ILogAnalysisHelper> logAnalysisHelper;
@@ -54,7 +54,7 @@ public class GitHubWorkflowAnalysisHelperTests
             .Setup(g => g.GetFailedWorkflowRunsForCommitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<WorkflowRun>());
 
-        await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None);
+        await helper.AnalyzeWorkflowsAsync(PrCommitRef, CancellationToken.None);
 
         gitHubService.Verify(
             g => g.GetFailedWorkflowRunsForCommitAsync(Owner, Repo, HeadSha, It.IsAny<CancellationToken>()),
@@ -70,7 +70,7 @@ public class GitHubWorkflowAnalysisHelperTests
             status: WorkflowRunStatus.Completed,
             conclusion: WorkflowRunConclusion.Failure));
 
-        var analysis = (await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None)).Single();
+        var analysis = (await helper.AnalyzeWorkflowsAsync(PrCommitRef, CancellationToken.None)).Single();
 
         Assert.Multiple(() =>
         {
@@ -89,7 +89,7 @@ public class GitHubWorkflowAnalysisHelperTests
             WorkflowRunFor(2, "prepare-pipelines"),
             WorkflowRunFor(3, "event-processor"));
 
-        var analyses = await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None);
+        var analyses = await helper.AnalyzeWorkflowsAsync(PrCommitRef, CancellationToken.None);
 
         Assert.That(analyses.Select(a => a.Name), Is.EqualTo(new[] { "analyze", "prepare-pipelines", "event-processor" }));
     }
@@ -103,7 +103,7 @@ public class GitHubWorkflowAnalysisHelperTests
             WorkflowRunFor(1, "analyze", workflowId: 42, createdAt: new DateTimeOffset(2026, 7, 28, 18, 0, 0, TimeSpan.Zero)),
             WorkflowRunFor(2, "analyze", workflowId: 42, createdAt: new DateTimeOffset(2026, 7, 28, 19, 0, 0, TimeSpan.Zero)));
 
-        var analyses = await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None);
+        var analyses = await helper.AnalyzeWorkflowsAsync(PrCommitRef, CancellationToken.None);
 
         Assert.That(analyses.Select(a => a.Url), Is.EqualTo(new[] { HtmlUrlFor(2) }));
     }
@@ -117,7 +117,7 @@ public class GitHubWorkflowAnalysisHelperTests
             .Setup(l => l.AnalyzeLogContent(It.IsAny<TextReader>(), It.IsAny<List<string>?>(), null, null, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([new LogEntry { Message = "Process completed with exit code 1." }]);
 
-        var analysis = (await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None)).Single();
+        var analysis = (await helper.AnalyzeWorkflowsAsync(PrCommitRef, CancellationToken.None)).Single();
 
         Assert.That(analysis.Logs.Select(l => l.Message), Is.EqualTo(new[] { "Process completed with exit code 1." }));
     }
@@ -129,7 +129,7 @@ public class GitHubWorkflowAnalysisHelperTests
         GivenWorkflowRuns(WorkflowRunFor(12345678, "analyze"));
         GivenLogs(12345678, logs);
 
-        var analysis = (await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None)).Single();
+        var analysis = (await helper.AnalyzeWorkflowsAsync(PrCommitRef, CancellationToken.None)).Single();
 
         Assert.That(analysis.Logs, Is.Empty);
         logAnalysisHelper.Verify(
@@ -146,7 +146,7 @@ public class GitHubWorkflowAnalysisHelperTests
             .ThrowsAsync(new NotFoundException("log archive expired", System.Net.HttpStatusCode.Gone));
         GivenJobs(12345678, WorkflowJobFor("build", WorkflowJobConclusion.Failure));
 
-        var analysis = (await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None)).Single();
+        var analysis = (await helper.AnalyzeWorkflowsAsync(PrCommitRef, CancellationToken.None)).Single();
 
         Assert.Multiple(() =>
         {
@@ -164,7 +164,7 @@ public class GitHubWorkflowAnalysisHelperTests
             .Setup(l => l.AnalyzeLogContent(It.IsAny<TextReader>(), It.IsAny<List<string>?>(), null, null, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([new LogEntry { Message = "boom" }]);
 
-        var analysis = (await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None)).Single();
+        var analysis = (await helper.AnalyzeWorkflowsAsync(PrCommitRef, CancellationToken.None)).Single();
 
         Assert.Multiple(() =>
         {
@@ -185,7 +185,7 @@ public class GitHubWorkflowAnalysisHelperTests
             .Setup(g => g.GetWorkflowRunJobsAsync(Owner, Repo, 12345678, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new ApiException("jobs unavailable", System.Net.HttpStatusCode.ServiceUnavailable));
 
-        var analysis = (await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None)).Single();
+        var analysis = (await helper.AnalyzeWorkflowsAsync(PrCommitRef, CancellationToken.None)).Single();
 
         Assert.That(analysis.Errors, Has.Exactly(1).Contains("Failed to read workflow run jobs"));
     }
@@ -196,7 +196,7 @@ public class GitHubWorkflowAnalysisHelperTests
         GivenWorkflowRuns(WorkflowRunFor(12345678, "analyze"));
         GivenJobs(12345678, WorkflowJobFor("build", conclusion: null, status: WorkflowJobStatus.InProgress));
 
-        var analysis = (await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None)).Single();
+        var analysis = (await helper.AnalyzeWorkflowsAsync(PrCommitRef, CancellationToken.None)).Single();
 
         Assert.That(analysis.Jobs, Is.EqualTo(new[] { "build: in_progress" }));
     }
@@ -206,9 +206,9 @@ public class GitHubWorkflowAnalysisHelperTests
     #region GetFailingChecksAsync
 
     [Test]
-    public async Task GetFailingChecksAsync_SourceWithoutPullRequest_ReturnsEmptyWithoutQueryingChecks()
+    public async Task GetFailingChecksAsync_CommitRefWithoutPullRequest_ReturnsEmptyWithoutQueryingChecks()
     {
-        var checks = await helper.GetFailingChecksAsync(BranchSource, CancellationToken.None);
+        var checks = await helper.GetFailingChecksAsync(BranchCommitRef, CancellationToken.None);
 
         Assert.That(checks, Is.Empty);
         gitHubService.Verify(
@@ -225,7 +225,7 @@ public class GitHubWorkflowAnalysisHelperTests
     {
         GivenChecks(CheckRun("net - core - ci", conclusion));
 
-        var checks = await helper.GetFailingChecksAsync(PrSource, CancellationToken.None);
+        var checks = await helper.GetFailingChecksAsync(PrCommitRef, CancellationToken.None);
 
         Assert.That(checks.Select(c => c.Name), Is.EqualTo(new[] { "net - core - ci" }));
     }
@@ -239,7 +239,7 @@ public class GitHubWorkflowAnalysisHelperTests
             CheckRun("net - template - ci", null),
             CheckRun("Publish Artifacts", "TIMED_OUT"));
 
-        var checks = await helper.GetFailingChecksAsync(PrSource, CancellationToken.None);
+        var checks = await helper.GetFailingChecksAsync(PrCommitRef, CancellationToken.None);
 
         Assert.That(checks.Select(c => c.Name), Is.EqualTo(new[] { "net - core - ci", "Publish Artifacts" }));
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/GitHubWorkflowAnalysisHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/GitHubWorkflowAnalysisHelperTests.cs
@@ -94,13 +94,27 @@ public class GitHubWorkflowAnalysisHelperTests
         Assert.That(analyses.Select(a => a.Name), Is.EqualTo(new[] { "analyze", "prepare-pipelines", "event-processor" }));
     }
 
+    // A commit routinely carries more than one failed run of the same workflow, and their logs are the same
+    // failure reported twice.
+    [Test]
+    public async Task AnalyzeWorkflowsAsync_ManyRunsOfOneWorkflow_AnalyzesOnlyTheLatest()
+    {
+        GivenWorkflowRuns(
+            WorkflowRunFor(1, "analyze", workflowId: 42, createdAt: new DateTimeOffset(2026, 7, 28, 18, 0, 0, TimeSpan.Zero)),
+            WorkflowRunFor(2, "analyze", workflowId: 42, createdAt: new DateTimeOffset(2026, 7, 28, 19, 0, 0, TimeSpan.Zero)));
+
+        var analyses = await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None);
+
+        Assert.That(analyses.Select(a => a.Url), Is.EqualTo(new[] { HtmlUrlFor(2) }));
+    }
+
     [Test]
     public async Task AnalyzeWorkflowsAsync_RunWithLogs_ReturnsExtractedErrorLines()
     {
         GivenWorkflowRuns(WorkflowRunFor(12345678, "analyze"));
         GivenLogs(12345678, "##[error]Process completed with exit code 1.");
         logAnalysisHelper
-            .Setup(l => l.AnalyzeLogContent(It.IsAny<TextReader>(), null, null, null, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(l => l.AnalyzeLogContent(It.IsAny<TextReader>(), It.IsAny<List<string>?>(), null, null, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([new LogEntry { Message = "Process completed with exit code 1." }]);
 
         var analysis = (await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None)).Single();
@@ -128,7 +142,7 @@ public class GitHubWorkflowAnalysisHelperTests
     {
         GivenWorkflowRuns(WorkflowRunFor(12345678, "analyze"));
         gitHubService
-            .Setup(g => g.GetWorkflowRunLogsAsync(Owner, Repo, 12345678, It.IsAny<CancellationToken>()))
+            .Setup(g => g.GetFailedWorkflowRunLogsAsync(Owner, Repo, 12345678, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new NotFoundException("log archive expired", System.Net.HttpStatusCode.Gone));
         GivenJobs(12345678, WorkflowJobFor("build", WorkflowJobConclusion.Failure));
 
@@ -142,24 +156,38 @@ public class GitHubWorkflowAnalysisHelperTests
     }
 
     [Test]
-    public async Task AnalyzeWorkflowsAsync_JobReadFails_ReportsErrorAndStillReportsLogs()
+    public async Task AnalyzeWorkflowsAsync_RunWithLogs_DoesNotListJobs()
     {
         GivenWorkflowRuns(WorkflowRunFor(12345678, "analyze"));
         GivenLogs(12345678, "##[error]boom");
         logAnalysisHelper
-            .Setup(l => l.AnalyzeLogContent(It.IsAny<TextReader>(), null, null, null, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(l => l.AnalyzeLogContent(It.IsAny<TextReader>(), It.IsAny<List<string>?>(), null, null, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([new LogEntry { Message = "boom" }]);
+
+        var analysis = (await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None)).Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(analysis.Logs.Select(l => l.Message), Is.EqualTo(new[] { "boom" }));
+            Assert.That(analysis.Jobs, Is.Empty);
+        });
+        gitHubService.Verify(
+            g => g.GetWorkflowRunJobsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<long>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task AnalyzeWorkflowsAsync_JobReadFailsWithoutLogs_ReportsError()
+    {
+        GivenWorkflowRuns(WorkflowRunFor(12345678, "analyze"));
+        GivenLogs(12345678, null);
         gitHubService
             .Setup(g => g.GetWorkflowRunJobsAsync(Owner, Repo, 12345678, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new ApiException("jobs unavailable", System.Net.HttpStatusCode.ServiceUnavailable));
 
         var analysis = (await helper.AnalyzeWorkflowsAsync(PrSource, CancellationToken.None)).Single();
 
-        Assert.Multiple(() =>
-        {
-            Assert.That(analysis.Errors, Has.Exactly(1).Contains("Failed to read workflow run jobs"));
-            Assert.That(analysis.Logs.Select(l => l.Message), Is.EqualTo(new[] { "boom" }));
-        });
+        Assert.That(analysis.Errors, Has.Exactly(1).Contains("Failed to read workflow run jobs"));
     }
 
     [Test]
@@ -227,7 +255,7 @@ public class GitHubWorkflowAnalysisHelperTests
 
     private void GivenLogs(long runId, string? logs) =>
         gitHubService
-            .Setup(g => g.GetWorkflowRunLogsAsync(Owner, Repo, runId, It.IsAny<CancellationToken>()))
+            .Setup(g => g.GetFailedWorkflowRunLogsAsync(Owner, Repo, runId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(logs);
 
     private void GivenJobs(long runId, params WorkflowJob[] jobs) =>
@@ -253,9 +281,11 @@ public class GitHubWorkflowAnalysisHelperTests
         long id,
         string name,
         WorkflowRunStatus status = WorkflowRunStatus.Completed,
-        WorkflowRunConclusion? conclusion = WorkflowRunConclusion.Failure) =>
+        WorkflowRunConclusion? conclusion = WorkflowRunConclusion.Failure,
+        long? workflowId = null,
+        DateTimeOffset createdAt = default) =>
         new(id, name, null!, 0, null!, "main", HeadSha, ".github/workflows/analyze.yml", 1, "pull_request",
-            name, status, conclusion, 0, null!, HtmlUrlFor(id), null!, default, default, null!, 1, null!,
+            name, status, conclusion, workflowId ?? id, null!, HtmlUrlFor(id), null!, createdAt, default, null!, 1, null!,
             default, null!, null!, null!, null!, null!, null!, null!, null!, null!, null!, null!, null!, 0);
 
     private static WorkflowJob WorkflowJobFor(

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/PipelineAnalysisHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/PipelineAnalysisHelperTests.cs
@@ -220,7 +220,7 @@ public class PipelineAnalysisHelperTests
         var (analyses, _) = await helper.AnalyzePipelineAsync([Build]);
 
         Assert.That(
-            analyses.Single().FailedBuildTasks.Errors.Select(e => e.Message),
+            analyses.Single().FailedBuildTasks!.Errors.Select(e => e.Message),
             Is.EqualTo(logAnalyzerResult.Select(e => e.Message)));
     }
 
@@ -233,7 +233,7 @@ public class PipelineAnalysisHelperTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(analyses.Single().FailedBuildTasks.HasErrors, Is.False);
+            Assert.That(analyses.Single().FailedBuildTasks, Is.Null);
             Assert.That(analyses.Single().Errors, Is.Null);
         });
     }
@@ -278,7 +278,7 @@ public class PipelineAnalysisHelperTests
         Assert.Multiple(() =>
         {
             Assert.That(
-                analyses.Single().FailedBuildTests[Platform],
+                analyses.Single().FailedBuildTests![Platform],
                 Is.EqualTo(new[] { "Azure.Core.Tests.PipelineTests.CanRetry" }));
             Assert.That(warnings, Is.Empty);
         });
@@ -297,7 +297,7 @@ public class PipelineAnalysisHelperTests
         Assert.Multiple(() =>
         {
             Assert.That(warnings, Has.Exactly(1).Contains("test-results.trx"));
-            Assert.That(analyses.Single().FailedBuildTests, Is.Empty);
+            Assert.That(analyses.Single().FailedBuildTests, Is.Null);
         });
     }
 
@@ -313,7 +313,7 @@ public class PipelineAnalysisHelperTests
         var (analyses, _) = await helper.AnalyzePipelineAsync([Build]);
 
         Assert.That(
-            analyses.Single().FailedBuildTests[Platform],
+            analyses.Single().FailedBuildTests![Platform],
             Is.EqualTo(new[] { "Azure.Core.Tests.PipelineTests.CanRetry" }));
     }
 
@@ -330,7 +330,7 @@ public class PipelineAnalysisHelperTests
 
         var (analyses, _) = await helper.AnalyzePipelineAsync([Build]);
 
-        var failedTests = analyses.Single().FailedBuildTests;
+        var failedTests = analyses.Single().FailedBuildTests!;
         Assert.Multiple(() =>
         {
             Assert.That(
@@ -355,7 +355,7 @@ public class PipelineAnalysisHelperTests
 
         var (analyses, _) = await helper.AnalyzePipelineAsync([Build]);
 
-        Assert.That(analyses.Single().FailedBuildTests.Keys, Is.EqualTo(new[] { "Ubuntu2404_NET80" }));
+        Assert.That(analyses.Single().FailedBuildTests!.Keys, Is.EqualTo(new[] { "Ubuntu2404_NET80" }));
     }
 
     [Test]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/PipelineAnalysisHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/PipelineAnalysisHelperTests.cs
@@ -26,6 +26,7 @@ public class PipelineAnalysisHelperTests
     private const int BuildId = 5209385;
     private const string Project = "public";
     private const string PipelineUrl = "https://dev.azure.com/azure-sdk/public/_build/results?buildId=5209385";
+    private const string Platform = "Ubuntu2404_NET80_PackageRef_Debug";
     private const int FailedTaskLogId = 42;
 
     private static readonly ResolvedBuild Build = new(BuildId, Project, PipelineUrl, "completed", "failed");
@@ -277,7 +278,7 @@ public class PipelineAnalysisHelperTests
         Assert.Multiple(() =>
         {
             Assert.That(
-                analyses.Single().FailedBuildTests.Select(t => t.TestCaseTitle),
+                analyses.Single().FailedBuildTests[Platform],
                 Is.EqualTo(new[] { "Azure.Core.Tests.PipelineTests.CanRetry" }));
             Assert.That(warnings, Is.Empty);
         });
@@ -312,8 +313,49 @@ public class PipelineAnalysisHelperTests
         var (analyses, _) = await helper.AnalyzePipelineAsync([Build]);
 
         Assert.That(
-            analyses.Single().FailedBuildTests.Select(t => t.TestCaseTitle),
+            analyses.Single().FailedBuildTests[Platform],
             Is.EqualTo(new[] { "Azure.Core.Tests.PipelineTests.CanRetry" }));
+    }
+
+    [Test]
+    public async Task AnalyzePipelineAsync_ArtifactsFromManyPlatforms_KeepsEachPlatformsFailuresSeparate()
+    {
+        GivenTestArtifacts(new Dictionary<string, List<string>>
+        {
+            ["Ubuntu2404_NET80"] = ["linux.trx"],
+            ["Windows2022_NET80"] = ["windows.trx"],
+        });
+        GivenParsedFailures("linux.trx", "Azure.Core.Tests.PipelineTests.CanRetry");
+        GivenParsedFailures("windows.trx", "Azure.Core.Tests.PipelineTests.HonorsTimeout");
+
+        var (analyses, _) = await helper.AnalyzePipelineAsync([Build]);
+
+        var failedTests = analyses.Single().FailedBuildTests;
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                failedTests["Ubuntu2404_NET80"],
+                Is.EqualTo(new[] { "Azure.Core.Tests.PipelineTests.CanRetry" }));
+            Assert.That(
+                failedTests["Windows2022_NET80"],
+                Is.EqualTo(new[] { "Azure.Core.Tests.PipelineTests.HonorsTimeout" }));
+        });
+    }
+
+    [Test]
+    public async Task AnalyzePipelineAsync_PlatformWithNoFailures_IsNotGivenAnEntry()
+    {
+        GivenTestArtifacts(new Dictionary<string, List<string>>
+        {
+            ["Ubuntu2404_NET80"] = ["linux.trx"],
+            ["Windows2022_NET80"] = ["windows.trx"],
+        });
+        GivenParsedFailures("linux.trx", "Azure.Core.Tests.PipelineTests.CanRetry");
+        GivenParsedFailures("windows.trx");
+
+        var (analyses, _) = await helper.AnalyzePipelineAsync([Build]);
+
+        Assert.That(analyses.Single().FailedBuildTests.Keys, Is.EqualTo(new[] { "Ubuntu2404_NET80" }));
     }
 
     [Test]
@@ -396,9 +438,12 @@ public class PipelineAnalysisHelperTests
             .ReturnsAsync(TimelineOf(records));
 
     private void GivenTestArtifacts(params string[] files) =>
+        GivenTestArtifacts(new Dictionary<string, List<string>> { [Platform] = [.. files] });
+
+    private void GivenTestArtifacts(Dictionary<string, List<string>> artifactsByPlatform) =>
         devOpsService
             .Setup(d => d.GetPipelineLlmArtifacts(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Dictionary<string, List<string>> { ["failed-test-results"] = [.. files] });
+            .ReturnsAsync(artifactsByPlatform);
 
     private void GivenParsedFailures(string file, params string[] testCaseTitles)
     {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/PipelineAnalysisHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/PipelineAnalysisHelperTests.cs
@@ -1,0 +1,453 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Helpers.Pipeline;
+using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.Pipeline;
+using Azure.Sdk.Tools.Cli.Models.Responses;
+using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
+using Microsoft.TeamFoundation.Build.WebApi;
+using Moq;
+using Newtonsoft.Json;
+
+namespace Azure.Sdk.Tools.Cli.Tests.Helpers.Pipeline;
+
+/// <summary>
+/// Seam: <see cref="PipelineAnalysisHelper"/> turns already-resolved builds into per-build log and test
+/// findings, given <see cref="IDevOpsService"/>, <see cref="ILogAnalysisHelper"/>, and
+/// <see cref="ITestResultParserResolver"/>.
+/// </summary>
+[TestFixture]
+public class PipelineAnalysisHelperTests
+{
+    // Shapes taken from a real azure-sdk-for-net public build.
+    private const int BuildId = 5209385;
+    private const string Project = "public";
+    private const string PipelineUrl = "https://dev.azure.com/azure-sdk/public/_build/results?buildId=5209385";
+    private const int FailedTaskLogId = 42;
+
+    private static readonly ResolvedBuild Build = new(BuildId, Project, PipelineUrl, "completed", "failed");
+
+    private Mock<IDevOpsService> devOpsService;
+    private Mock<ILogAnalysisHelper> logAnalysisHelper;
+    private Mock<ITestResultParserResolver> parserResolver;
+    private PipelineAnalysisHelper helper;
+
+    /// <summary>What the log analyzer reports for every log it is given.</summary>
+    private List<LogEntry> logAnalyzerResult;
+
+    [SetUp]
+    public void SetUp()
+    {
+        logAnalyzerResult = [];
+
+        devOpsService = new Mock<IDevOpsService>(MockBehavior.Loose);
+        devOpsService
+            .Setup(d => d.GetBuildTimelineAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TimelineOf());
+        devOpsService
+            .Setup(d => d.GetBuildLogLinesAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        devOpsService
+            .Setup(d => d.GetPipelineLlmArtifacts(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        logAnalysisHelper = new Mock<ILogAnalysisHelper>(MockBehavior.Loose);
+        logAnalysisHelper
+            .Setup(l => l.AnalyzeLogContent(It.IsAny<string>(), null, null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => logAnalyzerResult);
+
+        parserResolver = new Mock<ITestResultParserResolver>(MockBehavior.Loose);
+
+        helper = new PipelineAnalysisHelper(
+            devOpsService.Object,
+            logAnalysisHelper.Object,
+            parserResolver.Object,
+            new TestLogger<PipelineAnalysisHelper>());
+    }
+
+    #region AnalyzePipelineAsync - which logs get analyzed
+
+    [Test]
+    public async Task AnalyzePipelineAsync_ManyBuilds_ReturnsOneAnalysisPerBuild()
+    {
+        var (analyses, _) = await helper.AnalyzePipelineAsync(
+            [Build, Build with { BuildId = 5209386 }, Build with { BuildId = 5209387 }]);
+
+        Assert.That(analyses.Select(a => a.Build.BuildId), Is.EqualTo(new[] { 5209385, 5209386, 5209387 }));
+    }
+
+    [Test]
+    public async Task AnalyzePipelineAsync_ExplicitLogId_AnalyzesThatLogWithoutReadingTheTimeline()
+    {
+        await helper.AnalyzePipelineAsync([Build], logId: 99);
+
+        devOpsService.Verify(
+            d => d.GetBuildLogLinesAsync(Project, BuildId, 99, It.IsAny<CancellationToken>()), Times.Once);
+        devOpsService.Verify(
+            d => d.GetBuildTimelineAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task AnalyzePipelineAsync_LogIdZero_FallsBackToTheTimeline()
+    {
+        GivenTimeline(FailedTask("Build", FailedTaskLogId));
+
+        await helper.AnalyzePipelineAsync([Build], logId: 0);
+
+        devOpsService.Verify(
+            d => d.GetBuildLogLinesAsync(Project, BuildId, FailedTaskLogId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task AnalyzePipelineAsync_FailedTask_AnalyzesItsLog()
+    {
+        GivenTimeline(FailedTask("Build", FailedTaskLogId));
+
+        await helper.AnalyzePipelineAsync([Build]);
+
+        devOpsService.Verify(
+            d => d.GetBuildLogLinesAsync(Project, BuildId, FailedTaskLogId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task AnalyzePipelineAsync_SucceededTask_IsNotAnalyzed()
+    {
+        GivenTimeline(Record("Build", FailedTaskLogId, TaskResult.Succeeded, "Task"));
+
+        await helper.AnalyzePipelineAsync([Build]);
+
+        ThenNoLogsWereDownloaded();
+    }
+
+    [Test]
+    public async Task AnalyzePipelineAsync_FailedRecordThatIsNotATask_IsNotAnalyzed()
+    {
+        GivenTimeline(Record("Build", FailedTaskLogId, TaskResult.Failed, "Job"));
+
+        await helper.AnalyzePipelineAsync([Build]);
+
+        ThenNoLogsWereDownloaded();
+    }
+
+    [Test]
+    public async Task AnalyzePipelineAsync_FailedTestStepWithTestResults_IsNotAnalyzed()
+    {
+        GivenTimeline(FailedTask("Run Tests", FailedTaskLogId));
+        GivenRecoveredTestResults();
+
+        await helper.AnalyzePipelineAsync([Build]);
+
+        ThenNoLogsWereDownloaded();
+    }
+
+    /// <summary>
+    /// A test step also restores and compiles. When it fails there no test results are produced, so skipping
+    /// its log the way <see cref="AnalyzePipelineAsync_FailedTestStepWithTestResults_IsNotAnalyzed"/> expects
+    /// would leave the build with nothing at all to explain it.
+    /// </summary>
+    [Test]
+    public async Task AnalyzePipelineAsync_FailedTestStepWithoutTestResults_IsAnalyzedAnyway()
+    {
+        GivenTimeline(FailedTask("Run Tests", FailedTaskLogId));
+
+        await helper.AnalyzePipelineAsync([Build]);
+
+        devOpsService.Verify(
+            d => d.GetBuildLogLinesAsync(Project, BuildId, FailedTaskLogId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task AnalyzePipelineAsync_FailedTestStepWhoseTestResultsCannotBeRead_IsAnalyzedAnyway()
+    {
+        GivenTimeline(FailedTask("Run Tests", FailedTaskLogId));
+        devOpsService
+            .Setup(d => d.GetPipelineLlmArtifacts(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("artifact feed unavailable"));
+
+        await helper.AnalyzePipelineAsync([Build]);
+
+        devOpsService.Verify(
+            d => d.GetBuildLogLinesAsync(Project, BuildId, FailedTaskLogId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task AnalyzePipelineAsync_FailedDeployTestResourcesStep_IsAnalyzed()
+    {
+        GivenTimeline(FailedTask("Deploy test resources", FailedTaskLogId));
+        GivenRecoveredTestResults();
+
+        await helper.AnalyzePipelineAsync([Build]);
+
+        devOpsService.Verify(
+            d => d.GetBuildLogLinesAsync(Project, BuildId, FailedTaskLogId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task AnalyzePipelineAsync_FailedTaskWithoutALog_IsNotAnalyzed()
+    {
+        GivenTimeline(Record("Build", logId: null, TaskResult.Failed, "Task"));
+
+        await helper.AnalyzePipelineAsync([Build]);
+
+        ThenNoLogsWereDownloaded();
+    }
+
+    [Test]
+    public async Task AnalyzePipelineAsync_FailedTasksSharingALog_AnalyzeThatLogOnce()
+    {
+        GivenTimeline(FailedTask("Build", FailedTaskLogId), FailedTask("Pack", FailedTaskLogId));
+
+        await helper.AnalyzePipelineAsync([Build]);
+
+        devOpsService.Verify(
+            d => d.GetBuildLogLinesAsync(Project, BuildId, FailedTaskLogId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    #endregion
+
+    #region AnalyzePipelineAsync - how findings are reported
+
+    [Test]
+    public async Task AnalyzePipelineAsync_LogsContainErrors_ReportsThemAsFailedBuildTasks()
+    {
+        GivenTimeline(FailedTask("Build", FailedTaskLogId));
+        logAnalyzerResult = [new LogEntry { Message = "error CS0246: The type or namespace name 'Foo' could not be found" }];
+
+        var (analyses, _) = await helper.AnalyzePipelineAsync([Build]);
+
+        Assert.That(
+            analyses.Single().FailedBuildTasks.Errors.Select(e => e.Message),
+            Is.EqualTo(logAnalyzerResult.Select(e => e.Message)));
+    }
+
+    [Test]
+    public async Task AnalyzePipelineAsync_LogsContainNoErrors_LeavesFailedBuildTasksEmpty()
+    {
+        GivenTimeline(FailedTask("Build", FailedTaskLogId));
+
+        var (analyses, _) = await helper.AnalyzePipelineAsync([Build]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(analyses.Single().FailedBuildTasks.HasErrors, Is.False);
+            Assert.That(analyses.Single().Errors, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task AnalyzePipelineAsync_LogDownloadFails_ReportsErrorOnTheBuild()
+    {
+        GivenTimeline(FailedTask("Build", FailedTaskLogId));
+        devOpsService
+            .Setup(d => d.GetBuildLogLinesAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("log has been deleted"));
+
+        var (analyses, _) = await helper.AnalyzePipelineAsync([Build]);
+
+        Assert.That(analyses.Single().Errors, Has.Exactly(1).Contains("Failed to analyze pipeline 5209385"));
+    }
+
+    [Test]
+    public async Task AnalyzePipelineAsync_TimelineCannotBeRead_ReportsErrorOnTheBuild()
+    {
+        devOpsService
+            .Setup(d => d.GetBuildTimelineAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new UnauthorizedAccessException("no access to the internal project"));
+
+        var (analyses, _) = await helper.AnalyzePipelineAsync([Build]);
+
+        Assert.That(analyses.Single().Errors, Has.Exactly(1).Contains("Failed to analyze failure logs"));
+    }
+
+    #endregion
+
+    #region AnalyzePipelineAsync - test artifacts
+
+    [Test]
+    public async Task AnalyzePipelineAsync_TestArtifactParses_ReportsItsFailedTests()
+    {
+        GivenTestArtifacts("test-results.trx");
+        GivenParsedFailures("test-results.trx", "Azure.Core.Tests.PipelineTests.CanRetry");
+
+        var (analyses, warnings) = await helper.AnalyzePipelineAsync([Build]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                analyses.Single().FailedBuildTests.Select(t => t.TestCaseTitle),
+                Is.EqualTo(new[] { "Azure.Core.Tests.PipelineTests.CanRetry" }));
+            Assert.That(warnings, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task AnalyzePipelineAsync_TestArtifactCannotBeParsed_ReportsAWarningNamingIt()
+    {
+        GivenTestArtifacts("test-results.trx");
+        parserResolver
+            .Setup(p => p.ResolveAsync("test-results.trx", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("no registered parser recognizes this format"));
+
+        var (analyses, warnings) = await helper.AnalyzePipelineAsync([Build]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(warnings, Has.Exactly(1).Contains("test-results.trx"));
+            Assert.That(analyses.Single().FailedBuildTests, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task AnalyzePipelineAsync_OneUnparsableArtifact_DoesNotDiscardTheOthers()
+    {
+        GivenTestArtifacts("broken.xml", "test-results.trx");
+        parserResolver
+            .Setup(p => p.ResolveAsync("broken.xml", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("malformed content"));
+        GivenParsedFailures("test-results.trx", "Azure.Core.Tests.PipelineTests.CanRetry");
+
+        var (analyses, _) = await helper.AnalyzePipelineAsync([Build]);
+
+        Assert.That(
+            analyses.Single().FailedBuildTests.Select(t => t.TestCaseTitle),
+            Is.EqualTo(new[] { "Azure.Core.Tests.PipelineTests.CanRetry" }));
+    }
+
+    [Test]
+    public async Task AnalyzePipelineAsync_TestArtifactLookupFails_ReportsErrorOnTheBuild()
+    {
+        devOpsService
+            .Setup(d => d.GetPipelineLlmArtifacts(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("artifact feed unavailable"));
+
+        var (analyses, _) = await helper.AnalyzePipelineAsync([Build]);
+
+        Assert.That(analyses.Single().Errors, Has.Exactly(1).Contains("Failed to analyze test artifacts"));
+    }
+
+    [Test]
+    public async Task AnalyzePipelineAsync_OneBuildFailingToAnalyze_DoesNotStopTheNext()
+    {
+        devOpsService
+            .Setup(d => d.GetBuildTimelineAsync(Project, BuildId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new UnauthorizedAccessException("no access"));
+        GivenTestArtifacts("test-results.trx");
+        GivenParsedFailures("test-results.trx", "Azure.Core.Tests.PipelineTests.CanRetry");
+
+        var (analyses, _) = await helper.AnalyzePipelineAsync([Build, Build with { BuildId = 5209386 }]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(analyses[0].Errors, Is.Not.Null);
+            Assert.That(analyses[1].Errors, Is.Null);
+            Assert.That(analyses[1].FailedBuildTests, Has.Count.EqualTo(1));
+        });
+    }
+
+    #endregion
+
+    #region AnalyzePipelineFailureLogsAsync
+
+    [Test]
+    public async Task AnalyzePipelineFailureLogsAsync_NoLogIds_ReturnsNoErrorsForThePipeline()
+    {
+        var response = await helper.AnalyzePipelineFailureLogsAsync(Build, [], CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(response.Errors, Is.Empty);
+            Assert.That(response.PipelineUrl, Is.EqualTo(PipelineUrl));
+            Assert.That(response.ResponseError, Is.Null.Or.Empty);
+        });
+    }
+
+    [Test]
+    public async Task AnalyzePipelineFailureLogsAsync_ManyLogs_AggregatesTheErrorsOfEach()
+    {
+        logAnalyzerResult = [new LogEntry { Message = "error CS0246" }];
+
+        var response = await helper.AnalyzePipelineFailureLogsAsync(Build, [42, 43], CancellationToken.None);
+
+        Assert.That(response.Errors, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public async Task AnalyzePipelineFailureLogsAsync_LogDownloadFails_ReturnsResponseError()
+    {
+        devOpsService
+            .Setup(d => d.GetBuildLogLinesAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("log has been deleted"));
+
+        var response = await helper.AnalyzePipelineFailureLogsAsync(Build, [42], CancellationToken.None);
+
+        Assert.That(response.ResponseError, Does.Contain("Failed to analyze pipeline 5209385"));
+    }
+
+    #endregion
+
+    #region Arrange helpers
+
+    private void GivenTimeline(params TimelineRecord[] records) =>
+        devOpsService
+            .Setup(d => d.GetBuildTimelineAsync(Project, BuildId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TimelineOf(records));
+
+    private void GivenTestArtifacts(params string[] files) =>
+        devOpsService
+            .Setup(d => d.GetPipelineLlmArtifacts(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, List<string>> { ["failed-test-results"] = [.. files] });
+
+    private void GivenParsedFailures(string file, params string[] testCaseTitles)
+    {
+        var parser = new Mock<ITestHelper>(MockBehavior.Loose);
+        parser
+            .Setup(p => p.GetFailedTestCases(file, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FailedTestRunListResponse
+            {
+                Items = [.. testCaseTitles.Select(title => new FailedTestRunResponse { TestCaseTitle = title })]
+            });
+        parserResolver
+            .Setup(p => p.ResolveAsync(file, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(parser.Object);
+    }
+
+    /// <summary>A build whose test results were recovered, which is what suppresses test-step log analysis.</summary>
+    private void GivenRecoveredTestResults()
+    {
+        GivenTestArtifacts("test-results.trx");
+        GivenParsedFailures("test-results.trx", "Azure.Core.Tests.PipelineTests.CanRetry");
+    }
+
+    private void ThenNoLogsWereDownloaded() =>
+        devOpsService.Verify(
+            d => d.GetBuildLogLinesAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+    /// <summary>
+    /// <see cref="Timeline"/> has no public constructor; the DevOps client only ever materializes it from the
+    /// REST payload, so the tests do the same.
+    /// </summary>
+    private static Timeline TimelineOf(params TimelineRecord[] records)
+    {
+        var timeline = JsonConvert.DeserializeObject<Timeline>("""{ "records": [] }""")!;
+        timeline.Records.AddRange(records);
+        return timeline;
+    }
+
+    private static TimelineRecord FailedTask(string name, int logId) =>
+        Record(name, logId, TaskResult.Failed, "Task");
+
+    private static TimelineRecord Record(string name, int? logId, TaskResult result, string recordType) =>
+        new()
+        {
+            Name = name,
+            Result = result,
+            RecordType = recordType,
+            Log = logId == null ? null : new BuildLogReference { Id = logId.Value },
+        };
+
+    #endregion
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/PipelineAnalysisHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/PipelineAnalysisHelperTests.cs
@@ -29,7 +29,7 @@ public class PipelineAnalysisHelperTests
     private const string Platform = "Ubuntu2404_NET80_PackageRef_Debug";
     private const int FailedTaskLogId = 42;
 
-    private static readonly ResolvedBuild Build = new(BuildId, Project, PipelineUrl, "completed", "failed");
+    private static readonly AzurePipelineBuild Build = new(BuildId, Project, PipelineUrl, "completed", "failed");
 
     private Mock<IDevOpsService> devOpsService;
     private Mock<ILogAnalysisHelper> logAnalysisHelper;
@@ -77,7 +77,7 @@ public class PipelineAnalysisHelperTests
         var (analyses, _) = await helper.AnalyzePipelineAsync(
             [Build, Build with { BuildId = 5209386 }, Build with { BuildId = 5209387 }]);
 
-        Assert.That(analyses.Select(a => a.Build.BuildId), Is.EqualTo(new[] { 5209385, 5209386, 5209387 }));
+        Assert.That(analyses.Select(a => a.PipelineBuild.BuildId), Is.EqualTo(new[] { 5209385, 5209386, 5209387 }));
     }
 
     [Test]
@@ -212,7 +212,7 @@ public class PipelineAnalysisHelperTests
     #region AnalyzePipelineAsync - how findings are reported
 
     [Test]
-    public async Task AnalyzePipelineAsync_LogsContainErrors_ReportsThemAsFailedBuildTasks()
+    public async Task AnalyzePipelineAsync_LogsContainErrors_ReportsThemAsFailedPipelineTasks()
     {
         GivenTimeline(FailedTask("Build", FailedTaskLogId));
         logAnalyzerResult = [new LogEntry { Message = "error CS0246: The type or namespace name 'Foo' could not be found" }];
@@ -220,12 +220,12 @@ public class PipelineAnalysisHelperTests
         var (analyses, _) = await helper.AnalyzePipelineAsync([Build]);
 
         Assert.That(
-            analyses.Single().FailedBuildTasks!.Errors.Select(e => e.Message),
+            analyses.Single().FailedPipelineTasks!.Errors.Select(e => e.Message),
             Is.EqualTo(logAnalyzerResult.Select(e => e.Message)));
     }
 
     [Test]
-    public async Task AnalyzePipelineAsync_LogsContainNoErrors_LeavesFailedBuildTasksEmpty()
+    public async Task AnalyzePipelineAsync_LogsContainNoErrors_LeavesFailedPipelineTasksEmpty()
     {
         GivenTimeline(FailedTask("Build", FailedTaskLogId));
 
@@ -233,7 +233,7 @@ public class PipelineAnalysisHelperTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(analyses.Single().FailedBuildTasks, Is.Null);
+            Assert.That(analyses.Single().FailedPipelineTasks, Is.Null);
             Assert.That(analyses.Single().Errors, Is.Null);
         });
     }
@@ -278,7 +278,7 @@ public class PipelineAnalysisHelperTests
         Assert.Multiple(() =>
         {
             Assert.That(
-                analyses.Single().FailedBuildTests![Platform],
+                analyses.Single().FailedPipelineTests![Platform],
                 Is.EqualTo(new[] { "Azure.Core.Tests.PipelineTests.CanRetry" }));
             Assert.That(warnings, Is.Empty);
         });
@@ -297,7 +297,7 @@ public class PipelineAnalysisHelperTests
         Assert.Multiple(() =>
         {
             Assert.That(warnings, Has.Exactly(1).Contains("test-results.trx"));
-            Assert.That(analyses.Single().FailedBuildTests, Is.Null);
+            Assert.That(analyses.Single().FailedPipelineTests, Is.Null);
         });
     }
 
@@ -313,7 +313,7 @@ public class PipelineAnalysisHelperTests
         var (analyses, _) = await helper.AnalyzePipelineAsync([Build]);
 
         Assert.That(
-            analyses.Single().FailedBuildTests![Platform],
+            analyses.Single().FailedPipelineTests![Platform],
             Is.EqualTo(new[] { "Azure.Core.Tests.PipelineTests.CanRetry" }));
     }
 
@@ -330,7 +330,7 @@ public class PipelineAnalysisHelperTests
 
         var (analyses, _) = await helper.AnalyzePipelineAsync([Build]);
 
-        var failedTests = analyses.Single().FailedBuildTests!;
+        var failedTests = analyses.Single().FailedPipelineTests!;
         Assert.Multiple(() =>
         {
             Assert.That(
@@ -355,7 +355,7 @@ public class PipelineAnalysisHelperTests
 
         var (analyses, _) = await helper.AnalyzePipelineAsync([Build]);
 
-        Assert.That(analyses.Single().FailedBuildTests!.Keys, Is.EqualTo(new[] { "Ubuntu2404_NET80" }));
+        Assert.That(analyses.Single().FailedPipelineTests!.Keys, Is.EqualTo(new[] { "Ubuntu2404_NET80" }));
     }
 
     [Test]
@@ -385,7 +385,7 @@ public class PipelineAnalysisHelperTests
         {
             Assert.That(analyses[0].Errors, Is.Not.Null);
             Assert.That(analyses[1].Errors, Is.Null);
-            Assert.That(analyses[1].FailedBuildTests, Has.Count.EqualTo(1));
+            Assert.That(analyses[1].FailedPipelineTests, Has.Count.EqualTo(1));
         });
     }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/PipelineIdentifierHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/PipelineIdentifierHelperTests.cs
@@ -1,0 +1,508 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Helpers.Pipeline;
+using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.Pipeline;
+using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
+using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.TeamFoundation.Core.WebApi;
+using Moq;
+
+namespace Azure.Sdk.Tools.Cli.Tests.Helpers.Pipeline;
+
+/// <summary>
+/// Seam: <see cref="PipelineIdentifierHelper"/> turns a user-supplied identifier (build id, DevOps URL,
+/// GitHub PR URL, or bare PR number) into resolved builds and the GitHub commit they ran against, given
+/// <see cref="IDevOpsService"/>, <see cref="IGitHubService"/>, and <see cref="IGitHelper"/>.
+/// </summary>
+[TestFixture]
+public class PipelineIdentifierHelperTests
+{
+    // Shapes taken from a real azure-sdk-for-net pull request and its Azure Pipelines checks.
+    private const int BuildId = 5209385;
+    private const string PublicBuildUrl = "https://dev.azure.com/azure-sdk/public/_build/results?buildId=5209385&view=results";
+    private const string PrUrl = "https://github.com/Azure/azure-sdk-for-net/pull/44941";
+    private const string ProjectGuid = "590cfd2a-581c-4dcb-a12e-6568ce786175";
+
+    private Mock<IDevOpsService> devOpsService;
+    private Mock<IGitHubService> gitHubService;
+    private Mock<IGitHelper> gitHelper;
+    private PipelineIdentifierHelper helper;
+
+    [SetUp]
+    public void SetUp()
+    {
+        devOpsService = new Mock<IDevOpsService>(MockBehavior.Loose);
+        gitHubService = new Mock<IGitHubService>(MockBehavior.Loose);
+        gitHelper = new Mock<IGitHelper>(MockBehavior.Loose);
+        helper = new PipelineIdentifierHelper(
+            devOpsService.Object,
+            gitHubService.Object,
+            gitHelper.Object,
+            new TestLogger<PipelineIdentifierHelper>());
+    }
+
+    #region Parse
+
+    [Test]
+    public void Parse_NumericIdentifier_ReturnsBuildIdWithNoProject()
+    {
+        var (buildId, project) = helper.Parse("5209385");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(buildId, Is.EqualTo(BuildId));
+            Assert.That(project, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Parse_PipelineUrl_ReturnsBuildIdAndProjectFromPath()
+    {
+        var (buildId, project) = helper.Parse(PublicBuildUrl);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(buildId, Is.EqualTo(BuildId));
+            Assert.That(project, Is.EqualTo("public"));
+        });
+    }
+
+    [Test]
+    public void Parse_UrlWithoutProjectSegment_ReturnsNullProject()
+    {
+        var (buildId, project) = helper.Parse("https://dev.azure.com/azure-sdk/?buildId=5209385");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(buildId, Is.EqualTo(BuildId));
+            Assert.That(project, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Parse_IdentifierThatIsNeitherNumberNorUri_ThrowsArgumentException()
+    {
+        Assert.That(() => helper.Parse("net - core - ci"), Throws.ArgumentException);
+    }
+
+    [Test]
+    public void Parse_UrlWithoutBuildIdQuery_ThrowsArgumentException()
+    {
+        Assert.That(
+            () => helper.Parse("https://dev.azure.com/azure-sdk/public/_build/results?view=logs"),
+            Throws.ArgumentException);
+    }
+
+    [Test]
+    public void Parse_UrlWithNonNumericBuildId_ThrowsArgumentException()
+    {
+        Assert.That(
+            () => helper.Parse("https://dev.azure.com/azure-sdk/public/_build/results?buildId=latest"),
+            Throws.ArgumentException);
+    }
+
+    #endregion
+
+    #region GetPipelineUrl
+
+    [TestCase("azure-sdk-public", "public")]
+    [TestCase("Azure-SDK-Internal", "internal")]
+    public void GetPipelineUrl_LegacyProjectName_NormalizesToShortName(string project, string expected)
+    {
+        var url = helper.GetPipelineUrl(project, BuildId);
+
+        Assert.That(url, Is.EqualTo($"https://dev.azure.com/azure-sdk/{expected}/_build/results?buildId=5209385"));
+    }
+
+    [Test]
+    public void GetPipelineUrl_UnrecognizedProjectName_UsesItVerbatim()
+    {
+        var url = helper.GetPipelineUrl("azure-sdk-for-net", BuildId);
+
+        Assert.That(url, Is.EqualTo("https://dev.azure.com/azure-sdk/azure-sdk-for-net/_build/results?buildId=5209385"));
+    }
+
+    #endregion
+
+    #region TryParseGitHubPrLink
+
+    [Test]
+    public void TryParseGitHubPrLink_PullRequestUrl_ReturnsOwnerRepoAndNumber()
+    {
+        var link = helper.TryParseGitHubPrLink(PrUrl);
+
+        Assert.That(link, Is.EqualTo(new GitHubPrLink("Azure", "azure-sdk-for-net", 44941)));
+    }
+
+    [TestCase("https://github.com/Azure/azure-sdk-for-net/issues/44941", Description = "an issue, not a pull request")]
+    public void TryParseGitHubPrLink_NonPullRequestUrl_ReturnsNull(string identifier)
+    {
+        Assert.That(helper.TryParseGitHubPrLink(identifier), Is.Null);
+    }
+
+    #endregion
+
+    #region TryResolveGitHubPrAsync
+
+    [Test]
+    public async Task TryResolveGitHubPrAsync_PullRequestUrl_ResolvesWithoutConsultingGit()
+    {
+        var link = await helper.TryResolveGitHubPrAsync(PrUrl, CancellationToken.None);
+
+        Assert.That(link, Is.EqualTo(new GitHubPrLink("Azure", "azure-sdk-for-net", 44941)));
+        gitHelper.Verify(
+            g => g.GetRepoFullNameAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [TestCase("44941")]
+    [TestCase("999999", Description = "the largest number still treated as a PR number")]
+    public async Task TryResolveGitHubPrAsync_BarePrNumber_ResolvesRepoFromWorkingDirectory(string identifier)
+    {
+        GivenCurrentRepo("Azure/azure-sdk-for-net");
+
+        var link = await helper.TryResolveGitHubPrAsync(identifier, CancellationToken.None);
+
+        Assert.That(link, Is.EqualTo(new GitHubPrLink("Azure", "azure-sdk-for-net", int.Parse(identifier))));
+    }
+
+    [Test]
+    public async Task TryResolveGitHubPrAsync_NumberTooLargeForAPrNumber_ReturnsNull()
+    {
+        GivenCurrentRepo("Azure/azure-sdk-for-net");
+
+        var link = await helper.TryResolveGitHubPrAsync("1000000", CancellationToken.None);
+
+        Assert.That(link, Is.Null);
+    }
+
+    [Test]
+    public async Task TryResolveGitHubPrAsync_WorkingDirectoryIsNotARepo_ReturnsNull()
+    {
+        gitHelper
+            .Setup(g => g.GetRepoFullNameAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("not a git repository"));
+
+        var link = await helper.TryResolveGitHubPrAsync("44941", CancellationToken.None);
+
+        Assert.That(link, Is.Null);
+    }
+
+    [Test]
+    public async Task TryResolveGitHubPrAsync_RepoNameIsNotOwnerSlashRepo_ReturnsNull()
+    {
+        GivenCurrentRepo("azure-sdk-for-net");
+
+        var link = await helper.TryResolveGitHubPrAsync("44941", CancellationToken.None);
+
+        Assert.That(link, Is.Null);
+    }
+
+    #endregion
+
+    #region GetPipelineProjectAsync
+
+    [Test]
+    public async Task GetPipelineProjectAsync_BuildWithProject_ReturnsProjectName()
+    {
+        GivenBuildDetails(BuildFor("public"));
+
+        var project = await helper.GetPipelineProjectAsync(BuildId, null, CancellationToken.None);
+
+        Assert.That(project, Is.EqualTo("public"));
+    }
+
+    [Test]
+    public void GetPipelineProjectAsync_BuildWithoutProject_Throws()
+    {
+        GivenBuildDetails(new Build());
+
+        Assert.That(
+            async () => await helper.GetPipelineProjectAsync(BuildId, null, CancellationToken.None),
+            Throws.Exception.With.Message.Contains("Failed to parse project name"));
+    }
+
+    #endregion
+
+    #region ResolveBuildsAsync - DevOps identifiers
+
+    [Test]
+    public async Task ResolveBuildsAsync_BuildId_ReturnsBuildWithProjectStatusAndResult()
+    {
+        GivenBuildDetails(BuildFor("public", BuildStatus.Completed, BuildResult.PartiallySucceeded));
+
+        var build = (await helper.ResolveBuildsAsync("5209385", ct: CancellationToken.None)).Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(build.BuildId, Is.EqualTo(BuildId));
+            Assert.That(build.Project, Is.EqualTo("public"));
+            Assert.That(build.Status, Is.EqualTo("completed"));
+            Assert.That(build.Result, Is.EqualTo("partially_succeeded"));
+            Assert.That(build.PipelineUrl, Is.EqualTo("https://dev.azure.com/azure-sdk/public/_build/results?buildId=5209385"));
+        });
+    }
+
+    [Test]
+    public async Task ResolveBuildsAsync_BuildStillRunning_MarksOnlyTheResultUnavailable()
+    {
+        // A run that has not finished has no result yet, which is not the same as a build whose details
+        // could not be read at all.
+        GivenBuildDetails(BuildFor("public", BuildStatus.InProgress, result: null));
+
+        var build = (await helper.ResolveBuildsAsync("5209385", ct: CancellationToken.None)).Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(build.Status, Is.EqualTo("in_progress"));
+            Assert.That(build.Result, Is.EqualTo(ResolvedBuild.StatusUnavailable));
+        });
+    }
+
+    [Test]
+    public async Task ResolveBuildsAsync_BuildDetailsCannotBeRead_MarksStatusUnavailable()
+    {
+        devOpsService
+            .Setup(d => d.GetBuildDetailsAsync(It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new UnauthorizedAccessException("no access to the internal project"));
+
+        var build = (await helper.ResolveBuildsAsync("5209385", ct: CancellationToken.None)).Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(build.Status, Is.EqualTo(ResolvedBuild.StatusUnavailable));
+            Assert.That(build.Result, Is.EqualTo(ResolvedBuild.StatusUnavailable));
+        });
+    }
+
+    [Test]
+    public async Task ResolveBuildsAsync_ExplicitProject_IsUsedWhenTheIdentifierCarriesNone()
+    {
+        // The build details deliberately carry no project, so the resolved project can only have come
+        // from the caller-supplied argument.
+        GivenBuildDetails(new Build { Status = BuildStatus.Completed, Result = BuildResult.Failed });
+
+        var build = (await helper.ResolveBuildsAsync("5209385", project: "internal", ct: CancellationToken.None)).Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(build.Project, Is.EqualTo("internal"));
+            Assert.That(build.PipelineUrl, Is.EqualTo("https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5209385"));
+        });
+    }
+
+    [Test]
+    public void ResolveBuildsAsync_UnrecognizedProjectName_ThrowsArgumentException()
+    {
+        Assert.That(
+            async () => await helper.ResolveBuildsAsync(
+                "https://dev.azure.com/azure-sdk/azure-sdk-for-net/_build/results?buildId=5209385",
+                ct: CancellationToken.None),
+            Throws.ArgumentException);
+    }
+
+    [Test]
+    public async Task ResolveBuildsAsync_ProjectGuid_ResolvesItToTheProjectName()
+    {
+        GivenBuildDetails(BuildFor("internal", BuildStatus.Completed, BuildResult.Failed));
+
+        var build = (await helper.ResolveBuildsAsync(
+            $"https://dev.azure.com/azure-sdk/{ProjectGuid}/_build/results?buildId=5209385",
+            ct: CancellationToken.None)).Single();
+
+        Assert.That(build.Project, Is.EqualTo("internal"));
+    }
+
+    [Test]
+    public void ResolveBuildsAsync_ProjectGuidThatCannotBeResolved_ThrowsArgumentException()
+    {
+        devOpsService
+            .Setup(d => d.GetBuildDetailsAsync(It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("network down"));
+
+        Assert.That(
+            async () => await helper.ResolveBuildsAsync(
+                $"https://dev.azure.com/azure-sdk/{ProjectGuid}/_build/results?buildId=5209385",
+                ct: CancellationToken.None),
+            Throws.ArgumentException);
+    }
+
+    #endregion
+
+    #region ResolveBuildsAsync - GitHub pull requests
+
+    [Test]
+    public async Task ResolveBuildsAsync_PullRequest_ReturnsOnlyFailedAzurePipelinesChecks()
+    {
+        GivenBuildDetails(BuildFor("public", BuildStatus.Completed, BuildResult.Failed));
+        GivenPrChecks(
+            AzurePipelinesCheck("net - core - ci", "FAILURE", DetailsUrlFor(5209385)),
+            AzurePipelinesCheck("net - template - ci", "SUCCESS", DetailsUrlFor(5209386)),
+            new PrCheckRun { Name = "analyze", Conclusion = "FAILURE", AppName = "GitHub Actions", DetailsUrl = "https://github.com/Azure/azure-sdk-for-net/actions/runs/12345678" });
+
+        var builds = await helper.ResolveBuildsAsync(PrUrl, ct: CancellationToken.None);
+
+        Assert.That(builds.Select(b => b.BuildId), Is.EqualTo(new[] { 5209385 }));
+    }
+
+    [Test]
+    public async Task ResolveBuildsAsync_PullRequestWithSeveralChecksOnOneBuild_ReturnsThatBuildOnce()
+    {
+        GivenBuildDetails(BuildFor("public", BuildStatus.Completed, BuildResult.Failed));
+        GivenPrChecks(
+            AzurePipelinesCheck("net - core - ci", "FAILURE", DetailsUrlFor(5209385) + "&view=logs"),
+            AzurePipelinesCheck("net - core - ci (Analyze)", "FAILURE", DetailsUrlFor(5209385) + "&view=results"));
+
+        var builds = await helper.ResolveBuildsAsync(PrUrl, ct: CancellationToken.None);
+
+        Assert.That(builds, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public async Task ResolveBuildsAsync_FailedCheckWithoutDetailsUrl_IsSkipped()
+    {
+        GivenPrChecks(AzurePipelinesCheck("net - core - ci", "FAILURE", detailsUrl: null));
+
+        var builds = await helper.ResolveBuildsAsync(PrUrl, ct: CancellationToken.None);
+
+        Assert.That(builds, Is.Empty);
+    }
+
+    [Test]
+    public async Task ResolveBuildsAsync_FailedCheckWithNonDevOpsDetailsUrl_IsSkipped()
+    {
+        GivenPrChecks(AzurePipelinesCheck("net - core - ci", "FAILURE", "https://aka.ms/azsdk/checkenforcer"));
+
+        var builds = await helper.ResolveBuildsAsync(PrUrl, ct: CancellationToken.None);
+
+        Assert.That(builds, Is.Empty);
+    }
+
+    [Test]
+    public async Task ResolveBuildsAsync_CheckUrlWithoutAProject_KeepsTheCheckUrlAsThePipelineUrl()
+    {
+        // Nothing in this URL identifies a project, so no canonical pipeline URL can be built for it
+        // and the check's own link is the only thing left to point the caller at.
+        const string DetailsUrl = "https://dev.azure.com/azure-sdk/?buildId=5209385";
+        GivenBuildDetails(new Build { Status = BuildStatus.Completed, Result = BuildResult.Failed });
+        GivenPrChecks(AzurePipelinesCheck("net - core - ci", "FAILURE", DetailsUrl));
+
+        var build = (await helper.ResolveBuildsAsync(PrUrl, ct: CancellationToken.None)).Single();
+
+        Assert.That(build.PipelineUrl, Is.EqualTo(DetailsUrl));
+    }
+
+    [Test]
+    public async Task ResolveBuildsAsync_ChecksSharingAProjectGuid_ResolveThatGuidOnce()
+    {
+        GivenBuildDetails(BuildFor("internal", BuildStatus.Completed, BuildResult.Failed));
+        GivenPrChecks(
+            AzurePipelinesCheck("net - core - ci", "FAILURE", DetailsUrlFor(5209385, ProjectGuid)),
+            AzurePipelinesCheck("net - template - ci", "FAILURE", DetailsUrlFor(5209386, ProjectGuid)));
+
+        await helper.ResolveBuildsAsync(PrUrl, ct: CancellationToken.None);
+
+        devOpsService.Verify(
+            d => d.GetBuildDetailsAsync(It.IsAny<int>(), ProjectGuid, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    #endregion
+
+    #region ResolveGitHubSourceAsync
+
+    [Test]
+    public async Task ResolveGitHubSourceAsync_BuildBackedByGitHub_ReturnsItsSource()
+    {
+        var expected = new BuildGitHubSource("Azure", "azure-sdk-for-net", "0f1a2b3c", 44941);
+        GivenGitHubSource(BuildId, expected);
+
+        var source = await helper.ResolveGitHubSourceAsync([Resolved(BuildId)], CancellationToken.None);
+
+        Assert.That(source, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ResolveGitHubSourceAsync_FirstBuildCannotBeRead_FallsBackToTheNextBuild()
+    {
+        var expected = new BuildGitHubSource("Azure", "azure-sdk-for-net", "0f1a2b3c", 44941);
+        devOpsService
+            .Setup(d => d.ResolveBuildGitHubSourceAsync(5209385, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new UnauthorizedAccessException("no access"));
+        GivenGitHubSource(5209386, expected);
+
+        var source = await helper.ResolveGitHubSourceAsync(
+            [Resolved(5209385), Resolved(5209386)], CancellationToken.None);
+
+        Assert.That(source, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ResolveGitHubSourceAsync_FirstBuildHasNoCommit_FallsBackToTheNextBuild()
+    {
+        var expected = new BuildGitHubSource("Azure", "azure-sdk-for-net", "0f1a2b3c", 44941);
+        GivenGitHubSource(5209385, new BuildGitHubSource("Azure", "azure-sdk-for-net", null, null));
+        GivenGitHubSource(5209386, expected);
+
+        var source = await helper.ResolveGitHubSourceAsync(
+            [Resolved(5209385), Resolved(5209386)], CancellationToken.None);
+
+        Assert.That(source, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ResolveGitHubSourceAsync_NoBuildBackedByGitHub_ReturnsNull()
+    {
+        GivenGitHubSource(BuildId, null);
+
+        var source = await helper.ResolveGitHubSourceAsync([Resolved(BuildId)], CancellationToken.None);
+
+        Assert.That(source, Is.Null);
+    }
+
+    #endregion
+
+    #region Arrange helpers
+
+    private void GivenCurrentRepo(string fullName) =>
+        gitHelper
+            .Setup(g => g.GetRepoFullNameAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fullName);
+
+    private void GivenBuildDetails(Build build) =>
+        devOpsService
+            .Setup(d => d.GetBuildDetailsAsync(It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(build);
+
+    private void GivenPrChecks(params PrCheckRun[] checks) =>
+        gitHubService
+            .Setup(g => g.GetPrCheckRunsAsync("Azure", "azure-sdk-for-net", 44941, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(checks.ToList());
+
+    private void GivenGitHubSource(int buildId, BuildGitHubSource? source) =>
+        devOpsService
+            .Setup(d => d.ResolveBuildGitHubSourceAsync(buildId, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(source);
+
+    private static Build BuildFor(string project, BuildStatus? status = null, BuildResult? result = null) =>
+        new()
+        {
+            Project = new TeamProjectReference { Name = project },
+            Status = status,
+            Result = result,
+        };
+
+    private static ResolvedBuild Resolved(int buildId) => new(buildId, "public", null, null, null);
+
+    private static string DetailsUrlFor(int buildId, string project = "public") =>
+        $"https://dev.azure.com/azure-sdk/{project}/_build/results?buildId={buildId}";
+
+    private static PrCheckRun AzurePipelinesCheck(string name, string conclusion, string? detailsUrl) =>
+        new() { Name = name, Conclusion = conclusion, AppName = "Azure Pipelines", DetailsUrl = detailsUrl, Type = "CheckRun" };
+
+    #endregion
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/PipelineIdentifierHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/PipelineIdentifierHelperTests.cs
@@ -259,7 +259,7 @@ public class PipelineIdentifierHelperTests
         Assert.Multiple(() =>
         {
             Assert.That(build.Status, Is.EqualTo("in_progress"));
-            Assert.That(build.Result, Is.EqualTo(ResolvedBuild.StatusUnavailable));
+            Assert.That(build.Result, Is.EqualTo(AzurePipelineBuild.StatusUnavailable));
         });
     }
 
@@ -274,8 +274,8 @@ public class PipelineIdentifierHelperTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(build.Status, Is.EqualTo(ResolvedBuild.StatusUnavailable));
-            Assert.That(build.Result, Is.EqualTo(ResolvedBuild.StatusUnavailable));
+            Assert.That(build.Status, Is.EqualTo(AzurePipelineBuild.StatusUnavailable));
+            Assert.That(build.Result, Is.EqualTo(AzurePipelineBuild.StatusUnavailable));
         });
     }
 
@@ -428,55 +428,55 @@ public class PipelineIdentifierHelperTests
 
     #endregion
 
-    #region ResolveGitHubSourceAsync
+    #region ResolveCommitRefFromBuildsAsync
 
     [Test]
-    public async Task ResolveGitHubSourceAsync_BuildBackedByGitHub_ReturnsItsSource()
+    public async Task ResolveCommitRefFromBuildsAsync_BuildBackedByGitHub_ReturnsItsCommitRef()
     {
-        var expected = new BuildGitHubSource("Azure", "azure-sdk-for-net", "0f1a2b3c", 44941);
-        GivenGitHubSource(BuildId, expected);
+        var expected = new GitHubCommitRef("Azure", "azure-sdk-for-net", "0f1a2b3c", 44941);
+        GivenBuildCommitRef(BuildId, expected);
 
-        var source = await helper.ResolveGitHubSourceAsync([Resolved(BuildId)], CancellationToken.None);
+        var commitRef = await helper.ResolveCommitRefFromBuildsAsync([Resolved(BuildId)], CancellationToken.None);
 
-        Assert.That(source, Is.EqualTo(expected));
+        Assert.That(commitRef, Is.EqualTo(expected));
     }
 
     [Test]
-    public async Task ResolveGitHubSourceAsync_FirstBuildCannotBeRead_FallsBackToTheNextBuild()
+    public async Task ResolveCommitRefFromBuildsAsync_FirstBuildCannotBeRead_FallsBackToTheNextBuild()
     {
-        var expected = new BuildGitHubSource("Azure", "azure-sdk-for-net", "0f1a2b3c", 44941);
+        var expected = new GitHubCommitRef("Azure", "azure-sdk-for-net", "0f1a2b3c", 44941);
         devOpsService
-            .Setup(d => d.ResolveBuildGitHubSourceAsync(5209385, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Setup(d => d.ResolveBuildCommitRefAsync(5209385, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new UnauthorizedAccessException("no access"));
-        GivenGitHubSource(5209386, expected);
+        GivenBuildCommitRef(5209386, expected);
 
-        var source = await helper.ResolveGitHubSourceAsync(
+        var commitRef = await helper.ResolveCommitRefFromBuildsAsync(
             [Resolved(5209385), Resolved(5209386)], CancellationToken.None);
 
-        Assert.That(source, Is.EqualTo(expected));
+        Assert.That(commitRef, Is.EqualTo(expected));
     }
 
     [Test]
-    public async Task ResolveGitHubSourceAsync_FirstBuildHasNoCommit_FallsBackToTheNextBuild()
+    public async Task ResolveCommitRefFromBuildsAsync_FirstBuildHasNoCommit_FallsBackToTheNextBuild()
     {
-        var expected = new BuildGitHubSource("Azure", "azure-sdk-for-net", "0f1a2b3c", 44941);
-        GivenGitHubSource(5209385, new BuildGitHubSource("Azure", "azure-sdk-for-net", null, null));
-        GivenGitHubSource(5209386, expected);
+        var expected = new GitHubCommitRef("Azure", "azure-sdk-for-net", "0f1a2b3c", 44941);
+        GivenBuildCommitRef(5209385, null);
+        GivenBuildCommitRef(5209386, expected);
 
-        var source = await helper.ResolveGitHubSourceAsync(
+        var commitRef = await helper.ResolveCommitRefFromBuildsAsync(
             [Resolved(5209385), Resolved(5209386)], CancellationToken.None);
 
-        Assert.That(source, Is.EqualTo(expected));
+        Assert.That(commitRef, Is.EqualTo(expected));
     }
 
     [Test]
-    public async Task ResolveGitHubSourceAsync_NoBuildBackedByGitHub_ReturnsNull()
+    public async Task ResolveCommitRefFromBuildsAsync_NoBuildBackedByGitHub_ReturnsNull()
     {
-        GivenGitHubSource(BuildId, null);
+        GivenBuildCommitRef(BuildId, null);
 
-        var source = await helper.ResolveGitHubSourceAsync([Resolved(BuildId)], CancellationToken.None);
+        var commitRef = await helper.ResolveCommitRefFromBuildsAsync([Resolved(BuildId)], CancellationToken.None);
 
-        Assert.That(source, Is.Null);
+        Assert.That(commitRef, Is.Null);
     }
 
     #endregion
@@ -498,10 +498,10 @@ public class PipelineIdentifierHelperTests
             .Setup(g => g.GetPrCheckRunsAsync("Azure", "azure-sdk-for-net", 44941, It.IsAny<CancellationToken>()))
             .ReturnsAsync(checks.ToList());
 
-    private void GivenGitHubSource(int buildId, BuildGitHubSource? source) =>
+    private void GivenBuildCommitRef(int buildId, GitHubCommitRef? commitRef) =>
         devOpsService
-            .Setup(d => d.ResolveBuildGitHubSourceAsync(buildId, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(source);
+            .Setup(d => d.ResolveBuildCommitRefAsync(buildId, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(commitRef);
 
     private static Build BuildFor(string project, BuildStatus? status = null, BuildResult? result = null) =>
         new()
@@ -511,7 +511,7 @@ public class PipelineIdentifierHelperTests
             Result = result,
         };
 
-    private static ResolvedBuild Resolved(int buildId) => new(buildId, "public", null, null, null);
+    private static AzurePipelineBuild Resolved(int buildId) => new(buildId, "public", null, null, null);
 
     private static string DetailsUrlFor(int buildId, string project = "public") =>
         $"https://dev.azure.com/azure-sdk/{project}/_build/results?buildId={buildId}";

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/PipelineIdentifierHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/Pipeline/PipelineIdentifierHelperTests.cs
@@ -350,6 +350,21 @@ public class PipelineIdentifierHelperTests
     }
 
     [Test]
+    public async Task ResolveBuildsAsync_PullRequestWithNonFailureFailedConclusion_StillResolvesTheBuild()
+    {
+        // A cancelled or timed-out Azure Pipelines check is still a failure worth analyzing, so it must
+        // resolve to a build even though its conclusion is not the literal "FAILURE".
+        GivenBuildDetails(BuildFor("public", BuildStatus.Completed, BuildResult.Failed));
+        GivenPrChecks(
+            AzurePipelinesCheck("net - core - ci", "TIMED_OUT", DetailsUrlFor(5209385)),
+            AzurePipelinesCheck("net - template - ci", "SUCCESS", DetailsUrlFor(5209386)));
+
+        var builds = await helper.ResolveBuildsAsync(PrUrl, ct: CancellationToken.None);
+
+        Assert.That(builds.Select(b => b.BuildId), Is.EqualTo(new[] { 5209385 }));
+    }
+
+    [Test]
     public async Task ResolveBuildsAsync_PullRequestWithSeveralChecksOnOneBuild_ReturnsThatBuildOnce()
     {
         GivenBuildDetails(BuildFor("public", BuildStatus.Completed, BuildResult.Failed));

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
@@ -397,9 +397,9 @@ namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
             throw new NotImplementedException();
         }
 
-        public Task<BuildGitHubSource?> ResolveBuildGitHubSourceAsync(int buildId, string? project, CancellationToken ct)
+        public Task<GitHubCommitRef?> ResolveBuildCommitRefAsync(int buildId, string? project, CancellationToken ct)
         {
-            return Task.FromResult<BuildGitHubSource?>(null);
+            return Task.FromResult<GitHubCommitRef?>(null);
         }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
@@ -4,6 +4,7 @@ using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Services;
 using Azure.Sdk.Tools.Cli.Models.Responses.Package;
 using Azure.Sdk.Tools.Cli.Models.AzureDevOps;
+using Azure.Sdk.Tools.Cli.Models.Pipeline;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
 {
@@ -258,6 +259,26 @@ namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
             return Task.FromResult(new Dictionary<string, List<string>>());
         }
 
+        Task<Build> IDevOpsService.GetBuildDetailsAsync(int buildId, string? project, CancellationToken ct)
+        {
+            return Task.FromResult(ConfiguredPipelineRun
+                ?? throw new InvalidOperationException(
+                    $"{nameof(ConfiguredPipelineRun)} was not set on the mock before {nameof(IDevOpsService.GetBuildDetailsAsync)} was called."));
+        }
+
+        Task<Timeline> IDevOpsService.GetBuildTimelineAsync(string project, int buildId, CancellationToken ct)
+        {
+            // Timeline has no public constructor; the non-public parameterless ctor initializes an empty
+            // (non-null) Records list, giving a benign "no failed tasks" timeline for tests.
+            var timeline = (Timeline)Activator.CreateInstance(typeof(Timeline), nonPublic: true)!;
+            return Task.FromResult(timeline);
+        }
+
+        Task<List<string>> IDevOpsService.GetBuildLogLinesAsync(string project, int buildId, int logId, CancellationToken ct)
+        {
+            return Task.FromResult(new List<string>());
+        }
+
         Task<WorkItem> IDevOpsService.UpdateWorkItemAsync(int workItemId, Dictionary<string, string> fields, CancellationToken ct)
         {
             return ((IDevOpsService)this).UpdateWorkItemAsync(workItemId, fields, new Dictionary<string, string>(), ct);
@@ -374,6 +395,11 @@ namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
         public Task DeleteWorkItemAsync(int workItemId, CancellationToken ct)
         {
             throw new NotImplementedException();
+        }
+
+        public Task<BuildGitHubSource?> ResolveBuildGitHubSourceAsync(int buildId, string? project, CancellationToken ct)
+        {
+            return Task.FromResult<BuildGitHubSource?>(null);
         }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockGitHubService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockGitHubService.cs
@@ -370,11 +370,6 @@ namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
             throw new NotImplementedException();
         }
 
-        public Task<IReadOnlyList<PullRequestCommit>> GetPullRequestCommitsAsync(string repoOwner, string repoName, int pullRequestNumber, CancellationToken ct)
-        {
-            throw new NotImplementedException();
-        }
-
         public Task<IReadOnlyList<WorkflowRun>> GetFailedWorkflowRunsForCommitAsync(string owner, string repo, string commitSha, CancellationToken ct)
         {
             return Task.FromResult<IReadOnlyList<WorkflowRun>>([]);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockGitHubService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockGitHubService.cs
@@ -1,4 +1,5 @@
 using Octokit;
+using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Services;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
@@ -367,6 +368,31 @@ namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
         public Task<HashSet<string>> GetRepoLabels(string owner, string repo, CancellationToken ct)
         {
             throw new NotImplementedException();
+        }
+
+        public Task<IReadOnlyList<PullRequestCommit>> GetPullRequestCommitsAsync(string repoOwner, string repoName, int pullRequestNumber, CancellationToken ct)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IReadOnlyList<WorkflowRun>> GetFailedWorkflowRunsForCommitAsync(string owner, string repo, string commitSha, CancellationToken ct)
+        {
+            return Task.FromResult<IReadOnlyList<WorkflowRun>>([]);
+        }
+
+        public Task<string?> GetWorkflowRunLogsAsync(string owner, string repo, long runId, CancellationToken ct)
+        {
+            return Task.FromResult<string?>(null);
+        }
+
+        public Task<IReadOnlyList<WorkflowJob>> GetWorkflowRunJobsAsync(string owner, string repo, long runId, CancellationToken ct)
+        {
+            return Task.FromResult<IReadOnlyList<WorkflowJob>>([]);
+        }
+
+        public Task<List<PrCheckRun>> GetPrCheckRunsAsync(string owner, string repo, int prNumber, CancellationToken ct)
+        {
+            return Task.FromResult(new List<PrCheckRun>());
         }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockGitHubService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockGitHubService.cs
@@ -375,7 +375,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
             return Task.FromResult<IReadOnlyList<WorkflowRun>>([]);
         }
 
-        public Task<string?> GetWorkflowRunLogsAsync(string owner, string repo, long runId, CancellationToken ct)
+        public Task<string?> GetFailedWorkflowRunLogsAsync(string owner, string repo, long runId, CancellationToken ct)
         {
             return Task.FromResult<string?>(null);
         }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockGitHubService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockGitHubService.cs
@@ -375,9 +375,9 @@ namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
             return Task.FromResult<IReadOnlyList<WorkflowRun>>([]);
         }
 
-        public Task<string?> GetFailedWorkflowRunLogsAsync(string owner, string repo, long runId, CancellationToken ct)
+        public Task<IReadOnlyList<(string Name, string Content)>> GetFailedWorkflowRunLogsAsync(string owner, string repo, long runId, CancellationToken ct)
         {
-            return Task.FromResult<string?>(null);
+            return Task.FromResult<IReadOnlyList<(string Name, string Content)>>([]);
         }
 
         public Task<IReadOnlyList<WorkflowJob>> GetWorkflowRunJobsAsync(string owner, string repo, long runId, CancellationToken ct)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/AzureServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/AzureServiceTests.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Reflection;
+using Azure.Identity;
+using Azure.Sdk.Tools.Cli.Services;
+
+namespace Azure.Sdk.Tools.Cli.Tests.Services;
+
+[TestFixture]
+public class AzureServiceTests
+{
+    /// <summary>
+    /// AzureService wraps ManagedIdentityCredential in a managed-identity-only DefaultAzureCredential (DAC) so
+    /// the managed-identity probe fast-fails off-Azure instead of hanging. The tradeoff of DAC (vs. a hand-built
+    /// ChainedTokenCredential) is that when Azure.Identity adds a new credential type, DAC includes it by default,
+    /// which could silently pick up an unwanted identity from the environment. This test reflects over every
+    /// Exclude*Credential option DAC exposes and fails when a new one is not excluded, forcing whoever bumps the
+    /// Azure.Identity package to consciously exclude the new credential in AzureService.ManagedIdentityCredentialOptions.
+    /// </summary>
+    [Test]
+    public void ManagedIdentityCredentialOptions_ExcludesEveryCredentialExceptManagedIdentity()
+    {
+        var options = AzureService.ManagedIdentityCredentialOptions;
+
+        var excludeProperties = typeof(DefaultAzureCredentialOptions)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.PropertyType == typeof(bool)
+                        && p.CanRead
+                        && p.CanWrite
+                        && p.Name.StartsWith("Exclude", StringComparison.Ordinal)
+                        && p.Name.EndsWith("Credential", StringComparison.Ordinal)
+                        // Obsolete credentials are no longer probed by DefaultAzureCredential, so they are not a risk.
+                        && p.GetCustomAttribute<ObsoleteAttribute>() is null)
+            .ToList();
+
+        Assert.That(excludeProperties, Is.Not.Empty,
+            "Expected DefaultAzureCredentialOptions to expose Exclude*Credential properties; the reflection filter may be wrong.");
+
+        Assert.Multiple(() =>
+        {
+            foreach (var property in excludeProperties)
+            {
+                var isExcluded = (bool)property.GetValue(options)!;
+
+                if (property.Name == nameof(DefaultAzureCredentialOptions.ExcludeManagedIdentityCredential))
+                {
+                    Assert.That(isExcluded, Is.False,
+                        $"{property.Name} must be false so the managed identity credential is the one credential DefaultAzureCredential probes.");
+                }
+                else
+                {
+                    Assert.That(isExcluded, Is.True,
+                        $"{property.Name} is not excluded in AzureService.ManagedIdentityCredentialOptions. " +
+                        "A new credential type was likely added to DefaultAzureCredential; set this option to true (or, if it is the intended identity, update this test) " +
+                        "so the managed-identity-only credential does not silently pick up an unwanted identity from the environment.");
+                }
+            }
+        });
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/DevOpsServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/DevOpsServiceTests.cs
@@ -666,7 +666,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
                 throw new NotImplementedException();
             }
 
-            public Task<T> ReadBuildWithAnonymousFallbackAsync<T>(Func<BuildHttpClient, Task<T>> operation, CancellationToken ct)
+            public BuildHttpClient GetAnonymousBuildClient()
             {
                 throw new NotImplementedException();
             }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/DevOpsServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/DevOpsServiceTests.cs
@@ -661,6 +661,16 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
                 throw new NotImplementedException();
             }
 
+            public Azure.Core.AccessToken GetToken(CancellationToken ct)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task<T> ReadBuildWithAnonymousFallbackAsync<T>(Func<BuildHttpClient, Task<T>> operation, CancellationToken ct)
+            {
+                throw new NotImplementedException();
+            }
+
             public WorkItemTrackingHttpClient GetWorkItemClient(CancellationToken ct = default)
             {
                 return _workItemClient;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -4,11 +4,16 @@
 
 ### Features Added
 
+- `azp analyze` and `azsdk_analyze_pipeline` now also report the failed GitHub Actions runs for the commit under analysis (`github_workflow_analyses`, with the error lines extracted from each failed step's logs) and every check GitHub reports as red on the pull request (`failing_pull_request_checks`), so a pull request that is only failing outside Azure Pipelines is no longer reported as having nothing to analyze.
+- `azp analyze` and `azsdk_analyze_pipeline` flag a build that is still running, so partial results are not mistaken for a clean run.
+- `azsdk_get_pipeline_status` accepts the pipeline project, matching the `--project` option the command already exposed.
 - Added `detect-breaking-change` CLI command and `azsdk_package_detect_breaking_change` MCP tool to detect SDK breaking changes for a package. Accepts the sdk package via `--package-path`. Optional parameters: `--tsp-config-path`, `--changes-only`.
 - `codeowners add-label-owner` rejects a package-directory path (e.g. `sdk/<service>/<package>`) in favor of the package name; use `--force` to override, and wildcard (`*`) paths are always allowed.
 
 ### Bugs Fixed
 
+- Public Azure Pipelines runs and public GitHub repositories are now read anonymously, so analyzing a public build or pull request no longer prompts for an Azure or GitHub CLI sign-in it does not need.
+- Pipeline analysis failures now return next steps that match the failure (a malformed identifier, a run or pull request that does not exist, or an access error) instead of always advising an Azure CLI sign-in.
 - `codeowners generate --section` now scopes Label Owner entries to the requested section, so entries from other sections no longer leak into the generated block.
 - Updated `GitHub.Copilot.SDK` to 1.0.8 so Copilot-backed commands accept ISO-8601 `ping` timestamps returned by current Copilot CLI versions.
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/LogAnalysisHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/LogAnalysisHelper.cs
@@ -1,10 +1,12 @@
-using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.Responses;
 
 namespace Azure.Sdk.Tools.Cli.Helpers;
 
 public interface ILogAnalysisHelper
 {
     Task<List<LogEntry>> AnalyzeLogContent(string filePath, List<string>? keywords, int? beforeLines, int? afterLines, CancellationToken ct);
+
+    Task<List<LogEntry>> AnalyzeLogContent(TextReader reader, List<string>? keywords, int? beforeLines, int? afterLines, string url = "", string filePath = "", CancellationToken ct = default);
 }
 
 public class Keyword
@@ -110,7 +112,7 @@ public class LogAnalysisHelper(ILogger<LogAnalysisHelper> logger) : ILogAnalysis
         return await AnalyzeLogContent(stream, keywordOverrides, beforeLines, afterLines, filePath: filePath, ct: ct);
     }
 
-    public async Task<List<LogEntry>> AnalyzeLogContent(StreamReader reader, List<string>? keywordOverrides, int? beforeLines, int? afterLines, string url = "", string filePath = "", CancellationToken ct = default)
+    public async Task<List<LogEntry>> AnalyzeLogContent(TextReader reader, List<string>? keywordOverrides, int? beforeLines, int? afterLines, string url = "", string filePath = "", CancellationToken ct = default)
     {
         var keywords = defaultErrorKeywords;
         if (keywordOverrides?.Count > 0)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/GitHubWorkflowAnalysisHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/GitHubWorkflowAnalysisHelper.cs
@@ -43,15 +43,6 @@ public class GitHubWorkflowAnalysisHelper(
         return runAnalyses;
     }
 
-    /// <summary>
-    /// Conclusions that mean a check did not pass. Anything else - success, skipped, neutral, or a check that
-    /// is still running and has no conclusion yet - is not a failure to report.
-    /// </summary>
-    private static readonly HashSet<string> FailedCheckConclusions = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE",
-    };
-
     public async Task<List<PrCheckRun>> GetFailingChecksAsync(BuildGitHubSource source, CancellationToken ct)
     {
         if (source.PullRequestNumber == null)
@@ -60,7 +51,7 @@ public class GitHubWorkflowAnalysisHelper(
         }
 
         var checks = await gitHubService.GetPrCheckRunsAsync(source.Owner, source.Repo, source.PullRequestNumber.Value, ct);
-        return checks.Where(check => check.Conclusion != null && FailedCheckConclusions.Contains(check.Conclusion)).ToList();
+        return checks.Where(check => check.IsFailed).ToList();
     }
 
     /// <summary>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/GitHubWorkflowAnalysisHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/GitHubWorkflowAnalysisHelper.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.Pipeline;
+using Azure.Sdk.Tools.Cli.Services;
+using Octokit;
+
+namespace Azure.Sdk.Tools.Cli.Helpers.Pipeline;
+
+/// <summary>
+/// Analyzes the GitHub Actions runs for an already-resolved commit. Deliberately knows nothing about Azure
+/// Pipelines: the runs share only a commit with any build, so the two analyses are produced independently
+/// and composed by the caller.
+/// </summary>
+public interface IGitHubWorkflowAnalysisHelper
+{
+    /// <summary>
+    /// Collects the failed workflow runs for the source's commit, with the logs and jobs of each. Successful
+    /// runs are skipped: their logs carry no failure to explain and would otherwise dominate the analysis.
+    /// </summary>
+    Task<List<GitHubWorkflowRunAnalysis>> AnalyzeWorkflowsAsync(BuildGitHubSource source, CancellationToken ct);
+
+    /// <summary>
+    /// Lists the checks reported as failing on the source's pull request. This covers the red checks that no
+    /// workflow run accounts for: results published by Azure Pipelines, and commit statuses posted by
+    /// aggregating workflows that succeed while reporting a failure. Returns an empty list when the build was
+    /// not triggered by a pull request.
+    /// </summary>
+    Task<List<PrCheckRun>> GetFailingChecksAsync(BuildGitHubSource source, CancellationToken ct);
+}
+
+public class GitHubWorkflowAnalysisHelper(
+    IGitHubService gitHubService,
+    ILogAnalysisHelper logAnalysisHelper,
+    ILogger<GitHubWorkflowAnalysisHelper> logger
+) : IGitHubWorkflowAnalysisHelper
+{
+    public async Task<List<GitHubWorkflowRunAnalysis>> AnalyzeWorkflowsAsync(BuildGitHubSource source, CancellationToken ct)
+    {
+        var workflowRuns = await gitHubService.GetFailedWorkflowRunsForCommitAsync(source.Owner, source.Repo, source.HeadSha!, ct);
+
+        List<GitHubWorkflowRunAnalysis> runAnalyses = [];
+        foreach (var run in workflowRuns)
+        {
+            runAnalyses.Add(await AnalyzeWorkflowRunAsync(source, run, ct));
+        }
+
+        return runAnalyses;
+    }
+
+    /// <summary>
+    /// Conclusions that mean a check did not pass. Anything else - success, skipped, neutral, or a check that
+    /// is still running and has no conclusion yet - is not a failure to report.
+    /// </summary>
+    private static readonly HashSet<string> FailedCheckConclusions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE",
+    };
+
+    public async Task<List<PrCheckRun>> GetFailingChecksAsync(BuildGitHubSource source, CancellationToken ct)
+    {
+        if (source.PullRequestNumber == null)
+        {
+            return [];
+        }
+
+        var checks = await gitHubService.GetPrCheckRunsAsync(source.Owner, source.Repo, source.PullRequestNumber.Value, ct);
+        return checks.Where(check => check.Conclusion != null && FailedCheckConclusions.Contains(check.Conclusion)).ToList();
+    }
+
+    /// <summary>
+    /// Collects the logs and jobs for a single workflow run. Each read is attempted independently so a run
+    /// whose logs have expired (or whose jobs cannot be listed) is still reported with whatever was available.
+    /// </summary>
+    private async Task<GitHubWorkflowRunAnalysis> AnalyzeWorkflowRunAsync(BuildGitHubSource source, WorkflowRun run, CancellationToken ct)
+    {
+        var runAnalysis = new GitHubWorkflowRunAnalysis
+        {
+            Name = run.Name,
+            Status = run.Status.StringValue,
+            Conclusion = run.Conclusion?.StringValue,
+            Url = run.HtmlUrl,
+        };
+
+        try
+        {
+            // A run's archive holds every line every job printed, so only the error lines and their context
+            // are kept: the raw text is far too large to report or to hand to an agent.
+            var logs = await gitHubService.GetWorkflowRunLogsAsync(source.Owner, source.Repo, run.Id, ct);
+            if (!string.IsNullOrEmpty(logs))
+            {
+                using var reader = new StringReader(logs);
+                runAnalysis.Logs = await logAnalysisHelper.AnalyzeLogContent(reader, null, null, null, url: run.HtmlUrl, ct: ct);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to read logs for workflow run {runId}", run.Id);
+            (runAnalysis.Errors ??= []).Add($"Failed to read workflow run logs: {ex.Message}");
+        }
+
+        try
+        {
+            var jobs = await gitHubService.GetWorkflowRunJobsAsync(source.Owner, source.Repo, run.Id, ct);
+            runAnalysis.Jobs.AddRange(jobs.Select(job => $"{job.Name}: {job.Conclusion?.StringValue ?? job.Status.StringValue}"));
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to read jobs for workflow run {runId}", run.Id);
+            (runAnalysis.Errors ??= []).Add($"Failed to read workflow run jobs: {ex.Message}");
+        }
+
+        return runAnalysis;
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/GitHubWorkflowAnalysisHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/GitHubWorkflowAnalysisHelper.cs
@@ -11,18 +11,18 @@ namespace Azure.Sdk.Tools.Cli.Helpers.Pipeline;
 public interface IGitHubWorkflowAnalysisHelper
 {
     /// <summary>
-    /// Collects the failed workflow runs for the source's commit, with the logs and jobs of each. Successful
+    /// Collects the failed workflow runs for the referenced commit, with the logs and jobs of each. Successful
     /// runs are skipped: their logs carry no failure to explain and would otherwise dominate the analysis.
     /// </summary>
-    Task<List<GitHubWorkflowRunAnalysis>> AnalyzeWorkflowsAsync(BuildGitHubSource source, CancellationToken ct);
+    Task<List<GitHubWorkflowRunAnalysis>> AnalyzeWorkflowsAsync(GitHubCommitRef commitRef, CancellationToken ct);
 
     /// <summary>
-    /// Lists the checks reported as failing on the source's pull request. This covers the red checks that no
-    /// workflow run accounts for: results published by Azure Pipelines, and commit statuses posted by
+    /// Lists the checks reported as failing on the referenced commit's pull request. This covers the red checks
+    /// that no workflow run accounts for: results published by Azure Pipelines, and commit statuses posted by
     /// aggregating workflows that succeed while reporting a failure. Returns an empty list when the build was
     /// not triggered by a pull request.
     /// </summary>
-    Task<List<PrCheckRun>> GetFailingChecksAsync(BuildGitHubSource source, CancellationToken ct);
+    Task<List<PrCheckRun>> GetFailingChecksAsync(GitHubCommitRef commitRef, CancellationToken ct);
 }
 
 public class GitHubWorkflowAnalysisHelper(
@@ -34,14 +34,14 @@ public class GitHubWorkflowAnalysisHelper(
     // The GitHub Actions runner marks the failure that ends a step with this prefix.
     private static readonly List<string> RunnerErrorAnnotations = ["##[error]"];
 
-    public async Task<List<GitHubWorkflowRunAnalysis>> AnalyzeWorkflowsAsync(BuildGitHubSource source, CancellationToken ct)
+    public async Task<List<GitHubWorkflowRunAnalysis>> AnalyzeWorkflowsAsync(GitHubCommitRef commitRef, CancellationToken ct)
     {
-        var workflowRuns = await gitHubService.GetFailedWorkflowRunsForCommitAsync(source.Owner, source.Repo, source.HeadSha!, ct);
+        var workflowRuns = await gitHubService.GetFailedWorkflowRunsForCommitAsync(commitRef.Owner, commitRef.Repo, commitRef.HeadSha, ct);
 
         List<GitHubWorkflowRunAnalysis> runAnalyses = [];
         foreach (var run in MostRecentRunPerWorkflow(workflowRuns))
         {
-            runAnalyses.Add(await AnalyzeWorkflowRunAsync(source, run, ct));
+            runAnalyses.Add(await AnalyzeWorkflowRunAsync(commitRef, run, ct));
         }
 
         return runAnalyses;
@@ -62,14 +62,14 @@ public class GitHubWorkflowAnalysisHelper(
         return latest;
     }
 
-    public async Task<List<PrCheckRun>> GetFailingChecksAsync(BuildGitHubSource source, CancellationToken ct)
+    public async Task<List<PrCheckRun>> GetFailingChecksAsync(GitHubCommitRef commitRef, CancellationToken ct)
     {
-        if (source.PullRequestNumber == null)
+        if (commitRef.PullRequestNumber == null)
         {
             return [];
         }
 
-        var checks = await gitHubService.GetPrCheckRunsAsync(source.Owner, source.Repo, source.PullRequestNumber.Value, ct);
+        var checks = await gitHubService.GetPrCheckRunsAsync(commitRef.Owner, commitRef.Repo, commitRef.PullRequestNumber.Value, ct);
         return checks.Where(check => check.IsFailed).ToList();
     }
 
@@ -78,7 +78,7 @@ public class GitHubWorkflowAnalysisHelper(
     /// the run published none, the job list so the failure is at least named. Each read is attempted
     /// independently so a run whose logs have expired is still reported with whatever was available.
     /// </summary>
-    private async Task<GitHubWorkflowRunAnalysis> AnalyzeWorkflowRunAsync(BuildGitHubSource source, WorkflowRun run, CancellationToken ct)
+    private async Task<GitHubWorkflowRunAnalysis> AnalyzeWorkflowRunAsync(GitHubCommitRef commitRef, WorkflowRun run, CancellationToken ct)
     {
         var runAnalysis = new GitHubWorkflowRunAnalysis
         {
@@ -91,7 +91,7 @@ public class GitHubWorkflowAnalysisHelper(
         string? logs = null;
         try
         {
-            logs = await gitHubService.GetFailedWorkflowRunLogsAsync(source.Owner, source.Repo, run.Id, ct);
+            logs = await gitHubService.GetFailedWorkflowRunLogsAsync(commitRef.Owner, commitRef.Repo, run.Id, ct);
             if (!string.IsNullOrEmpty(logs))
             {
                 runAnalysis.Logs = await AnalyzeLogsAsync(logs, run.HtmlUrl, ct);
@@ -107,7 +107,7 @@ public class GitHubWorkflowAnalysisHelper(
         {
             try
             {
-                var jobs = await gitHubService.GetWorkflowRunJobsAsync(source.Owner, source.Repo, run.Id, ct);
+                var jobs = await gitHubService.GetWorkflowRunJobsAsync(commitRef.Owner, commitRef.Repo, run.Id, ct);
                 runAnalysis.Jobs.AddRange(jobs.Select(job => $"{job.Name}: {job.Conclusion?.StringValue ?? job.Status.StringValue}"));
             }
             catch (Exception ex)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/GitHubWorkflowAnalysisHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/GitHubWorkflowAnalysisHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Models.Pipeline;
+using Azure.Sdk.Tools.Cli.Models.Responses;
 using Azure.Sdk.Tools.Cli.Services;
 using Octokit;
 
@@ -30,17 +31,35 @@ public class GitHubWorkflowAnalysisHelper(
     ILogger<GitHubWorkflowAnalysisHelper> logger
 ) : IGitHubWorkflowAnalysisHelper
 {
+    // The GitHub Actions runner marks the failure that ends a step with this prefix.
+    private static readonly List<string> RunnerErrorAnnotations = ["##[error]"];
+
     public async Task<List<GitHubWorkflowRunAnalysis>> AnalyzeWorkflowsAsync(BuildGitHubSource source, CancellationToken ct)
     {
         var workflowRuns = await gitHubService.GetFailedWorkflowRunsForCommitAsync(source.Owner, source.Repo, source.HeadSha!, ct);
 
         List<GitHubWorkflowRunAnalysis> runAnalyses = [];
-        foreach (var run in workflowRuns)
+        foreach (var run in MostRecentRunPerWorkflow(workflowRuns))
         {
             runAnalyses.Add(await AnalyzeWorkflowRunAsync(source, run, ct));
         }
 
         return runAnalyses;
+    }
+
+    private IEnumerable<WorkflowRun> MostRecentRunPerWorkflow(IReadOnlyList<WorkflowRun> runs)
+    {
+        var latest = runs
+            .GroupBy(run => run.WorkflowId)
+            .Select(group => group.OrderByDescending(run => run.CreatedAt).First())
+            .ToList();
+
+        if (latest.Count < runs.Count)
+        {
+            logger.LogDebug("Skipped {count} failed workflow run(s) superseded by a later run of the same workflow", runs.Count - latest.Count);
+        }
+
+        return latest;
     }
 
     public async Task<List<PrCheckRun>> GetFailingChecksAsync(BuildGitHubSource source, CancellationToken ct)
@@ -55,8 +74,9 @@ public class GitHubWorkflowAnalysisHelper(
     }
 
     /// <summary>
-    /// Collects the logs and jobs for a single workflow run. Each read is attempted independently so a run
-    /// whose logs have expired (or whose jobs cannot be listed) is still reported with whatever was available.
+    /// Collects what explains a single workflow run's failure: the logs of the steps that failed, or, when
+    /// the run published none, the job list so the failure is at least named. Each read is attempted
+    /// independently so a run whose logs have expired is still reported with whatever was available.
     /// </summary>
     private async Task<GitHubWorkflowRunAnalysis> AnalyzeWorkflowRunAsync(BuildGitHubSource source, WorkflowRun run, CancellationToken ct)
     {
@@ -68,13 +88,13 @@ public class GitHubWorkflowAnalysisHelper(
             Url = run.HtmlUrl,
         };
 
+        string? logs = null;
         try
         {
-            var logs = await gitHubService.GetWorkflowRunLogsAsync(source.Owner, source.Repo, run.Id, ct);
+            logs = await gitHubService.GetFailedWorkflowRunLogsAsync(source.Owner, source.Repo, run.Id, ct);
             if (!string.IsNullOrEmpty(logs))
             {
-                using var reader = new StringReader(logs);
-                runAnalysis.Logs = await logAnalysisHelper.AnalyzeLogContent(reader, null, null, null, url: run.HtmlUrl, ct: ct);
+                runAnalysis.Logs = await AnalyzeLogsAsync(logs, run.HtmlUrl, ct);
             }
         }
         catch (Exception ex)
@@ -83,17 +103,41 @@ public class GitHubWorkflowAnalysisHelper(
             (runAnalysis.Errors ??= []).Add($"Failed to read workflow run logs: {ex.Message}");
         }
 
-        try
+        if (string.IsNullOrEmpty(logs))
         {
-            var jobs = await gitHubService.GetWorkflowRunJobsAsync(source.Owner, source.Repo, run.Id, ct);
-            runAnalysis.Jobs.AddRange(jobs.Select(job => $"{job.Name}: {job.Conclusion?.StringValue ?? job.Status.StringValue}"));
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Failed to read jobs for workflow run {runId}", run.Id);
-            (runAnalysis.Errors ??= []).Add($"Failed to read workflow run jobs: {ex.Message}");
+            try
+            {
+                var jobs = await gitHubService.GetWorkflowRunJobsAsync(source.Owner, source.Repo, run.Id, ct);
+                runAnalysis.Jobs.AddRange(jobs.Select(job => $"{job.Name}: {job.Conclusion?.StringValue ?? job.Status.StringValue}"));
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to read jobs for workflow run {runId}", run.Id);
+                (runAnalysis.Errors ??= []).Add($"Failed to read workflow run jobs: {ex.Message}");
+            }
         }
 
         return runAnalysis;
+    }
+
+    /// <summary>
+    /// Extracts the failure from a run's logs, keyed on the annotation the runner writes for it. The general
+    /// keywords anchor on any line containing "error", which picks up benign "ERROR:" notices from tools that
+    /// went on to succeed, so they are only used as a fallback when no annotation is present.
+    /// </summary>
+    private async Task<List<LogEntry>> AnalyzeLogsAsync(string logs, string url, CancellationToken ct)
+    {
+        using (var annotatedReader = new StringReader(logs))
+        {
+            var annotated = await logAnalysisHelper.AnalyzeLogContent(annotatedReader, RunnerErrorAnnotations, null, null, url: url, ct: ct);
+            if (annotated?.Count > 0)
+            {
+                return annotated;
+            }
+        }
+
+        logger.LogDebug("No runner error annotation found in the logs for {url}; falling back to the general error keywords", url);
+        using var reader = new StringReader(logs);
+        return await logAnalysisHelper.AnalyzeLogContent(reader, null, null, null, url: url, ct: ct);
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/GitHubWorkflowAnalysisHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/GitHubWorkflowAnalysisHelper.cs
@@ -88,11 +88,11 @@ public class GitHubWorkflowAnalysisHelper(
             Url = run.HtmlUrl,
         };
 
-        string? logs = null;
+        IReadOnlyList<(string Name, string Content)> logs = [];
         try
         {
             logs = await gitHubService.GetFailedWorkflowRunLogsAsync(commitRef.Owner, commitRef.Repo, run.Id, ct);
-            if (!string.IsNullOrEmpty(logs))
+            if (logs.Count > 0)
             {
                 runAnalysis.Logs = await AnalyzeLogsAsync(logs, run.HtmlUrl, ct);
             }
@@ -103,7 +103,7 @@ public class GitHubWorkflowAnalysisHelper(
             (runAnalysis.Errors ??= []).Add($"Failed to read workflow run logs: {ex.Message}");
         }
 
-        if (string.IsNullOrEmpty(logs))
+        if (logs.Count == 0)
         {
             try
             {
@@ -123,21 +123,33 @@ public class GitHubWorkflowAnalysisHelper(
     /// <summary>
     /// Extracts the failure from a run's logs, keyed on the annotation the runner writes for it. The general
     /// keywords anchor on any line containing "error", which picks up benign "ERROR:" notices from tools that
-    /// went on to succeed, so they are only used as a fallback when no annotation is present.
+    /// went on to succeed, so they are only used as a fallback when no log file carries an annotation.
     /// </summary>
-    private async Task<List<LogEntry>> AnalyzeLogsAsync(string logs, string url, CancellationToken ct)
+    private async Task<List<LogEntry>> AnalyzeLogsAsync(IReadOnlyList<(string Name, string Content)> logs, string url, CancellationToken ct)
     {
-        using (var annotatedReader = new StringReader(logs))
+        var annotated = await AnalyzeLogsAsync(logs, RunnerErrorAnnotations, url, ct);
+        if (annotated.Count > 0)
         {
-            var annotated = await logAnalysisHelper.AnalyzeLogContent(annotatedReader, RunnerErrorAnnotations, null, null, url: url, ct: ct);
-            if (annotated?.Count > 0)
-            {
-                return annotated;
-            }
+            return annotated;
         }
 
         logger.LogDebug("No runner error annotation found in the logs for {url}; falling back to the general error keywords", url);
-        using var reader = new StringReader(logs);
-        return await logAnalysisHelper.AnalyzeLogContent(reader, null, null, null, url: url, ct: ct);
+        return await AnalyzeLogsAsync(logs, null, url, ct);
+    }
+
+    private async Task<List<LogEntry>> AnalyzeLogsAsync(IReadOnlyList<(string Name, string Content)> logs, List<string>? keywords, string url, CancellationToken ct)
+    {
+        List<LogEntry> entries = [];
+        foreach (var log in logs)
+        {
+            using var reader = new StringReader(log.Content);
+            var matches = await logAnalysisHelper.AnalyzeLogContent(reader, keywords, null, null, url: url, filePath: log.Name, ct: ct);
+            if (matches?.Count > 0)
+            {
+                entries.AddRange(matches);
+            }
+        }
+
+        return entries;
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/GitHubWorkflowAnalysisHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/GitHubWorkflowAnalysisHelper.cs
@@ -7,11 +7,6 @@ using Octokit;
 
 namespace Azure.Sdk.Tools.Cli.Helpers.Pipeline;
 
-/// <summary>
-/// Analyzes the GitHub Actions runs for an already-resolved commit. Deliberately knows nothing about Azure
-/// Pipelines: the runs share only a commit with any build, so the two analyses are produced independently
-/// and composed by the caller.
-/// </summary>
 public interface IGitHubWorkflowAnalysisHelper
 {
     /// <summary>
@@ -84,8 +79,6 @@ public class GitHubWorkflowAnalysisHelper(
 
         try
         {
-            // A run's archive holds every line every job printed, so only the error lines and their context
-            // are kept: the raw text is far too large to report or to hand to an agent.
             var logs = await gitHubService.GetWorkflowRunLogsAsync(source.Owner, source.Repo, run.Id, ct);
             if (!string.IsNullOrEmpty(logs))
             {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/PipelineAnalysisHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/PipelineAnalysisHelper.cs
@@ -19,14 +19,14 @@ public interface IPipelineAnalysisHelper
     /// Analyzes the given builds, returning one analysis per build plus any warnings that apply to the
     /// overall result (for example test artifacts that could not be parsed).
     /// </summary>
-    Task<(List<BuildAnalysis> BuildAnalyses, List<string> Warnings)> AnalyzePipelineAsync(
-        List<ResolvedBuild> builds,
+    Task<(List<AzurePipelineAnalysis> AzurePipelineAnalyses, List<string> Warnings)> AnalyzePipelineAsync(
+        List<AzurePipelineBuild> builds,
         int? logId = null,
         CancellationToken ct = default);
 
     /// <summary>Downloads and analyzes the specific failure logs for a build.</summary>
     Task<LogAnalysisResponse> AnalyzePipelineFailureLogsAsync(
-        ResolvedBuild build,
+        AzurePipelineBuild build,
         List<int> logIds,
         CancellationToken ct);
 }
@@ -38,29 +38,29 @@ public class PipelineAnalysisHelper(
     ILogger<PipelineAnalysisHelper> logger
 ) : IPipelineAnalysisHelper
 {
-    public async Task<(List<BuildAnalysis> BuildAnalyses, List<string> Warnings)> AnalyzePipelineAsync(
-        List<ResolvedBuild> builds,
+    public async Task<(List<AzurePipelineAnalysis> AzurePipelineAnalyses, List<string> Warnings)> AnalyzePipelineAsync(
+        List<AzurePipelineBuild> builds,
         int? logId = null,
         CancellationToken ct = default)
     {
-        List<BuildAnalysis> buildAnalyses = [];
+        List<AzurePipelineAnalysis> pipelineAnalyses = [];
         List<string> warnings = [];
 
         foreach (var build in builds)
         {
             // Each build is analyzed independently so a failure reading one run does not abort the batch.
-            var buildAnalysis = new BuildAnalysis
+            var pipelineAnalysis = new AzurePipelineAnalysis
             {
-                Build = build
+                PipelineBuild = build
             };
-            buildAnalyses.Add(buildAnalysis);
+            pipelineAnalyses.Add(pipelineAnalysis);
 
             var recoveredFailedTests = false;
             try
             {
                 var (failedTests, skippedArtifacts) = await AnalyzeBuildTestArtifactsAsync(build, ct);
                 recoveredFailedTests = failedTests.Count > 0;
-                buildAnalysis.FailedBuildTests = recoveredFailedTests ? failedTests : null;
+                pipelineAnalysis.FailedPipelineTests = recoveredFailedTests ? failedTests : null;
 
                 if (skippedArtifacts.Count > 0)
                 {
@@ -74,7 +74,7 @@ public class PipelineAnalysisHelper(
             catch (Exception ex)
             {
                 logger.LogError(ex, "Failed to analyze failed-test artifacts for build {buildId}", build.BuildId);
-                (buildAnalysis.Errors ??= []).Add($"Failed to analyze test artifacts: {ex.Message}");
+                (pipelineAnalysis.Errors ??= []).Add($"Failed to analyze test artifacts: {ex.Message}");
                 // Leaving recoveredFailedTests false widens the log search below.
             }
 
@@ -86,21 +86,21 @@ public class PipelineAnalysisHelper(
                 var pipelineFailureLogs = await AnalyzePipelineFailureLogsAsync(build, logIds, ct);
                 if (pipelineFailureLogs.HasErrors)
                 {
-                    buildAnalysis.FailedBuildTasks = pipelineFailureLogs;
+                    pipelineAnalysis.FailedPipelineTasks = pipelineFailureLogs;
                 }
                 else if (!string.IsNullOrEmpty(pipelineFailureLogs.ResponseError))
                 {
-                    (buildAnalysis.Errors ??= []).Add(pipelineFailureLogs.ResponseError);
+                    (pipelineAnalysis.Errors ??= []).Add(pipelineFailureLogs.ResponseError);
                 }
             }
             catch (Exception ex)
             {
                 logger.LogError(ex, "Failed to analyze pipeline failure logs for build {buildId}", build.BuildId);
-                (buildAnalysis.Errors ??= []).Add($"Failed to analyze failure logs: {ex.Message}");
+                (pipelineAnalysis.Errors ??= []).Add($"Failed to analyze failure logs: {ex.Message}");
             }
         }
 
-        return (buildAnalyses, warnings);
+        return (pipelineAnalyses, warnings);
     }
 
     /// <summary>
@@ -108,7 +108,7 @@ public class PipelineAnalysisHelper(
     /// published for. Artifacts that cannot be read or parsed are returned to the caller rather than
     /// reported here.
     /// </summary>
-    private async Task<(Dictionary<string, List<string>> FailedTests, List<string> SkippedArtifacts)> AnalyzeBuildTestArtifactsAsync(ResolvedBuild build, CancellationToken ct)
+    private async Task<(Dictionary<string, List<string>> FailedTests, List<string> SkippedArtifacts)> AnalyzeBuildTestArtifactsAsync(AzurePipelineBuild build, CancellationToken ct)
     {
         var failedTests = new Dictionary<string, List<string>>();
         var failedTestArtifacts = await devopsService.GetPipelineLlmArtifacts(build.Project, build.BuildId, ct);
@@ -148,7 +148,7 @@ public class PipelineAnalysisHelper(
     /// Collects the log ids of the build's failed tasks. Test steps are excluded only when the build's test
     /// results were recovered from its artifacts.
     /// </summary>
-    private async Task<List<int>> getPipelineFailureLogIds(ResolvedBuild build, bool excludeTestSteps, CancellationToken ct = default)
+    private async Task<List<int>> getPipelineFailureLogIds(AzurePipelineBuild build, bool excludeTestSteps, CancellationToken ct = default)
     {
         logger.LogDebug("Getting pipeline task failures for {project} {buildId}", build.Project, build.BuildId);
 
@@ -162,7 +162,7 @@ public class PipelineAnalysisHelper(
         return failedTasks.Select(t => t.Log?.Id ?? 0).Where(id => id != 0).Distinct().ToList();
     }
 
-    public async Task<LogAnalysisResponse> AnalyzePipelineFailureLogsAsync(ResolvedBuild build, List<int> logIds, CancellationToken ct)
+    public async Task<LogAnalysisResponse> AnalyzePipelineFailureLogsAsync(AzurePipelineBuild build, List<int> logIds, CancellationToken ct)
     {
         try
         {
@@ -178,7 +178,7 @@ public class PipelineAnalysisHelper(
         }
     }
 
-    private async Task<LogAnalysisResponse> analyzePipelineFailureLogsAsync(ResolvedBuild resolvedBuild, List<int> logIds, CancellationToken ct)
+    private async Task<LogAnalysisResponse> analyzePipelineFailureLogsAsync(AzurePipelineBuild build, List<int> logIds, CancellationToken ct)
     {
         List<string> logFilePaths = [];
 
@@ -186,8 +186,8 @@ public class PipelineAnalysisHelper(
         {
             foreach (var logId in logIds)
             {
-                logger.LogDebug("Downloading pipeline failure log for {project} {buildId} {logId}", resolvedBuild.Project, resolvedBuild.BuildId, logId);
-                var logContent = await devopsService.GetBuildLogLinesAsync(resolvedBuild.Project, resolvedBuild.BuildId, logId, ct);
+                logger.LogDebug("Downloading pipeline failure log for {project} {buildId} {logId}", build.Project, build.BuildId, logId);
+                var logContent = await devopsService.GetBuildLogLinesAsync(build.Project, build.BuildId, logId, ct);
                 var logText = string.Join("\n", logContent);
 
                 var tempPath = Path.Combine(Path.GetTempPath(), $"log-analysis-{Guid.NewGuid():N}.txt");
@@ -198,7 +198,7 @@ public class PipelineAnalysisHelper(
 
             LogAnalysisResponse response = new()
             {
-                PipelineUrl = resolvedBuild.PipelineUrl,
+                PipelineUrl = build.PipelineUrl,
                 Errors = []
             };
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/PipelineAnalysisHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/PipelineAnalysisHelper.cs
@@ -1,0 +1,228 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Azure.Sdk.Tools.Cli.Configuration;
+using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.Pipeline;
+using Azure.Sdk.Tools.Cli.Models.Responses;
+using Azure.Sdk.Tools.Cli.Services;
+using Microsoft.TeamFoundation.Build.WebApi;
+
+namespace Azure.Sdk.Tools.Cli.Helpers.Pipeline;
+
+/// <summary>
+/// Analyzes already-resolved Azure Pipelines runs: downloads and analyzes failure logs and failed test
+/// results. Resolution of identifiers to builds and commits is the identifier helper's job, and GitHub
+/// Actions runs are the workflow helper's; this type only consumes what it is handed and returns its own
+/// findings, so the caller decides how they are presented.
+/// </summary>
+public interface IPipelineAnalysisHelper
+{
+    /// <summary>
+    /// Analyzes the given builds, returning one analysis per build plus any warnings that apply to the
+    /// overall result (for example test artifacts that could not be parsed).
+    /// </summary>
+    Task<(List<BuildAnalysis> BuildAnalyses, List<string> Warnings)> AnalyzePipelineAsync(
+        List<ResolvedBuild> builds,
+        int? logId = null,
+        CancellationToken ct = default);
+
+    /// <summary>Downloads and analyzes the specific failure logs for a build.</summary>
+    Task<LogAnalysisResponse> AnalyzePipelineFailureLogsAsync(
+        ResolvedBuild build,
+        List<int> logIds,
+        CancellationToken ct);
+}
+
+public class PipelineAnalysisHelper(
+    IDevOpsService devopsService,
+    ILogAnalysisHelper logAnalysisHelper,
+    ITestResultParserResolver parserResolver,
+    ILogger<PipelineAnalysisHelper> logger
+) : IPipelineAnalysisHelper
+{
+    public async Task<(List<BuildAnalysis> BuildAnalyses, List<string> Warnings)> AnalyzePipelineAsync(
+        List<ResolvedBuild> builds,
+        int? logId = null,
+        CancellationToken ct = default)
+    {
+        List<BuildAnalysis> buildAnalyses = [];
+        List<string> warnings = [];
+
+        foreach (var build in builds)
+        {
+            // Each build is analyzed independently so a failure reading one run does not abort the batch.
+            var buildAnalysis = new BuildAnalysis
+            {
+                Build = build
+            };
+            buildAnalyses.Add(buildAnalysis);
+
+            // Step 1: Analyze failed-test artifacts for the whole build.
+            var recoveredFailedTests = false;
+            try
+            {
+                var (failedTests, skippedArtifacts) = await AnalyzeBuildTestArtifactsAsync(build, ct);
+                buildAnalysis.FailedBuildTests.AddRange(failedTests);
+                recoveredFailedTests = failedTests.Count > 0;
+
+                if (skippedArtifacts.Count > 0)
+                {
+                    // Surface partial results to the caller (not only the log) so an incomplete test analysis is visible.
+                    warnings.Add(
+                        $"Build {build.BuildId}: test results may be incomplete: {skippedArtifacts.Count} artifact(s) " +
+                        "could not be read or parsed (missing file, unrecognized format, or malformed content): " +
+                        $"{string.Join(", ", skippedArtifacts)}.");
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to analyze failed-test artifacts for build {buildId}", build.BuildId);
+                (buildAnalysis.Errors ??= []).Add($"Failed to analyze test artifacts: {ex.Message}");
+                // Leaving recoveredFailedTests false widens the log search below.
+            }
+
+            // Step 2: Analyze failure logs (either the caller-specified log or every failed task's log).
+            try
+            {
+                var logIds = logId.HasValue && logId.Value != 0
+                    ? [logId.Value]
+                    : await getPipelineFailureLogIds(build, recoveredFailedTests, ct);
+                var pipelineFailureLogs = await AnalyzePipelineFailureLogsAsync(build, logIds, ct);
+                if (pipelineFailureLogs.HasErrors)
+                {
+                    buildAnalysis.FailedBuildTasks = pipelineFailureLogs;
+                }
+                else if (!string.IsNullOrEmpty(pipelineFailureLogs.ResponseError))
+                {
+                    (buildAnalysis.Errors ??= []).Add(pipelineFailureLogs.ResponseError);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to analyze pipeline failure logs for build {buildId}", build.BuildId);
+                (buildAnalysis.Errors ??= []).Add($"Failed to analyze failure logs: {ex.Message}");
+            }
+        }
+
+        return (buildAnalyses, warnings);
+    }
+
+    /// <summary>
+    /// Parses the failed-test artifacts published by a build. Artifacts that cannot be read or parsed are
+    /// returned to the caller rather than reported here, so the decision of how to surface a partial result
+    /// stays with the code that owns the response.
+    /// </summary>
+    private async Task<(List<FailedTestRunResponse> FailedTests, List<string> SkippedArtifacts)> AnalyzeBuildTestArtifactsAsync(ResolvedBuild build, CancellationToken ct)
+    {
+        var failedTests = new FailedTestRunListResponse();
+        var failedTestArtifacts = await devopsService.GetPipelineLlmArtifacts(build.Project, build.BuildId, ct);
+        var skippedArtifacts = new List<string>();
+
+        foreach (var testFiles in failedTestArtifacts)
+        {
+            foreach (var file in testFiles.Value)
+            {
+                try
+                {
+                    var parser = await parserResolver.ResolveAsync(file, ct);
+                    var failed = await parser.GetFailedTestCases(file, ct: ct);
+                    failedTests.Items.AddRange(failed.Items);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Skipping test result artifact {FilePath}", file);
+                    skippedArtifacts.Add(file);
+                }
+            }
+        }
+
+        return (failedTests.Items, skippedArtifacts);
+    }
+
+    /// <summary>
+    /// Collects the log ids of the build's failed tasks. Test steps are excluded only when the build's test
+    /// results were recovered from its artifacts, because those describe a test failure far better than
+    /// scraping the step's log does. When no test results were recovered the step's log is kept: a test step
+    /// also restores and compiles, and when it fails at those stages its log is the only record of why.
+    /// </summary>
+    private async Task<List<int>> getPipelineFailureLogIds(ResolvedBuild build, bool excludeTestSteps, CancellationToken ct = default)
+    {
+        logger.LogDebug("Getting pipeline task failures for {project} {buildId}", build.Project, build.BuildId);
+
+        var timeline = await devopsService.GetBuildTimelineAsync(build.Project, build.BuildId, ct);
+        var failedTasks = timeline.Records
+            .Where(r => r.Result == TaskResult.Failed
+                && r.RecordType == "Task"
+                && !(excludeTestSteps && isTestStep(r.Name)))
+            .ToList();
+        logger.LogDebug("Found {count} failed tasks", failedTasks.Count);
+        return failedTasks.Select(t => t.Log?.Id ?? 0).Where(id => id != 0).Distinct().ToList();
+    }
+
+    public async Task<LogAnalysisResponse> AnalyzePipelineFailureLogsAsync(ResolvedBuild build, List<int> logIds, CancellationToken ct)
+    {
+        try
+        {
+            return await analyzePipelineFailureLogsAsync(build, logIds, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to analyze pipeline {buildId}", build.BuildId);
+            return new LogAnalysisResponse()
+            {
+                ResponseError = $"Failed to analyze pipeline {build.BuildId}: {ex.Message}",
+            };
+        }
+    }
+
+    private async Task<LogAnalysisResponse> analyzePipelineFailureLogsAsync(ResolvedBuild resolvedBuild, List<int> logIds, CancellationToken ct)
+    {
+        List<string> logFilePaths = [];
+
+        try
+        {
+            foreach (var logId in logIds)
+            {
+                logger.LogDebug("Downloading pipeline failure log for {project} {buildId} {logId}", resolvedBuild.Project, resolvedBuild.BuildId, logId);
+                var logContent = await devopsService.GetBuildLogLinesAsync(resolvedBuild.Project, resolvedBuild.BuildId, logId, ct);
+                var logText = string.Join("\n", logContent);
+
+                var tempPath = Path.Combine(Path.GetTempPath(), $"log-analysis-{Guid.NewGuid():N}.txt");
+                logger.LogDebug("Writing log id {logId} to temporary file {tempPath}", logId, tempPath);
+                await File.WriteAllTextAsync(tempPath, logText, ct);
+                logFilePaths.Add(tempPath);
+            }
+
+            LogAnalysisResponse response = new()
+            {
+                PipelineUrl = resolvedBuild.PipelineUrl,
+                Errors = []
+            };
+
+            foreach (var log in logFilePaths)
+            {
+                var localLogResult = await logAnalysisHelper.AnalyzeLogContent(log, null, null, null, ct);
+                response.Errors.AddRange(localLogResult);
+            }
+
+            return response;
+        }
+        finally
+        {
+            foreach (var log in logFilePaths)
+            {
+                try { File.Delete(log); }
+                catch (Exception ex) { logger.LogDebug(ex, "Failed to clean up temp file {log}", log); }
+            }
+        }
+    }
+
+    private bool isTestStep(string stepName)
+    {
+        if (stepName.Contains("deploy test resources", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+        return stepName.Contains("test", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/PipelineAnalysisHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/PipelineAnalysisHelper.cs
@@ -59,8 +59,8 @@ public class PipelineAnalysisHelper(
             try
             {
                 var (failedTests, skippedArtifacts) = await AnalyzeBuildTestArtifactsAsync(build, ct);
-                buildAnalysis.FailedBuildTests = failedTests;
                 recoveredFailedTests = failedTests.Count > 0;
+                buildAnalysis.FailedBuildTests = recoveredFailedTests ? failedTests : null;
 
                 if (skippedArtifacts.Count > 0)
                 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/PipelineAnalysisHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/PipelineAnalysisHelper.cs
@@ -11,9 +11,7 @@ namespace Azure.Sdk.Tools.Cli.Helpers.Pipeline;
 
 /// <summary>
 /// Analyzes already-resolved Azure Pipelines runs: downloads and analyzes failure logs and failed test
-/// results. Resolution of identifiers to builds and commits is the identifier helper's job, and GitHub
-/// Actions runs are the workflow helper's; this type only consumes what it is handed and returns its own
-/// findings, so the caller decides how they are presented.
+/// results.
 /// </summary>
 public interface IPipelineAnalysisHelper
 {
@@ -57,12 +55,11 @@ public class PipelineAnalysisHelper(
             };
             buildAnalyses.Add(buildAnalysis);
 
-            // Step 1: Analyze failed-test artifacts for the whole build.
             var recoveredFailedTests = false;
             try
             {
                 var (failedTests, skippedArtifacts) = await AnalyzeBuildTestArtifactsAsync(build, ct);
-                buildAnalysis.FailedBuildTests.AddRange(failedTests);
+                buildAnalysis.FailedBuildTests = failedTests;
                 recoveredFailedTests = failedTests.Count > 0;
 
                 if (skippedArtifacts.Count > 0)
@@ -81,7 +78,6 @@ public class PipelineAnalysisHelper(
                 // Leaving recoveredFailedTests false widens the log search below.
             }
 
-            // Step 2: Analyze failure logs (either the caller-specified log or every failed task's log).
             try
             {
                 var logIds = logId.HasValue && logId.Value != 0
@@ -108,13 +104,13 @@ public class PipelineAnalysisHelper(
     }
 
     /// <summary>
-    /// Parses the failed-test artifacts published by a build. Artifacts that cannot be read or parsed are
-    /// returned to the caller rather than reported here, so the decision of how to surface a partial result
-    /// stays with the code that owns the response.
+    /// Parses the failed-test artifacts published by a build, keyed by the platform each artifact was
+    /// published for. Artifacts that cannot be read or parsed are returned to the caller rather than
+    /// reported here.
     /// </summary>
-    private async Task<(List<FailedTestRunResponse> FailedTests, List<string> SkippedArtifacts)> AnalyzeBuildTestArtifactsAsync(ResolvedBuild build, CancellationToken ct)
+    private async Task<(Dictionary<string, List<string>> FailedTests, List<string> SkippedArtifacts)> AnalyzeBuildTestArtifactsAsync(ResolvedBuild build, CancellationToken ct)
     {
-        var failedTests = new FailedTestRunListResponse();
+        var failedTests = new Dictionary<string, List<string>>();
         var failedTestArtifacts = await devopsService.GetPipelineLlmArtifacts(build.Project, build.BuildId, ct);
         var skippedArtifacts = new List<string>();
 
@@ -126,7 +122,16 @@ public class PipelineAnalysisHelper(
                 {
                     var parser = await parserResolver.ResolveAsync(file, ct);
                     var failed = await parser.GetFailedTestCases(file, ct: ct);
-                    failedTests.Items.AddRange(failed.Items);
+                    if (failed.Items.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    if (!failedTests.TryGetValue(testFiles.Key, out var platformTests))
+                    {
+                        failedTests[testFiles.Key] = platformTests = [];
+                    }
+                    platformTests.AddRange(failed.Items.Select(t => t.TestCaseTitle));
                 }
                 catch (Exception ex)
                 {
@@ -136,14 +141,12 @@ public class PipelineAnalysisHelper(
             }
         }
 
-        return (failedTests.Items, skippedArtifacts);
+        return (failedTests, skippedArtifacts);
     }
 
     /// <summary>
     /// Collects the log ids of the build's failed tasks. Test steps are excluded only when the build's test
-    /// results were recovered from its artifacts, because those describe a test failure far better than
-    /// scraping the step's log does. When no test results were recovered the step's log is kept: a test step
-    /// also restores and compiles, and when it fails at those stages its log is the only record of why.
+    /// results were recovered from its artifacts.
     /// </summary>
     private async Task<List<int>> getPipelineFailureLogIds(ResolvedBuild build, bool excludeTestSteps, CancellationToken ct = default)
     {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/PipelineIdentifierHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/PipelineIdentifierHelper.cs
@@ -41,7 +41,7 @@ public interface IPipelineIdentifierHelper
     /// Resolves any identifier (build ID, Azure Pipeline link, GitHub PR link, or bare PR number)
     /// to a list of Azure Pipeline builds. For PR identifiers, returns the failed AZP builds from check runs.
     /// </summary>
-    Task<List<ResolvedBuild>> ResolveBuildsAsync(string identifier, string? project = null, CancellationToken ct = default);
+    Task<List<AzurePipelineBuild>> ResolveBuildsAsync(string identifier, string? project = null, CancellationToken ct = default);
 
     /// <summary>
     /// Resolves the GitHub repository and commit the given builds ran against. The commit always comes from
@@ -49,7 +49,7 @@ public interface IPipelineIdentifierHelper
     /// rather than to whatever the branch or pull request points at now. Returns null when none of the builds
     /// are backed by a GitHub repository.
     /// </summary>
-    Task<BuildGitHubSource?> ResolveGitHubSourceAsync(IEnumerable<ResolvedBuild> builds, CancellationToken ct);
+    Task<GitHubCommitRef?> ResolveCommitRefFromBuildsAsync(IEnumerable<AzurePipelineBuild> builds, CancellationToken ct);
 
     /// <summary>
     /// Resolves the GitHub repository and commit directly from an identifier that names a pull request, for
@@ -57,7 +57,7 @@ public interface IPipelineIdentifierHelper
     /// the pull request's current head. Returns null when the identifier is not a pull request or its head
     /// cannot be read.
     /// </summary>
-    Task<BuildGitHubSource?> ResolveGitHubSourceFromPrAsync(string identifier, CancellationToken ct);
+    Task<GitHubCommitRef?> ResolveCommitRefFromPrAsync(string identifier, CancellationToken ct);
 }
 
 public record GitHubPrLink(string Owner, string Repo, int PrNumber);
@@ -166,7 +166,7 @@ public class PipelineIdentifierHelper(
         return null;
     }
 
-    public async Task<List<ResolvedBuild>> ResolveBuildsAsync(string identifier, string? project = null, CancellationToken ct = default)
+    public async Task<List<AzurePipelineBuild>> ResolveBuildsAsync(string identifier, string? project = null, CancellationToken ct = default)
     {
         // Check if this is a GitHub PR identifier (URL or bare PR number)
         var prLink = await TryResolveGitHubPrAsync(identifier, ct);
@@ -185,16 +185,16 @@ public class PipelineIdentifierHelper(
             resolvedProject = await ResolveProjectNameAsync(singleBuildId, resolvedProject, ct);
         }
 
-        var resolvedBuild = new ResolvedBuild(singleBuildId, resolvedProject, null, null, null);
-        return new List<ResolvedBuild> { await GetBuildStatusesAsync(resolvedBuild, ct) };
+        var build = new AzurePipelineBuild(singleBuildId, resolvedProject, null, null, null);
+        return new List<AzurePipelineBuild> { await GetBuildStatusesAsync(build, ct) };
     }
 
-    private async Task<List<ResolvedBuild>> ResolveBuildsFromPrAsync(GitHubPrLink prLink, string? project = null, CancellationToken ct = default)
+    private async Task<List<AzurePipelineBuild>> ResolveBuildsFromPrAsync(GitHubPrLink prLink, string? project = null, CancellationToken ct = default)
     {
         var checkRuns = await gitHubService.GetPrCheckRunsAsync(prLink.Owner, prLink.Repo, prLink.PrNumber, ct);
 
         // Filter to failed Azure Pipelines check runs (any non-passing conclusion, not just FAILURE), de-dup by buildId
-        var builds = new Dictionary<int, ResolvedBuild>();
+        var builds = new Dictionary<int, AzurePipelineBuild>();
         var projectNameCache = new Dictionary<string, string>();
 
         foreach (var run in checkRuns.Where(r => r.AppName == "Azure Pipelines" && r.IsFailed))
@@ -223,8 +223,8 @@ public class PipelineIdentifierHelper(
                     ? GetPipelineUrl(resolvedProject, buildId)
                     : run.DetailsUrl;
 
-                ResolvedBuild resolvedBuild = new ResolvedBuild(buildId, resolvedProject, pipelineUrl, null, null);
-                builds[buildId] = await GetBuildStatusesAsync(resolvedBuild, ct);
+                AzurePipelineBuild build = new AzurePipelineBuild(buildId, resolvedProject, pipelineUrl, null, null);
+                builds[buildId] = await GetBuildStatusesAsync(build, ct);
             }
             catch (ArgumentException)
             {
@@ -235,25 +235,25 @@ public class PipelineIdentifierHelper(
         return [.. builds.Values];
     }
 
-    public async Task<BuildGitHubSource?> ResolveGitHubSourceAsync(IEnumerable<ResolvedBuild> builds, CancellationToken ct)
+    public async Task<GitHubCommitRef?> ResolveCommitRefFromBuildsAsync(IEnumerable<AzurePipelineBuild> builds, CancellationToken ct)
     {
         foreach (var build in builds)
         {
             try
             {
-                var source = await devOpsService.ResolveBuildGitHubSourceAsync(build.BuildId, build.Project, ct);
-                if (source != null && !string.IsNullOrEmpty(source.HeadSha))
+                var commitRef = await devOpsService.ResolveBuildCommitRefAsync(build.BuildId, build.Project, ct);
+                if (commitRef != null)
                 {
                     logger.LogDebug(
                         "Correlated build {buildId} to {owner}/{repo} @ {sha}",
-                        build.BuildId, source.Owner, source.Repo, source.HeadSha);
-                    return source;
+                        build.BuildId, commitRef.Owner, commitRef.Repo, commitRef.HeadSha);
+                    return commitRef;
                 }
             }
             catch (Exception ex)
             {
                 // Resolution is best effort: a build that cannot be read just means the next one is tried.
-                logger.LogDebug(ex, "Could not resolve a GitHub source for build {buildId}", build.BuildId);
+                logger.LogDebug(ex, "Could not resolve a GitHub commit for build {buildId}", build.BuildId);
             }
         }
 
@@ -261,7 +261,7 @@ public class PipelineIdentifierHelper(
         return null;
     }
 
-    public async Task<BuildGitHubSource?> ResolveGitHubSourceFromPrAsync(string identifier, CancellationToken ct)
+    public async Task<GitHubCommitRef?> ResolveCommitRefFromPrAsync(string identifier, CancellationToken ct)
     {
         var prLink = await TryResolveGitHubPrAsync(identifier, ct);
         if (prLink == null)
@@ -280,7 +280,7 @@ public class PipelineIdentifierHelper(
             }
 
             logger.LogDebug("Resolved {owner}/{repo}#{pr} to commit {sha}", prLink.Owner, prLink.Repo, prLink.PrNumber, headSha);
-            return new BuildGitHubSource(prLink.Owner, prLink.Repo, headSha, prLink.PrNumber);
+            return new GitHubCommitRef(prLink.Owner, prLink.Repo, headSha, prLink.PrNumber);
         }
         catch (Exception ex)
         {
@@ -324,7 +324,7 @@ public class PipelineIdentifierHelper(
         throw new ArgumentException($"Unrecognized project name: {project} for build {buildId}. Expected a known project name (public, internal) or a valid project GUID.");
     }
 
-    private async Task<ResolvedBuild> GetBuildStatusesAsync(ResolvedBuild build, CancellationToken ct)
+    private async Task<AzurePipelineBuild> GetBuildStatusesAsync(AzurePipelineBuild build, CancellationToken ct)
     {
         try
         {
@@ -336,24 +336,24 @@ public class PipelineIdentifierHelper(
             var status = details.Status != null ? JsonNamingPolicy.SnakeCaseLower.ConvertName(details.Status.Value.ToString()) : null;
             var result = details.Result != null ? JsonNamingPolicy.SnakeCaseLower.ConvertName(details.Result.Value.ToString()) : null;
 
-            return new ResolvedBuild(
+            return new AzurePipelineBuild(
                 build.BuildId,
                 buildProject,
                 build.PipelineUrl ?? GetPipelineUrl(buildProject, build.BuildId),
-                status ?? ResolvedBuild.StatusUnavailable,
-                result ?? ResolvedBuild.StatusUnavailable);
+                status ?? AzurePipelineBuild.StatusUnavailable,
+                result ?? AzurePipelineBuild.StatusUnavailable);
         }
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Failed to read status for build {buildId}; marking status unavailable", build.BuildId);
 
             var fallbackProject = build.Project ?? string.Empty;
-            return new ResolvedBuild(
+            return new AzurePipelineBuild(
                 build.BuildId,
                 fallbackProject,
                 build.PipelineUrl ?? GetPipelineUrl(fallbackProject, build.BuildId),
-                ResolvedBuild.StatusUnavailable,
-                ResolvedBuild.StatusUnavailable);
+                AzurePipelineBuild.StatusUnavailable,
+                AzurePipelineBuild.StatusUnavailable);
         }
     }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/PipelineIdentifierHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/PipelineIdentifierHelper.cs
@@ -50,6 +50,14 @@ public interface IPipelineIdentifierHelper
     /// are backed by a GitHub repository.
     /// </summary>
     Task<BuildGitHubSource?> ResolveGitHubSourceAsync(IEnumerable<ResolvedBuild> builds, CancellationToken ct);
+
+    /// <summary>
+    /// Resolves the GitHub repository and commit directly from an identifier that names a pull request, for
+    /// the case where no build correlates it: a pull request can fail on GitHub Actions alone. The commit is
+    /// the pull request's current head. Returns null when the identifier is not a pull request or its head
+    /// cannot be read.
+    /// </summary>
+    Task<BuildGitHubSource?> ResolveGitHubSourceFromPrAsync(string identifier, CancellationToken ct);
 }
 
 public record GitHubPrLink(string Owner, string Repo, int PrNumber);
@@ -251,6 +259,34 @@ public class PipelineIdentifierHelper(
 
         logger.LogDebug("None of the resolved builds are backed by a GitHub repository and commit");
         return null;
+    }
+
+    public async Task<BuildGitHubSource?> ResolveGitHubSourceFromPrAsync(string identifier, CancellationToken ct)
+    {
+        var prLink = await TryResolveGitHubPrAsync(identifier, ct);
+        if (prLink == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var pullRequest = await gitHubService.GetPullRequestAsync(prLink.Owner, prLink.Repo, prLink.PrNumber, ct);
+            var headSha = pullRequest?.Head?.Sha;
+            if (string.IsNullOrEmpty(headSha))
+            {
+                logger.LogDebug("No head commit reported for {owner}/{repo}#{pr}", prLink.Owner, prLink.Repo, prLink.PrNumber);
+                return null;
+            }
+
+            logger.LogDebug("Resolved {owner}/{repo}#{pr} to commit {sha}", prLink.Owner, prLink.Repo, prLink.PrNumber, headSha);
+            return new BuildGitHubSource(prLink.Owner, prLink.Repo, headSha, prLink.PrNumber);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Could not read {owner}/{repo}#{pr} to resolve its head commit", prLink.Owner, prLink.Repo, prLink.PrNumber);
+            return null;
+        }
     }
 
     /// <summary>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/PipelineIdentifierHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/PipelineIdentifierHelper.cs
@@ -185,11 +185,11 @@ public class PipelineIdentifierHelper(
     {
         var checkRuns = await gitHubService.GetPrCheckRunsAsync(prLink.Owner, prLink.Repo, prLink.PrNumber, ct);
 
-        // Filter to Azure Pipelines check runs with FAILURE conclusion, de-dup by buildId
+        // Filter to failed Azure Pipelines check runs (any non-passing conclusion, not just FAILURE), de-dup by buildId
         var builds = new Dictionary<int, ResolvedBuild>();
         var projectNameCache = new Dictionary<string, string>();
 
-        foreach (var run in checkRuns.Where(r => r.AppName == "Azure Pipelines" && r.Conclusion == "FAILURE"))
+        foreach (var run in checkRuns.Where(r => r.AppName == "Azure Pipelines" && r.IsFailed))
         {
             if (string.IsNullOrEmpty(run.DetailsUrl))
             {
@@ -259,7 +259,7 @@ public class PipelineIdentifierHelper(
     /// uniquely identifies its project. Any other value (the org name "azure-sdk", a typo, etc.) is
     /// unrecognized and rejected with an ArgumentException so callers fail early.
     /// </summary>
-    private async Task<string> ResolveProjectNameAsync(int buildId, string project = null, CancellationToken ct = default)
+    private async Task<string> ResolveProjectNameAsync(int buildId, string? project = null, CancellationToken ct = default)
     {
         var normalized = NormalizeProjectName(project);
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/PipelineIdentifierHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/PipelineIdentifierHelper.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using System.Net.Http.Headers;
-using System.Text;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Web;
 using Azure.Sdk.Tools.Cli.Configuration;
 using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Models.Pipeline;
 
-namespace Azure.Sdk.Tools.Cli.Helpers;
+namespace Azure.Sdk.Tools.Cli.Helpers.Pipeline;
 
 public interface IPipelineIdentifierHelper
 {
@@ -40,41 +38,24 @@ public interface IPipelineIdentifierHelper
     Task<GitHubPrLink?> TryResolveGitHubPrAsync(string identifier, CancellationToken ct);
 
     /// <summary>
-    /// Queries GitHub's GraphQL API for check runs on a PR's latest commit.
-    /// </summary>
-    Task<List<PrCheckRun>> GetPrCheckRunsAsync(string owner, string repo, int prNumber, CancellationToken ct);
-
-    /// <summary>
     /// Resolves any identifier (build ID, Azure Pipeline link, GitHub PR link, or bare PR number)
     /// to a list of Azure Pipeline builds. For PR identifiers, returns the failed AZP builds from check runs.
     /// </summary>
     Task<List<ResolvedBuild>> ResolveBuildsAsync(string identifier, string? project = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resolves the GitHub repository and commit the given builds ran against. The commit always comes from
+    /// the builds themselves, so an identifier naming an old run correlates to the commit that run tested
+    /// rather than to whatever the branch or pull request points at now. Returns null when none of the builds
+    /// are backed by a GitHub repository.
+    /// </summary>
+    Task<BuildGitHubSource?> ResolveGitHubSourceAsync(IEnumerable<ResolvedBuild> builds, CancellationToken ct);
 }
 
 public record GitHubPrLink(string Owner, string Repo, int PrNumber);
 
-public record ResolvedBuild(int BuildId, string? Project, string? PipelineUrl);
-
-public class PrCheckRun
-{
-    [JsonPropertyName("name")]
-    public string Name { get; set; } = "";
-
-    [JsonPropertyName("conclusion")]
-    public string? Conclusion { get; set; }
-
-    [JsonPropertyName("details_url")]
-    public string? DetailsUrl { get; set; }
-
-    [JsonPropertyName("app_name")]
-    public string? AppName { get; set; }
-
-    [JsonPropertyName("type")]
-    public string Type { get; set; } = "";
-}
-
 public class PipelineIdentifierHelper(
-    IHttpClientFactory httpClientFactory,
+    IDevOpsService devOpsService,
     IGitHubService gitHubService,
     IGitHelper gitHelper,
     ILogger<PipelineIdentifierHelper> logger
@@ -86,38 +67,6 @@ public class PipelineIdentifierHelper(
 
     // AZP build IDs are 7+ digits; GitHub PR numbers are typically ≤ 6 digits
     private const int MaxGitHubPrNumber = 999_999;
-
-    private const string CheckRunsGraphQLQuery = @"
-query($owner: String!, $repo: String!, $pr: Int!) {
-  repository(owner: $owner, name: $repo) {
-    pullRequest(number: $pr) {
-      commits(last: 1) {
-        nodes {
-          commit {
-            statusCheckRollup {
-              contexts(first: 100) {
-                nodes {
-                  __typename
-                  ... on CheckRun {
-                    name
-                    conclusion
-                    detailsUrl
-                    checkSuite { app { name } }
-                  }
-                  ... on StatusContext {
-                    context
-                    state
-                    targetUrl
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}";
 
     public (int BuildId, string? Project) Parse(string pipelineIdentifier)
     {
@@ -149,46 +98,13 @@ query($owner: String!, $repo: String!, $pr: Int!) {
 
     public async Task<string> GetPipelineProjectAsync(int buildId, string? project, CancellationToken ct)
     {
-        var httpClient = httpClientFactory.CreateClient();
-
-        if (project == Constants.AZURE_SDK_DEVOPS_PUBLIC_PROJECT || string.IsNullOrEmpty(project))
+        var build = await devOpsService.GetBuildDetailsAsync(buildId, project, ct);
+        var projectName = build.Project?.Name;
+        if (string.IsNullOrEmpty(projectName))
         {
-            var pipelineUrl = $"{Constants.AZURE_SDK_DEVOPS_BASE_URL}/{Constants.AZURE_SDK_DEVOPS_PUBLIC_PROJECT}/_apis/build/builds/{buildId}?api-version=7.1";
-            logger.LogDebug("Getting pipeline details from {url} via http", pipelineUrl);
-            var response = await httpClient.GetAsync(pipelineUrl, ct);
-
-            if (string.IsNullOrEmpty(project) && !response.IsSuccessStatusCode)
-            {
-                return await GetPipelineProjectAsync(buildId, Constants.AZURE_SDK_DEVOPS_INTERNAL_PROJECT, ct);
-            }
-
-            if (response.StatusCode == System.Net.HttpStatusCode.NonAuthoritativeInformation)
-            {
-                throw new Exception($"Not authorized to get pipeline details from {pipelineUrl}");
-            }
-            response.EnsureSuccessStatusCode();
-            var json = await response.Content.ReadAsStringAsync(ct);
-            using var doc = JsonDocument.Parse(json);
-            var projectName = doc.RootElement.GetProperty("project").GetProperty("name").GetString();
-            if (string.IsNullOrEmpty(projectName))
-            {
-                throw new Exception($"Failed to parse project name from build details for build {buildId}");
-            }
-            return projectName;
+            throw new Exception($"Failed to parse project name from build details for build {buildId}");
         }
-
-        var internalUrl = $"{Constants.AZURE_SDK_DEVOPS_BASE_URL}/{project}/_apis/build/builds/{buildId}?api-version=7.1";
-        logger.LogDebug("Getting pipeline details from {url} via http", internalUrl);
-        var internalResponse = await httpClient.GetAsync(internalUrl, ct);
-        if (internalResponse.StatusCode == System.Net.HttpStatusCode.NonAuthoritativeInformation)
-        {
-            throw new Exception($"Not authorized to get pipeline details from {internalUrl}");
-        }
-        internalResponse.EnsureSuccessStatusCode();
-        var internalJson = await internalResponse.Content.ReadAsStringAsync(ct);
-        using var internalDoc = JsonDocument.Parse(internalJson);
-        var internalProjectName = internalDoc.RootElement.GetProperty("project").GetProperty("name").GetString();
-        return internalProjectName ?? project;
+        return projectName;
     }
 
     public string GetPipelineUrl(string project, int buildId)
@@ -242,86 +158,6 @@ query($owner: String!, $repo: String!, $pr: Int!) {
         return null;
     }
 
-    public async Task<List<PrCheckRun>> GetPrCheckRunsAsync(string owner, string repo, int prNumber, CancellationToken ct)
-    {
-        var httpClient = httpClientFactory.CreateClient();
-
-        var token = gitHubService.GetAuthToken();
-        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-        httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("AzureSDKDevToolsMCP", "1.0"));
-
-        var requestBody = JsonSerializer.Serialize(new
-        {
-            query = CheckRunsGraphQLQuery,
-            variables = new { owner, repo, pr = prNumber }
-        });
-
-        logger.LogDebug("Querying GitHub GraphQL for PR check runs: {owner}/{repo}#{prNumber}", owner, repo, prNumber);
-        var response = await httpClient.PostAsync(
-            "https://api.github.com/graphql",
-            new StringContent(requestBody, Encoding.UTF8, "application/json"),
-            ct);
-        response.EnsureSuccessStatusCode();
-
-        var json = await response.Content.ReadAsStringAsync(ct);
-        using var doc = JsonDocument.Parse(json);
-
-        if (doc.RootElement.TryGetProperty("errors", out var errors))
-        {
-            var errorMsg = errors.EnumerateArray().FirstOrDefault().GetProperty("message").GetString();
-            throw new Exception($"GitHub GraphQL error: {errorMsg}");
-        }
-
-        var checkRuns = new List<PrCheckRun>();
-        var nodes = doc.RootElement
-            .GetProperty("data")
-            .GetProperty("repository")
-            .GetProperty("pullRequest")
-            .GetProperty("commits")
-            .GetProperty("nodes");
-
-        foreach (var commitNode in nodes.EnumerateArray())
-        {
-            var rollup = commitNode.GetProperty("commit").GetProperty("statusCheckRollup");
-            if (rollup.ValueKind == JsonValueKind.Null)
-            {
-                continue;
-            }
-
-            foreach (var contextNode in rollup.GetProperty("contexts").GetProperty("nodes").EnumerateArray())
-            {
-                var typeName = contextNode.GetProperty("__typename").GetString();
-
-                if (typeName == "CheckRun")
-                {
-                    checkRuns.Add(new PrCheckRun
-                    {
-                        Type = "CheckRun",
-                        Name = contextNode.GetProperty("name").GetString() ?? "",
-                        Conclusion = contextNode.GetProperty("conclusion").GetString(),
-                        DetailsUrl = contextNode.GetProperty("detailsUrl").GetString(),
-                        AppName = contextNode.GetProperty("checkSuite")
-                            .GetProperty("app")
-                            .GetProperty("name").GetString(),
-                    });
-                }
-                else if (typeName == "StatusContext")
-                {
-                    checkRuns.Add(new PrCheckRun
-                    {
-                        Type = "StatusContext",
-                        Name = contextNode.GetProperty("context").GetString() ?? "",
-                        Conclusion = contextNode.GetProperty("state").GetString(),
-                        DetailsUrl = contextNode.GetProperty("targetUrl").GetString(),
-                        AppName = "StatusContext",
-                    });
-                }
-            }
-        }
-
-        return checkRuns;
-    }
-
     public async Task<List<ResolvedBuild>> ResolveBuildsAsync(string identifier, string? project = null, CancellationToken ct = default)
     {
         // Check if this is a GitHub PR identifier (URL or bare PR number)
@@ -341,12 +177,13 @@ query($owner: String!, $repo: String!, $pr: Int!) {
             resolvedProject = await ResolveProjectNameAsync(singleBuildId, resolvedProject, ct);
         }
 
-        return [new ResolvedBuild(singleBuildId, resolvedProject, null)];
+        var resolvedBuild = new ResolvedBuild(singleBuildId, resolvedProject, null, null, null);
+        return new List<ResolvedBuild> { await GetBuildStatusesAsync(resolvedBuild, ct) };
     }
 
     private async Task<List<ResolvedBuild>> ResolveBuildsFromPrAsync(GitHubPrLink prLink, string? project = null, CancellationToken ct = default)
     {
-        var checkRuns = await GetPrCheckRunsAsync(prLink.Owner, prLink.Repo, prLink.PrNumber, ct);
+        var checkRuns = await gitHubService.GetPrCheckRunsAsync(prLink.Owner, prLink.Repo, prLink.PrNumber, ct);
 
         // Filter to Azure Pipelines check runs with FAILURE conclusion, de-dup by buildId
         var builds = new Dictionary<int, ResolvedBuild>();
@@ -378,7 +215,8 @@ query($owner: String!, $repo: String!, $pr: Int!) {
                     ? GetPipelineUrl(resolvedProject, buildId)
                     : run.DetailsUrl;
 
-                builds[buildId] = new ResolvedBuild(buildId, resolvedProject, pipelineUrl);
+                ResolvedBuild resolvedBuild = new ResolvedBuild(buildId, resolvedProject, pipelineUrl, null, null);
+                builds[buildId] = await GetBuildStatusesAsync(resolvedBuild, ct);
             }
             catch (ArgumentException)
             {
@@ -387,6 +225,32 @@ query($owner: String!, $repo: String!, $pr: Int!) {
         }
 
         return [.. builds.Values];
+    }
+
+    public async Task<BuildGitHubSource?> ResolveGitHubSourceAsync(IEnumerable<ResolvedBuild> builds, CancellationToken ct)
+    {
+        foreach (var build in builds)
+        {
+            try
+            {
+                var source = await devOpsService.ResolveBuildGitHubSourceAsync(build.BuildId, build.Project, ct);
+                if (source != null && !string.IsNullOrEmpty(source.HeadSha))
+                {
+                    logger.LogDebug(
+                        "Correlated build {buildId} to {owner}/{repo} @ {sha}",
+                        build.BuildId, source.Owner, source.Repo, source.HeadSha);
+                    return source;
+                }
+            }
+            catch (Exception ex)
+            {
+                // Resolution is best effort: a build that cannot be read just means the next one is tried.
+                logger.LogDebug(ex, "Could not resolve a GitHub source for build {buildId}", build.BuildId);
+            }
+        }
+
+        logger.LogDebug("None of the resolved builds are backed by a GitHub repository and commit");
+        return null;
     }
 
     /// <summary>
@@ -422,6 +286,40 @@ query($owner: String!, $repo: String!, $pr: Int!) {
 
         logger.LogDebug("Unrecognized project name {project} for build {buildId}. Expected a known project name (public, internal) or a valid project GUID.", project, buildId);
         throw new ArgumentException($"Unrecognized project name: {project} for build {buildId}. Expected a known project name (public, internal) or a valid project GUID.");
+    }
+
+    private async Task<ResolvedBuild> GetBuildStatusesAsync(ResolvedBuild build, CancellationToken ct)
+    {
+        try
+        {
+            // One fetch resolves the owning project (public/internal probe + GUID → name) and the run
+            // status/result. Public runs read anonymously; internal runs fall back to the authed client.
+            var details = await devOpsService.GetBuildDetailsAsync(build.BuildId, build.Project, ct);
+            var buildProject = NormalizeProjectName(details.Project?.Name ?? build.Project ?? string.Empty);
+
+            // Convert the DevOps SDK status/result enums to snake_case for the wire contract.
+            var status = details.Status != null ? JsonNamingPolicy.SnakeCaseLower.ConvertName(details.Status.Value.ToString()) : null;
+            var result = details.Result != null ? JsonNamingPolicy.SnakeCaseLower.ConvertName(details.Result.Value.ToString()) : null;
+
+            return new ResolvedBuild(
+                build.BuildId,
+                buildProject,
+                build.PipelineUrl ?? GetPipelineUrl(buildProject, build.BuildId),
+                status ?? ResolvedBuild.StatusUnavailable,
+                result ?? ResolvedBuild.StatusUnavailable);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to read status for build {buildId}; marking status unavailable", build.BuildId);
+
+            var fallbackProject = build.Project ?? string.Empty;
+            return new ResolvedBuild(
+                build.BuildId,
+                fallbackProject,
+                build.PipelineUrl ?? GetPipelineUrl(fallbackProject, build.BuildId),
+                ResolvedBuild.StatusUnavailable,
+                ResolvedBuild.StatusUnavailable);
+        }
     }
 
     /// <summary>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/PipelineIdentifierHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Pipeline/PipelineIdentifierHelper.cs
@@ -293,11 +293,10 @@ public class PipelineIdentifierHelper(
         try
         {
             // One fetch resolves the owning project (public/internal probe + GUID → name) and the run
-            // status/result. Public runs read anonymously; internal runs fall back to the authed client.
+            // status/result.
             var details = await devOpsService.GetBuildDetailsAsync(build.BuildId, build.Project, ct);
             var buildProject = NormalizeProjectName(details.Project?.Name ?? build.Project ?? string.Empty);
 
-            // Convert the DevOps SDK status/result enums to snake_case for the wire contract.
             var status = details.Status != null ? JsonNamingPolicy.SnakeCaseLower.ConvertName(details.Status.Value.ToString()) : null;
             var result = details.Result != null ? JsonNamingPolicy.SnakeCaseLower.ConvertName(details.Result.Value.ToString()) : null;
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Pipeline/AzurePipelineAnalysis.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Pipeline/AzurePipelineAnalysis.cs
@@ -3,26 +3,26 @@ using Azure.Sdk.Tools.Cli.Models.Responses;
 
 namespace Azure.Sdk.Tools.Cli.Models.Pipeline;
 
-public class BuildAnalysis
+public class AzurePipelineAnalysis
 {
-    [JsonPropertyName("build")]
-    public required ResolvedBuild Build { get; set; }
+    [JsonPropertyName("pipeline_build")]
+    public required AzurePipelineBuild PipelineBuild { get; set; }
 
     /// <summary>
     /// Failed tests recovered from the build's test artifacts, keyed by the platform the artifact was
     /// published for (for example "Ubuntu2404_NET80_PackageRef_Debug"). Null when no failed tests were
     /// recovered.
     /// </summary>
-    [JsonPropertyName("failed_build_tests")]
+    [JsonPropertyName("failed_pipeline_tests")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public Dictionary<string, List<string>>? FailedBuildTests { get; set; }
+    public Dictionary<string, List<string>>? FailedPipelineTests { get; set; }
 
     /// <summary>
     /// Task-level failures recovered from the build's logs. Null when no failing tasks were found.
     /// </summary>
-    [JsonPropertyName("failed_build_tasks")]
+    [JsonPropertyName("failed_pipeline_tasks")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public LogAnalysisResponse? FailedBuildTasks { get; set; }
+    public LogAnalysisResponse? FailedPipelineTasks { get; set; }
 
     /// <summary>
     /// Non-fatal errors encountered while analyzing this specific build (for example a log or test-artifact
@@ -33,7 +33,7 @@ public class BuildAnalysis
     public List<string>? Errors { get; set; }
 }
 
-public record ResolvedBuild(
+public record AzurePipelineBuild(
     [property: JsonPropertyName("build_id")] int BuildId,
     [property: JsonPropertyName("project")] string? Project,
     [property: JsonPropertyName("pipeline_url")] string? PipelineUrl,

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Pipeline/BuildAnalysis.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Pipeline/BuildAnalysis.cs
@@ -8,9 +8,13 @@ public class BuildAnalysis
     [JsonPropertyName("build")]
     public required ResolvedBuild Build { get; set; }
 
+    /// <summary>
+    /// Failed tests recovered from the build's test artifacts, keyed by the platform the artifact was
+    /// published for (for example "Ubuntu2404_NET80_PackageRef_Debug").
+    /// </summary>
     [JsonPropertyName("failed_build_tests")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public List<FailedTestRunResponse> FailedBuildTests { get; set; } = [];
+    public Dictionary<string, List<string>> FailedBuildTests { get; set; } = [];
 
     [JsonPropertyName("failed_build_tasks")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
@@ -32,7 +36,6 @@ public record ResolvedBuild(
     [property: JsonPropertyName("status")] string? Status,
     [property: JsonPropertyName("result")] string? Result)
 {
-    /// <summary>Sentinel used when the run status could not be read from DevOps.</summary>
     public const string StatusUnavailable = "Not available";
 
     /// <summary>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Pipeline/BuildAnalysis.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Pipeline/BuildAnalysis.cs
@@ -1,0 +1,48 @@
+using System.Text.Json.Serialization;
+using Azure.Sdk.Tools.Cli.Models.Responses;
+
+namespace Azure.Sdk.Tools.Cli.Models.Pipeline;
+
+public class BuildAnalysis
+{
+    [JsonPropertyName("build")]
+    public required ResolvedBuild Build { get; set; }
+
+    [JsonPropertyName("failed_build_tests")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public List<FailedTestRunResponse> FailedBuildTests { get; set; } = [];
+
+    [JsonPropertyName("failed_build_tasks")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public LogAnalysisResponse FailedBuildTasks { get; set; } = new LogAnalysisResponse();
+
+    /// <summary>
+    /// Non-fatal errors encountered while analyzing this specific build (for example a log or test-artifact
+    /// read that failed). Kept per-build so one build's failure does not hide the analysis of the others.
+    /// </summary>
+    [JsonPropertyName("errors")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? Errors { get; set; }
+}
+
+public record ResolvedBuild(
+    [property: JsonPropertyName("build_id")] int BuildId,
+    [property: JsonPropertyName("project")] string? Project,
+    [property: JsonPropertyName("pipeline_url")] string? PipelineUrl,
+    [property: JsonPropertyName("status")] string? Status,
+    [property: JsonPropertyName("result")] string? Result)
+{
+    /// <summary>Sentinel used when the run status could not be read from DevOps.</summary>
+    public const string StatusUnavailable = "Not available";
+
+    /// <summary>
+    /// True when the build has a known run status that is not terminal ("completed"). While in this
+    /// state failure logs and test artifacts may not be published yet, so an empty analysis does not
+    /// necessarily mean the build is healthy. A missing/unavailable status is treated as not in progress.
+    /// </summary>
+    [JsonIgnore]
+    public bool IsInProgress =>
+        !string.IsNullOrEmpty(Status)
+        && !string.Equals(Status, "completed", StringComparison.OrdinalIgnoreCase)
+        && !string.Equals(Status, StatusUnavailable, StringComparison.OrdinalIgnoreCase);
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Pipeline/BuildAnalysis.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Pipeline/BuildAnalysis.cs
@@ -10,15 +10,19 @@ public class BuildAnalysis
 
     /// <summary>
     /// Failed tests recovered from the build's test artifacts, keyed by the platform the artifact was
-    /// published for (for example "Ubuntu2404_NET80_PackageRef_Debug").
+    /// published for (for example "Ubuntu2404_NET80_PackageRef_Debug"). Null when no failed tests were
+    /// recovered.
     /// </summary>
     [JsonPropertyName("failed_build_tests")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public Dictionary<string, List<string>> FailedBuildTests { get; set; } = [];
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Dictionary<string, List<string>>? FailedBuildTests { get; set; }
 
+    /// <summary>
+    /// Task-level failures recovered from the build's logs. Null when no failing tasks were found.
+    /// </summary>
     [JsonPropertyName("failed_build_tasks")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public LogAnalysisResponse FailedBuildTasks { get; set; } = new LogAnalysisResponse();
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public LogAnalysisResponse? FailedBuildTasks { get; set; }
 
     /// <summary>
     /// Non-fatal errors encountered while analyzing this specific build (for example a log or test-artifact

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Pipeline/GitHubWorkflowAnalysis.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Pipeline/GitHubWorkflowAnalysis.cs
@@ -38,8 +38,14 @@ public class GitHubWorkflowRunAnalysis
 }
 
 /// <summary>
-/// The GitHub repository, commit, and pull request a DevOps build ran against. Only resolvable for pipelines
-/// whose source is a GitHub repository; <see cref="HeadSha"/> is null when the build reports no source version,
-/// and <see cref="PullRequestNumber"/> is null for builds that were not triggered by a pull request.
+/// Points at the GitHub commit an analysis runs against: the repository that owns it, the commit itself, and
+/// the pull request it belongs to when there is one. Resolved either from a DevOps build's source version or
+/// directly from a pull request; resolution returns null rather than a ref with no commit, so a ref always
+/// names one. <see cref="PullRequestNumber"/> is null for commits not associated with a pull request.
 /// </summary>
-public record BuildGitHubSource(string Owner, string Repo, string? HeadSha, int? PullRequestNumber);
+public record GitHubCommitRef(string Owner, string Repo, string HeadSha, int? PullRequestNumber)
+{
+    public string HeadSha { get; init; } = string.IsNullOrEmpty(HeadSha)
+        ? throw new ArgumentException("A GitHub commit ref must name a commit.", nameof(HeadSha))
+        : HeadSha;
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Pipeline/GitHubWorkflowAnalysis.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Pipeline/GitHubWorkflowAnalysis.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+using Azure.Sdk.Tools.Cli.Models.Responses;
+
+namespace Azure.Sdk.Tools.Cli.Models.Pipeline;
+
+/// <summary>
+/// The GitHub repository, commit, and pull request a DevOps build ran against. Only resolvable for pipelines
+/// whose source is a GitHub repository; <see cref="HeadSha"/> is null when the build reports no source version,
+/// and <see cref="PullRequestNumber"/> is null for builds that were not triggered by a pull request.
+/// </summary>
+public record BuildGitHubSource(string Owner, string Repo, string? HeadSha, int? PullRequestNumber);
+
+/// <summary>
+/// A single failed GitHub Actions workflow run along with its logs and jobs. Logs and jobs are fetched
+/// best-effort, so either may be missing while the rest of the run detail is still reported.
+/// </summary>
+public class GitHubWorkflowRunAnalysis
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    [JsonPropertyName("status")]
+    public string? Status { get; set; }
+
+    [JsonPropertyName("conclusion")]
+    public string? Conclusion { get; set; }
+
+    [JsonPropertyName("url")]
+    public string? Url { get; set; }
+
+    /// <summary>Error lines, with surrounding context, extracted from the run's logs.</summary>
+    [JsonPropertyName("logs")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public List<LogEntry> Logs { get; set; } = [];
+
+    /// <summary>The run's jobs, each summarized as "name: conclusion".</summary>
+    [JsonPropertyName("jobs")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public List<string> Jobs { get; set; } = [];
+
+    /// <summary>Non-fatal errors encountered while reading this run's logs or jobs.</summary>
+    [JsonPropertyName("errors")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? Errors { get; set; }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Pipeline/GitHubWorkflowAnalysis.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Pipeline/GitHubWorkflowAnalysis.cs
@@ -4,13 +4,6 @@ using Azure.Sdk.Tools.Cli.Models.Responses;
 namespace Azure.Sdk.Tools.Cli.Models.Pipeline;
 
 /// <summary>
-/// The GitHub repository, commit, and pull request a DevOps build ran against. Only resolvable for pipelines
-/// whose source is a GitHub repository; <see cref="HeadSha"/> is null when the build reports no source version,
-/// and <see cref="PullRequestNumber"/> is null for builds that were not triggered by a pull request.
-/// </summary>
-public record BuildGitHubSource(string Owner, string Repo, string? HeadSha, int? PullRequestNumber);
-
-/// <summary>
 /// A single failed GitHub Actions workflow run along with its logs and jobs. Logs and jobs are fetched
 /// best-effort, so either may be missing while the rest of the run detail is still reported.
 /// </summary>
@@ -43,3 +36,10 @@ public class GitHubWorkflowRunAnalysis
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<string>? Errors { get; set; }
 }
+
+/// <summary>
+/// The GitHub repository, commit, and pull request a DevOps build ran against. Only resolvable for pipelines
+/// whose source is a GitHub repository; <see cref="HeadSha"/> is null when the build reports no source version,
+/// and <see cref="PullRequestNumber"/> is null for builds that were not triggered by a pull request.
+/// </summary>
+public record BuildGitHubSource(string Owner, string Repo, string? HeadSha, int? PullRequestNumber);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/PrCheckRun.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/PrCheckRun.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Text.Json.Serialization;
+
+namespace Azure.Sdk.Tools.Cli.Models;
+
+/// <summary>
+/// A single CI check reported on a GitHub commit. Covers both of the shapes GitHub exposes: modern
+/// check runs (GitHub Actions, Azure Pipelines) and legacy commit statuses, normalized into one type
+/// so callers do not have to care which API produced the result.
+/// </summary>
+public class PrCheckRun
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    [JsonPropertyName("conclusion")]
+    public string? Conclusion { get; set; }
+
+    [JsonPropertyName("details_url")]
+    public string? DetailsUrl { get; set; }
+
+    [JsonPropertyName("app_name")]
+    public string? AppName { get; set; }
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "";
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/PrCheckRun.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/PrCheckRun.cs
@@ -11,6 +11,16 @@ namespace Azure.Sdk.Tools.Cli.Models;
 /// </summary>
 public class PrCheckRun
 {
+    /// <summary>
+    /// Conclusions that mean a check did not pass. Anything else - success, skipped, neutral, or a check
+    /// that is still running and has no conclusion yet - is not a failure to report. Compared case-insensitively
+    /// because the REST and GraphQL APIs disagree on the casing they return.
+    /// </summary>
+    private static readonly HashSet<string> FailedConclusions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE",
+    };
+
     [JsonPropertyName("name")]
     public string Name { get; set; } = "";
 
@@ -25,4 +35,11 @@ public class PrCheckRun
 
     [JsonPropertyName("type")]
     public string Type { get; set; } = "";
+
+    /// <summary>
+    /// True when this check's conclusion means it did not pass. See <see cref="FailedConclusions"/> for the
+    /// exact set. A null conclusion (still running) is not treated as a failure.
+    /// </summary>
+    [JsonIgnore]
+    public bool IsFailed => Conclusion != null && FailedConclusions.Contains(Conclusion);
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/AnalyzePipelineResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/AnalyzePipelineResponse.cs
@@ -151,8 +151,6 @@ public class AnalyzePipelineResponse : CommandResponse
         sb.AppendLine("--------------------------------------------------------------------------------");
         sb.AppendLine("Failing checks on the pull request");
         sb.AppendLine("--------------------------------------------------------------------------------");
-        sb.AppendLine("Every check GitHub reports as red. Those backed by a build or workflow run are detailed");
-        sb.AppendLine("above; the remainder are statuses that aggregate or restate one of those failures.");
 
         foreach (var check in FailingPullRequestChecks)
         {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/AnalyzePipelineResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/AnalyzePipelineResponse.cs
@@ -58,20 +58,20 @@ public class AnalyzePipelineResponse : CommandResponse
                 sb.AppendLine();
             }
 
-            if (buildAnalysis.FailedBuildTests.Count > 0)
+            if (buildAnalysis.FailedBuildTests is { Count: > 0 } failedTests)
             {
                 sb.AppendLine("--------------------------------------------------------------------------------");
                 sb.AppendLine("Failed Tests");
                 sb.AppendLine("--------------------------------------------------------------------------------");
-                sb.AppendLine(JsonSerializer.Serialize(buildAnalysis.FailedBuildTests, jsonOptions));
+                sb.AppendLine(JsonSerializer.Serialize(failedTests, jsonOptions));
             }
 
-            if (buildAnalysis.FailedBuildTasks.HasErrors)
+            if (buildAnalysis.FailedBuildTasks is { HasErrors: true } failedTasks)
             {
                 sb.AppendLine("--------------------------------------------------------------------------------");
                 sb.AppendLine("Failed Tasks");
                 sb.AppendLine("--------------------------------------------------------------------------------");
-                sb.AppendLine(buildAnalysis.FailedBuildTasks.ToString());
+                sb.AppendLine(failedTasks.ToString());
                 sb.AppendLine("--------------------------------------------------------------------------------");
             }
 
@@ -87,7 +87,7 @@ public class AnalyzePipelineResponse : CommandResponse
                 sb.AppendLine("--------------------------------------------------------------------------------");
             }
 
-            if (buildAnalysis.FailedBuildTests.Count == 0 && !buildAnalysis.FailedBuildTasks.HasErrors && (buildAnalysis.Errors?.Count ?? 0) == 0)
+            if ((buildAnalysis.FailedBuildTests?.Count ?? 0) == 0 && buildAnalysis.FailedBuildTasks?.HasErrors != true && (buildAnalysis.Errors?.Count ?? 0) == 0)
             {
                 sb.AppendLine("");
                 sb.AppendLine(buildAnalysis.Build.IsInProgress

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/AnalyzePipelineResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/AnalyzePipelineResponse.cs
@@ -1,20 +1,35 @@
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Azure.Sdk.Tools.Cli.Models.Pipeline;
 
-namespace Azure.Sdk.Tools.Cli.Models;
+namespace Azure.Sdk.Tools.Cli.Models.Responses;
 
 public class AnalyzePipelineResponse : CommandResponse
 {
-    [JsonPropertyName("failed_test_titles")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public Dictionary<string, List<string>> FailedTests { get; set; } = [];
+    [JsonPropertyName("build_analyses")]
+    public List<BuildAnalysis> BuildAnalyses { get; set; } = [];
 
-    [JsonPropertyName("failed_tasks")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public List<LogAnalysisResponse> FailedTasks { get; set; } = [];
+    /// <summary>
+    /// Failed GitHub Actions runs for the commit the builds were queued against. Independent of the build
+    /// analyses: a red workflow run does not mean a pipeline failed, and vice versa. Null when the pipeline's
+    /// source is not a GitHub repository or no commit could be resolved.
+    /// </summary>
+    [JsonPropertyName("github_workflow_analyses")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<GitHubWorkflowRunAnalysis>? GitHubWorkflowAnalyses { get; set; }
 
-    private readonly JsonSerializerOptions jsonOptions = new()
+    /// <summary>
+    /// Every check GitHub reports as failing on the pull request, so the analysis can be reconciled against
+    /// what the PR page shows. Included without logs because a failing check is not itself a source of
+    /// diagnostics: it is either a view of a build or workflow run detailed above, or a status posted by an
+    /// aggregating workflow that restates another failure. Null when no pull request could be resolved.
+    /// </summary>
+    [JsonPropertyName("failing_checks")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<PrCheckRun>? FailingChecks { get; set; }
+
+    private static readonly JsonSerializerOptions jsonOptions = new()
     {
         WriteIndented = true,
     };
@@ -23,32 +38,125 @@ public class AnalyzePipelineResponse : CommandResponse
     {
         var sb = new StringBuilder();
 
-        if (FailedTests.Count > 0)
+        if (BuildAnalyses.Count == 0)
         {
-            sb.AppendLine("--------------------------------------------------------------------------------");
-            sb.AppendLine("Failed Tests");
-            sb.AppendLine("--------------------------------------------------------------------------------");
-            sb.AppendLine(JsonSerializer.Serialize(FailedTests, jsonOptions));
+            sb.AppendLine("No failed Azure Pipeline builds found.");
         }
 
-        if (FailedTasks.Count > 0)
+        foreach (var buildAnalysis in BuildAnalyses)
         {
-            sb.AppendLine("--------------------------------------------------------------------------------");
-            sb.AppendLine("Failed Tasks");
-            sb.AppendLine("--------------------------------------------------------------------------------");
-            foreach (var task in FailedTasks)
+            sb.AppendLine($"Build: {buildAnalysis.Build.BuildId} Project: {buildAnalysis.Build.Project} PipelineUrl: {buildAnalysis.Build.PipelineUrl}");
+
+            if (buildAnalysis.Build.IsInProgress)
             {
-                sb.AppendLine(task.ToString());
                 sb.AppendLine("--------------------------------------------------------------------------------");
+                sb.AppendLine($"Build not complete (status: {buildAnalysis.Build.Status})");
+                sb.AppendLine("--------------------------------------------------------------------------------");
+                sb.AppendLine("The build has not finished running, so failure logs and test result artifacts");
+                sb.AppendLine("may not be published yet. Any results below are partial \u2014 re-run the analysis");
+                sb.AppendLine("once the build completes for the full picture.");
+                sb.AppendLine();
+            }
+
+            if (buildAnalysis.FailedBuildTests.Count > 0)
+            {
+                sb.AppendLine("--------------------------------------------------------------------------------");
+                sb.AppendLine("Failed Tests");
+                sb.AppendLine("--------------------------------------------------------------------------------");
+                sb.AppendLine(JsonSerializer.Serialize(buildAnalysis.FailedBuildTests, jsonOptions));
+            }
+
+            if (buildAnalysis.FailedBuildTasks.HasErrors)
+            {
+                sb.AppendLine("--------------------------------------------------------------------------------");
+                sb.AppendLine("Failed Tasks");
+                sb.AppendLine("--------------------------------------------------------------------------------");
+                sb.AppendLine(buildAnalysis.FailedBuildTasks.ToString());
+                sb.AppendLine("--------------------------------------------------------------------------------");
+            }
+
+            if (buildAnalysis.Errors?.Count > 0)
+            {
+                sb.AppendLine("--------------------------------------------------------------------------------");
+                sb.AppendLine("Analysis could not be completed for this build:");
+                sb.AppendLine("--------------------------------------------------------------------------------");
+                foreach (var error in buildAnalysis.Errors)
+                {
+                    sb.AppendLine($"- {error}");
+                }
+                sb.AppendLine("--------------------------------------------------------------------------------");
+            }
+
+            if (buildAnalysis.FailedBuildTests.Count == 0 && !buildAnalysis.FailedBuildTasks.HasErrors && (buildAnalysis.Errors?.Count ?? 0) == 0)
+            {
+                sb.AppendLine("");
+                sb.AppendLine(buildAnalysis.Build.IsInProgress
+                    ? "No failures found yet \u2014 the build is still running."
+                    : "No failures found");
             }
         }
 
-        if (FailedTests.Count == 0 && FailedTasks.Count == 0)
-        {
-            sb.AppendLine("");
-            sb.AppendLine("No failures found");
-        }
+        AppendGitHubWorkflowAnalysis(sb);
+        AppendFailingChecks(sb);
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Reports the GitHub Actions runs in their own section. These are deliberately not folded into any build's
+    /// output: they run on the same commit but are otherwise unrelated to the pipeline, and attributing an
+    /// Actions failure to a build would be misleading.
+    /// </summary>
+    private void AppendGitHubWorkflowAnalysis(StringBuilder sb)
+    {
+        if (GitHubWorkflowAnalyses == null || GitHubWorkflowAnalyses.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var runAnalysis in GitHubWorkflowAnalyses)
+        {
+            sb.AppendLine($"Workflow: {runAnalysis.Name} Status: {runAnalysis.Status} Conclusion: {runAnalysis.Conclusion} Url: {runAnalysis.Url}");
+
+            foreach (var job in runAnalysis.Jobs)
+            {
+                sb.AppendLine($"  Job: {job}");
+            }
+
+            foreach (var logEntry in runAnalysis.Logs)
+            {
+                sb.AppendLine($"  Log line {logEntry.Line}:");
+                sb.AppendLine(logEntry.Message);
+            }
+
+            foreach (var error in runAnalysis.Errors ?? [])
+            {
+                sb.AppendLine($"  - Analysis incomplete: {error}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Lists the failing checks last, as a reconciliation against the pull request page rather than as new
+    /// findings. The list is expected to overlap the sections above; an entry that appears only here is a
+    /// check whose failure originates somewhere this analysis cannot reach.
+    /// </summary>
+    private void AppendFailingChecks(StringBuilder sb)
+    {
+        if (FailingChecks == null || FailingChecks.Count == 0)
+        {
+            return;
+        }
+
+        sb.AppendLine("--------------------------------------------------------------------------------");
+        sb.AppendLine("Failing checks on the pull request");
+        sb.AppendLine("--------------------------------------------------------------------------------");
+        sb.AppendLine("Every check GitHub reports as red. Those backed by a build or workflow run are detailed");
+        sb.AppendLine("above; the remainder are statuses that aggregate or restate one of those failures.");
+
+        foreach (var check in FailingChecks)
+        {
+            sb.AppendLine($"  {check.Name} [{check.Conclusion}] Reported by: {check.AppName} Url: {check.DetailsUrl}");
+        }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/AnalyzePipelineResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/AnalyzePipelineResponse.cs
@@ -7,11 +7,11 @@ namespace Azure.Sdk.Tools.Cli.Models.Responses;
 
 public class AnalyzePipelineResponse : CommandResponse
 {
-    [JsonPropertyName("build_analyses")]
-    public List<BuildAnalysis> BuildAnalyses { get; set; } = [];
+    [JsonPropertyName("azure_pipeline_analyses")]
+    public List<AzurePipelineAnalysis> AzurePipelineAnalyses { get; set; } = [];
 
     /// <summary>
-    /// Failed GitHub Actions runs for the commit the builds were queued against. Independent of the build
+    /// Failed GitHub Actions runs for the commit the builds were queued against. Independent of the pipeline
     /// analyses: a red workflow run does not mean a pipeline failed, and vice versa. Null when the pipeline's
     /// source is not a GitHub repository or no commit could be resolved.
     /// </summary>
@@ -25,9 +25,9 @@ public class AnalyzePipelineResponse : CommandResponse
     /// diagnostics: it is either a view of a build or workflow run detailed above, or a status posted by an
     /// aggregating workflow that restates another failure. Null when no pull request could be resolved.
     /// </summary>
-    [JsonPropertyName("failing_checks")]
+    [JsonPropertyName("failing_pull_request_checks")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<PrCheckRun>? FailingChecks { get; set; }
+    public List<PrCheckRun>? FailingPullRequestChecks { get; set; }
 
     private static readonly JsonSerializerOptions jsonOptions = new()
     {
@@ -38,27 +38,27 @@ public class AnalyzePipelineResponse : CommandResponse
     {
         var sb = new StringBuilder();
 
-        if (BuildAnalyses.Count == 0)
+        if (AzurePipelineAnalyses.Count == 0)
         {
             sb.AppendLine("No failed Azure Pipeline builds found.");
         }
 
-        foreach (var buildAnalysis in BuildAnalyses)
+        foreach (var pipelineAnalysis in AzurePipelineAnalyses)
         {
-            sb.AppendLine($"Build: {buildAnalysis.Build.BuildId} Project: {buildAnalysis.Build.Project} PipelineUrl: {buildAnalysis.Build.PipelineUrl}");
+            sb.AppendLine($"Build: {pipelineAnalysis.PipelineBuild.BuildId} Project: {pipelineAnalysis.PipelineBuild.Project} PipelineUrl: {pipelineAnalysis.PipelineBuild.PipelineUrl}");
 
-            if (buildAnalysis.Build.IsInProgress)
+            if (pipelineAnalysis.PipelineBuild.IsInProgress)
             {
                 sb.AppendLine("--------------------------------------------------------------------------------");
-                sb.AppendLine($"Build not complete (status: {buildAnalysis.Build.Status})");
+                sb.AppendLine($"Azure Pipeline not complete (status: {pipelineAnalysis.PipelineBuild.Status})");
                 sb.AppendLine("--------------------------------------------------------------------------------");
-                sb.AppendLine("The build has not finished running, so failure logs and test result artifacts");
-                sb.AppendLine("may not be published yet. Any results below are partial \u2014 re-run the analysis");
-                sb.AppendLine("once the build completes for the full picture.");
+                sb.AppendLine("The azure pipeline has not finished running, so failure logs and test result artifacts");
+                sb.AppendLine("may not be published yet. Any results below are partial, re-run the analysis");
+                sb.AppendLine("once the pipeline completes for the full picture.");
                 sb.AppendLine();
             }
 
-            if (buildAnalysis.FailedBuildTests is { Count: > 0 } failedTests)
+            if (pipelineAnalysis.FailedPipelineTests is { Count: > 0 } failedTests)
             {
                 sb.AppendLine("--------------------------------------------------------------------------------");
                 sb.AppendLine("Failed Tests");
@@ -66,7 +66,7 @@ public class AnalyzePipelineResponse : CommandResponse
                 sb.AppendLine(JsonSerializer.Serialize(failedTests, jsonOptions));
             }
 
-            if (buildAnalysis.FailedBuildTasks is { HasErrors: true } failedTasks)
+            if (pipelineAnalysis.FailedPipelineTasks is { HasErrors: true } failedTasks)
             {
                 sb.AppendLine("--------------------------------------------------------------------------------");
                 sb.AppendLine("Failed Tasks");
@@ -75,23 +75,23 @@ public class AnalyzePipelineResponse : CommandResponse
                 sb.AppendLine("--------------------------------------------------------------------------------");
             }
 
-            if (buildAnalysis.Errors?.Count > 0)
+            if (pipelineAnalysis.Errors?.Count > 0)
             {
                 sb.AppendLine("--------------------------------------------------------------------------------");
                 sb.AppendLine("Analysis could not be completed for this build:");
                 sb.AppendLine("--------------------------------------------------------------------------------");
-                foreach (var error in buildAnalysis.Errors)
+                foreach (var error in pipelineAnalysis.Errors)
                 {
                     sb.AppendLine($"- {error}");
                 }
                 sb.AppendLine("--------------------------------------------------------------------------------");
             }
 
-            if ((buildAnalysis.FailedBuildTests?.Count ?? 0) == 0 && buildAnalysis.FailedBuildTasks?.HasErrors != true && (buildAnalysis.Errors?.Count ?? 0) == 0)
+            if ((pipelineAnalysis.FailedPipelineTests?.Count ?? 0) == 0 && pipelineAnalysis.FailedPipelineTasks?.HasErrors != true && (pipelineAnalysis.Errors?.Count ?? 0) == 0)
             {
                 sb.AppendLine("");
-                sb.AppendLine(buildAnalysis.Build.IsInProgress
-                    ? "No failures found yet \u2014 the build is still running."
+                sb.AppendLine(pipelineAnalysis.PipelineBuild.IsInProgress
+                    ? "No failures found yet, the azure pipeline is still running."
                     : "No failures found");
             }
         }
@@ -143,7 +143,7 @@ public class AnalyzePipelineResponse : CommandResponse
     /// </summary>
     private void AppendFailingChecks(StringBuilder sb)
     {
-        if (FailingChecks == null || FailingChecks.Count == 0)
+        if (FailingPullRequestChecks == null || FailingPullRequestChecks.Count == 0)
         {
             return;
         }
@@ -154,7 +154,7 @@ public class AnalyzePipelineResponse : CommandResponse
         sb.AppendLine("Every check GitHub reports as red. Those backed by a build or workflow run are detailed");
         sb.AppendLine("above; the remainder are statuses that aggregate or restate one of those failures.");
 
-        foreach (var check in FailingChecks)
+        foreach (var check in FailingPullRequestChecks)
         {
             sb.AppendLine($"  {check.Name} [{check.Conclusion}] Reported by: {check.AppName} Url: {check.DetailsUrl}");
         }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/LogAnalysisResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/LogAnalysisResponse.cs
@@ -1,7 +1,7 @@
 using System.Text;
 using System.Text.Json.Serialization;
 
-namespace Azure.Sdk.Tools.Cli.Models;
+namespace Azure.Sdk.Tools.Cli.Models.Responses;
 
 public class LogAnalysisResponse : CommandResponse
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/PrChecksResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/PrChecksResponse.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Text.Json.Serialization;
-using Azure.Sdk.Tools.Cli.Helpers;
 
 namespace Azure.Sdk.Tools.Cli.Models;
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Azure/AzureService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Azure/AzureService.cs
@@ -68,18 +68,27 @@ public class AzureService : IAzureService
     /// </summary>
     private static DefaultAzureCredential CreateManagedIdentityCredential()
     {
-        return new DefaultAzureCredential(new DefaultAzureCredentialOptions
-        {
-            ExcludeEnvironmentCredential = true,
-            ExcludeWorkloadIdentityCredential = true,
-            ExcludeManagedIdentityCredential = false,
-            ExcludeVisualStudioCredential = true,
-            ExcludeAzureCliCredential = true,
-            ExcludeAzurePowerShellCredential = true,
-            ExcludeAzureDeveloperCliCredential = true,
-            ExcludeInteractiveBrowserCredential = true,
-        });
+        return new DefaultAzureCredential(ManagedIdentityCredentialOptions);
     }
+
+    /// <summary>
+    /// The options used to build the managed-identity-only <see cref="DefaultAzureCredential"/>. Every credential
+    /// type that DefaultAzureCredential can probe must be excluded except ManagedIdentity, otherwise the wrapper
+    /// could silently pick up an unwanted identity from the environment.
+    /// </summary>
+    public static DefaultAzureCredentialOptions ManagedIdentityCredentialOptions => new()
+    {
+        ExcludeEnvironmentCredential = true,
+        ExcludeWorkloadIdentityCredential = true,
+        ExcludeManagedIdentityCredential = false,
+        ExcludeVisualStudioCredential = true,
+        ExcludeVisualStudioCodeCredential = true,
+        ExcludeAzureCliCredential = true,
+        ExcludeAzurePowerShellCredential = true,
+        ExcludeAzureDeveloperCliCredential = true,
+        ExcludeInteractiveBrowserCredential = true,
+        ExcludeBrokerCredential = true,
+    };
 
     private static bool IsGitHubAction()
     {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Azure/AzureService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Azure/AzureService.cs
@@ -40,20 +40,15 @@ public class AzureService : IAzureService
             );
         }
 
-        try
-        {
-            return new ChainedTokenCredential(
-                new AzureCliCredential(new AzureCliCredentialOptions { TenantId = tenantId }),
-                new AzurePowerShellCredential(new AzurePowerShellCredentialOptions { TenantId = tenantId }),
-                new AzureDeveloperCliCredential(new AzureDeveloperCliCredentialOptions { TenantId = tenantId }),
-                new VisualStudioCredential(new VisualStudioCredentialOptions { TenantId = tenantId }),
-                new ManagedIdentityCredential(GetManagedIdentityClientId())
-            );
-        }
-        catch (CredentialUnavailableException)
-        {
-            return new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TenantId = tenantId });
-        }
+        // Local dev: prefer developer credentials (Azure CLI, then PowerShell, Developer CLI, Visual Studio) and
+        // fall back to managed identity last, so a signed-in developer's `az login` always wins.
+        return new ChainedTokenCredential(
+            new AzureCliCredential(new AzureCliCredentialOptions { TenantId = tenantId }),
+            new AzurePowerShellCredential(new AzurePowerShellCredentialOptions { TenantId = tenantId }),
+            new AzureDeveloperCliCredential(new AzureDeveloperCliCredentialOptions { TenantId = tenantId }),
+            new VisualStudioCredential(new VisualStudioCredentialOptions { TenantId = tenantId }),
+            CreateManagedIdentityCredential()
+        );
     }
 
     private static bool IsRunningInPipeline()
@@ -63,13 +58,27 @@ public class AzureService : IAzureService
     }
 
     /// <summary>
-    /// Gets the client ID for a user-assigned managed identity from the AZURE_CLIENT_ID environment variable.
-    /// Returns null if not set, allowing the credential to use system-assigned managed identity.
+    /// Builds the managed-identity link for the local-dev credential chain. A bare
+    /// ManagedIdentityCredential placed in a ChainedTokenCredential blocks on the IMDS
+    /// endpoint when running off-Azure, because a hand-built chain does not enable the fast-fail
+    /// IMDS probe. Wrapping managed identity in a managed-identity-only DefaultAzureCredential restores
+    /// that probe, so the credential fails fast with CredentialUnavailableException (about a second)
+    /// when no IMDS endpoint is reachable instead of hanging. ManagedIdentityClientId defaults to the AZURE_CLIENT_ID
+    /// environment variable, so a user-assigned identity is honored when one is configured.
     /// </summary>
-    /// <returns>The client ID for user-assigned managed identity, or null for system-assigned.</returns>
-    private static string? GetManagedIdentityClientId()
+    private static DefaultAzureCredential CreateManagedIdentityCredential()
     {
-        return Environment.GetEnvironmentVariable("AZURE_CLIENT_ID");
+        return new DefaultAzureCredential(new DefaultAzureCredentialOptions
+        {
+            ExcludeEnvironmentCredential = true,
+            ExcludeWorkloadIdentityCredential = true,
+            ExcludeManagedIdentityCredential = false,
+            ExcludeVisualStudioCredential = true,
+            ExcludeAzureCliCredential = true,
+            ExcludeAzurePowerShellCredential = true,
+            ExcludeAzureDeveloperCliCredential = true,
+            ExcludeInteractiveBrowserCredential = true,
+        });
     }
 
     private static bool IsGitHubAction()

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -9,11 +11,13 @@ using Azure.Identity;
 using Azure.Sdk.Tools.Cli.Configuration;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Models.AzureDevOps;
+using Azure.Sdk.Tools.Cli.Models.Pipeline;
 using Azure.Sdk.Tools.Cli.Models.Responses.Package;
 using Microsoft.TeamFoundation.Build.WebApi;
 using Microsoft.TeamFoundation.Core.WebApi;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
+using Microsoft.VisualStudio.Services.Common;
 using Microsoft.VisualStudio.Services.OAuth;
 using Microsoft.VisualStudio.Services.WebApi;
 using Microsoft.VisualStudio.Services.WebApi.Patch.Json;
@@ -25,14 +29,21 @@ namespace Azure.Sdk.Tools.Cli.Services
         public BuildHttpClient GetBuildClient(CancellationToken ct);
         public WorkItemTrackingHttpClient GetWorkItemClient(CancellationToken ct);
         public ProjectHttpClient GetProjectClient(CancellationToken ct);
+
+        public AccessToken GetToken(CancellationToken ct);
+
+        public Task<T> ReadBuildWithAnonymousFallbackAsync<T>(Func<BuildHttpClient, Task<T>> operation, CancellationToken ct);
     }
 
     public class DevOpsConnection(IAzureService azureService) : IDevOpsConnection
     {
         private BuildHttpClient _buildClient;
+        private BuildHttpClient _anonymousBuildClient;
         private WorkItemTrackingHttpClient _workItemClient;
         private ProjectHttpClient _projectClient;
         private AccessToken? _token;
+
+        private static readonly TimeSpan InteractiveLoginTimeout = TimeSpan.FromMinutes(3);
 
         private void RefreshConnection(CancellationToken ct)
         {
@@ -56,9 +67,11 @@ namespace Azure.Sdk.Tools.Cli.Services
                 {
                     credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TenantId = null });
                     // Retry with interactive browser credential if the initial credential fails
-                    _token = credential.GetToken(new TokenRequestContext([Constants.AZURE_DEVOPS_TOKEN_SCOPE]), ct);
+                    using var interactiveLoginCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                    interactiveLoginCts.CancelAfter(InteractiveLoginTimeout);
+                    _token = credential.GetToken(new TokenRequestContext([Constants.AZURE_DEVOPS_TOKEN_SCOPE]), interactiveLoginCts.Token);
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
                 {
                     throw;
                 }
@@ -105,6 +118,37 @@ namespace Azure.Sdk.Tools.Cli.Services
             RefreshConnection(ct);
             return _projectClient;
         }
+
+        public AccessToken GetToken(CancellationToken ct)
+        {
+            RefreshConnection(ct);
+            return _token!.Value;
+        }
+
+        private BuildHttpClient AnonymousBuildClient =>
+            _anonymousBuildClient ??= new VssConnection(
+                new Uri(Constants.AZURE_SDK_DEVOPS_BASE_URL),
+                new VssBasicCredential())
+                .GetClient<BuildHttpClient>();
+
+        /// <summary>
+        /// Runs a read-only Build operation anonymously first so that public build data (for example the
+        /// status, artifacts, timeline, or logs of a public Azure SDK pipeline run) can be read without
+        /// authentication.
+        /// </summary>
+        public async Task<T> ReadBuildWithAnonymousFallbackAsync<T>(Func<BuildHttpClient, Task<T>> operation, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                return await operation(AnonymousBuildClient);
+            }
+            catch (VssUnauthorizedException)
+            {
+                ct.ThrowIfCancellationRequested();
+                return await operation(GetBuildClient(ct));
+            }
+        }
     }
 
     public interface IDevOpsService
@@ -131,6 +175,9 @@ namespace Azure.Sdk.Tools.Cli.Services
         public Task<List<PackageWorkitemResponse>> ListPartialPackageWorkItemAsync(string packageName, string language, CancellationToken ct);
         public Task<Build> RunPipelineAsync(int pipelineDefinitionId, Dictionary<string, string> templateParams, string apiSpecBranchRef = "main", CancellationToken ct = default);
         public Task<Dictionary<string, List<string>>> GetPipelineLlmArtifacts(string project, int buildId, CancellationToken ct);
+        public Task<Build> GetBuildDetailsAsync(int buildId, string? project, CancellationToken ct);
+        public Task<Timeline> GetBuildTimelineAsync(string project, int buildId, CancellationToken ct);
+        public Task<List<string>> GetBuildLogLinesAsync(string project, int buildId, int logId, CancellationToken ct);
         public Task<WorkItem> UpdateWorkItemAsync(int workItemId, Dictionary<string, string> fields, CancellationToken ct);
         public Task<WorkItem> UpdateWorkItemAsync(int workItemId, Dictionary<string, string> fields, Dictionary<string, string> multilineFieldFormats, CancellationToken ct);
         public Task<List<GitHubLableWorkItem>> GetGitHubLableWorkItemsAsync(CancellationToken ct);
@@ -145,10 +192,14 @@ namespace Azure.Sdk.Tools.Cli.Services
         Task<WorkItem> CreateWorkItemRelationAsync(int id, string relationType, int? targetId = null, string? targetUrl = null, CancellationToken ct = default);
         Task RemoveWorkItemRelationAsync(int id, string relationType, int targetId, CancellationToken ct);
         Task DeleteWorkItemAsync(int workItemId, CancellationToken ct);
+        Task<BuildGitHubSource?> ResolveBuildGitHubSourceAsync(int buildId, string? project, CancellationToken ct);
     }
 
     public partial class DevOpsService(ILogger<DevOpsService> logger, IDevOpsConnection connection) : IDevOpsService
     {
+        private readonly HttpClient _noRedirectClient = new(new HttpClientHandler { AllowAutoRedirect = false });
+        private readonly HttpClient _downloadClient = new();
+
         private static readonly string RELEASE_PLANNER_APP_TEST = "Release Planner App Test";
         private static readonly string MISSING_EMITTER_CONFIG = "MissingEmitterConfig";
         private static readonly string NOT_APPLICABLE = "Not applicable";
@@ -156,6 +207,12 @@ namespace Azure.Sdk.Tools.Cli.Services
         private List<WorkItemRelationType>? _cachedRelationTypes;
 
         private static readonly string[] SUPPORTED_SDK_LANGUAGES = { "Dotnet", "JavaScript", "Python", "Java", "Go" };
+
+        private static bool IsAuthException(HttpStatusCode status) =>
+            status is HttpStatusCode.Unauthorized            // 401
+                   or HttpStatusCode.Forbidden               // 403
+                   or HttpStatusCode.Found                    // 302 (sign-in redirect)
+                   or HttpStatusCode.NonAuthoritativeInformation; // 203 (DevOps anonymous-needs-auth)
 
         [GeneratedRegex("\\|\\s(Beta|Stable|GA)\\s\\|\\s([\\S]+)\\s\\|\\s([\\S]+)\\s\\|")]
         private static partial Regex SdkReleaseDetailsRegex();
@@ -373,7 +430,7 @@ namespace Azure.Sdk.Tools.Cli.Services
                 LanguageExclusionRequesterNote = workItem.Fields.TryGetValue("Custom.ReleaseExclusionRequestNote", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 LanguageExclusionApproverNote = workItem.Fields.TryGetValue("Custom.ReleaseExclusionApprovalNote", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 APISpecProjectPath = workItem.Fields.TryGetValue("Custom.ApiSpecProjectPath", out value) ? value?.ToString() ?? string.Empty : string.Empty,
-                AttestationStatus = workItem.Fields.TryGetValue("Custom.AttestationStatus", out value) ? value?.ToString() ?? string.Empty : string.Empty,                
+                AttestationStatus = workItem.Fields.TryGetValue("Custom.AttestationStatus", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 ReleasePlanType = workItem.Fields.TryGetValue("Custom.ReleasePlanType", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 Owner = workItem.Fields.TryGetValue("Custom.PrimaryPM", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 IsTestReleasePlan = workItem.Fields.TryGetValue("System.Tags", out value) && value is String tags && tags.Contains(RELEASE_PLANNER_APP_TEST)
@@ -1001,6 +1058,87 @@ namespace Azure.Sdk.Tools.Cli.Services
             return await buildClient.GetBuildAsync(Constants.AZURE_SDK_DEVOPS_INTERNAL_PROJECT, buildId, cancellationToken: ct);
         }
 
+        /// <summary>
+        /// Reads build details (project, status, result) for a single run. When project is
+        /// null or empty the build is probed in the public project first and then the internal project, so a bare
+        /// build id resolves without the caller knowing which project owns it. Public runs are read anonymously
+        /// (no sign-in required) via the anonymous-first fallback; internal runs fall back to the authenticated client.
+        /// </summary>
+        public async Task<Build> GetBuildDetailsAsync(int buildId, string? project, CancellationToken ct)
+        {
+            string[] candidates = string.IsNullOrEmpty(project)
+                ? [Constants.AZURE_SDK_DEVOPS_PUBLIC_PROJECT, Constants.AZURE_SDK_DEVOPS_INTERNAL_PROJECT]
+                : [project];
+
+            foreach (var candidate in candidates)
+            {
+                try
+                {
+                    return await connection.ReadBuildWithAnonymousFallbackAsync(
+                        c => c.GetBuildAsync(candidate, buildId, cancellationToken: ct), ct);
+                }
+                catch (BuildNotFoundException)
+                {
+                    // The build does not live in this project; try the next candidate.
+                }
+            }
+
+            throw new BuildNotFoundException(
+                $"Build {buildId} was not found in any of the following projects: {string.Join(", ", candidates)}.");
+        }
+
+        /// <summary>
+        /// Reads the timeline (task and job records) for a build. Public runs are read anonymously via the
+        /// anonymous-first fallback; internal runs fall back to the authenticated client.
+        /// </summary>
+        public async Task<Timeline> GetBuildTimelineAsync(string project, int buildId, CancellationToken ct)
+        {
+            return await connection.ReadBuildWithAnonymousFallbackAsync(
+                c => c.GetBuildTimelineAsync(project, buildId, cancellationToken: ct), ct);
+        }
+
+        /// <summary>
+        /// Reads the lines of a single build log. A public run is fetched anonymously; a private or internal run
+        /// answers the anonymous request with a redirect to a sign-in page, so it is retried once with a bearer
+        /// token.
+        /// </summary>
+        public async Task<List<string>> GetBuildLogLinesAsync(string project, int buildId, int logId, CancellationToken ct)
+        {
+            var logUrl = $"{Constants.AZURE_SDK_DEVOPS_BASE_URL}/{project}/_apis/build/builds/{buildId}/logs/{logId}?api-version=7.1";
+
+            using var anonymousResponse = await _noRedirectClient.GetAsync(logUrl, ct);
+
+            string content;
+            // Check the auth-challenge statuses before IsSuccessStatusCode: a needs-auth 203 is itself a 2xx,
+            // so a success-first check would read the sign-in page as content instead of retrying with a token.
+            if (IsAuthException(anonymousResponse.StatusCode))
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, logUrl);
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", connection.GetToken(ct).Token);
+                using var authenticatedResponse = await _noRedirectClient.SendAsync(request, ct);
+                if (IsAuthException(authenticatedResponse.StatusCode))
+                {
+                    var body = await authenticatedResponse.Content.ReadAsStringAsync(ct);
+                    throw new HttpRequestException(
+                        $"Authenticated request to {logUrl} still returned an authentication status {(int)authenticatedResponse.StatusCode} ({authenticatedResponse.StatusCode}) after a bearer token was supplied; the token may be expired, lack the required scope, or target the wrong tenant: {body}");
+                }
+                authenticatedResponse.EnsureSuccessStatusCode();
+                content = await authenticatedResponse.Content.ReadAsStringAsync(ct);
+            }
+            else if (anonymousResponse.IsSuccessStatusCode)
+            {
+                content = await anonymousResponse.Content.ReadAsStringAsync(ct);
+            }
+            else
+            {
+                var body = await anonymousResponse.Content.ReadAsStringAsync(ct);
+                throw new HttpRequestException(
+                    $"Anonymous request to {logUrl} failed with status {(int)anonymousResponse.StatusCode} ({anonymousResponse.StatusCode}): {body}");
+            }
+
+            return string.IsNullOrEmpty(content) ? [] : content.Replace("\r\n", "\n").TrimEnd('\n').Split('\n').ToList();
+        }
+
         public async Task<string> GetSDKPullRequestFromPipelineRunAsync(int buildId, string language, int workItemId, CancellationToken ct)
         {
             var buildClient = connection.GetBuildClient(ct);
@@ -1499,139 +1637,133 @@ namespace Azure.Sdk.Tools.Cli.Services
             return sdkReleaseInfo;
         }
 
-        private async Task<Dictionary<string, List<string>>> GetLlmArtifactsAuthenticated(string project, int buildId, CancellationToken ct)
+        public async Task<Dictionary<string, List<string>>> GetPipelineLlmArtifacts(string project, int buildId, CancellationToken ct)
         {
-            var buildClient = connection.GetBuildClient(ct);
             var result = new Dictionary<string, List<string>>();
-            var artifacts = await buildClient.GetArtifactsAsync(project, buildId, cancellationToken: ct);
-            foreach (var artifact in artifacts)
+
+            var artifactsUrl = $"{Constants.AZURE_SDK_DEVOPS_BASE_URL}/{project}/_apis/build/builds/{buildId}/artifacts?api-version=7.1-preview.5";
+
+            // Read the artifact list anonymously; a private/internal build's anonymous read fails (its sign-in
+            // redirect surfaces as a non-success status because redirects are disabled), so it is retried with a
+            // bearer token that is then reused for the content downloads below.
+            using var anonymousResponse = await _noRedirectClient.GetAsync(artifactsUrl, ct);
+
+            string artifactsJson;
+            string? bearerToken = null;
+            // Check the auth-challenge statuses before IsSuccessStatusCode: a needs-auth 203 is itself a 2xx,
+            // so a success-first check would read the sign-in page as content instead of retrying with a token.
+            if (IsAuthException(anonymousResponse.StatusCode))
             {
-                if (artifact.Name.StartsWith("LLM Artifacts", StringComparison.OrdinalIgnoreCase))
+                bearerToken = connection.GetToken(ct).Token;
+                var request = new HttpRequestMessage(HttpMethod.Get, artifactsUrl);
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
+                using var authenticatedResponse = await _noRedirectClient.SendAsync(request, ct);
+                if (IsAuthException(authenticatedResponse.StatusCode))
                 {
-                    var tempDir = Path.Combine(Path.GetTempPath(), $"{artifact.Name}_{Guid.NewGuid()}");
-                    Directory.CreateDirectory(tempDir);
-
-                    logger.LogDebug("Downloading artifact '{artifactName}' to '{tempDir}'", artifact.Name, tempDir);
-
-                    using var stream = await buildClient.GetArtifactContentZipAsync(project, buildId, artifact.Name, cancellationToken: ct);
-                    var zipPath = Path.Combine(tempDir, "artifact.zip");
-                    using (var fileStream = File.Create(zipPath))
-                    {
-                        await stream.CopyToAsync(fileStream, ct);
-                    }
-
-                    await Task.Factory.StartNew(() =>
-                    {
-                        System.IO.Compression.ZipFile.ExtractToDirectory(zipPath, tempDir);
-                        File.Delete(zipPath);
-                    }, ct);
-
-                    var files = Directory.GetFiles(tempDir, "*", SearchOption.AllDirectories).ToList();
-                    result[artifact.Name] = files;
+                    var body = await authenticatedResponse.Content.ReadAsStringAsync(ct);
+                    throw new HttpRequestException(
+                        $"Authenticated request to {artifactsUrl} still returned an authentication status {(int)authenticatedResponse.StatusCode} ({authenticatedResponse.StatusCode}) after a bearer token was supplied; the token may be expired, lack the required scope, or target the wrong tenant: {body}");
                 }
+                authenticatedResponse.EnsureSuccessStatusCode();
+                artifactsJson = await authenticatedResponse.Content.ReadAsStringAsync(ct);
             }
+            else if (anonymousResponse.IsSuccessStatusCode)
+            {
+                artifactsJson = await anonymousResponse.Content.ReadAsStringAsync(ct);
+            }
+            else
+            {
+                var body = await anonymousResponse.Content.ReadAsStringAsync(ct);
+                throw new HttpRequestException(
+                    $"Anonymous request to {artifactsUrl} failed with status {(int)anonymousResponse.StatusCode} ({anonymousResponse.StatusCode}): {body}");
+            }
+
+            // Given an artifact name like "LLM Artifacts - Ubuntu2404_NET80_PackageRef_Debug - 1"
+            // where '1' == the job attempt number, only keep artifacts from the most recent attempt.
+            using var doc = JsonDocument.Parse(artifactsJson);
+            var llmArtifacts = doc.RootElement.GetProperty("value").EnumerateArray()
+                .Select(a => (
+                    Name: a.GetProperty("name").GetString() ?? string.Empty,
+                    DownloadUrl: a.TryGetProperty("resource", out var resource) && resource.TryGetProperty("downloadUrl", out var url)
+                        ? url.GetString()
+                        : null))
+                .Where(a => a.Name.StartsWith("LLM Artifacts", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(a.DownloadUrl))
+                .ToList();
+            if (llmArtifacts.Count == 0)
+            {
+                return result;
+            }
+            var mostRecentJobAttempt = llmArtifacts.Max(a => ParseLlmArtifactJobAttempt(a.Name));
+            if (mostRecentJobAttempt == 0)
+            {
+                // No artifact has a parseable job-attempt suffix; skip rather than treating attempt 0 as newest.
+                return result;
+            }
+            var mostRecentJobAttempts = llmArtifacts.Where(a => ParseLlmArtifactJobAttempt(a.Name) == mostRecentJobAttempt).ToList();
+
+            var tempDir = await PrepareArtifactTempDirAsync(buildId, ct);
+            var seenFiles = new HashSet<string>();
+            foreach (var artifact in mostRecentJobAttempts)
+            {
+                logger.LogDebug("Downloading artifact '{artifactName}' to '{tempDir}'", artifact.Name, tempDir);
+
+                var request = new HttpRequestMessage(HttpMethod.Get, artifact.DownloadUrl!);
+                if (!string.IsNullOrEmpty(bearerToken))
+                {
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
+                }
+
+                var zipPath = Path.Combine(tempDir, "artifact.zip");
+                using (var response = await _downloadClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct))
+                {
+                    response.EnsureSuccessStatusCode();
+                    using var stream = await response.Content.ReadAsStreamAsync(ct);
+                    using var fileStream = File.Create(zipPath);
+                    await stream.CopyToAsync(fileStream, ct);
+                }
+
+                await ExtractArtifactZipAsync(zipPath, tempDir, artifact.Name, seenFiles, result, ct);
+            }
+
             return result;
         }
 
-        private async Task<Dictionary<string, List<string>>> GetLlmArtifactsUnauthenticated(string project, int buildId, CancellationToken ct)
+        private static async Task<string> PrepareArtifactTempDirAsync(int buildId, CancellationToken ct)
         {
-            var result = new Dictionary<string, List<string>>();
-            using var httpClient = new HttpClient();
-            var artifactsUrl = $"{Constants.AZURE_SDK_DEVOPS_BASE_URL}/{project}/_apis/build/builds/{buildId}/artifacts?api-version=7.1-preview.5";
-            var artifactsResponse = await httpClient.GetAsync(artifactsUrl, ct);
-            // Devops will return a sign-in html page if the user is not authorized
-            if (artifactsResponse.StatusCode == System.Net.HttpStatusCode.NonAuthoritativeInformation)
-            {
-                throw new Exception($"Not authorized to get artifacts from {artifactsUrl}");
-            }
-            artifactsResponse.EnsureSuccessStatusCode();
-            var artifactsJson = await artifactsResponse.Content.ReadAsStringAsync(ct);
-            using var doc = JsonDocument.Parse(artifactsJson);
-            var artifacts = doc.RootElement.GetProperty("value").EnumerateArray();
-
-            var seenFiles = new HashSet<string>();
             var tempDir = Path.Combine(Path.GetTempPath(), buildId.ToString());
             if (Directory.Exists(tempDir))
             {
-                await Task.Factory.StartNew(() =>
-                {
-                    Directory.Delete(tempDir, true);
-                }, ct);
+                await Task.Factory.StartNew(() => Directory.Delete(tempDir, true), ct);
             }
             Directory.CreateDirectory(tempDir);
-
-            List<JsonElement> mostRecentArtifacts = [];
-            var mostRecentJobAttempt = 1;
-            // Given an artifact name like "LLM Artifacts - Ubuntu2404_NET80_PackageRef_Debug - 1"
-            // where '1' == the job attempt number
-            // only find artifacts from the most recent job attempt.
-            foreach (var artifact in artifacts)
-            {
-                var name = artifact.GetProperty("name").GetString();
-                var jobAttempt = name?.Split('-').LastOrDefault()?.Trim();
-                var jobAttemptNumber = int.TryParse(jobAttempt, out var attempt) ? attempt : 0;
-                if (jobAttemptNumber == mostRecentJobAttempt)
-                {
-                    mostRecentArtifacts.Add(artifact);
-                }
-                else if (jobAttemptNumber > mostRecentJobAttempt)
-                {
-                    mostRecentArtifacts.Clear();
-                    mostRecentArtifacts.Add(artifact);
-                }
-            }
-
-            foreach (var artifact in mostRecentArtifacts)
-            {
-                var name = artifact.GetProperty("name").GetString();
-                if (name == null || name.StartsWith("LLM Artifacts", StringComparison.OrdinalIgnoreCase) == false)
-                {
-                    continue;
-                }
-
-                var downloadUrl = artifact.GetProperty("resource").GetProperty("downloadUrl").GetString();
-                if (string.IsNullOrEmpty(downloadUrl))
-                {
-                    continue;
-                }
-
-                logger.LogDebug("Downloading artifact '{artifactName}' to '{tempDir}'", name, tempDir);
-
-                var zipPath = Path.Combine(tempDir, "artifact.zip");
-
-                using (var zipStream = await httpClient.GetStreamAsync(downloadUrl, ct))
-                using (var fileStream = File.Create(zipPath))
-                {
-                    await zipStream.CopyToAsync(fileStream, ct);
-                }
-
-                await Task.Factory.StartNew(() =>
-                {
-                    System.IO.Compression.ZipFile.ExtractToDirectory(zipPath, tempDir);
-                    File.Delete(zipPath);
-                }, ct);
-
-                var files = Directory.GetFiles(tempDir, "*", SearchOption.AllDirectories).ToList();
-                var newFiles = files.Where(f => !seenFiles.Contains(f)).ToList();
-                seenFiles.UnionWith(newFiles);
-
-                // Given an artifact name like "LLM Artifacts - Ubuntu2404_NET80_PackageRef_Debug - 1"
-                // create a key/platform name like "Ubuntu2404_NET80_PackageRef_Debug"
-                var parts = name.Split(" - ", StringSplitOptions.RemoveEmptyEntries);
-                var testPlatform = string.Join(" - ", parts[1..^1]);
-                result[testPlatform] = newFiles;
-            }
-
-            return result;
+            return tempDir;
         }
 
-        public async Task<Dictionary<string, List<string>>> GetPipelineLlmArtifacts(string project, int buildId, CancellationToken ct)
+        private static async Task ExtractArtifactZipAsync(string zipPath, string tempDir, string artifactName, HashSet<string> seenFiles, Dictionary<string, List<string>> result, CancellationToken ct)
         {
-            if (project == Constants.AZURE_SDK_DEVOPS_PUBLIC_PROJECT)
+            await Task.Factory.StartNew(() =>
             {
-                return await GetLlmArtifactsUnauthenticated(project, buildId, ct);
-            }
-            return await GetLlmArtifactsAuthenticated(project, buildId, ct);
+                System.IO.Compression.ZipFile.ExtractToDirectory(zipPath, tempDir, overwriteFiles: true);
+                File.Delete(zipPath);
+            }, ct);
+
+            var files = Directory.GetFiles(tempDir, "*", SearchOption.AllDirectories).ToList();
+            var newFiles = files.Where(f => !seenFiles.Contains(f)).ToList();
+            seenFiles.UnionWith(newFiles);
+
+            // Given an artifact name like "LLM Artifacts - Ubuntu2404_NET80_PackageRef_Debug - 1"
+            // create a key/platform name like "Ubuntu2404_NET80_PackageRef_Debug"
+            var parts = artifactName.Split(" - ", StringSplitOptions.RemoveEmptyEntries);
+            var testPlatform = string.Join(" - ", parts[1..^1]);
+            result[testPlatform] = newFiles;
+        }
+
+        private static int ParseLlmArtifactJobAttempt(string artifactName)
+        {
+            // Artifact names look like "LLM Artifacts - <platform> - <jobAttempt>"; split on the same " - "
+            // delimiter used to extract the platform name so the trailing job-attempt number is isolated.
+            var jobAttempt = artifactName.Split(" - ", StringSplitOptions.RemoveEmptyEntries).LastOrDefault()?.Trim();
+            return int.TryParse(jobAttempt, out var attempt) ? attempt : 0;
         }
 
         public async Task<WorkItem> UpdateWorkItemAsync(int workItemId, Dictionary<string, string> fields, CancellationToken ct)
@@ -2023,5 +2155,74 @@ namespace Azure.Sdk.Tools.Cli.Services
             var workItemClient = connection.GetWorkItemClient(ct);
             await workItemClient.DeleteWorkItemAsync(workItemId, destroy: false, cancellationToken: ct);
         }
+
+        /// <summary>
+        /// Best-effort resolution of the GitHub repository and commit a build ran against. Returns null when the
+        /// pipeline's source is not a GitHub repository (for example an Azure Repos run, whose repository id is a
+        /// GUID rather than "owner/repo"), so callers can skip GitHub lookups instead of failing.
+        /// </summary>
+        public async Task<BuildGitHubSource?> ResolveBuildGitHubSourceAsync(int buildId, string? project, CancellationToken ct)
+        {
+            var build = await GetBuildDetailsAsync(buildId, project, ct);
+
+            // GitHub-backed pipelines report the repository as type "GitHub" with an id of "owner/repo".
+            var repository = build.Repository;
+            if (repository == null || !string.Equals(repository.Type, "GitHub", StringComparison.OrdinalIgnoreCase))
+            {
+                logger.LogDebug("Build {buildId} does not have a GitHub repository (type '{repositoryType}')", buildId, repository?.Type ?? "unknown");
+                return null;
+            }
+
+            var parts = repository.Id?.Split('/');
+            if (parts == null || parts.Length != 2 || string.IsNullOrEmpty(parts[0]) || string.IsNullOrEmpty(parts[1]))
+            {
+                logger.LogDebug("Build {buildId} has a GitHub repository id '{repositoryId}' that is not in 'owner/repo' form", buildId, repository.Id ?? "unknown");
+                return null;
+            }
+
+            return new BuildGitHubSource(parts[0], parts[1], ResolveHeadSha(build), ResolvePullRequestNumber(build));
+        }
+
+        /// <summary>
+        /// Resolves the commit SHA that a build actually ran against. For a PR validation run the source branch is
+        /// a `refs/pull/&lt;n&gt;/merge` ref and <see cref="Build.SourceVersion"/> is the ephemeral merge commit, which
+        /// does not exist in the GitHub repository; in that case the PR head SHA reported by the trigger info is
+        /// used instead. Both values are recorded on the build, so an old build resolves to the commit it tested
+        /// rather than to the current head of the branch or pull request. Returns null when the build reports no
+        /// source version.
+        /// </summary>
+        private static string? ResolveHeadSha(Build build)
+        {
+            var sourceVersion = build.SourceVersion;
+            if (string.IsNullOrEmpty(sourceVersion))
+            {
+                return null;
+            }
+
+            var isMerge = build.SourceBranch?.EndsWith("/merge", StringComparison.OrdinalIgnoreCase) == true;
+            if (!isMerge)
+            {
+                return sourceVersion;
+            }
+
+            return build.TriggerInfo != null
+                && build.TriggerInfo.TryGetValue("pr.sourceSha", out var prSourceSha)
+                && !string.IsNullOrEmpty(prSourceSha)
+                    ? prSourceSha
+                    : sourceVersion;
+        }
+
+        /// <summary>
+        /// Resolves the pull request a build validated, from its `refs/pull/&lt;n&gt;/merge` source branch. Returns
+        /// null for builds triggered by a branch push rather than a pull request.
+        /// </summary>
+        private static int? ResolvePullRequestNumber(Build build)
+        {
+            var match = PullRequestBranchRegex().Match(build.SourceBranch ?? "");
+            return match.Success && int.TryParse(match.Groups[1].Value, out var prNumber) ? prNumber : null;
+        }
+
+        [GeneratedRegex(@"^refs/pull/(\d+)/", RegexOptions.IgnoreCase)]
+        private static partial Regex PullRequestBranchRegex();
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -192,7 +192,7 @@ namespace Azure.Sdk.Tools.Cli.Services
         Task<WorkItem> CreateWorkItemRelationAsync(int id, string relationType, int? targetId = null, string? targetUrl = null, CancellationToken ct = default);
         Task RemoveWorkItemRelationAsync(int id, string relationType, int targetId, CancellationToken ct);
         Task DeleteWorkItemAsync(int workItemId, CancellationToken ct);
-        Task<BuildGitHubSource?> ResolveBuildGitHubSourceAsync(int buildId, string? project, CancellationToken ct);
+        Task<GitHubCommitRef?> ResolveBuildCommitRefAsync(int buildId, string? project, CancellationToken ct);
     }
 
     public partial class DevOpsService(ILogger<DevOpsService> logger, IDevOpsConnection connection) : IDevOpsService
@@ -2159,9 +2159,10 @@ namespace Azure.Sdk.Tools.Cli.Services
         /// <summary>
         /// Best-effort resolution of the GitHub repository and commit a build ran against. Returns null when the
         /// pipeline's source is not a GitHub repository (for example an Azure Repos run, whose repository id is a
-        /// GUID rather than "owner/repo"), so callers can skip GitHub lookups instead of failing.
+        /// GUID rather than "owner/repo") or when the build reports no source version, so callers can skip GitHub
+        /// lookups instead of failing.
         /// </summary>
-        public async Task<BuildGitHubSource?> ResolveBuildGitHubSourceAsync(int buildId, string? project, CancellationToken ct)
+        public async Task<GitHubCommitRef?> ResolveBuildCommitRefAsync(int buildId, string? project, CancellationToken ct)
         {
             var build = await GetBuildDetailsAsync(buildId, project, ct);
 
@@ -2180,7 +2181,14 @@ namespace Azure.Sdk.Tools.Cli.Services
                 return null;
             }
 
-            return new BuildGitHubSource(parts[0], parts[1], ResolveHeadSha(build), ResolvePullRequestNumber(build));
+            var headSha = ResolveHeadSha(build);
+            if (string.IsNullOrEmpty(headSha))
+            {
+                logger.LogDebug("Build {buildId} reports no source version, so it cannot be correlated to a commit", buildId);
+                return null;
+            }
+
+            return new GitHubCommitRef(parts[0], parts[1], headSha, ResolvePullRequestNumber(build));
         }
 
         /// <summary>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -143,7 +143,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             {
                 return await operation(AnonymousBuildClient);
             }
-            catch (VssUnauthorizedException)
+            catch (VssException ex) when (ex is not BuildException)
             {
                 ct.ThrowIfCancellationRequested();
                 return await operation(GetBuildClient(ct));
@@ -197,8 +197,8 @@ namespace Azure.Sdk.Tools.Cli.Services
 
     public partial class DevOpsService(ILogger<DevOpsService> logger, IDevOpsConnection connection) : IDevOpsService
     {
-        private readonly HttpClient _noRedirectClient = new(new HttpClientHandler { AllowAutoRedirect = false });
-        private readonly HttpClient _downloadClient = new();
+        private static readonly HttpClient _noRedirectClient = new(new HttpClientHandler { AllowAutoRedirect = false });
+        private static readonly HttpClient _downloadClient = new();
 
         private static readonly string RELEASE_PLANNER_APP_TEST = "Release Planner App Test";
         private static readonly string MISSING_EMITTER_CONFIG = "MissingEmitterConfig";

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -27,12 +27,11 @@ namespace Azure.Sdk.Tools.Cli.Services
     public interface IDevOpsConnection
     {
         public BuildHttpClient GetBuildClient(CancellationToken ct);
+        public BuildHttpClient GetAnonymousBuildClient();
         public WorkItemTrackingHttpClient GetWorkItemClient(CancellationToken ct);
         public ProjectHttpClient GetProjectClient(CancellationToken ct);
 
         public AccessToken GetToken(CancellationToken ct);
-
-        public Task<T> ReadBuildWithAnonymousFallbackAsync<T>(Func<BuildHttpClient, Task<T>> operation, CancellationToken ct);
     }
 
     public class DevOpsConnection(IAzureService azureService) : IDevOpsConnection
@@ -107,6 +106,15 @@ namespace Azure.Sdk.Tools.Cli.Services
             return _buildClient;
         }
 
+        /// <summary>
+        /// An unauthenticated Build client suitable for read-only access to public Azure SDK pipeline runs.
+        /// </summary>
+        public BuildHttpClient GetAnonymousBuildClient() =>
+            _anonymousBuildClient ??= new VssConnection(
+                new Uri(Constants.AZURE_SDK_DEVOPS_BASE_URL),
+                new VssBasicCredential())
+                .GetClient<BuildHttpClient>();
+
         public WorkItemTrackingHttpClient GetWorkItemClient(CancellationToken ct)
         {
             RefreshConnection(ct);
@@ -123,31 +131,6 @@ namespace Azure.Sdk.Tools.Cli.Services
         {
             RefreshConnection(ct);
             return _token!.Value;
-        }
-
-        private BuildHttpClient AnonymousBuildClient =>
-            _anonymousBuildClient ??= new VssConnection(
-                new Uri(Constants.AZURE_SDK_DEVOPS_BASE_URL),
-                new VssBasicCredential())
-                .GetClient<BuildHttpClient>();
-
-        /// <summary>
-        /// Runs a read-only Build operation anonymously first so that public build data (for example the
-        /// status, artifacts, timeline, or logs of a public Azure SDK pipeline run) can be read without
-        /// authentication.
-        /// </summary>
-        public async Task<T> ReadBuildWithAnonymousFallbackAsync<T>(Func<BuildHttpClient, Task<T>> operation, CancellationToken ct)
-        {
-            ct.ThrowIfCancellationRequested();
-            try
-            {
-                return await operation(AnonymousBuildClient);
-            }
-            catch (VssException ex) when (ex is not BuildException)
-            {
-                ct.ThrowIfCancellationRequested();
-                return await operation(GetBuildClient(ct));
-            }
         }
     }
 
@@ -1062,7 +1045,7 @@ namespace Azure.Sdk.Tools.Cli.Services
         /// Reads build details (project, status, result) for a single run. When project is
         /// null or empty the build is probed in the public project first and then the internal project, so a bare
         /// build id resolves without the caller knowing which project owns it. Public runs are read anonymously
-        /// (no sign-in required) via the anonymous-first fallback; internal runs fall back to the authenticated client.
+        /// (no sign-in required); internal runs fall back to the authenticated client.
         /// </summary>
         public async Task<Build> GetBuildDetailsAsync(int buildId, string? project, CancellationToken ct)
         {
@@ -1074,8 +1057,15 @@ namespace Azure.Sdk.Tools.Cli.Services
             {
                 try
                 {
-                    return await connection.ReadBuildWithAnonymousFallbackAsync(
-                        c => c.GetBuildAsync(candidate, buildId, cancellationToken: ct), ct);
+                    try
+                    {
+                        return await connection.GetAnonymousBuildClient().GetBuildAsync(candidate, buildId, cancellationToken: ct);
+                    }
+                    catch (VssException ex) when (ex is not BuildException)
+                    {
+                        ct.ThrowIfCancellationRequested();
+                        return await connection.GetBuildClient(ct).GetBuildAsync(candidate, buildId, cancellationToken: ct);
+                    }
                 }
                 catch (BuildNotFoundException)
                 {
@@ -1088,13 +1078,20 @@ namespace Azure.Sdk.Tools.Cli.Services
         }
 
         /// <summary>
-        /// Reads the timeline (task and job records) for a build. Public runs are read anonymously via the
-        /// anonymous-first fallback; internal runs fall back to the authenticated client.
+        /// Reads the timeline (task and job records) for a build. Public runs are read anonymously
+        /// (no sign-in required); internal runs fall back to the authenticated client.
         /// </summary>
         public async Task<Timeline> GetBuildTimelineAsync(string project, int buildId, CancellationToken ct)
         {
-            return await connection.ReadBuildWithAnonymousFallbackAsync(
-                c => c.GetBuildTimelineAsync(project, buildId, cancellationToken: ct), ct);
+            try
+            {
+                return await connection.GetAnonymousBuildClient().GetBuildTimelineAsync(project, buildId, cancellationToken: ct);
+            }
+            catch (VssException ex) when (ex is not BuildException)
+            {
+                ct.ThrowIfCancellationRequested();
+                return await connection.GetBuildClient(ct).GetBuildTimelineAsync(project, buildId, cancellationToken: ct);
+            }
         }
 
         /// <summary>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/GitHubService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/GitHubService.cs
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
 using Azure.Sdk.Tools.Cli.Configuration;
 using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Models;
 using Octokit;
 
 namespace Azure.Sdk.Tools.Cli.Services
@@ -134,6 +138,7 @@ namespace Azure.Sdk.Tools.Cli.Services
         public Task<string> GetGitHubParentRepoUrlAsync(string owner, string repoName, CancellationToken ct);
         public Task<PullRequestResult> CreatePullRequestAsync(string repoName, string repoOwner, string baseBranch, string headBranch, string title, string body, bool draft = true, CancellationToken ct = default);
         public Task<List<string>> GetPullRequestCommentsAsync(string repoOwner, string repoName, int pullRequestNumber, CancellationToken ct);
+        public Task<IReadOnlyList<PullRequestCommit>> GetPullRequestCommitsAsync(string repoOwner, string repoName, int pullRequestNumber, CancellationToken ct);
         public Task<PullRequest?> GetPullRequestForBranchAsync(string repoOwner, string repoName, string remoteBranch, CancellationToken ct);
         public Task<IReadOnlyList<PullRequest?>> SearchPullRequestsByTitleAsync(string repoOwner, string repoName, string titleSearchTerm, ItemState? state = ItemState.Open, CancellationToken ct = default);
         public Task<Issue> GetIssueAsync(string repoOwner, string repoName, int issueNumber, CancellationToken ct);
@@ -153,6 +158,10 @@ namespace Azure.Sdk.Tools.Cli.Services
         public Task<Octokit.SearchCodeResult> SearchFilesAsync(string searchQuery, CancellationToken ct);
         public Task<Team> GetTeamByNameAsync(string org, string teamSlug, CancellationToken ct);
         public Task<HashSet<string>> GetRepoLabels(string owner, string repo, CancellationToken ct);
+        public Task<IReadOnlyList<WorkflowRun>> GetFailedWorkflowRunsForCommitAsync(string owner, string repo, string commitSha, CancellationToken ct);
+        public Task<string?> GetWorkflowRunLogsAsync(string owner, string repo, long runId, CancellationToken ct);
+        public Task<IReadOnlyList<WorkflowJob>> GetWorkflowRunJobsAsync(string owner, string repo, long runId, CancellationToken ct);
+        public Task<List<PrCheckRun>> GetPrCheckRunsAsync(string owner, string repo, int prNumber, CancellationToken ct);
     }
 
     // We enforce cancellation token usage broadly via an analyzer across this codebase,
@@ -162,11 +171,14 @@ namespace Azure.Sdk.Tools.Cli.Services
     public class GitHubService : GitConnection, IGitHubService
     {
         private readonly ILogger<GitHubService> logger;
-        public GitHubService(ILogger<GitHubService> _logger, IProcessHelper processHelper) : base(processHelper)
+        private readonly IHttpClientFactory httpClientFactory;
+
+        public GitHubService(ILogger<GitHubService> _logger, IProcessHelper processHelper, IHttpClientFactory httpClientFactory) : base(processHelper)
         {
             logger = _logger;
+            this.httpClientFactory = httpClientFactory;
         }
-
+        
         public string GetAuthToken() => GetGitHubAuthToken();
 
         public async Task<User> GetGitUserDetailsAsync(CancellationToken ct)
@@ -512,6 +524,11 @@ namespace Azure.Sdk.Tools.Cli.Services
             }
         }
 
+        public async Task<IReadOnlyList<PullRequestCommit>> GetPullRequestCommitsAsync(string repoOwner, string repoName, int pullRequestNumber, CancellationToken ct)
+        {
+            return await gitHubClient.PullRequest.Commits(repoOwner, repoName, pullRequestNumber);
+        }
+
         public async Task<List<String>> GetPullRequestChecksAsync(int pullRequestNumber, string repoName, string repoOwner, CancellationToken ct)
         {
             var checkResults = new List<string>();
@@ -746,6 +763,220 @@ namespace Azure.Sdk.Tools.Cli.Services
         {
             var labels = await gitHubClient.Issue.Labels.GetAllForRepository(owner, repo);
             return labels.Select(l => l.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Lists the failed GitHub Actions workflow runs triggered by a specific commit. For a pull request
+        /// build this must be the PR head SHA, since no run is associated with the ephemeral merge commit.
+        /// </summary>
+        public async Task<IReadOnlyList<WorkflowRun>> GetFailedWorkflowRunsForCommitAsync(string owner, string repo, string commitSha, CancellationToken ct)
+        {
+            logger.LogInformation("Getting failed workflow runs for commit {CommitSha} in {Owner}/{Repo}", commitSha, owner, repo);
+
+            // A commit in this org can carry dozens of runs, nearly all of them green, so the failures are
+            // selected by the API rather than fetched and discarded here.
+            var request = new WorkflowRunsRequest
+            {
+                HeadSha = commitSha,
+                Status = CheckRunStatusFilter.Failure,
+            };
+            var response = await ReadWithAnonymousFallbackAsync(client => client.Actions.Workflows.Runs.List(owner, repo, request), ct);
+            return response?.WorkflowRuns ?? [];
+        }
+
+        /// <summary>
+        /// Downloads the log archive for a workflow run and flattens it to text. GitHub returns a zip whose
+        /// root entries are the complete per-job logs and whose subfolder entries are the same content split
+        /// per step, so only the root entries are read to avoid emitting every line twice. Returns null when
+        /// the run has no logs (they expire, and in-progress runs may not have published any yet).
+        /// </summary>
+        public async Task<string?> GetWorkflowRunLogsAsync(string owner, string repo, long runId, CancellationToken ct)
+        {
+            logger.LogInformation("Getting logs for workflow run {RunId} in {Owner}/{Repo}", runId, owner, repo);
+            var archive = await ReadWithAnonymousFallbackAsync(client => client.Actions.Workflows.Runs.GetLogs(owner, repo, runId), ct);
+            if (archive == null || archive.Length == 0)
+            {
+                return null;
+            }
+
+            using var stream = new MemoryStream(archive);
+            using var zip = new ZipArchive(stream, ZipArchiveMode.Read);
+
+            var builder = new StringBuilder();
+            foreach (var entry in zip.Entries.Where(e => !e.FullName.Contains('/') && e.Length > 0))
+            {
+                using var reader = new StreamReader(entry.Open());
+                builder.AppendLine($"===== {entry.FullName} =====");
+                builder.AppendLine(await reader.ReadToEndAsync(ct));
+            }
+
+            return builder.Length == 0 ? null : builder.ToString();
+        }
+
+        public async Task<IReadOnlyList<WorkflowJob>> GetWorkflowRunJobsAsync(string owner, string repo, long runId, CancellationToken ct)
+        {
+            logger.LogInformation("Getting jobs for workflow run {RunId} in {Owner}/{Repo}", runId, owner, repo);
+            var response = await ReadWithAnonymousFallbackAsync(client => client.Actions.Workflows.Jobs.List(owner, repo, runId), ct);
+            return response?.Jobs ?? [];
+        }
+
+        private const string CheckRunsGraphQLQuery = @"
+query($owner: String!, $repo: String!, $pr: Int!, $after: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      commits(last: 1) {
+        nodes {
+          commit {
+            statusCheckRollup {
+              contexts(first: 100, after: $after) {
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+                nodes {
+                  __typename
+                  ... on CheckRun {
+                    name
+                    conclusion
+                    detailsUrl
+                    checkSuite { app { name } }
+                  }
+                  ... on StatusContext {
+                    context
+                    state
+                    targetUrl
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}";
+
+        /// <summary>
+        /// Lists the CI checks reported on a pull request's latest commit. Uses GraphQL rather than Octokit
+        /// because the status-check rollup returns check runs and legacy commit statuses together; the REST
+        /// equivalent requires a separate call per shape and a prior lookup of the head SHA.
+        /// </summary>
+        public async Task<List<PrCheckRun>> GetPrCheckRunsAsync(string owner, string repo, int prNumber, CancellationToken ct)
+        {
+            logger.LogDebug("Querying GitHub GraphQL for PR check runs: {owner}/{repo}#{prNumber}", owner, repo, prNumber);
+
+            var checkRuns = new List<PrCheckRun>();
+            string? after = null;
+
+            // Repositories in this org routinely report more checks than fit in a single page, and a truncated
+            // rollup would silently drop failed checks, so every page is read before returning.
+            do
+            {
+                using var doc = await PostGraphQLAsync(CheckRunsGraphQLQuery, new { owner, repo, pr = prNumber, after }, ct);
+
+                var nodes = doc.RootElement
+                    .GetProperty("data")
+                    .GetProperty("repository")
+                    .GetProperty("pullRequest")
+                    .GetProperty("commits")
+                    .GetProperty("nodes");
+
+                after = null;
+                foreach (var commitNode in nodes.EnumerateArray())
+                {
+                    var rollup = commitNode.GetProperty("commit").GetProperty("statusCheckRollup");
+                    if (rollup.ValueKind == JsonValueKind.Null)
+                    {
+                        continue;
+                    }
+
+                    var contexts = rollup.GetProperty("contexts");
+                    foreach (var contextNode in contexts.GetProperty("nodes").EnumerateArray())
+                    {
+                        var typeName = contextNode.GetProperty("__typename").GetString();
+
+                        if (typeName == "CheckRun")
+                        {
+                            checkRuns.Add(new PrCheckRun
+                            {
+                                Type = "CheckRun",
+                                Name = contextNode.GetProperty("name").GetString() ?? "",
+                                Conclusion = contextNode.GetProperty("conclusion").GetString(),
+                                DetailsUrl = contextNode.GetProperty("detailsUrl").GetString(),
+                                AppName = ReadCheckSuiteAppName(contextNode),
+                            });
+                        }
+                        else if (typeName == "StatusContext")
+                        {
+                            checkRuns.Add(new PrCheckRun
+                            {
+                                Type = "StatusContext",
+                                Name = contextNode.GetProperty("context").GetString() ?? "",
+                                Conclusion = contextNode.GetProperty("state").GetString(),
+                                DetailsUrl = contextNode.GetProperty("targetUrl").GetString(),
+                                AppName = "StatusContext",
+                            });
+                        }
+                    }
+
+                    var pageInfo = contexts.GetProperty("pageInfo");
+                    if (pageInfo.GetProperty("hasNextPage").GetBoolean())
+                    {
+                        after = pageInfo.GetProperty("endCursor").GetString();
+                    }
+                }
+            }
+            while (after != null);
+
+            return checkRuns;
+        }
+
+        /// <summary>
+        /// Reads the name of the GitHub App that produced a check run. The app is optional in the schema and is
+        /// absent for check suites whose app has since been uninstalled, so a missing one is not an error.
+        /// </summary>
+        private static string? ReadCheckSuiteAppName(JsonElement checkRunNode)
+        {
+            if (checkRunNode.TryGetProperty("checkSuite", out var checkSuite)
+                && checkSuite.ValueKind == JsonValueKind.Object
+                && checkSuite.TryGetProperty("app", out var app)
+                && app.ValueKind == JsonValueKind.Object)
+            {
+                return app.GetProperty("name").GetString();
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Posts a GraphQL query and returns the parsed response, translating the errors GitHub reports in the
+        /// body of an otherwise successful response into an exception. The caller owns the returned document.
+        /// </summary>
+        private async Task<JsonDocument> PostGraphQLAsync(string query, object variables, CancellationToken ct)
+        {
+            var httpClient = httpClientFactory.CreateClient();
+            httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GetGitHubAuthToken());
+            httpClient.DefaultRequestHeaders.UserAgent.Add(new System.Net.Http.Headers.ProductInfoHeaderValue("AzureSDKDevToolsMCP", "1.0"));
+
+            var requestBody = JsonSerializer.Serialize(new { query, variables });
+
+            var response = await httpClient.PostAsync(
+                "https://api.github.com/graphql",
+                new StringContent(requestBody, Encoding.UTF8, "application/json"),
+                ct);
+            response.EnsureSuccessStatusCode();
+
+            var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync(ct));
+
+            // GraphQL reports failures in the body with a 200 status, so this has to be checked explicitly.
+            if (doc.RootElement.TryGetProperty("errors", out var errors))
+            {
+                var errorMsg = errors.EnumerateArray().FirstOrDefault().GetProperty("message").GetString();
+                doc.Dispose();
+                throw new Exception($"GitHub GraphQL error: {errorMsg}");
+            }
+
+            return doc;
         }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/GitHubService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/GitHubService.cs
@@ -138,7 +138,6 @@ namespace Azure.Sdk.Tools.Cli.Services
         public Task<string> GetGitHubParentRepoUrlAsync(string owner, string repoName, CancellationToken ct);
         public Task<PullRequestResult> CreatePullRequestAsync(string repoName, string repoOwner, string baseBranch, string headBranch, string title, string body, bool draft = true, CancellationToken ct = default);
         public Task<List<string>> GetPullRequestCommentsAsync(string repoOwner, string repoName, int pullRequestNumber, CancellationToken ct);
-        public Task<IReadOnlyList<PullRequestCommit>> GetPullRequestCommitsAsync(string repoOwner, string repoName, int pullRequestNumber, CancellationToken ct);
         public Task<PullRequest?> GetPullRequestForBranchAsync(string repoOwner, string repoName, string remoteBranch, CancellationToken ct);
         public Task<IReadOnlyList<PullRequest?>> SearchPullRequestsByTitleAsync(string repoOwner, string repoName, string titleSearchTerm, ItemState? state = ItemState.Open, CancellationToken ct = default);
         public Task<Issue> GetIssueAsync(string repoOwner, string repoName, int issueNumber, CancellationToken ct);
@@ -522,11 +521,6 @@ namespace Azure.Sdk.Tools.Cli.Services
                 responseList.Add($"Failed to get comments for pull request {pullRequestNumber}. Error: {ex.Message}");
                 return responseList;
             }
-        }
-
-        public async Task<IReadOnlyList<PullRequestCommit>> GetPullRequestCommitsAsync(string repoOwner, string repoName, int pullRequestNumber, CancellationToken ct)
-        {
-            return await gitHubClient.PullRequest.Commits(repoOwner, repoName, pullRequestNumber);
         }
 
         public async Task<List<String>> GetPullRequestChecksAsync(int pullRequestNumber, string repoName, string repoOwner, CancellationToken ct)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/GitHubService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/GitHubService.cs
@@ -159,7 +159,7 @@ namespace Azure.Sdk.Tools.Cli.Services
         public Task<Team> GetTeamByNameAsync(string org, string teamSlug, CancellationToken ct);
         public Task<HashSet<string>> GetRepoLabels(string owner, string repo, CancellationToken ct);
         public Task<IReadOnlyList<WorkflowRun>> GetFailedWorkflowRunsForCommitAsync(string owner, string repo, string commitSha, CancellationToken ct);
-        public Task<string?> GetFailedWorkflowRunLogsAsync(string owner, string repo, long runId, CancellationToken ct);
+        public Task<IReadOnlyList<(string Name, string Content)>> GetFailedWorkflowRunLogsAsync(string owner, string repo, long runId, CancellationToken ct);
         public Task<IReadOnlyList<WorkflowJob>> GetWorkflowRunJobsAsync(string owner, string repo, long runId, CancellationToken ct);
         public Task<List<PrCheckRun>> GetPrCheckRunsAsync(string owner, string repo, int prNumber, CancellationToken ct);
     }
@@ -778,14 +778,14 @@ namespace Azure.Sdk.Tools.Cli.Services
             var response = await ReadWithAnonymousFallbackAsync(client => client.Actions.Workflows.Runs.List(owner, repo, request), ct);
             return response?.WorkflowRuns ?? [];
         }
-
-        public async Task<string?> GetFailedWorkflowRunLogsAsync(string owner, string repo, long runId, CancellationToken ct)
+        
+        public async Task<IReadOnlyList<(string Name, string Content)>> GetFailedWorkflowRunLogsAsync(string owner, string repo, long runId, CancellationToken ct)
         {
             logger.LogInformation("Getting logs for workflow run {RunId} in {Owner}/{Repo}", runId, owner, repo);
             var archive = await ReadWithAnonymousFallbackAsync(client => client.Actions.Workflows.Runs.GetLogs(owner, repo, runId), ct);
             if (archive == null || archive.Length == 0)
             {
-                return null;
+                return [];
             }
 
             // A failure to list the jobs costs the step filtering, not the logs, so the whole run is reported.
@@ -809,15 +809,14 @@ namespace Azure.Sdk.Tools.Cli.Services
                 entries = [.. zip.Entries.Where(e => JobLogNameOf(e) != null && e.Length > 0)];
             }
 
-            var builder = new StringBuilder();
+            List<(string Name, string Content)> logs = [];
             foreach (var entry in entries)
             {
                 using var reader = new StreamReader(entry.Open());
-                builder.AppendLine($"===== {entry.FullName} =====");
-                builder.AppendLine(await reader.ReadToEndAsync(ct));
+                logs.Add((entry.FullName, await reader.ReadToEndAsync(ct)));
             }
 
-            return builder.Length == 0 ? null : builder.ToString();
+            return logs;
         }
 
         /// <summary>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/GitHubService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/GitHubService.cs
@@ -868,10 +868,23 @@ query($owner: String!, $repo: String!, $pr: Int!, $after: String) {
             {
                 using var doc = await PostGraphQLAsync(CheckRunsGraphQLQuery, new { owner, repo, pr = prNumber, after }, ct);
 
-                var nodes = doc.RootElement
-                    .GetProperty("data")
-                    .GetProperty("repository")
-                    .GetProperty("pullRequest")
+                // A missing repository or a null pullRequest (wrong name, private, or
+                // deleted) otherwise surfaces as an opaque KeyNotFound/InvalidOperation deep in the chain.
+                if (!doc.RootElement.TryGetProperty("data", out var data)
+                    || data.ValueKind != JsonValueKind.Object
+                    || !data.TryGetProperty("repository", out var repository)
+                    || repository.ValueKind != JsonValueKind.Object)
+                {
+                    throw new Exception($"GitHub GraphQL response did not contain repository data for {owner}/{repo}.");
+                }
+
+                if (!repository.TryGetProperty("pullRequest", out var pullRequest)
+                    || pullRequest.ValueKind == JsonValueKind.Null)
+                {
+                    throw new Exception($"Pull request #{prNumber} was not found in {owner}/{repo}.");
+                }
+
+                var nodes = pullRequest
                     .GetProperty("commits")
                     .GetProperty("nodes");
 
@@ -963,11 +976,17 @@ query($owner: String!, $repo: String!, $pr: Int!, $after: String) {
             var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync(ct));
 
             // GraphQL reports failures in the body with a 200 status, so this has to be checked explicitly.
-            if (doc.RootElement.TryGetProperty("errors", out var errors))
+            if (doc.RootElement.TryGetProperty("errors", out var errors)
+                && errors.ValueKind == JsonValueKind.Array
+                && errors.GetArrayLength() > 0)
             {
-                var errorMsg = errors.EnumerateArray().FirstOrDefault().GetProperty("message").GetString();
+                var firstError = errors[0];
+                var errorMsg = firstError.ValueKind == JsonValueKind.Object
+                    && firstError.TryGetProperty("message", out var messageElement)
+                        ? messageElement.GetString()
+                        : null;
                 doc.Dispose();
-                throw new Exception($"GitHub GraphQL error: {errorMsg}");
+                throw new Exception($"GitHub GraphQL error: {errorMsg ?? "unknown error"}");
             }
 
             return doc;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/GitHubService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/GitHubService.cs
@@ -3,6 +3,7 @@
 using System.IO.Compression;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Azure.Sdk.Tools.Cli.Configuration;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
@@ -158,7 +159,7 @@ namespace Azure.Sdk.Tools.Cli.Services
         public Task<Team> GetTeamByNameAsync(string org, string teamSlug, CancellationToken ct);
         public Task<HashSet<string>> GetRepoLabels(string owner, string repo, CancellationToken ct);
         public Task<IReadOnlyList<WorkflowRun>> GetFailedWorkflowRunsForCommitAsync(string owner, string repo, string commitSha, CancellationToken ct);
-        public Task<string?> GetWorkflowRunLogsAsync(string owner, string repo, long runId, CancellationToken ct);
+        public Task<string?> GetFailedWorkflowRunLogsAsync(string owner, string repo, long runId, CancellationToken ct);
         public Task<IReadOnlyList<WorkflowJob>> GetWorkflowRunJobsAsync(string owner, string repo, long runId, CancellationToken ct);
         public Task<List<PrCheckRun>> GetPrCheckRunsAsync(string owner, string repo, int prNumber, CancellationToken ct);
     }
@@ -778,13 +779,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             return response?.WorkflowRuns ?? [];
         }
 
-        /// <summary>
-        /// Downloads the log archive for a workflow run and flattens it to text. GitHub returns a zip whose
-        /// root entries are the complete per-job logs and whose subfolder entries are the same content split
-        /// per step, so only the root entries are read to avoid emitting every line twice. Returns null when
-        /// the run has no logs (they expire, and in-progress runs may not have published any yet).
-        /// </summary>
-        public async Task<string?> GetWorkflowRunLogsAsync(string owner, string repo, long runId, CancellationToken ct)
+        public async Task<string?> GetFailedWorkflowRunLogsAsync(string owner, string repo, long runId, CancellationToken ct)
         {
             logger.LogInformation("Getting logs for workflow run {RunId} in {Owner}/{Repo}", runId, owner, repo);
             var archive = await ReadWithAnonymousFallbackAsync(client => client.Actions.Workflows.Runs.GetLogs(owner, repo, runId), ct);
@@ -793,11 +788,29 @@ namespace Azure.Sdk.Tools.Cli.Services
                 return null;
             }
 
+            // A failure to list the jobs costs the step filtering, not the logs, so the whole run is reported.
+            IReadOnlyList<WorkflowJob> jobs = [];
+            try
+            {
+                jobs = await GetWorkflowRunJobsAsync(owner, repo, runId, ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Could not list the jobs of workflow run {RunId}; reporting its full logs", runId);
+            }
+
             using var stream = new MemoryStream(archive);
             using var zip = new ZipArchive(stream, ZipArchiveMode.Read);
 
+            var entries = SelectFailedStepLogEntries(zip, jobs);
+            if (entries.Count == 0)
+            {
+                logger.LogDebug("No failed step logs matched for workflow run {RunId}; falling back to the full job logs", runId);
+                entries = [.. zip.Entries.Where(e => JobLogNameOf(e) != null && e.Length > 0)];
+            }
+
             var builder = new StringBuilder();
-            foreach (var entry in zip.Entries.Where(e => !e.FullName.Contains('/') && e.Length > 0))
+            foreach (var entry in entries)
             {
                 using var reader = new StreamReader(entry.Open());
                 builder.AppendLine($"===== {entry.FullName} =====");
@@ -806,6 +819,59 @@ namespace Azure.Sdk.Tools.Cli.Services
 
             return builder.Length == 0 ? null : builder.ToString();
         }
+
+        /// <summary>
+        /// Picks the archive entries that explain each failed job: the logs of the steps it reports as failed,
+        /// or its full job log when the archive carries no matching step entry.
+        /// </summary>
+        private static List<ZipArchiveEntry> SelectFailedStepLogEntries(ZipArchive zip, IReadOnlyList<WorkflowJob> jobs)
+        {
+            List<ZipArchiveEntry> selected = [];
+
+            foreach (var job in jobs.Where(j => j.Conclusion == WorkflowJobConclusion.Failure))
+            {
+                var failedSteps = (job.Steps ?? [])
+                    .Where(s => s.Conclusion == WorkflowJobConclusion.Failure)
+                    .Select(s => s.Number)
+                    .ToHashSet();
+
+                var stepEntries = zip.Entries
+                    .Where(e => e.Length > 0 && StepLogRegex.Match(e.FullName) is { Success: true } m
+                        && string.Equals(m.Groups["job"].Value, job.Name, StringComparison.OrdinalIgnoreCase)
+                        && int.TryParse(m.Groups["step"].Value, out var step)
+                        && failedSteps.Contains(step))
+                    .ToList();
+
+                if (stepEntries.Count > 0)
+                {
+                    selected.AddRange(stepEntries);
+                    continue;
+                }
+
+                var jobEntry = zip.Entries.FirstOrDefault(e =>
+                    e.Length > 0 && string.Equals(JobLogNameOf(e), job.Name, StringComparison.OrdinalIgnoreCase));
+                if (jobEntry != null)
+                {
+                    selected.Add(jobEntry);
+                }
+            }
+
+            return selected;
+        }
+
+        /// <summary>
+        /// Returns the job a root-level archive entry holds the full log for, or null if the entry is not one.
+        /// </summary>
+        private static string? JobLogNameOf(ZipArchiveEntry entry)
+        {
+            var match = JobLogRegex.Match(entry.FullName);
+            return match.Success ? match.Groups["job"].Value : null;
+        }
+
+        // A run's log archive names each job's full log "<index>_<job>.txt" at the root, and each step's log
+        // "<job>/<step>_<name>.txt", where the step number is the one the jobs API reports.
+        private static readonly Regex JobLogRegex = new(@"^\d+_(?<job>[^/]+)\.txt$", RegexOptions.Compiled);
+        private static readonly Regex StepLogRegex = new(@"^(?<job>.+)/(?<step>\d+)_[^/]+\.txt$", RegexOptions.Compiled);
 
         public async Task<IReadOnlyList<WorkflowJob>> GetWorkflowRunJobsAsync(string owner, string repo, long runId, CancellationToken ct)
         {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
@@ -12,6 +12,7 @@ using Azure.Sdk.Tools.Cli.Commands;
 using Azure.Sdk.Tools.Cli.CopilotAgents;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Helpers.Codeowners;
+using Azure.Sdk.Tools.Cli.Helpers.Pipeline;
 using Azure.Sdk.Tools.Cli.Helpers.Codeowners.Rules;
 using Azure.Sdk.Tools.Cli.Tools.Core;
 using Azure.Sdk.Tools.Cli.Services.APIView;
@@ -115,6 +116,8 @@ namespace Azure.Sdk.Tools.Cli.Services
 
             // Pipeline helpers
             services.AddSingleton<IPipelineIdentifierHelper, PipelineIdentifierHelper>();
+            services.AddScoped<IPipelineAnalysisHelper, PipelineAnalysisHelper>();
+            services.AddScoped<IGitHubWorkflowAnalysisHelper, GitHubWorkflowAnalysisHelper>();
 
             // Services that need to be scoped so we can track/update state across services per request
             services.AddScoped<TokenUsageHelper>();

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/EngSys/LogAnalysisTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/EngSys/LogAnalysisTool.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using Azure.Sdk.Tools.Cli.Commands;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.Responses;
 using Azure.Sdk.Tools.Cli.Tools.Core;
 using ModelContextProtocol.Server;
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineAnalysisTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineAnalysisTool.cs
@@ -2,33 +2,22 @@
 // Licensed under the MIT License.
 using System.CommandLine;
 using System.ComponentModel;
-using System.Linq;
 using System.Text.Json;
-using Azure.Core;
-using Microsoft.TeamFoundation.Build.WebApi;
-using Microsoft.TeamFoundation.TestManagement.WebApi;
-using Microsoft.VisualStudio.Services.OAuth;
-using Microsoft.VisualStudio.Services.TestResults.WebApi;
-using Microsoft.VisualStudio.Services.WebApi;
 using ModelContextProtocol.Server;
 using Azure.Sdk.Tools.Cli.Commands;
-using Azure.Sdk.Tools.Cli.Configuration;
 using Azure.Sdk.Tools.Cli.CopilotAgents;
-using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Helpers.Pipeline;
 using Azure.Sdk.Tools.Cli.Models;
-using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Models.Responses;
 using Azure.Sdk.Tools.Cli.Tools.Core;
 
 namespace Azure.Sdk.Tools.Cli.Tools.Pipeline;
 
 [McpServerToolType, Description("Fetches data from an Azure Pipelines run.")]
 public class PipelineAnalysisTool(
-    IPipelineIdentifierHelper pipelineHelper,
-    IHttpClientFactory httpClientFactory,
-    IAzureService azureService,
-    IDevOpsService devopsService,
-    ILogAnalysisHelper logAnalysisHelper,
-    ITestResultParserResolver parserResolver,
+    IPipelineAnalysisHelper pipelineAnalysisHelper,
+    IGitHubWorkflowAnalysisHelper workflowAnalysisHelper,
+    IPipelineIdentifierHelper pipelineIdentifierHelper,
     ICopilotAgentRunner copilotAgentRunner,
     ILogger<PipelineAnalysisTool> logger
 ) : MCPTool
@@ -69,7 +58,6 @@ public class PipelineAnalysisTool(
         var logId = parseResult.GetValue(logIdOpt);
         var useCopilot = parseResult.GetValue(copilotOpt);
 
-        logger.LogInformation("Analyzing pipeline {pipelineIdentifier}...", pipelineIdentifier);
         var result = await AnalyzePipeline(pipelineIdentifier, project, logId != 0 ? logId : null, ct);
 
         if (!useCopilot)
@@ -77,10 +65,90 @@ public class PipelineAnalysisTool(
             return result;
         }
 
-        return await AnalyzeWithCopilot(result, pipelineIdentifier, ct);
+        return await AnalyzeWithCopilotAsync(result, pipelineIdentifier, ct);
     }
 
-    private async Task<CommandResponse> AnalyzeWithCopilot(AnalyzePipelineResponse pipelineResult, string pipelineIdentifier, CancellationToken ct)
+    [McpServerTool(Name = AnalyzePipelineToolName), Description("Analyzes and returns structured failure data and logs from an Azure Pipeline build. Accepts an Azure Pipeline link, Build ID, GitHub Pull Request link, or PR number.")]
+    public async Task<AnalyzePipelineResponse> AnalyzePipeline(
+        [Description("Azure Pipeline link, Build ID, GitHub Pull Request link, or PR number")] string pipelineIdentifier,
+        [Description("Pipeline project name (optional)")] string? project = null,
+        [Description("Specific log ID to analyze (optional)")] int? logId = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            AnalyzePipelineResponse response = new AnalyzePipelineResponse();
+
+            var builds = await pipelineIdentifierHelper.ResolveBuildsAsync(pipelineIdentifier, project, ct);
+            if (builds.Count == 0)
+            {
+                return new AnalyzePipelineResponse
+                {
+                    ResponseError = $"No failed Azure Pipeline builds found for {pipelineIdentifier}"
+                };
+            }
+
+            logger.LogInformation("Analyzing pipeline {pipelineIdentifier}...", pipelineIdentifier);
+
+            var (buildAnalyses, warnings) = await pipelineAnalysisHelper.AnalyzePipelineAsync(builds, logId, ct);
+            response.BuildAnalyses = buildAnalyses;
+            if (warnings.Count > 0)
+            {
+                (response.NextSteps ??= []).AddRange(warnings);
+            }
+
+            var gitHubSource = await pipelineIdentifierHelper.ResolveGitHubSourceAsync(builds, ct);
+
+            if (gitHubSource != null && !string.IsNullOrEmpty(gitHubSource.HeadSha))
+            {
+                try
+                {
+                    response.GitHubWorkflowAnalyses = await workflowAnalysisHelper.AnalyzeWorkflowsAsync(gitHubSource, ct);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to analyze GitHub workflow runs for {owner}/{repo} @ {sha}", gitHubSource.Owner, gitHubSource.Repo, gitHubSource.HeadSha);
+                    (response.NextSteps ??= []).Add(
+                        $"GitHub Actions runs for {gitHubSource.Owner}/{gitHubSource.Repo} @ {gitHubSource.HeadSha} could not be listed " +
+                        $"({ex.Message}); the pipeline results are unaffected.");
+                }
+            }
+
+            if (gitHubSource?.PullRequestNumber != null)
+            {
+                try
+                {
+                    response.FailingChecks = await workflowAnalysisHelper.GetFailingChecksAsync(gitHubSource, ct);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to list failing checks for {owner}/{repo}#{pr}", gitHubSource.Owner, gitHubSource.Repo, gitHubSource.PullRequestNumber);
+                    (response.NextSteps ??= []).Add(
+                        $"Failing checks for {gitHubSource.Owner}/{gitHubSource.Repo}#{gitHubSource.PullRequestNumber} could not be listed " +
+                        $"({ex.Message}); the results above may not cover every red check on the pull request.");
+                }
+            }
+
+            return response;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to analyze pipeline {pipelineIdentifier}", pipelineIdentifier);
+            return new AnalyzePipelineResponse()
+            {
+                ResponseError = $"Failed to analyze pipeline {pipelineIdentifier}: {ex.Message}",
+                NextSteps =
+                [
+                    "Make sure you're authenticated with the Azure CLI (`az login --tenant microsoft.onmicrosoft.com`) and have access to the azure-sdk DevOps project (https://aka.ms/azsdk/access).",
+                ],
+            };
+        }
+    }
+
+    /// <summary>
+    /// Summarizes a completed pipeline analysis with the Copilot agent as a markdown root-cause report.
+    /// </summary>
+    private async Task<CommandResponse> AnalyzeWithCopilotAsync(AnalyzePipelineResponse pipelineResult, string pipelineIdentifier, CancellationToken ct)
     {
         try
         {
@@ -105,6 +173,16 @@ public class PipelineAnalysisTool(
 
                 If there are no failures, state that the pipeline appears healthy.
 
+                If any build in `build_analyses` has a `build.status` that is present and is neither
+                "completed" nor "Not available", that build is still running: note that its failure
+                logs and test artifacts may not be published yet, so the analysis may be incomplete
+                and the developer should re-run it once the build finishes. In that case do not
+                describe that build as healthy just because no failures were found.
+
+                `github_workflow_analyses`, if present, holds GitHub Actions runs for the same commit.
+                These are independent of the pipeline builds: report them separately and do not treat an
+                Actions failure as a pipeline failure (or vice versa).
+
                 Here is the pipeline analysis data:
 
                 {pipelineData}
@@ -128,415 +206,5 @@ public class PipelineAnalysisTool(
                 ResponseError = $"Failed to run Copilot analysis: {ex.Message}"
             };
         }
-    }
-
-    private bool initialized = false;
-    private BuildHttpClient buildClientValue;
-    private BuildHttpClient buildClient
-    {
-        get
-        {
-            Initialize();
-            return buildClientValue;
-        }
-    }
-    private TestResultsHttpClient testClientValue;
-    private TestResultsHttpClient testClient
-    {
-        get
-        {
-            Initialize();
-            return testClientValue;
-        }
-    }
-
-    private void Initialize(bool auth = true, CancellationToken ct = default)
-    {
-        if (initialized)
-        {
-            return;
-        }
-
-        if (auth)
-        {
-            var tokenScope = new[] { Constants.AZURE_DEVOPS_TOKEN_SCOPE };
-            var token = azureService.GetCredential(Constants.MICROSOFT_CORP_TENANT).GetToken(new TokenRequestContext(tokenScope), ct);
-            var tokenCredential = new VssOAuthAccessTokenCredential(token.Token);
-            var connection = new VssConnection(new Uri(Constants.AZURE_SDK_DEVOPS_BASE_URL), tokenCredential);
-            buildClientValue = connection.GetClient<BuildHttpClient>();
-            testClientValue = connection.GetClient<TestResultsHttpClient>();
-        }
-        else
-        {
-            var connection = new VssConnection(new Uri(Constants.AZURE_SDK_DEVOPS_BASE_URL), null);
-            buildClientValue = connection.GetClient<BuildHttpClient>();
-            testClientValue = connection.GetClient<TestResultsHttpClient>();
-        }
-
-        initialized = true;
-    }
-
-    private async Task<List<int>> getPipelineFailureLogIds(string project, int buildId, CancellationToken ct = default)
-    {
-        logger.LogDebug("Getting pipeline task failures for {project} {buildId}", project, buildId);
-
-        if (project != Constants.AZURE_SDK_DEVOPS_PUBLIC_PROJECT)
-        {
-            var timeline = await buildClient.GetBuildTimelineAsync(project, buildId, cancellationToken: ct);
-            var _failedTasks = timeline.Records.Where(
-                                    r => r.Result == TaskResult.Failed
-                                    && r.RecordType == "Task"
-                                    && !isTestStep(r.Name))
-                                .ToList();
-            logger.LogDebug("Found {count} failed tasks", _failedTasks.Count);
-            return _failedTasks.Select(t => t.Log?.Id ?? 0).Where(id => id != 0).Distinct().ToList();
-        }
-
-        var timelineUrl = $"{Constants.AZURE_SDK_DEVOPS_BASE_URL}/{project}/_apis/build/builds/{buildId}/timeline?api-version=7.1";
-        logger.LogDebug("Getting timeline records from {url}", timelineUrl);
-        var response = await httpClientFactory.CreateClient().GetAsync(timelineUrl, ct);
-        // Devops will return a sign-in html page if the user is not authorized
-        if (response.StatusCode == System.Net.HttpStatusCode.NonAuthoritativeInformation)
-        {
-            throw new Exception($"Not authorized to get timeline records from {timelineUrl}");
-        }
-        response.EnsureSuccessStatusCode();
-        var json = await response.Content.ReadAsStringAsync(ct);
-        if (string.IsNullOrEmpty(json))
-        {
-            throw new Exception($"No timeline records found for build {buildId} in project {project}");
-        }
-
-        using var doc = JsonDocument.Parse(json);
-        var failedTasks = doc.RootElement.GetProperty("records")
-            .EnumerateArray()
-            .Where(r =>
-                r.GetProperty("result").GetString() == "failed" &&
-                r.GetProperty("type").GetString() == "Task" &&
-                !isTestStep(r.GetProperty("name").GetString())).ToList();
-
-        List<int> logIds = [];
-        foreach (var task in failedTasks)
-        {
-            if (task.TryGetProperty("log", out var logProp) && logProp.TryGetProperty("id", out var idProp))
-            {
-                var id = idProp.GetInt32();
-                if (id != 0)
-                {
-                    logIds.Add(id);
-                }
-            }
-        }
-
-        logger.LogDebug("Found {count} failed tasks", failedTasks.Count);
-        return logIds;
-    }
-
-    private async Task<FailedTestRunListResponse> getPipelineFailedTestResults(string project, int buildId, CancellationToken ct = default)
-    {
-        try
-        {
-            logger.LogDebug("Getting pipeline failed test results for {project} {buildId}", project, buildId);
-            var results = new List<ShallowTestCaseResult>();
-
-            var testRuns = await testClient.GetTestResultsByPipelineAsync(project, buildId, cancellationToken: ct);
-            results.AddRange(testRuns);
-            while (testRuns.ContinuationToken != null)
-            {
-                var nextResults = await testClient.GetTestResultsByPipelineAsync(project, buildId, continuationToken: testRuns.ContinuationToken, cancellationToken: ct);
-                results.AddRange(nextResults);
-                testRuns.ContinuationToken = nextResults.ContinuationToken;
-            }
-
-            var failedRuns = results.Where(
-                r => r.Outcome == TestOutcome.Failed.ToString()
-                || r.Outcome == TestOutcome.Aborted.ToString())
-            .Select(r => r.RunId)
-            .Distinct()
-            .ToList();
-
-            logger.LogDebug("Getting test results for {count} failed test runs", failedRuns.Count);
-
-            var failedRunData = new FailedTestRunListResponse();
-
-            foreach (var runId in failedRuns)
-            {
-                var testCases = await testClient.GetTestResultsAsync(
-                                    project,
-                                    runId,
-                                    outcomes: [TestOutcome.Failed, TestOutcome.Aborted],
-                                    cancellationToken: ct);
-
-                foreach (var tc in testCases)
-                {
-                    failedRunData.Items.Add(new FailedTestRunResponse
-                    {
-                        RunId = runId,
-                        TestCaseTitle = tc.TestCaseTitle,
-                        ErrorMessage = tc.ErrorMessage,
-                        StackTrace = tc.StackTrace,
-                        Outcome = tc.Outcome,
-                        Uri = tc.Url
-                    });
-                }
-            }
-
-            return failedRunData;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to get pipeline failed test results {buildId}", buildId);
-            return new() { ResponseError = $"Failed to get pipeline failed test results {buildId}: {ex.Message}" };
-        }
-    }
-
-    private async Task<string> getBuildLogLinesUnauthenticated(string project, int buildId, int logId, CancellationToken ct = default)
-    {
-        var logUrl = $"{Constants.AZURE_SDK_DEVOPS_BASE_URL}/{project}/_apis/build/builds/{buildId}/logs/{logId}?api-version=7.1";
-        logger.LogDebug("Fetching log file from {url}", logUrl);
-        var response = await httpClientFactory.CreateClient().GetAsync(logUrl, ct);
-        // Devops will return a sign-in html page if the user is not authorized
-        if (response.StatusCode == System.Net.HttpStatusCode.NonAuthoritativeInformation)
-        {
-            throw new Exception($"Not authorized to get log file from {logUrl}");
-        }
-        response.EnsureSuccessStatusCode();
-        var logContent = await response.Content.ReadAsStringAsync(ct);
-        return logContent;
-    }
-
-    public async Task<LogAnalysisResponse> AnalyzePipelineFailureLogs(string? project, int buildId, List<int> logIds, CancellationToken ct)
-    {
-        try
-        {
-            return await analyzePipelineFailureLogs(project, buildId, logIds, ct);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to analyze pipeline {buildId}", buildId);
-            return new LogAnalysisResponse()
-            {
-                ResponseError = $"Failed to analyze pipeline {buildId}: {ex.Message}",
-            };
-        }
-    }
-
-    private async Task<LogAnalysisResponse> analyzePipelineFailureLogs(string? project, int buildId, List<int> logIds, CancellationToken ct)
-    {
-        project ??= Constants.AZURE_SDK_DEVOPS_PUBLIC_PROJECT;
-        List<string> logFilePaths = [];
-
-        try
-        {
-            foreach (var logId in logIds)
-            {
-                string logText;
-                logger.LogDebug("Downloading pipeline failure log for {project} {buildId} {logId}", project, buildId, logId);
-
-                if (project == Constants.AZURE_SDK_DEVOPS_PUBLIC_PROJECT)
-                {
-                    logText = await getBuildLogLinesUnauthenticated(project, buildId, logId, ct);
-                }
-                else
-                {
-                    var logContent = await buildClient.GetBuildLogLinesAsync(project, buildId, logId, cancellationToken: ct);
-                    logText = string.Join("\n", logContent);
-                }
-
-                var tempPath = Path.Combine(Path.GetTempPath(), $"log-analysis-{Guid.NewGuid():N}.txt");
-                logger.LogDebug("Writing log id {logId} to temporary file {tempPath}", logId, tempPath);
-                await File.WriteAllTextAsync(tempPath, logText, ct);
-                logFilePaths.Add(tempPath);
-            }
-
-            LogAnalysisResponse response = new()
-            {
-                PipelineUrl = pipelineHelper.GetPipelineUrl(project, buildId),
-                Errors = []
-            };
-
-            foreach (var log in logFilePaths)
-            {
-                var localLogResult = await logAnalysisHelper.AnalyzeLogContent(log, null, null, null, ct);
-                response.Errors.AddRange(localLogResult);
-            }
-
-            return response;
-        }
-        finally
-        {
-            foreach (var log in logFilePaths)
-            {
-                try { File.Delete(log); }
-                catch (Exception ex) { logger.LogDebug(ex, "Failed to clean up temp file {log}", log); }
-            }
-        }
-    }
-
-    [McpServerTool(Name = AnalyzePipelineToolName), Description("Analyzes and returns structured failure data and logs from an Azure Pipeline build. Accepts an Azure Pipeline link, Build ID, GitHub Pull Request link, or PR number.")]
-    public async Task<AnalyzePipelineResponse> AnalyzePipeline(
-        [Description("Azure Pipeline link, Build ID, GitHub Pull Request link, or PR number")] string pipelineIdentifier,
-        [Description("Pipeline project name (optional)")] string? project = null,
-        [Description("Specific log ID to analyze (optional)")] int? logId = null,
-        CancellationToken ct = default)
-    {
-        try
-        {
-            var builds = await pipelineHelper.ResolveBuildsAsync(pipelineIdentifier, project, ct);
-
-            if (builds.Count == 0)
-            {
-                return new AnalyzePipelineResponse
-                {
-                    ResponseError = $"No failed Azure Pipeline builds found for {pipelineIdentifier}"
-                };
-            }
-
-            var aggregatedResponse = new AnalyzePipelineResponse();
-
-            foreach (var build in builds)
-            {
-                var buildProject = build.Project;
-
-                if (logId.HasValue && logId.Value != 0)
-                {
-                    var logResult = await AnalyzePipelineFailureLogs(buildProject, build.BuildId, [logId.Value], ct);
-                    if (logResult.HasErrors)
-                    {
-                        aggregatedResponse.FailedTasks.Add(logResult);
-                    }
-                }
-                else
-                {
-                    var result = await AnalyzePipelineInternal(buildProject, build.BuildId, ct);
-                    if (result.ResponseError != null)
-                    {
-                        aggregatedResponse.ResponseErrors ??= [];
-                        aggregatedResponse.ResponseErrors.Add($"Build {build.BuildId}: {result.ResponseError}");
-                        continue;
-                    }
-
-                    aggregatedResponse.FailedTasks.AddRange(result.FailedTasks);
-                    foreach (var (key, value) in result.FailedTests)
-                    {
-                        if (aggregatedResponse.FailedTests.TryGetValue(key, out var existing))
-                        {
-                            existing.AddRange(value);
-                        }
-                        else
-                        {
-                            aggregatedResponse.FailedTests[key] = value;
-                        }
-                    }
-                }
-            }
-
-            return aggregatedResponse;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to analyze pipeline {pipelineIdentifier}", pipelineIdentifier);
-            return new AnalyzePipelineResponse()
-            {
-                ResponseError = $"Failed to analyze pipeline {pipelineIdentifier}: {ex.Message}",
-            };
-        }
-    }
-
-    private async Task<AnalyzePipelineResponse> AnalyzePipelineInternal(string? project, int buildId, CancellationToken ct)
-    {
-        try
-        {
-            if (string.IsNullOrEmpty(project))
-            {
-                project = await pipelineHelper.GetPipelineProjectAsync(buildId, null, ct);
-            }
-
-            var failureLogIds = await getPipelineFailureLogIds(project, buildId, ct);
-            var analysis = await analyzePipelineFailureLogs(project, buildId, failureLogIds, ct);
-
-            var failedTests = new FailedTestRunListResponse();
-            var failedTestArtifacts = await devopsService.GetPipelineLlmArtifacts(project, buildId, ct);
-            var skippedArtifacts = new List<string>();
-
-            foreach (var testFiles in failedTestArtifacts)
-            {
-                foreach (var file in testFiles.Value)
-                {
-                    try
-                    {
-                        var parser = await parserResolver.ResolveAsync(file, ct);
-                        var failed = await parser.GetFailedTestCases(file, ct: ct);
-                        failedTests.Items.AddRange(failed.Items);
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.LogWarning(ex, "Skipping test result artifact {FilePath}", file);
-                        skippedArtifacts.Add(file);
-                    }
-                }
-            }
-
-            var failedTestsByUri = failedTests.Items
-                .GroupBy(ft => ft.Uri)
-                .ToDictionary(
-                    g => g.Key,
-                    g => g.Select(ft => ft.TestCaseTitle).ToList()
-                );
-
-            var response = new AnalyzePipelineResponse()
-            {
-                FailedTasks = analysis.HasErrors ? [analysis] : [],
-                FailedTests = failedTestsByUri
-            };
-
-            if (skippedArtifacts.Count > 0)
-            {
-                response.NextSteps =
-                [
-                    $"Test results may be incomplete: {skippedArtifacts.Count} artifact(s) could not be read or parsed " +
-                    $"(missing file, unrecognized format, or malformed content): {string.Join(", ", skippedArtifacts)}."
-                ];
-            }
-
-            return response;
-        }
-        catch (Exception ex) when (IsAuthException(ex) && project != Constants.AZURE_SDK_DEVOPS_PUBLIC_PROJECT)
-        {
-            logger.LogError(ex, "Authorization failure analyzing pipeline {buildId} in project {project}", buildId, project);
-            return new AnalyzePipelineResponse()
-            {
-                ResponseError = $"Not authorized to access build {buildId} in project '{project}'. " +
-                    "This is an internal build requiring authentication. " +
-                    "Ensure you are signed in with `az login` using an account with access to the Azure SDK DevOps organization.",
-            };
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to analyze pipeline {buildId}", buildId);
-            return new AnalyzePipelineResponse()
-            {
-                ResponseError = $"Failed to analyze pipeline {buildId}: {ex.Message}",
-            };
-        }
-    }
-
-    private bool isTestStep(string stepName)
-    {
-        if (stepName.Contains("deploy test resources", StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-        return stepName.Contains("test", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static bool IsAuthException(Exception ex)
-    {
-        var message = ex.ToString();
-        return message.Contains("401")
-            || message.Contains("403")
-            || message.Contains("NonAuthoritativeInformation")
-            || message.Contains("Not authorized")
-            || message.Contains("unauthorized", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineAnalysisTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineAnalysisTool.cs
@@ -80,24 +80,30 @@ public class PipelineAnalysisTool(
             AnalyzePipelineResponse response = new AnalyzePipelineResponse();
 
             var builds = await pipelineIdentifierHelper.ResolveBuildsAsync(pipelineIdentifier, project, ct);
-            if (builds.Count == 0)
+
+            // A pull request can be red on GitHub Actions alone, so when no build backs the identifier the
+            // source is resolved from the pull request itself rather than reporting nothing to analyze.
+            var gitHubSource = builds.Count > 0
+                ? await pipelineIdentifierHelper.ResolveGitHubSourceAsync(builds, ct)
+                : await pipelineIdentifierHelper.ResolveGitHubSourceFromPrAsync(pipelineIdentifier, ct);
+
+            if (builds.Count == 0 && gitHubSource == null)
             {
-                return new AnalyzePipelineResponse
-                {
-                    ResponseError = $"No failed Azure Pipeline builds found for {pipelineIdentifier}"
-                };
+                response.ResponseError = $"No failed Azure Pipeline builds found for {pipelineIdentifier}";
+                return response;
             }
 
             logger.LogInformation("Analyzing pipeline {pipelineIdentifier}...", pipelineIdentifier);
 
-            var (buildAnalyses, warnings) = await pipelineAnalysisHelper.AnalyzePipelineAsync(builds, logId, ct);
-            response.BuildAnalyses = buildAnalyses;
-            if (warnings.Count > 0)
+            if (builds.Count > 0)
             {
-                (response.NextSteps ??= []).AddRange(warnings);
+                var (buildAnalyses, warnings) = await pipelineAnalysisHelper.AnalyzePipelineAsync(builds, logId, ct);
+                response.BuildAnalyses = buildAnalyses;
+                if (warnings.Count > 0)
+                {
+                    (response.NextSteps ??= []).AddRange(warnings);
+                }
             }
-
-            var gitHubSource = await pipelineIdentifierHelper.ResolveGitHubSourceAsync(builds, ct);
 
             if (gitHubSource != null && !string.IsNullOrEmpty(gitHubSource.HeadSha))
             {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineAnalysisTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineAnalysisTool.cs
@@ -2,7 +2,11 @@
 // Licensed under the MIT License.
 using System.CommandLine;
 using System.ComponentModel;
+using System.Net;
 using System.Text.Json;
+using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.VisualStudio.Services.Common;
+using Microsoft.VisualStudio.Services.WebApi;
 using ModelContextProtocol.Server;
 using Azure.Sdk.Tools.Cli.Commands;
 using Azure.Sdk.Tools.Cli.CopilotAgents;
@@ -143,13 +147,41 @@ public class PipelineAnalysisTool(
             return new AnalyzePipelineResponse()
             {
                 ResponseError = $"Failed to analyze pipeline {pipelineIdentifier}: {ex.Message}",
-                NextSteps =
-                [
-                    "Make sure you're authenticated with the Azure CLI (`az login --tenant microsoft.onmicrosoft.com`) and have access to the azure-sdk DevOps project (https://aka.ms/azsdk/access).",
-                ],
+                NextSteps = NextStepsForFailure(ex),
             };
         }
     }
+
+    /// <summary>
+    /// Picks next steps that match how the analysis failed. Public builds and public pull requests are read
+    /// without credentials, so telling the user to sign in is misleading for the failures signing in would not
+    /// fix: a malformed identifier, or a run or pull request that does not exist. Failures that already carry
+    /// their own instructions - the DevOps and GitHub CLI sign-in errors - are left to speak for themselves.
+    /// </summary>
+    private static List<string>? NextStepsForFailure(Exception ex) => ex switch
+    {
+        ArgumentException =>
+        [
+            "Pass an Azure Pipelines run link, a build ID, a GitHub pull request link, or a pull request number.",
+        ],
+        BuildNotFoundException =>
+        [
+            "Check that the identifier names a run that still exists, and that any project in its link is correct.",
+        ],
+        VssUnauthorizedException or VssServiceResponseException { HttpStatusCode: HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden } =>
+        [
+            "Make sure you're authenticated with the Azure CLI (`az login --tenant microsoft.onmicrosoft.com`) and have access to the azure-sdk DevOps project (https://aka.ms/azsdk/access).",
+        ],
+        Octokit.NotFoundException =>
+        [
+            "Check that the repository and pull request named by the identifier exist.",
+        ],
+        Octokit.ApiException =>
+        [
+            "If the repository is private, or the request was rate limited, authenticate the GitHub CLI (`gh auth login`) and try again.",
+        ],
+        _ => null,
+    };
 
     /// <summary>
     /// Summarizes a completed pipeline analysis with the Copilot agent as a markdown root-cause report.

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineAnalysisTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineAnalysisTool.cs
@@ -83,11 +83,11 @@ public class PipelineAnalysisTool(
 
             // A pull request can be red on GitHub Actions alone, so when no build backs the identifier the
             // source is resolved from the pull request itself rather than reporting nothing to analyze.
-            var gitHubSource = builds.Count > 0
-                ? await pipelineIdentifierHelper.ResolveGitHubSourceAsync(builds, ct)
-                : await pipelineIdentifierHelper.ResolveGitHubSourceFromPrAsync(pipelineIdentifier, ct);
+            var commitRef = builds.Count > 0
+                ? await pipelineIdentifierHelper.ResolveCommitRefFromBuildsAsync(builds, ct)
+                : await pipelineIdentifierHelper.ResolveCommitRefFromPrAsync(pipelineIdentifier, ct);
 
-            if (builds.Count == 0 && gitHubSource == null)
+            if (builds.Count == 0 && commitRef == null)
             {
                 response.ResponseError = $"No failed Azure Pipeline builds found for {pipelineIdentifier}";
                 return response;
@@ -97,40 +97,40 @@ public class PipelineAnalysisTool(
 
             if (builds.Count > 0)
             {
-                var (buildAnalyses, warnings) = await pipelineAnalysisHelper.AnalyzePipelineAsync(builds, logId, ct);
-                response.BuildAnalyses = buildAnalyses;
+                var (pipelineAnalyses, warnings) = await pipelineAnalysisHelper.AnalyzePipelineAsync(builds, logId, ct);
+                response.AzurePipelineAnalyses = pipelineAnalyses;
                 if (warnings.Count > 0)
                 {
                     (response.NextSteps ??= []).AddRange(warnings);
                 }
             }
 
-            if (gitHubSource != null && !string.IsNullOrEmpty(gitHubSource.HeadSha))
+            if (commitRef != null)
             {
                 try
                 {
-                    response.GitHubWorkflowAnalyses = await workflowAnalysisHelper.AnalyzeWorkflowsAsync(gitHubSource, ct);
+                    response.GitHubWorkflowAnalyses = await workflowAnalysisHelper.AnalyzeWorkflowsAsync(commitRef, ct);
                 }
                 catch (Exception ex)
                 {
-                    logger.LogError(ex, "Failed to analyze GitHub workflow runs for {owner}/{repo} @ {sha}", gitHubSource.Owner, gitHubSource.Repo, gitHubSource.HeadSha);
+                    logger.LogError(ex, "Failed to analyze GitHub workflow runs for {owner}/{repo} @ {sha}", commitRef.Owner, commitRef.Repo, commitRef.HeadSha);
                     (response.NextSteps ??= []).Add(
-                        $"GitHub Actions runs for {gitHubSource.Owner}/{gitHubSource.Repo} @ {gitHubSource.HeadSha} could not be listed " +
+                        $"GitHub Actions runs for {commitRef.Owner}/{commitRef.Repo} @ {commitRef.HeadSha} could not be listed " +
                         $"({ex.Message}); the pipeline results are unaffected.");
                 }
             }
 
-            if (gitHubSource?.PullRequestNumber != null)
+            if (commitRef?.PullRequestNumber != null)
             {
                 try
                 {
-                    response.FailingChecks = await workflowAnalysisHelper.GetFailingChecksAsync(gitHubSource, ct);
+                    response.FailingPullRequestChecks = await workflowAnalysisHelper.GetFailingChecksAsync(commitRef, ct);
                 }
                 catch (Exception ex)
                 {
-                    logger.LogError(ex, "Failed to list failing checks for {owner}/{repo}#{pr}", gitHubSource.Owner, gitHubSource.Repo, gitHubSource.PullRequestNumber);
+                    logger.LogError(ex, "Failed to list failing checks for {owner}/{repo}#{pr}", commitRef.Owner, commitRef.Repo, commitRef.PullRequestNumber);
                     (response.NextSteps ??= []).Add(
-                        $"Failing checks for {gitHubSource.Owner}/{gitHubSource.Repo}#{gitHubSource.PullRequestNumber} could not be listed " +
+                        $"Failing checks for {commitRef.Owner}/{commitRef.Repo}#{commitRef.PullRequestNumber} could not be listed " +
                         $"({ex.Message}); the results above may not cover every red check on the pull request.");
                 }
             }
@@ -158,7 +158,7 @@ public class PipelineAnalysisTool(
     {
         try
         {
-            // Serialize as JSON to ensure Copilot gets the full context (FailedTasks, FailedTests)
+            // Serialize as JSON to ensure Copilot gets the full context (FailedPipelineTasks, FailedPipelineTests)
             // even when ResponseErrors is set, since ToString() suppresses Format() output on errors.
             var pipelineData = JsonSerializer.Serialize(pipelineResult, new JsonSerializerOptions { WriteIndented = true });
 
@@ -169,8 +169,9 @@ public class PipelineAnalysisTool(
 
             var instructions = $"""
                 You are a pipeline failure analyst. You have been given the output of a CI/CD pipeline analysis.
-                Your job is to examine the failed tasks and failed tests, identify root causes, and provide
-                a clear, actionable summary for a developer.
+                Your job is to examine the `failed_pipeline_tasks` and `failed_pipeline_tests` of each entry in
+                `azure_pipeline_analyses`, identify root causes, and provide a clear, actionable summary for a
+                developer.
 
                 Respond in markdown format. Structure your response as:
                 1. **Root Cause Analysis** - What likely caused each failure
@@ -179,15 +180,20 @@ public class PipelineAnalysisTool(
 
                 If there are no failures, state that the pipeline appears healthy.
 
-                If any build in `build_analyses` has a `build.status` that is present and is neither
-                "completed" nor "Not available", that build is still running: note that its failure
+                If any build in `azure_pipeline_analyses` has a `pipeline_build.status` that is present and is
+                neither "completed" nor "Not available", that build is still running: note that its failure
                 logs and test artifacts may not be published yet, so the analysis may be incomplete
                 and the developer should re-run it once the build finishes. In that case do not
                 describe that build as healthy just because no failures were found.
 
-                `github_workflow_analyses`, if present, holds GitHub Actions runs for the same commit.
+                `github_workflow_analyses`, if present, holds GitHub Actions runs for the same commit, with
+                their failures in `logs` and `jobs` rather than the `failed_pipeline_*` fields above.
                 These are independent of the pipeline builds: report them separately and do not treat an
                 Actions failure as a pipeline failure (or vice versa).
+
+                `failing_pull_request_checks`, if present, lists every check GitHub reports as red on the pull
+                request. This can be a duplicate of a pipeline or Actions failure. But it is a catch all for
+                anything that failed.
 
                 Here is the pipeline analysis data:
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineChecksTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineChecksTool.cs
@@ -4,8 +4,9 @@ using System.CommandLine;
 using System.CommandLine.Parsing;
 using System.ComponentModel;
 using Azure.Sdk.Tools.Cli.Commands;
-using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Helpers.Pipeline;
 using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Services;
 using Azure.Sdk.Tools.Cli.Tools.Core;
 using ModelContextProtocol.Server;
 
@@ -15,6 +16,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Pipeline;
 [McpServerToolType]
 public class PipelineChecksTool(
     IPipelineIdentifierHelper pipelineHelper,
+    IGitHubService gitHubService,
     ILogger<PipelineChecksTool> logger
 ) : MCPTool
 {
@@ -70,7 +72,7 @@ public class PipelineChecksTool(
             }
 
             logger.LogInformation("Getting check runs for {owner}/{repo}#{prNumber}", parsed.Owner, parsed.Repo, parsed.PrNumber);
-            var checks = await pipelineHelper.GetPrCheckRunsAsync(parsed.Owner, parsed.Repo, parsed.PrNumber, ct);
+            var checks = await gitHubService.GetPrCheckRunsAsync(parsed.Owner, parsed.Repo, parsed.PrNumber, ct);
 
             if (failed)
             {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineTestsTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineTestsTool.cs
@@ -4,7 +4,7 @@ using System.CommandLine;
 using System.ComponentModel;
 using ModelContextProtocol.Server;
 using Azure.Sdk.Tools.Cli.Commands;
-using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Helpers.Pipeline;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Services;
 using Azure.Sdk.Tools.Cli.Tools.Core;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Pipeline/PipelineTool.cs
@@ -2,15 +2,9 @@
 // Licensed under the MIT License.
 using System.CommandLine;
 using System.ComponentModel;
-using System.Net.Http.Headers;
-using System.Text.Json;
-using System.Text.Json.Serialization;
-using Azure.Core;
 using Azure.Sdk.Tools.Cli.Commands;
-using Azure.Sdk.Tools.Cli.Configuration;
-using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Helpers.Pipeline;
 using Azure.Sdk.Tools.Cli.Models;
-using Azure.Sdk.Tools.Cli.Services;
 using Azure.Sdk.Tools.Cli.Tools.Core;
 using ModelContextProtocol.Server;
 
@@ -20,8 +14,6 @@ namespace Azure.Sdk.Tools.Cli.Tools.Pipeline;
 [McpServerToolType]
 public class PipelineTool(
     IPipelineIdentifierHelper pipelineHelper,
-    IHttpClientFactory httpClientFactory,
-    IAzureService azureService,
     ILogger<PipelineTool> logger
 ) : MCPTool
 {
@@ -44,17 +36,18 @@ public class PipelineTool(
         var pipelineIdentifier = parseResult.GetValue(SharedOptions.PipelineLocator);
         var project = parseResult.GetValue(projectOpt);
 
-        return await GetPipelineRunStatus(pipelineIdentifier, ct);
+        return await GetPipelineRunStatus(pipelineIdentifier, project, ct);
     }
 
     [McpServerTool(Name = GetPipelineStatusToolName), Description("Get pipeline status for a given Azure Pipeline link, Build ID, GitHub Pull Request link, or PR number")]
     public async Task<ObjectCommandResponse> GetPipelineRunStatus(
         [Description("Azure Pipeline link, Build ID, GitHub Pull Request link, or PR number")] string pipelineIdentifier,
+        [Description("Pipeline project name (optional)")] string? project = null,
         CancellationToken ct = default
     ) {
         try
         {
-            var builds = await pipelineHelper.ResolveBuildsAsync(pipelineIdentifier, null, ct);
+            var builds = await pipelineHelper.ResolveBuildsAsync(pipelineIdentifier, project, ct);
 
             if (builds.Count == 0)
             {
@@ -64,14 +57,10 @@ public class PipelineTool(
                 };
             }
 
-            var statuses = new List<BuildStatusResult>();
-            foreach (var build in builds)
+            return new ObjectCommandResponse
             {
-                var status = await GetSingleBuildStatus(build, ct);
-                statuses.Add(status);
-            }
-
-            return new ObjectCommandResponse { Result = statuses };
+                Result = builds
+            };
         }
         catch (Exception ex)
         {
@@ -82,53 +71,4 @@ public class PipelineTool(
             };
         }
     }
-
-    private async Task<BuildStatusResult> GetSingleBuildStatus(ResolvedBuild build, CancellationToken ct)
-    {
-        var buildProject = build.Project;
-        if (string.IsNullOrEmpty(buildProject))
-        {
-            buildProject = await pipelineHelper.GetPipelineProjectAsync(build.BuildId, null, ct);
-        }
-
-        var httpClient = httpClientFactory.CreateClient();
-
-        if (buildProject != Constants.AZURE_SDK_DEVOPS_PUBLIC_PROJECT)
-        {
-            var tokenScope = new[] { Constants.AZURE_DEVOPS_TOKEN_SCOPE };
-            var token = azureService.GetCredential(Constants.MICROSOFT_CORP_TENANT).GetToken(new TokenRequestContext(tokenScope), ct);
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
-        }
-
-        var buildUrl = $"{Constants.AZURE_SDK_DEVOPS_BASE_URL}/{buildProject}/_apis/build/builds/{build.BuildId}?api-version=7.1";
-        logger.LogDebug("Getting build status from {url}", buildUrl);
-        var response = await httpClient.GetAsync(buildUrl, ct);
-        response.EnsureSuccessStatusCode();
-
-        var json = await response.Content.ReadAsStringAsync(ct);
-        using var doc = JsonDocument.Parse(json);
-        var root = doc.RootElement;
-
-        var result = root.TryGetProperty("result", out var resultProp) ? resultProp.GetString() : null;
-        var status = root.TryGetProperty("status", out var statusProp) ? statusProp.GetString() : null;
-
-        return new BuildStatusResult
-        {
-            BuildId = build.BuildId,
-            Status = result ?? status ?? "Not available",
-            PipelineUrl = build.PipelineUrl ?? pipelineHelper.GetPipelineUrl(buildProject, build.BuildId),
-        };
-    }
-}
-
-public class BuildStatusResult
-{
-    [JsonPropertyName("build_id")]
-    public int BuildId { get; set; }
-
-    [JsonPropertyName("status")]
-    public string Status { get; set; } = "";
-
-    [JsonPropertyName("pipeline_url")]
-    public string PipelineUrl { get; set; } = "";
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Mock/Handlers/Pipeline/AnalyzeAndArtifactsHandlers.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Mock/Handlers/Pipeline/AnalyzeAndArtifactsHandlers.cs
@@ -33,15 +33,12 @@ public class AnalyzePipelineHandler : IMockToolHandler
                 new BuildAnalysis
                 {
                     Build = new ResolvedBuild(buildIdValue, "internal", pipelineUrl, "completed", "failed"),
-                    FailedBuildTests = new List<FailedTestRunResponse>
+                    FailedBuildTests = new Dictionary<string, List<string>>
                     {
-                        new FailedTestRunResponse
-                        {
-                            TestCaseTitle = "WidgetClientLiveTests.GetWidget",
-                            Outcome = "Failed",
-                            Uri = "sdk/widgets/Azure.Widgets/tests/WidgetClientLiveTests.cs",
-                            ErrorMessage = "expected 200 got 404"
-                        }
+                        ["Ubuntu2404_NET80_PackageRef_Debug"] =
+                        [
+                            "WidgetClientLiveTests.GetWidget"
+                        ]
                     },
                     FailedBuildTasks = new LogAnalysisResponse
                     {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Mock/Handlers/Pipeline/AnalyzeAndArtifactsHandlers.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Mock/Handlers/Pipeline/AnalyzeAndArtifactsHandlers.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.Pipeline;
+using Azure.Sdk.Tools.Cli.Models.Responses;
 
 namespace Azure.Sdk.Tools.Mock.Handlers.Pipeline;
 
@@ -21,40 +23,41 @@ public class AnalyzePipelineHandler : IMockToolHandler
 
     public CommandResponse Handle(Dictionary<string, object?>? arguments)
     {
-        var buildId = arguments?.GetValueOrDefault("buildId")?.ToString() ?? "6455504";
-        const string versionParseError =
-            "TryGetServiceVersion failed to parse the new service versions \"2026-10-06\" (V2026_10_06) and \"2026-12-06\" (V2026_12_06): both cases are missing from the parser switch. Expected: True But was: False";
+        var buildId = arguments?.GetValueOrDefault("buildId")?.ToString() ?? "90001";
+        var buildIdValue = int.TryParse(buildId, out var parsed) ? parsed : 90001;
+        var pipelineUrl = $"https://dev.azure.com/azure-sdk/internal/_build/results?buildId={buildId}";
         return new AnalyzePipelineResponse
         {
-            FailedTests = new Dictionary<string, List<string>>
+            BuildAnalyses = new List<BuildAnalysis>
             {
-                ["azure.storage.queues.tests.dll"] =
-                    ["Azure.Storage.Queues.Test.QueueClientOptionsTests.TryGetServiceVersion_ParsesAllServiceVersions"],
-                ["azure.storage.files.shares.tests.dll"] =
-                    ["Azure.Storage.Files.Shares.Tests.ShareClientOptionsTests.TryGetServiceVersion_ParsesAllServiceVersions"]
-            },
-            FailedTasks =
-            [
-                new LogAnalysisResponse
+                new BuildAnalysis
                 {
-                    PipelineUrl = $"https://dev.azure.com/azure-sdk/public/_build/results?buildId={buildId}",
-                    Errors =
-                    [
-                        new LogEntry
+                    Build = new ResolvedBuild(buildIdValue, "internal", pipelineUrl, "completed", "failed"),
+                    FailedBuildTests = new List<FailedTestRunResponse>
+                    {
+                        new FailedTestRunResponse
                         {
-                            File = "sdk/storage/Azure.Storage.Queues/tests/QueueClientOptionsTests.cs",
-                            Line = 24,
-                            Message = versionParseError
-                        },
-                        new LogEntry
-                        {
-                            File = "sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientOptionsTests.cs",
-                            Line = 24,
-                            Message = versionParseError
+                            TestCaseTitle = "WidgetClientLiveTests.GetWidget",
+                            Outcome = "Failed",
+                            Uri = "sdk/widgets/Azure.Widgets/tests/WidgetClientLiveTests.cs",
+                            ErrorMessage = "expected 200 got 404"
                         }
-                    ]
+                    },
+                    FailedBuildTasks = new LogAnalysisResponse
+                    {
+                        PipelineUrl = pipelineUrl,
+                        Errors =
+                        [
+                            new LogEntry
+                            {
+                                File = "logs/test.log",
+                                Line = 128,
+                                Message = "Test WidgetClientLiveTests.GetWidget failed: expected 200 got 404"
+                            }
+                        ]
+                    }
                 }
-            ]
+            }
         };
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Mock/Handlers/Pipeline/AnalyzeAndArtifactsHandlers.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Mock/Handlers/Pipeline/AnalyzeAndArtifactsHandlers.cs
@@ -23,7 +23,7 @@ public class AnalyzePipelineHandler : IMockToolHandler
 
     public CommandResponse Handle(Dictionary<string, object?>? arguments)
     {
-        var buildId = arguments?.GetValueOrDefault("buildId")?.ToString() ?? "90001";
+        var buildId = MockPipelineIdentifier.GetBuildId(arguments) ?? "90001";
         var buildIdValue = int.TryParse(buildId, out var parsed) ? parsed : 90001;
         var pipelineUrl = $"https://dev.azure.com/azure-sdk/internal/_build/results?buildId={buildId}";
         return new AnalyzePipelineResponse
@@ -66,7 +66,7 @@ public class GetPipelineLlmArtifactsHandler : IMockToolHandler
 
     public CommandResponse Handle(Dictionary<string, object?>? arguments)
     {
-        var buildId = arguments?.GetValueOrDefault("buildId")?.ToString() ?? "90001";
+        var buildId = MockPipelineIdentifier.GetBuildId(arguments) ?? "90001";
         return new ObjectCommandResponse
         {
             Message = $"Retrieved LLM artifacts for build {buildId} (mock)",

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Mock/Handlers/Pipeline/AnalyzeAndArtifactsHandlers.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Mock/Handlers/Pipeline/AnalyzeAndArtifactsHandlers.cs
@@ -28,19 +28,19 @@ public class AnalyzePipelineHandler : IMockToolHandler
         var pipelineUrl = $"https://dev.azure.com/azure-sdk/internal/_build/results?buildId={buildId}";
         return new AnalyzePipelineResponse
         {
-            BuildAnalyses = new List<BuildAnalysis>
+            AzurePipelineAnalyses = new List<AzurePipelineAnalysis>
             {
-                new BuildAnalysis
+                new AzurePipelineAnalysis
                 {
-                    Build = new ResolvedBuild(buildIdValue, "internal", pipelineUrl, "completed", "failed"),
-                    FailedBuildTests = new Dictionary<string, List<string>>
+                    PipelineBuild = new AzurePipelineBuild(buildIdValue, "internal", pipelineUrl, "completed", "failed"),
+                    FailedPipelineTests = new Dictionary<string, List<string>>
                     {
                         ["Ubuntu2404_NET80_PackageRef_Debug"] =
                         [
                             "WidgetClientLiveTests.GetWidget"
                         ]
                     },
-                    FailedBuildTasks = new LogAnalysisResponse
+                    FailedPipelineTasks = new LogAnalysisResponse
                     {
                         PipelineUrl = pipelineUrl,
                         Errors =

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Mock/Handlers/Pipeline/GetPipelineStatusHandler.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Mock/Handlers/Pipeline/GetPipelineStatusHandler.cs
@@ -7,7 +7,7 @@ namespace Azure.Sdk.Tools.Mock.Handlers.Pipeline;
 
 /// <summary>
 /// Mock handler for azsdk_get_pipeline_status.
-/// Switches on buildId — returns a completed pipeline status for known IDs, default otherwise.
+/// Switches on buildId, returning a completed pipeline status for known IDs and a default otherwise.
 /// </summary>
 public class GetPipelineStatusHandler : IMockToolHandler
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Mock/Handlers/Pipeline/GetPipelineStatusHandler.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Mock/Handlers/Pipeline/GetPipelineStatusHandler.cs
@@ -7,7 +7,7 @@ namespace Azure.Sdk.Tools.Mock.Handlers.Pipeline;
 
 /// <summary>
 /// Mock handler for azsdk_get_pipeline_status.
-/// Switches on buildId — returns a succeeded pipeline status for known IDs, default otherwise.
+/// Switches on buildId — returns a completed pipeline status for known IDs, default otherwise.
 /// </summary>
 public class GetPipelineStatusHandler : IMockToolHandler
 {
@@ -19,20 +19,24 @@ public class GetPipelineStatusHandler : IMockToolHandler
 
         return buildId switch
         {
-            "90001" => SucceededPipelineResponse(buildId),
+            "90001" => CompletedPipelineResponse(buildId),
             _ => MockToolFactory.GetDefaultResponse()
         };
     }
 
-    private static DefaultCommandResponse SucceededPipelineResponse(string buildId) => new()
+    private static DefaultCommandResponse CompletedPipelineResponse(string buildId) => new()
     {
-        Message = "Pipeline completed successfully",
-        Result = new
+        Message = "Pipeline completed with failures",
+        Result = new[]
         {
-            buildId,
-            status = "Succeeded",
-            result = "succeeded",
-            url = $"https://dev.azure.com/azure-sdk/internal/_build/results?buildId={buildId}"
+            new
+            {
+                build_id = int.TryParse(buildId, out var id) ? id : 0,
+                project = "internal",
+                pipeline_url = $"https://dev.azure.com/azure-sdk/internal/_build/results?buildId={buildId}",
+                status = "completed",
+                result = "failed"
+            }
         }
     };
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Mock/Handlers/Pipeline/GetPipelineStatusHandler.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Mock/Handlers/Pipeline/GetPipelineStatusHandler.cs
@@ -15,7 +15,7 @@ public class GetPipelineStatusHandler : IMockToolHandler
 
     public CommandResponse Handle(Dictionary<string, object?>? arguments)
     {
-        var buildId = arguments?.GetValueOrDefault("buildId")?.ToString() ?? "0";
+        var buildId = MockPipelineIdentifier.GetBuildId(arguments) ?? "0";
 
         return buildId switch
         {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Mock/Handlers/Pipeline/MockPipelineIdentifier.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Mock/Handlers/Pipeline/MockPipelineIdentifier.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+
+namespace Azure.Sdk.Tools.Mock.Handlers.Pipeline;
+
+/// <summary>
+/// Reads the build id out of the pipeline tools' shared <c>pipelineIdentifier</c> argument. The real tools
+/// accept a build id, a pipeline URL, a GitHub PR link or a PR number; only the first two name a build, so
+/// anything else yields null and the caller decides whether to fall back to a fixture or the default response.
+/// </summary>
+internal static class MockPipelineIdentifier
+{
+    private static readonly Regex BuildIdInUrl = new(@"[?&]buildId=(\d+)", RegexOptions.IgnoreCase);
+
+    public static string? GetBuildId(Dictionary<string, object?>? arguments)
+    {
+        var identifier = arguments?.GetValueOrDefault("pipelineIdentifier")?.ToString();
+        if (string.IsNullOrWhiteSpace(identifier))
+        {
+            return null;
+        }
+
+        if (int.TryParse(identifier, out var buildId))
+        {
+            return buildId.ToString();
+        }
+
+        var match = BuildIdInUrl.Match(identifier);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Mock/test-prompt.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Mock/test-prompt.md
@@ -47,7 +47,7 @@ The workflow should call these tools in roughly this order:
 | Tool | Mock Response |
 |------|---------------|
 | `azsdk_run_generate_sdk` | Returns build IDs 90001–90005 per language |
-| `azsdk_get_pipeline_status` | Always returns "Succeeded" |
+| `azsdk_get_pipeline_status` | Always returns status `completed` with result `failed` (build 90001 is the failed-run fixture) |
 | `azsdk_get_sdk_pull_request_link` | Returns PR URLs like `azure-sdk-for-net/pull/45001` |
 | `azsdk_create_release_plan` | Returns work item 35000, release plan ID 50001 |
 | `azsdk_get_release_plan` | Returns same release plan with SDK info populated |


### PR DESCRIPTION
The analyze tool held identifier resolution, build analysis, log parsing and the Copilot handoff in one type. Split those responsibilities so each can be tested and changed independently:

- PipelineIdentifierHelper resolves identifiers (build ids, pipeline URLs, GitHub PR links) to builds, and to the GitHub repo/commit/PR a build ran against.
- PipelineAnalysisHelper analyzes builds only: failed tasks, failed tests, logs.
- GitHubWorkflowAnalysisHelper analyzes GitHub Actions for the resolved commit.

Pipeline models move to Models/Pipeline, and LogAnalysisResponse moves to Models.Responses.

When analyzing logs, test steps are no longer dropped when no failed test results were recovered from the build's artifacts. When results are recovered the step's log is skipped as it contains duplicate failure information.
Analysis is per build. This is done so each build can be grouped with its own failures, and if one build fails it doesn't affect others.

Report the GitHub side of a pull request's CI, which includes workflows and status checks:

- Failed workflow runs for the build's commit, with their jobs and log analysis. For PR builds the head SHA comes from the build's trigger info.
- Every failing check on the pull request, read from the status check rollup. This covers red checks that no workflow run accounts for: Azure Pipelines results, and commit statuses posted by aggregating workflows that conclude successfully while reporting a failure. No logs are fetched for these, since they restate a failure detailed elsewhere in the report.
- The rollup GraphQL query is now paginated. Repositories in this org routinely report more checks than fit in one page, which silently dropped failing checks.

Fix a stall on unauthenticated analyze runs. A bare ManagedIdentityCredential inside a hand-built ChainedTokenCredential does not enable the fast-fail IMDS probe, so off Azure it blocks on the IMDS endpoint rather than falling through to the next credential. Wrapping it in a managed-identity-only DefaultAzureCredential restores the probe, and the chain moves on in about a second. The catch (CredentialUnavailableException) around the chain's construction is removed as unreachable: ChainedTokenCredential does not authenticate when constructed, so it could never fire.

Mock services, mock pipeline handlers and test-prompt.md are updated to match the new interfaces and fixture behavior.