### PR TITLE
Clarify release plan notification email

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/NotificationServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/NotificationServiceTests.cs
@@ -199,6 +199,29 @@ public class NotificationServiceTests
         Assert.That(body, Does.Not.Contain("<h3>Missing required information for KPI attestation</h3>"));
     }
 
+    [Test]
+    public void EmailTemplate_ManagementPlane_MissingProductType_IncludesAutoSdkAndActionRequired()
+    {
+        var releasePlan = new ReleasePlanWorkItem
+        {
+            ReleasePlanId = 9,
+            ProductName = "Fabrikam Relay",
+            IsManagementPlane = true,
+            CreatedUsing = "Automation",
+            ProductTreeId = "product-1",
+            ServiceTreeId = "service-1",
+            ProductType = string.Empty,
+            ApiReleaseType = ApiReleaseType.GA,
+            SDKInfo = [new SDKInfo { Language = ".NET", PackageName = "Azure.ResourceManager.FabrikamRelay" }]
+        };
+
+        var body = new NewReleasePlanEmail(releasePlan).Body;
+
+        Assert.That(body, Does.Contain(AutomatedSdkPullRequestText));
+        Assert.That(body, Does.Contain("<strong>Action required:</strong>"));
+        Assert.That(body, Does.Not.Contain("<strong>SDK pull requests:</strong>"));
+    }
+
     [TestCase(true, false, false)]
     [TestCase(false, true, false)]
     [TestCase(false, false, true)]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/NotificationServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/NotificationServiceTests.cs
@@ -19,6 +19,11 @@ public class NotificationServiceTests
 {
     private const string ServiceUrl = "https://notifications.example.com/send";
 
+    private const string AutomatedSdkPullRequestText =
+        "SDK pull requests: One SDK pull request per language (.NET, Java, JavaScript/TypeScript, Python, and Go (optional for data plane)) will be generated and linked to this plan. " +
+        "When each PR is ready, review and approve it, then complete the merge and release by following your release plan dashboard. " +
+        "The Azure SDK Tools Agent can walk you through these steps. You will be reminded automatically if an SDK is not published by the target date.";
+
     private TestLogger<NotificationService> logger;
     private Mock<IHttpClientFactory> mockHttpClientFactory;
     private Mock<IEnvironmentHelper> mockEnvironmentHelper;
@@ -87,7 +92,8 @@ public class NotificationServiceTests
         Assert.That(body, Does.Contain("A release plan is a guided workflow"));
         Assert.That(body, Does.Contain("https://aka.ms/azsdkdocs/release-plans"));
         Assert.That(body, Does.Contain("<h3>What happens next</h3>"));
-        Assert.That(body, Does.Contain("SDK pull requests for supported languages will be automatically generated"));
+        Assert.That(body, Does.Contain(AutomatedSdkPullRequestText));
+        Assert.That(body, Does.Not.Contain("<strong>SDK pull requests:</strong>"));
         Assert.That(body, Does.Not.Contain("<h3>SDK pull requests</h3>"));
         Assert.That(body, Does.Not.Contain("<strong>Action required:</strong>"));
         Assert.That(body, Does.Contain("https://aka.ms/azsdk/agent"));
@@ -149,7 +155,8 @@ public class NotificationServiceTests
         Assert.That(to, Is.EqualTo("author@microsoft.com;extra@microsoft.com"));
 
         var body = root.GetProperty("Body").GetString();
-        Assert.That(body, Does.Contain("SDK pull requests for supported languages will be automatically generated"));
+        Assert.That(body, Does.Contain(AutomatedSdkPullRequestText));
+        Assert.That(body, Does.Not.Contain("<strong>SDK pull requests:</strong>"));
         Assert.That(body, Does.Not.Contain("<strong>Action required:</strong>"));
 
         var subject = root.GetProperty("Subject").GetString();
@@ -186,6 +193,7 @@ public class NotificationServiceTests
         var body = doc.RootElement.GetProperty("Body").GetString();
 
         Assert.That(body, Does.Contain("Use the azsdk agent to generate SDK pull requests"));
+        Assert.That(body, Does.Not.Contain("<strong>SDK pull requests:</strong>"));
         Assert.That(body, Does.Contain("<strong>Action required:</strong>"));
         Assert.That(body, Does.Contain("This release plan is missing its Service Tree Product ID, Service ID, or Product Type"));
         Assert.That(body, Does.Not.Contain("<h3>Missing required information for KPI attestation</h3>"));
@@ -341,7 +349,8 @@ public class NotificationServiceTests
         var body = new NewReleasePlanEmail(releasePlan).Body;
 
         Assert.That(body, Does.Contain("Use the azsdk agent to generate SDK pull requests"));
-        Assert.That(body, Does.Not.Contain("SDK pull requests for supported languages will be automatically generated"));
+        Assert.That(body, Does.Not.Contain("<strong>SDK pull requests:</strong>"));
+        Assert.That(body, Does.Not.Contain("One SDK pull request per language"));
     }
 
     [Test]
