### PR TITLE
Increment azsdk-cli to 0.6.32 and make release retries idempotent

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-publish-net.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-publish-net.yml
@@ -140,12 +140,25 @@ stages:
             AuthToken: '$(GH_TOKEN_Azure)'
             PushAuthToken: '$(GH_TOKEN_azure-sdk)'
 
+      # Publish the processed files so they are available for inspection/consumption by
+      # later jobs and stages. On success we use the stable "processed-files" name that
+      # downstream consumers expect. On failure we publish under a pipeline-unique,
+      # per-attempt name so that re-running the failed job does not collide with the
+      # artifact already published by a previous attempt (which would fail with
+      # "Artifact processed-files already exists for build <id>") and block retries.
       - task: 1ES.PublishPipelineArtifact@1
         displayName: 'Publish processed files'
+        condition: succeeded()
         inputs:
           artifactName: processed-files
           targetPath: $(Artifacts)
-        condition: always()
+
+      - task: 1ES.PublishPipelineArtifact@1
+        displayName: 'Publish processed files (failed attempt $(System.JobAttempt))'
+        condition: failed()
+        inputs:
+          artifactName: processed-files_$(System.JobAttempt)
+          targetPath: $(Artifacts)
 
   - ${{ each job in parameters.CustomReleaseJobs }}:
     - ${{ job }}

--- a/eng/pipelines/templates/stages/archetype-sdk-publish-net.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-publish-net.yml
@@ -92,8 +92,18 @@ stages:
             # This script is different from the azure-sdk-tools repo in that it A) doesn't need the eng/common $Language variable set
             # AND it sets an output variable for all the release names that were created. The output variable should be added to the eng/common
             # version and a basic override of $Language should be supported before we can remove this build-tools repo script.
+            #
+            # -forceCreate makes this step idempotent and retry-safe:
+            #   * Without it the script computes "Deployable" by querying https://api.nuget.org for the package version. These tools publish to
+            #     the private public/azure-sdk-for-net Azure Artifacts feed (never nuget.org), so that check targets the wrong repository. On a
+            #     network-isolated release agent (nuget.org is not reachable) the request throws with no HTTP response and the script exit(1)s
+            #     (observed failure: "Nuget Invocation failed: StatusCode:"). Even when reachable, once a version is published the script treats
+            #     it as "already deployed" and exit(1)s, so any retry after a successful publish is guaranteed to fail.
+            #   * -forceCreate short-circuits that check (Deployable = $forceCreate -or ...), so api.nuget.org is never contacted. Duplicate
+            #     releases are still prevented by the tag-vs-SHA check (CheckArtifactShaAgainstTagsList), which skips a tag that already exists at
+            #     the same release SHA. This lets a failed Post Package Publish job be retried after the package has already been published.
             filePath: '$(BuildToolScripts)/create-tags-and-git-release.ps1'
-            arguments: '-artifactLocation $(Artifacts) -workingDirectory $(System.DefaultWorkingDirectory) -packageRepository Nuget -releaseSha $(Build.SourceVersion) -repoId $(Build.Repository.Id)'
+            arguments: '-artifactLocation $(Artifacts) -workingDirectory $(System.DefaultWorkingDirectory) -packageRepository Nuget -releaseSha $(Build.SourceVersion) -repoId $(Build.Repository.Id) -forceCreate'
           env:
             GH_TOKEN: $(GH_TOKEN_Azure)
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Removed `package get-work-item` CLI command - the intended use case is no longer relevant.
 - Removed `package update-work-item` CLI command - the intended use case is no longer relevant.
 
+### Other Changes
+
+- The 0.6.31 package was successfully published, but the release pipeline failed in a post-publish step, so no automated version-increment PR was opened at the time; the increment to 0.6.32 completes that release.
+
 ## 0.6.31 (2026-07-27)
 
 ### Features Added


### PR DESCRIPTION
## Context

The `tools - azsdk-cli` release of **0.6.31** (pipeline [7684](https://dev.azure.com/azure-sdk/internal/_build?definitionId=7684)) published the package successfully, but the pipeline then **failed in the post-publish `Post Package Publish` job**. Because that job failed, the automated version-increment + changelog PR was never opened, and a later full re-run hit a `409 Conflict` trying to re-push the already-published `azsdk 0.6.31`.

Retrying the failed `Post Package Publish` job also surfaced two non-idempotent behaviors that block retries.

## Changes

1. **Increment version to 0.6.32** — ran `eng/scripts/Increment-dotnet-package.ps1` to bump `VersionPrefix` in `Azure.Sdk.Tools.Cli.csproj`, completing the 0.6.31 release.
2. **CHANGELOG entry** — ran `eng/common/scripts/Update-Changelog.ps1` to add a `## 0.6.32 (2026-07-28)` entry with an **Other Changes** note explaining the increment completes the previous release. Validated with `Verify-ChangeLog.ps1 -ForRelease $true`.
3. **Retry-safe `processed-files` artifact** — in `archetype-sdk-publish-net.yml`, split the `Publish processed files` step:
   - `condition: succeeded()` → stable name `processed-files`
   - `condition: failed()` → per-attempt unique name `processed-files_$(System.JobAttempt)`

   so a failed `Post Package Publish` job can be retried without the `Artifact processed-files already exists` collision.
4. **Retry-safe `Verify Package Tags and Create Git Releases`** — pass `-forceCreate` to `create-tags-and-git-release.ps1`. That script computes package "Deployability" by querying **api.nuget.org**, but these tools publish to the private **public/azure-sdk-for-net** feed (never nuget.org). On a network-isolated release agent the api.nuget.org request throws with no HTTP response and the script `exit(1)`s (observed: `Nuget Invocation failed: StatusCode:`); even when reachable, an already-published version makes it `exit(1)` too. `-forceCreate` short-circuits that check (api.nuget.org is never contacted); duplicate releases are still prevented by the tag-vs-SHA check, which skips a tag already existing at the same release SHA — making the step idempotent.

## Blast radius

Changes 3 & 4 live in the shared `archetype-sdk-publish-net.yml`, used by all .NET tools built via `archetype-sdk-tool-dotnet.yml` (identity-resolution, secret-management, azsdk-cli, snippet-generator, api parsers, content-validation, pipeline-generator, notification-configuration, test-proxy, ...). All of them publish to the same private feed, so the removed nuget.org check protected nothing for them, and duplicate-release protection is retained via the tag-SHA check.