### PR TITLE
Add azsdk-cli exception to unblock release

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -28,7 +28,7 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      ${{ if eq(variables['Build.DefinitionName'], 'net - partner-release') }}:
+      ${{ if or(eq(variables['Build.DefinitionName'], 'net - partner-release'), eq(variables['Build.DefinitionName'], 'tools - azsdk-cli')) }}:
         networkIsolationPolicy: Permissive
       ${{ else }}:
         networkIsolationPolicy: Permissive, CFSClean


### PR DESCRIPTION
## Summary
- Adds `tools - azsdk-cli` to the temporary 1ES redirect exception list.
- Uses the permissive network isolation policy for that pipeline to unblock release.

## Validation
- Not run; pipeline configuration change only.