@@ -362,7 +371,8 @@ public class NotificationServiceTests
         var body = new NewReleasePlanEmail(releasePlan).Body;
 
         Assert.That(body, Does.Contain("SDK details are currently missing from the release plan"));
-        Assert.That(body, Does.Not.Contain("SDK pull requests for supported languages will be automatically generated"));
+        Assert.That(body, Does.Not.Contain("<strong>SDK pull requests:</strong>"));
+        Assert.That(body, Does.Not.Contain("One SDK pull request per language"));
         Assert.That(body, Does.Not.Contain("Use the azsdk agent to generate SDK pull requests"));
     }
 
@@ -389,7 +399,8 @@ public class NotificationServiceTests
         var body = new NewReleasePlanEmail(releasePlan).Body;
 
         Assert.That(body, Does.Contain("SDK details are currently missing from the release plan"));
-        Assert.That(body, Does.Not.Contain("SDK pull requests for supported languages will be automatically generated"));
+        Assert.That(body, Does.Not.Contain("<strong>SDK pull requests:</strong>"));
+        Assert.That(body, Does.Not.Contain("One SDK pull request per language"));
         Assert.That(body, Does.Not.Contain("Use the azsdk agent to generate SDK pull requests"));
     }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/NotificationServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/NotificationServiceTests.cs
@@ -22,7 +22,7 @@ public class NotificationServiceTests
     private const string AutomatedSdkPullRequestText =
         "SDK pull requests: One SDK pull request per language (.NET, Java, JavaScript/TypeScript, Python, and Go (optional for data plane)) will be generated and linked to this plan. " +
         "When each PR is ready, review and approve it, then complete the merge and release by following your release plan dashboard. " +
-        "The Azure SDK Tools Agent can walk you through these steps. You will be reminded automatically if an SDK is not published by the target date.";
+        "The Azure SDK Tools Agent can walk you through these steps.";
 
     private TestLogger<NotificationService> logger;
     private Mock<IHttpClientFactory> mockHttpClientFactory;
@@ -84,7 +84,7 @@ public class NotificationServiceTests
         var subject = template.Subject;
         var body = template.Body;
 
-        Assert.That(subject, Is.EqualTo("Release plan created for Contoso (GA)"));
+        Assert.That(subject, Is.EqualTo("Azure SDK Release plan created for Contoso (GA)"));
         Assert.That(body, Does.Contain("https://github.com/pr/1"));
         Assert.That(body, Does.Contain(releasePlan.ReleasePlanLink));
         Assert.That(body, Does.Contain("An Azure SDK release plan has been automatically created after merging"));
@@ -93,6 +93,7 @@ public class NotificationServiceTests
         Assert.That(body, Does.Contain("https://aka.ms/azsdkdocs/release-plans"));
         Assert.That(body, Does.Contain("<h3>What happens next</h3>"));
         Assert.That(body, Does.Contain(AutomatedSdkPullRequestText));
