### PR TITLE
Fix New-RegenerateMatrix silently dropping packages from the matrix

### DIFF
--- a/eng/common/scripts/New-RegenerateMatrix.ps1
+++ b/eng/common/scripts/New-RegenerateMatrix.ps1
@@ -40,7 +40,11 @@ function Split-Items([array]$Items) {
   }
   
   $itemsPerGroup = [math]::Floor($itemCount / $JobCount)
-  $largeJobCount = $itemCount % $itemsPerGroup
+  # The remainder has to be taken over the number of groups, not the size of a group.
+  # Taking it over $itemsPerGroup produces too few large groups whenever
+  # $itemCount % $itemsPerGroup -lt $itemCount % $JobCount, and the trailing items are
+  # then silently dropped from the matrix.
+  $largeJobCount = $itemCount % $JobCount
   $groups = [object[]]::new($JobCount)
 
   $i = 0

--- a/eng/common/scripts/New-RegenerateMatrix.ps1
+++ b/eng/common/scripts/New-RegenerateMatrix.ps1
@@ -6,11 +6,15 @@ param (
   [Parameter()]
   [string]$OutputVariableName,
 
+  # Both counts are used as divisors when splitting the items, so reject zero and
+  # negative values here rather than failing later with a divide-by-zero.
   [Parameter()]
+  [ValidateRange(1, [int]::MaxValue)]
   [int]$JobCount = 8,
 
   # The minimum number of items per job. If the number of items is less than this, then the number of jobs will be reduced.
   [Parameter()]
+  [ValidateRange(1, [int]::MaxValue)]
   [int]$MinimumPerJob = 10,
 
   [Parameter()]


### PR DESCRIPTION
## The bug

`Split-Items` picks how many groups get an extra item using the wrong operand:

```powershell
$itemsPerGroup = [math]::Floor($itemCount / $JobCount)
$largeJobCount = $itemCount % $itemsPerGroup   # <-- group *size*, not group *count*
```

Whenever `$itemCount % $itemsPerGroup` is less than `$itemCount % $JobCount`, too few groups are widened, the sizes sum to less than `$itemCount`, and the trailing items are dropped from the matrix. Nothing throws, so those packages simply never get regenerated and no one finds out.

## Impact

The `azure-sdk-for-net` mgmt regeneration pipeline hits this today. 230 packages / 18 jobs gives `largeJobCount = 230 % 12 = 2` instead of `230 % 18 = 14`, so the groups sum to **218 — 12 packages dropped**, including `Azure.ResourceManager.AppService`, the second-largest package in that repo.

Confirmed in a real run, not just on paper: the last emitted job key is `se_st_17` (ending at `storagediscovery`), exactly what the truncated split produces; the correct split ends at `st_wo_17`.

It survived review because the worked example in the comment above the function, 22 items / 5 jobs, gives the same answer either way — `22 % 4` and `22 % 5` are both `2`.

## Changes

1. Take the remainder over `$JobCount`, plus a comment so the next reader doesn't have to rederive it.
2. `[ValidateRange(1, [int]::MaxValue)]` on `$JobCount` and `$MinimumPerJob` (per review feedback). Both are divisors, and `0`/negative values previously failed inside `Split-Items` with `Attempted to divide by zero` / `Arithmetic operation resulted in an overflow`, naming neither parameter — unhelpful when the value comes from pipeline YAML. Now it fails at parameter binding with the parameter named.

## Verification

Exercised the real `Split-Items` over item counts `1..300` × job counts `1..30` (9000 combinations), asserting the groups hold exactly the input items, each exactly once, with sizes differing by at most 1.

| | dropping combinations |
|---|---|
| before | **408** |
| after | **0** |

The 230 / 18 production case now yields `13×14 + 12×4 = 230`.
