### PR TITLE
Resolve CFSClean break in several pipelines

### DIFF
--- a/tools/apiview/emitters/typespec-apiview/ci.yml
+++ b/tools/apiview/emitters/typespec-apiview/ci.yml
@@ -44,6 +44,8 @@ extends:
               os: linux
 
             steps:
+              - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+              
               - task: NodeTool@0
                 inputs:
                   versionSpec: '$(NodeVersion)'

--- a/tools/apiview/emitters/typespec-apiview/package-lock.json
+++ b/tools/apiview/emitters/typespec-apiview/package-lock.json
@@ -14,7 +14,7 @@
         "@typespec/eslint-plugin": ">=0.67 <1.0",
         "@typespec/http": "^1.0.0",
         "@typespec/library-linter": ">=0.67 <1.0",
-        "@typespec/prettier-plugin-typespec": ">=0.67 <1.0",
+        "@typespec/prettier-plugin-typespec": "^1.9.0",
         "@typespec/rest": ">=0.67 <1.0",
         "@vitest/coverage-v8": "^4.1.8",
         "c8": "^9.1.0",
@@ -2137,19 +2137,19 @@
       }
     },
     "node_modules/@typespec/prettier-plugin-typespec": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@typespec/prettier-plugin-typespec/-/prettier-plugin-typespec-0.68.0.tgz",
-      "integrity": "sha512-SmNW7G2ddJMu2MJTJaxTjwH9S/BGD+wP2LE4EuFWLCfxUIITpZ2ae3BC8C9RdXDz+TbDmyab9ZBza9fzljEshg==",
+      "version": "1.14.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typespec/prettier-plugin-typespec/-/prettier-plugin-typespec-1.14.0.tgz",
+      "integrity": "sha1-Nxm4JXSYi1zOL+2OUA5awqudBXI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "prettier": "~3.5.3"
+        "prettier": "^3.8.1"
       }
     },
     "node_modules/@typespec/prettier-plugin-typespec/node_modules/prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "version": "3.9.6",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha1-s+pRRlFdQPxT8YqmP3Tfqx4Q2/Y=",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/tools/apiview/emitters/typespec-apiview/package-lock.json
+++ b/tools/apiview/emitters/typespec-apiview/package-lock.json
@@ -14,7 +14,7 @@
         "@typespec/eslint-plugin": ">=0.67 <1.0",
         "@typespec/http": "^1.0.0",
         "@typespec/library-linter": ">=0.67 <1.0",
-        "@typespec/prettier-plugin-typespec": "^1.9.0",
+        "@typespec/prettier-plugin-typespec": ">=0.67 <1.0",
         "@typespec/rest": ">=0.67 <1.0",
         "@vitest/coverage-v8": "^4.1.8",
         "c8": "^9.1.0",