+        Assert.That(body, Does.Not.Contain("You will be reminded automatically if an SDK is not published by the target date."));
         Assert.That(body, Does.Not.Contain("<strong>SDK pull requests:</strong>"));
         Assert.That(body, Does.Not.Contain("<h3>SDK pull requests</h3>"));
         Assert.That(body, Does.Not.Contain("<strong>Action required:</strong>"));
@@ -160,7 +161,7 @@ public class NotificationServiceTests
         Assert.That(body, Does.Not.Contain("<strong>Action required:</strong>"));
 
         var subject = root.GetProperty("Subject").GetString();
-        Assert.That(subject, Is.EqualTo("Release plan created for Contoso (GA)"));
+        Assert.That(subject, Is.EqualTo("Azure SDK Release plan created for Contoso (GA)"));
     }
 
     [Test]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/NotificationServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/NotificationServiceTests.cs
@@ -82,8 +82,14 @@ public class NotificationServiceTests
         Assert.That(subject, Is.EqualTo("Release plan created for Contoso (GA)"));
         Assert.That(body, Does.Contain("https://github.com/pr/1"));
         Assert.That(body, Does.Contain(releasePlan.ReleasePlanLink));
-        Assert.That(body, Does.Contain("SDK pull requests will be auto generated"));
-        Assert.That(body, Does.Contain("<h3>SDK pull requests</h3>"));
+        Assert.That(body, Does.Contain("An Azure SDK release plan has been automatically created after merging"));
+        Assert.That(body, Does.Not.Contain("created successfully"));
+        Assert.That(body, Does.Contain("A release plan is a guided workflow"));
+        Assert.That(body, Does.Contain("https://aka.ms/azsdkdocs/release-plans"));
+        Assert.That(body, Does.Contain("<h3>What happens next</h3>"));
+        Assert.That(body, Does.Contain("SDK pull requests for supported languages will be automatically generated"));
+        Assert.That(body, Does.Not.Contain("<h3>SDK pull requests</h3>"));
+        Assert.That(body, Does.Not.Contain("<strong>Action required:</strong>"));
         Assert.That(body, Does.Contain("https://aka.ms/azsdk/agent"));
         Assert.That(body, Does.Not.Contain("{"));
     }
@@ -143,8 +149,8 @@ public class NotificationServiceTests
         Assert.That(to, Is.EqualTo("author@microsoft.com;extra@microsoft.com"));
 
         var body = root.GetProperty("Body").GetString();
-        Assert.That(body, Does.Contain("SDK pull requests will be auto generated"));
-        Assert.That(body, Does.Not.Contain("KPI attestation"));
+        Assert.That(body, Does.Contain("SDK pull requests for supported languages will be automatically generated"));
+        Assert.That(body, Does.Not.Contain("<strong>Action required:</strong>"));
 
         var subject = root.GetProperty("Subject").GetString();
         Assert.That(subject, Is.EqualTo("Release plan created for Contoso (GA)"));
@@ -179,9 +185,34 @@ public class NotificationServiceTests
         using var doc = JsonDocument.Parse(captured[0]);
         var body = doc.RootElement.GetProperty("Body").GetString();
 
