### PR TITLE
Fix ADO shell-arg sanitizer warning in save-package-properties.yml

### DIFF
--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -71,13 +71,30 @@ steps:
         workingDirectory: '${{ parameters.WorkingDirectory }}'
 
   - ${{ else }}:
+      # Split into two variants gated by a runtime condition on the SetDevVersion
+      # pipeline variable. This avoids passing a parenthesized $env: expression in
+      # 'arguments:', which the ADO agent argument sanitizer flags (aka.ms/ado/75787).
+      # Exactly one variant runs, preserving the original
+      # -AddDevVersion:($env:SETDEVVERSION -eq 'true') behavior.
       - task: Powershell@2
         displayName: Save package properties
+        condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'))
         inputs:
           filePath: ${{ parameters.ScriptDirectory }}/Save-Package-Properties.ps1
           arguments: >
             -ServiceDirectory '${{parameters.ServiceDirectory}}'
             -OutDirectory '${{ parameters.PackageInfoDirectory }}'
-            -AddDevVersion:($env:SETDEVVERSION -eq 'true')
+          pwsh: true
+          workingDirectory: '${{ parameters.WorkingDirectory }}'
+
+      - task: Powershell@2
+        displayName: Save package properties (with dev version)
+        condition: and(succeeded(), eq(variables['SetDevVersion'], 'true'))
+        inputs:
+          filePath: ${{ parameters.ScriptDirectory }}/Save-Package-Properties.ps1
+          arguments: >
+            -ServiceDirectory '${{parameters.ServiceDirectory}}'
+            -OutDirectory '${{ parameters.PackageInfoDirectory }}'
+            -AddDevVersion
           pwsh: true
           workingDirectory: '${{ parameters.WorkingDirectory }}'


### PR DESCRIPTION
Copilot agent :copilot: (on behalf of @jeremymeng): Fix the ADO argument-sanitizer warning emitted by the "Save package properties" step in language-repo builds (observed in `Azure/azure-sdk-for-js` `js - core`, step "Save package properties"):

```
##[warning]Detected characters in arguments that may not be executed correctly by the shell. Please escape special characters using backtick (`). More information is available here: https://aka.ms/ado/75787
```

## Root cause

In `eng/common/pipelines/templates/steps/save-package-properties.yml`, the non-PR (`${{ else }}`) branch passed this to the `Powershell@2` task:

```yaml
arguments: >
  -ServiceDirectory '${{parameters.ServiceDirectory}}'
  -OutDirectory '${{ parameters.PackageInfoDirectory }}'
  -AddDevVersion:($env:SETDEVVERSION -eq 'true')
```

The `-AddDevVersion:($env:SETDEVVERSION -eq 'true')` fragment contains `(`, `)`, `$`, and quotes. The ADO agent argument sanitizer flags these special characters (aka.ms/ado/75787) when building the shell command line, producing the warning on every non-PR build.

`-AddDevVersion` is a `[switch]` on `Save-Package-Properties.ps1`, effectively `$true` only when the `SETDEVVERSION` env var (mirror of the runtime pipeline variable `SetDevVersion`, set in `daily-dev-build-variable.yml`) equals `'true'`, and `$false` (equivalent to omitting the switch) otherwise. Because `SetDevVersion` is set at runtime, a compile-time `${{ if }}` cannot read it — the decision must be made with a runtime `condition:`.

## Fix

Split the single non-PR task into two `Powershell@2` variants gated by a runtime `condition:` on `variables['SetDevVersion']`, so no parenthesized `$env:` expression is ever passed as an argument:

- `ne(variables['SetDevVersion'], 'true')` → arguments **without** `-AddDevVersion`
- `eq(variables['SetDevVersion'], 'true')` → arguments **with** a bare `-AddDevVersion` switch

Exactly one variant runs, so this is behavior-preserving and equivalent to the original `-AddDevVersion:($env:SETDEVVERSION -eq 'true')`, while the argument strings now contain only plain flags plus single-quoted values — satisfying the sanitizer.

## Scope / notes

- This repo is the source of truth for `eng/common`, which is synced out to language repos; the fix is made here.
- Grepped all of `eng/common`: this is the only parenthesized `$env:` expression inside an `arguments:` block, so the change is scoped to `save-package-properties.yml`.
- `variables['SetDevVersion']` is equivalent to `$env:SETDEVVERSION` because the value is published as a pipeline variable (thus both a `variables[...]` entry and an env var).
- YAML validated as well-formed.