@@ -2137,19 +2137,19 @@
       }
     },
     "node_modules/@typespec/prettier-plugin-typespec": {
-      "version": "1.14.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typespec/prettier-plugin-typespec/-/prettier-plugin-typespec-1.14.0.tgz",
-      "integrity": "sha1-Nxm4JXSYi1zOL+2OUA5awqudBXI=",
+      "version": "0.68.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typespec/prettier-plugin-typespec/-/prettier-plugin-typespec-0.68.0.tgz",
+      "integrity": "sha1-wZiRVdCP9nsf+hfNONToWJk+fI4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "prettier": "^3.8.1"
+        "prettier": "~3.5.3"
       }
     },
     "node_modules/@typespec/prettier-plugin-typespec/node_modules/prettier": {
-      "version": "3.9.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/prettier/-/prettier-3.9.6.tgz",
-      "integrity": "sha1-s+pRRlFdQPxT8YqmP3Tfqx4Q2/Y=",
+      "version": "3.5.3",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha1-T8LODWV+egLmAlSfBTsjnLff4bU=",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/tools/apiview/emitters/typespec-apiview/package.json
+++ b/tools/apiview/emitters/typespec-apiview/package.json
@@ -63,7 +63,7 @@
     "@types/node": "^22.0.0",
     "@typespec/eslint-plugin": ">=0.67 <1.0",
     "@typespec/library-linter": ">=0.67 <1.0",
-    "@typespec/prettier-plugin-typespec": "^1.9.0",
+    "@typespec/prettier-plugin-typespec": ">=0.67 <1.0",
     "@typespec/rest": ">=0.67 <1.0",
     "@typespec/http": "^1.0.0",
     "@vitest/coverage-v8": "^4.1.8",

--- a/tools/apiview/emitters/typespec-apiview/package.json
+++ b/tools/apiview/emitters/typespec-apiview/package.json
@@ -63,7 +63,7 @@
     "@types/node": "^22.0.0",
     "@typespec/eslint-plugin": ">=0.67 <1.0",
     "@typespec/library-linter": ">=0.67 <1.0",
-    "@typespec/prettier-plugin-typespec": ">=0.67 <1.0",
+    "@typespec/prettier-plugin-typespec": "^1.9.0",
     "@typespec/rest": ">=0.67 <1.0",
     "@typespec/http": "^1.0.0",
     "@vitest/coverage-v8": "^4.1.8",

--- a/tools/apiview/parsers/js-api-parser/ci.yml
+++ b/tools/apiview/parsers/js-api-parser/ci.yml
@@ -43,6 +43,8 @@ extends:
               os: linux
 
             steps:
+              - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+
               - task: NodeTool@0
                 inputs:
                   versionSpec: '$(NodeVersion)'

--- a/tools/js-sdk-release-tools/ci.yml
+++ b/tools/js-sdk-release-tools/ci.yml
@@ -47,7 +47,7 @@ extends:
               os: linux
             steps:
             - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
-            
+
             - task: NodeTool@0
               inputs:
                 versionSpec: '$(NodeVersion)'

--- a/tools/oav-traffic-converter/ci.yml
+++ b/tools/oav-traffic-converter/ci.yml
@@ -46,6 +46,8 @@ extends:
         - job: Test
 
           steps:
+          - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+
           - task: NodeTool@0
             inputs:
               versionSpec: '$(NodeVersion)'

--- a/tools/sdk-testgen/ci.yml
+++ b/tools/sdk-testgen/ci.yml
@@ -48,6 +48,9 @@ extends:
               - template: /eng/common/pipelines/templates/steps/verify-path-length.yml
                 parameters:
                   SourceDirectory: 'tools/sdk-testgen'
+
+              - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+
               - task: NodeTool@0
                 inputs:
                   versionSpec: "24.x"

--- a/tools/test-proxy/ci.yml
+++ b/tools/test-proxy/ci.yml
@@ -53,10 +53,13 @@ extends:
           #vso[task.setvariable variable=COMPlus_Pkcs12UnspecifiedPasswordIterationLimit]-1
         displayName: Override Acceptable Password Iteration Count
     TestPostSteps:
+      - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+
       - task: UseNode@1
         inputs:
           version: ">=24"
         displayName: "Use Node"
+
       - pwsh: |
           npm ci
           npm exec --no -- tsp compile .

--- a/tools/tsp-client/build-tsp-client.yml
+++ b/tools/tsp-client/build-tsp-client.yml
@@ -4,6 +4,8 @@ parameters:
     default: false
 
 steps:
+  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+
   - task: NodeTool@0
     inputs:
       versionSpec: "$(NodeVersion)"

--- a/tools/tsp-client/test/npm-pinning.spec.ts
+++ b/tools/tsp-client/test/npm-pinning.spec.ts
@@ -58,6 +58,7 @@ describe("use-npm-pinning flag", () => {
     });
 
     const args = {
+      "output-dir": tmpDir,
       "package-json": joinPaths(cwd(), "test", "examples", "package.json"),
       "emitter-package-json-path": emitterPackageJsonPath,
       "use-npm-pinning": true,
@@ -81,6 +82,7 @@ describe("use-npm-pinning flag", () => {
     });
 
     const args = {
+      "output-dir": tmpDir,
       "package-json": joinPaths(cwd(), "test", "examples", "package.json"),
       "emitter-package-json-path": emitterPackageJsonPath,
       "use-npm-pinning": true,
@@ -98,6 +100,7 @@ describe("use-npm-pinning flag", () => {
 
   it("does not call npmViewPackageDevDependencies when use-npm-pinning is not set", async () => {
     const args = {
+      "output-dir": tmpDir,
       "package-json": joinPaths(cwd(), "test", "examples", "package.json"),
       "emitter-package-json-path": emitterPackageJsonPath,
     };
@@ -113,6 +116,7 @@ describe("use-npm-pinning flag", () => {
 
   it("does not call npmViewPackageDevDependencies when use-npm-pinning is false", async () => {
     const args = {
+      "output-dir": tmpDir,
       "package-json": joinPaths(cwd(), "test", "examples", "package.json"),
       "emitter-package-json-path": emitterPackageJsonPath,
       "use-npm-pinning": false,
@@ -131,6 +135,7 @@ describe("use-npm-pinning flag", () => {
     mockedNpmView.mockResolvedValue(undefined);
 
     const args = {
+      "output-dir": tmpDir,
       "package-json": joinPaths(cwd(), "test", "examples", "package.json"),
       "emitter-package-json-path": emitterPackageJsonPath,
       "use-npm-pinning": true,
@@ -158,6 +163,7 @@ describe("use-npm-pinning flag", () => {
     });
 
     const args = {
+      "output-dir": tmpDir,
       "package-json": joinPaths(cwd(), "test", "examples", "package-sdk-pinning.json"),
       "emitter-package-json-path": emitterPackageJsonPath,
       "use-npm-pinning": true,
@@ -182,6 +188,7 @@ describe("use-npm-pinning flag", () => {
     });
 
     const args = {
+      "output-dir": tmpDir,
       "package-json": joinPaths(cwd(), "test", "examples", "package.json"),
       "emitter-package-json-path": emitterPackageJsonPath,
       overrides: joinPaths(cwd(), "test", "examples", "overrides.json"),

--- a/tools/typespec-bump-deps/build-typespec-bump-deps.yml
+++ b/tools/typespec-bump-deps/build-typespec-bump-deps.yml
@@ -4,12 +4,12 @@ parameters:
     default: false
 
 steps:
+  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+
   - task: NodeTool@0
     inputs:
       versionSpec: '$(NodeVersion)'
     displayName: 'Install Node.js'
-
-  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
 
   - bash: |
       npm ci


### PR DESCRIPTION
This pull request updates several CI pipeline YAML files to ensure that an authenticated `.npmrc` file is created before running Node.js tasks. This improves the reliability of npm package installations, especially when accessing private npm registries.

**CI pipeline improvements:**

* Added the `create-authenticated-npmrc.yml` template step before Node.js setup tasks in the following pipeline files to ensure npm authentication is configured early:
  - `tools/apiview/emitters/typespec-apiview/ci.yml`
  - `tools/apiview/parsers/js-api-parser/ci.yml`
  - `tools/oav-traffic-converter/ci.yml`
  - `tools/sdk-testgen/ci.yml`
  - `tools/test-proxy/ci.yml`
  - `tools/tsp-client/build-tsp-client.yml`

* In `tools/typespec-bump-deps/build-typespec-bump-deps.yml`, moved the `create-authenticated-npmrc.yml` step earlier, before the Node.js setup, to maintain consistent ordering and prevent authentication issues.