-        Assert.That(body, Does.Contain("Please use azsdk agent to generate the SDK pull requests"));
-        Assert.That(body, Does.Contain("<h3>Missing required information for KPI attestation</h3>"));
-        Assert.That(body, Does.Contain("complete KPI attestation"));
+        Assert.That(body, Does.Contain("Use the azsdk agent to generate SDK pull requests"));
+        Assert.That(body, Does.Contain("<strong>Action required:</strong>"));
+        Assert.That(body, Does.Contain("This release plan is missing its Service Tree Product ID, Service ID, or Product Type"));
+        Assert.That(body, Does.Not.Contain("<h3>Missing required information for KPI attestation</h3>"));
+    }
+
+    [TestCase(true, false, false)]
+    [TestCase(false, true, false)]
+    [TestCase(false, false, true)]
+    public void EmailTemplate_MissingAnyProductDetail_IncludesActionRequired(
+        bool missingProductTreeId,
+        bool missingServiceTreeId,
+        bool missingProductType)
+    {
+        var releasePlan = new ReleasePlanWorkItem
+        {
+            ReleasePlanId = 8,
+            ProductName = "Fabrikam",
+            ProductTreeId = missingProductTreeId ? string.Empty : "product-1",
+            ServiceTreeId = missingServiceTreeId ? string.Empty : "service-1",
+            ProductType = missingProductType ? string.Empty : "Offering",
+            SDKInfo = [new SDKInfo { Language = "Python", PackageName = "azure-mgmt-fabrikam" }]
+        };
+
+        var body = new NewReleasePlanEmail(releasePlan).Body;
+
+        Assert.That(body, Does.Contain("<strong>Action required:</strong>"));
+        Assert.That(body, Does.Contain("This release plan is missing its Service Tree Product ID, Service ID, or Product Type"));
     }
 
     [Test]
@@ -309,8 +340,8 @@ public class NotificationServiceTests
 
         var body = new NewReleasePlanEmail(releasePlan).Body;
 
-        Assert.That(body, Does.Contain("Please use azsdk agent to generate the SDK pull requests"));
-        Assert.That(body, Does.Not.Contain("SDK pull requests will be auto generated"));
+        Assert.That(body, Does.Contain("Use the azsdk agent to generate SDK pull requests"));
+        Assert.That(body, Does.Not.Contain("SDK pull requests for supported languages will be automatically generated"));
     }
 
     [Test]
@@ -331,8 +362,8 @@ public class NotificationServiceTests
         var body = new NewReleasePlanEmail(releasePlan).Body;
 
         Assert.That(body, Does.Contain("SDK details are currently missing from the release plan"));
-        Assert.That(body, Does.Not.Contain("SDK pull requests will be auto generated"));
-        Assert.That(body, Does.Not.Contain("Please use azsdk agent to generate the SDK pull requests"));
+        Assert.That(body, Does.Not.Contain("SDK pull requests for supported languages will be automatically generated"));
+        Assert.That(body, Does.Not.Contain("Use the azsdk agent to generate SDK pull requests"));
     }
 
     [Test]
@@ -358,8 +389,8 @@ public class NotificationServiceTests
         var body = new NewReleasePlanEmail(releasePlan).Body;
 
         Assert.That(body, Does.Contain("SDK details are currently missing from the release plan"));
-        Assert.That(body, Does.Not.Contain("SDK pull requests will be auto generated"));
-        Assert.That(body, Does.Not.Contain("Please use azsdk agent to generate the SDK pull requests"));
+        Assert.That(body, Does.Not.Contain("SDK pull requests for supported languages will be automatically generated"));
+        Assert.That(body, Does.Not.Contain("Use the azsdk agent to generate SDK pull requests"));
     }
 
     [Test]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Notification/Templates/NewReleasePlanEmail.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Notification/Templates/NewReleasePlanEmail.cs
@@ -22,7 +22,7 @@ namespace Azure.Sdk.Tools.Cli.Services.Notification.Templates
             "Each release plan is scoped to <strong>one release type</strong> (Private Preview, Public Preview, or GA) " +
             "<strong>and one plane</strong> (data plane or management (ARM) plane). " +
             "A release plan is required before any Azure SDK-related Cloud Lifecycle (CPEX) KPIs can be approved for this release. " +
