### PR TITLE
Allow force-create release for azsdk-cli

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -28,7 +28,7 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      ${{ if or(eq(variables['Build.DefinitionName'], 'net - partner-release'), eq(variables['Build.DefinitionName'], 'tools - azsdk-cli')) }}:
+      ${{ if eq(variables['Build.DefinitionName'], 'net - partner-release') }}:
         networkIsolationPolicy: Permissive
       ${{ else }}:
         networkIsolationPolicy: Permissive, CFSClean

--- a/eng/pipelines/templates/stages/archetype-sdk-publish-net.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-publish-net.yml
@@ -9,6 +9,7 @@ parameters:
   VerifyChangelog: false
   ToolDirectory: ''
   CustomReleaseJobs: []
+  ForceCreate: false
 # Needs Github Release variable group linked.
 # Needs AzureSDK Nuget Release Pipelines Secrets variable group linked.
 
@@ -93,7 +94,7 @@ stages:
             # AND it sets an output variable for all the release names that were created. The output variable should be added to the eng/common
             # version and a basic override of $Language should be supported before we can remove this build-tools repo script.
             filePath: '$(BuildToolScripts)/create-tags-and-git-release.ps1'
-            arguments: '-artifactLocation $(Artifacts) -workingDirectory $(System.DefaultWorkingDirectory) -packageRepository Nuget -releaseSha $(Build.SourceVersion) -repoId $(Build.Repository.Id)'
+            arguments: '-artifactLocation $(Artifacts) -workingDirectory $(System.DefaultWorkingDirectory) -packageRepository Nuget -releaseSha $(Build.SourceVersion) -repoId $(Build.Repository.Id) -forceCreate:$${{ parameters.ForceCreate }}'
           env:
             GH_TOKEN: $(GH_TOKEN_Azure)
 

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -71,6 +71,9 @@ parameters:
   - name: CustomReleaseJobs
     type: jobList
     default: []
+  - name: ForceCreate
+    type: boolean
+    default: false
 
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
@@ -245,6 +248,7 @@ extends:
             VerifyChangelog: ${{ parameters.VerifyChangelog }}
             ToolDirectory: '${{ coalesce(parameters.PackageDirectory, parameters.ToolDirectory) }}'
             CustomReleaseJobs: ${{ parameters.CustomReleaseJobs }}
+            ForceCreate: ${{ parameters.ForceCreate }}
 
       - ${{ if and(ne(parameters.SkipReleaseStage, true), not(eq(length(parameters.DockerDeployments), 0)), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
         - stage: PublishDockerImages

--- a/tools/azsdk-cli/ci.yml
+++ b/tools/azsdk-cli/ci.yml
@@ -40,6 +40,9 @@ extends:
     ToolDirectory: $(ToolDir)
     TestDirectory: tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests
     VerifyChangelog: true
+    # Force-create git tags/releases to work around the CFSClean network isolation
+    # policy bypass for this pipeline. Tracked by https://github.com/Azure/azure-sdk-tools/issues/16602
+    ForceCreate: true
     # GitHub.Copilot.SDK dependency is not strong name signed. Skip validation in order to sign azsdk cli.
     RequireStrongNames: false
     # Install copilot-cli separately from the copilot agent sdk.


### PR DESCRIPTION
## Summary
- Adds a `ForceCreate` parameter to the .NET SDK publish and tool pipeline templates.
- Passes the parameter through to `create-tags-and-git-release.ps1` as `-forceCreate`.
- Enables `ForceCreate` for the azsdk-cli pipeline to unblock package release while the network isolation workaround is tracked in #16602.