-            $"<a href=\"{ReleasePlanDocumentationUrl}\">Learn more about release plans.</a></p>";
+            "<a href=\"" + ReleasePlanDocumentationUrl + "\">Learn more about release plans.</a></p>";
 
         private const string AutomatedSdkPullRequestNextStep =
             "<li>SDK pull requests: One SDK pull request per language (.NET, Java, JavaScript/TypeScript, Python, and Go (optional for data plane)) will be generated and linked to this plan. " +

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Notification/Templates/NewReleasePlanEmail.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Notification/Templates/NewReleasePlanEmail.cs
@@ -25,12 +25,12 @@ namespace Azure.Sdk.Tools.Cli.Services.Notification.Templates
             $"<a href=\"{ReleasePlanDocumentationUrl}\">Learn more about release plans.</a></p>";
 
         private const string AutomatedSdkPullRequestNextStep =
-            "<li><strong>SDK pull requests:</strong> SDK pull requests for supported languages will be automatically generated and linked to this plan. " +
-            "When each pull request is ready, review and approve it, then follow the release plan dashboard to merge and release it. " +
+            "<li>SDK pull requests: One SDK pull request per language (.NET, Java, JavaScript/TypeScript, Python, and Go (optional for data plane)) will be generated and linked to this plan. " +
+            "When each PR is ready, review and approve it, then complete the merge and release by following your release plan dashboard. " +
             "The Azure SDK Tools Agent can walk you through these steps. You will be reminded automatically if an SDK is not published by the target date.</li>";
 
         private const string ManualSdkPullRequestNextStep =
-            "<li><strong>SDK pull requests:</strong> Use the azsdk agent to generate SDK pull requests and link them to this plan. " +
+            "<li>SDK pull requests: Use the azsdk agent to generate SDK pull requests and link them to this plan. " +
             "When each pull request is ready, review and approve it, then follow the release plan dashboard to merge and release it.</li>";
 
         private const string KpiAttestationActionRequiredSection =
@@ -40,7 +40,7 @@ namespace Azure.Sdk.Tools.Cli.Services.Notification.Templates
             "Use the azsdk agent to add them.</li>";
 
         private const string MissingSdkDetailsNextStep =
-            "<li><strong>SDK pull requests:</strong> SDK details are currently missing from the release plan, likely because the emitter configuration is not defined in tspconfig.yaml. " +
+            "<li>SDK pull requests: SDK details are currently missing from the release plan, likely because the emitter configuration is not defined in tspconfig.yaml. " +
             "As a result, SDK pull requests cannot be generated until the emitter configuration is added to tspconfig.yaml and the release plan is updated with the SDK details.</li>";
 
         private const string AzSdkAgentDocumentationUrl = "https://aka.ms/azsdk/agent";

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Notification/Templates/NewReleasePlanEmail.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Notification/Templates/NewReleasePlanEmail.cs
@@ -13,22 +13,35 @@ namespace Azure.Sdk.Tools.Cli.Services.Notification.Templates
     /// </summary>
     public class NewReleasePlanEmail : EmailPayload
     {
-        private const string AutomatedSDKGenMessage =
-            "<p>SDK pull requests will be auto generated and linked to the release plan.</p>";
-
-        private const string ManualSDKGenMessage =
-            "<p>Please use azsdk agent to generate the SDK pull requests and link them to the release plan.</p>";
-
         private const string AutomationCreatedUsing = "Automation";
 
-        private const string KpiAttestationSection =
-            "<h3>Missing required information for KPI attestation</h3>" +
-            "<p>This release plan is currently missing Product ID, Service ID, or Product Type.</p>" +
-            "<p>Please use azsdk agent to update the release plan with Product ID, Service ID, and Product Type to complete KPI attestation when release plan is completed.</p>";
+        private const string ReleasePlanDocumentationUrl = "https://aka.ms/azsdkdocs/release-plans";
 
-        private const string MissingSdkDetailsSection =
-            "<p>SDK details are currently missing from the release plan, likely because the emitter configuration is not defined in tspconfig.yaml. " +
-            "As a result, the SDK pull request cannot be generated until the emitter configuration is added to tspconfig.yaml and the release plan is updated with the SDK details.</p>";
+        private const string ReleasePlanOverview =
+            "<p>A release plan is a guided workflow that tracks an <strong>API release</strong> from API spec review, through SDK generation, to SDK release. " +
+            "Each release plan is scoped to <strong>one release type</strong> (Private Preview, Public Preview, or GA) " +
+            "<strong>and one plane</strong> (data plane or management (ARM) plane). " +
+            "A release plan is required before any Azure SDK-related Cloud Lifecycle (CPEX) KPIs can be approved for this release. " +
+            $"<a href=\"{ReleasePlanDocumentationUrl}\">Learn more about release plans.</a></p>";
+
+        private const string AutomatedSdkPullRequestNextStep =
+            "<li><strong>SDK pull requests:</strong> SDK pull requests for supported languages will be automatically generated and linked to this plan. " +
+            "When each pull request is ready, review and approve it, then follow the release plan dashboard to merge and release it. " +
+            "The Azure SDK Tools Agent can walk you through these steps. You will be reminded automatically if an SDK is not published by the target date.</li>";
+
+        private const string ManualSdkPullRequestNextStep =
+            "<li><strong>SDK pull requests:</strong> Use the azsdk agent to generate SDK pull requests and link them to this plan. " +
+            "When each pull request is ready, review and approve it, then follow the release plan dashboard to merge and release it.</li>";
+
+        private const string KpiAttestationActionRequiredSection =
+            "<li><strong>Action required:</strong> If your product is part of an official Cloud Lifecycle phase release, complete the CPEX / KPI attestation details. " +
+            "This release plan is missing its Service Tree Product ID, Service ID, or Product Type (for example, Feature, SKU, or Offering). " +
+            "These details link the plan to its Service Tree product so Cloud Lifecycle KPIs can be auto-attested when the release completes. " +
+            "Use the azsdk agent to add them.</li>";
+
+        private const string MissingSdkDetailsNextStep =
+            "<li><strong>SDK pull requests:</strong> SDK details are currently missing from the release plan, likely because the emitter configuration is not defined in tspconfig.yaml. " +
+            "As a result, SDK pull requests cannot be generated until the emitter configuration is added to tspconfig.yaml and the release plan is updated with the SDK details.</li>";
 
         private const string AzSdkAgentDocumentationUrl = "https://aka.ms/azsdk/agent";
 
@@ -69,17 +82,17 @@ namespace Azure.Sdk.Tools.Cli.Services.Notification.Templates
             <body>
                 <p>Hello,</p>
                 {CreationSummary}
+                {ReleasePlanOverview}
                 <p>The release plan dashboard contains the actions required to complete this release plan.</p>
                 <ul>
                     <li><strong>Release plan:</strong> <a href="{releasePlan.ReleasePlanLink}">{releasePlan.ReleasePlanLink}</a></li>
                     <li><strong>Release plan type:</strong> {releasePlan.ApiReleaseType.ToDisplayLabel()}</li>
                 </ul>
-                <br>
-                <h3>SDK pull requests</h3>
-                {SdkPullRequestSectionContent}
-                <br>
-                {KpiAttestationSectionContent}
-                <br>
+                <h3>What happens next</h3>
+                <ul>
+                    {SdkPullRequestNextStepContent}
+                    {KpiAttestationActionRequiredContent}
+                </ul>
                 <p>For more information about the azsdk agent, see <a href="{AzSdkAgentDocumentationUrl}">{AzSdkAgentDocumentationUrl}</a>.</p>
                 <p>If you need any assistance, please reach out to the AzSDK Agent team via the <a href="https://teams.microsoft.com/l/channel/19%3A6d2c19322c254a80bcc521675134da03%40thread.skype/AzSDK%20Tools%20Agent?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47">Teams channel</a>.</p>
                 <p>Best regards,</p>
@@ -97,8 +110,8 @@ namespace Azure.Sdk.Tools.Cli.Services.Notification.Templates
                     string.Equals(releasePlan.CreatedUsing, AutomationCreatedUsing, StringComparison.OrdinalIgnoreCase);
 
                 return isAutomationCreated && !string.IsNullOrWhiteSpace(specPullRequest)
-                    ? $"""<p>A release plan has been created successfully after merging <a href="{specPullRequest}">{specPullRequest}</a>, which added a new API version.</p>"""
-                    : "<p>A release plan has been created successfully.</p>";
+                    ? $"""<p>An Azure SDK release plan has been automatically created after merging <a href="{specPullRequest}">{specPullRequest}</a>, which added a new API version.</p>"""
+                    : "<p>An Azure SDK release plan has been created.</p>";
             }
         }
 
@@ -111,15 +124,15 @@ namespace Azure.Sdk.Tools.Cli.Services.Notification.Templates
             }
         }
 
-        private string PlaneSpecificMessage =>
+        private string SdkPullRequestNextStep =>
             releasePlan.IsManagementPlane
             && string.Equals(releasePlan.CreatedUsing, AutomationCreatedUsing, StringComparison.OrdinalIgnoreCase)
-                ? AutomatedSDKGenMessage
-                : ManualSDKGenMessage;
+            ? AutomatedSdkPullRequestNextStep
+            : ManualSdkPullRequestNextStep;
 
-        private string KpiAttestationSectionContent => IsMissingProductInfo ? KpiAttestationSection : string.Empty;
+        private string KpiAttestationActionRequiredContent => IsMissingProductInfo ? KpiAttestationActionRequiredSection : string.Empty;
 
-        private string SdkPullRequestSectionContent => IsMissingSdkDetails ? MissingSdkDetailsSection : PlaneSpecificMessage;
+        private string SdkPullRequestNextStepContent => IsMissingSdkDetails ? MissingSdkDetailsNextStep : SdkPullRequestNextStep;
 
         private bool IsMissingSdkDetails =>
             releasePlan.SDKInfo is null

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Notification/Templates/NewReleasePlanEmail.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/Notification/Templates/NewReleasePlanEmail.cs
@@ -27,7 +27,7 @@ namespace Azure.Sdk.Tools.Cli.Services.Notification.Templates
         private const string AutomatedSdkPullRequestNextStep =
             "<li>SDK pull requests: One SDK pull request per language (.NET, Java, JavaScript/TypeScript, Python, and Go (optional for data plane)) will be generated and linked to this plan. " +
             "When each PR is ready, review and approve it, then complete the merge and release by following your release plan dashboard. " +
-            "The Azure SDK Tools Agent can walk you through these steps. You will be reminded automatically if an SDK is not published by the target date.</li>";
+            "The Azure SDK Tools Agent can walk you through these steps.</li>";
 
         private const string ManualSdkPullRequestNextStep =
             "<li>SDK pull requests: Use the azsdk agent to generate SDK pull requests and link them to this plan. " +
@@ -74,7 +74,7 @@ namespace Azure.Sdk.Tools.Cli.Services.Notification.Templates
         }
 
         public override string Subject =>
-            $"Release plan created for {releasePlan.ProductName} ({releasePlan.ApiReleaseType.ToDisplayLabel()})";
+            $"Azure SDK Release plan created for {releasePlan.ProductName} ({releasePlan.ApiReleaseType.ToDisplayLabel()})";
 
         public override string Body =>
             $"""


### PR DESCRIPTION
Notification email under different conditions:


Management Plan:

<img width="2450" height="1689" alt="image" src="https://github.com/user-attachments/assets/89ef636c-40f8-492d-9b89-217920d5794c" />

<img width="2423" height="1690" alt="image" src="https://github.com/user-attachments/assets/fd118c4b-94a7-428b-93e0-4e4c3a35506b" />

<img width="2515" height="1624" alt="image" src="https://github.com/user-attachments/assets/db02da5a-a46e-41df-b1c2-5f8ef53ad926" />

Manual Data Plan:

<img width="2478" height="1712" alt="image" src="https://github.com/user-attachments/assets/83b8ffdf-a669-49bb-a1aa-6c07f1157fa9" />




## Related issues

- fix #16604 - Clarify new release plan notification email