### PR TITLE
Update Rust APIView upload guidance

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Languages/JsonLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/JsonLanguageService.cs
@@ -19,7 +19,7 @@ namespace APIViewWeb
 
         public override bool IsSupportedFile(string name)
         {
-            // Skip JS uploads
+            // Skip JS and Rust token file uploads handled by language-specific services.
             return base.IsSupportedFile(name)
                 && !name.EndsWith(".api.json", StringComparison.OrdinalIgnoreCase)
                 && !name.EndsWith(".rust.json", StringComparison.OrdinalIgnoreCase)

--- a/src/dotnet/APIView/APIViewWeb/Languages/JsonLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/JsonLanguageService.cs
@@ -20,7 +20,10 @@ namespace APIViewWeb
         public override bool IsSupportedFile(string name)
         {
             // Skip JS uploads
-            return base.IsSupportedFile(name) && !name.EndsWith(".api.json", StringComparison.OrdinalIgnoreCase) && !name.EndsWith(".rust.json", StringComparison.OrdinalIgnoreCase);
+            return base.IsSupportedFile(name)
+                && !name.EndsWith(".api.json", StringComparison.OrdinalIgnoreCase)
+                && !name.EndsWith(".rust.json", StringComparison.OrdinalIgnoreCase)
+                && !name.EndsWith("_rust.json", StringComparison.OrdinalIgnoreCase);
         }
 
         public override async Task<CodeFile> GetCodeFileAsync(string originalName, Stream stream, bool runAnalysis, string croscrossLanguageMetada = null)

--- a/src/dotnet/APIView/APIViewWeb/Languages/RustLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/RustLanguageService.cs
@@ -10,7 +10,7 @@ namespace APIViewWeb
     public class RustLanguageService : LanguageProcessor
     {
         public override string Name { get; } = "Rust";
-        public override string[] Extensions { get; } = { ".rust.json" };
+        public override string[] Extensions { get; } = { ".rust.json", "_rust.json" };
         public override string ProcessName { get; } = "node";
         public override string VersionString { get; } = "1.3.0";
         private readonly string _rustParserToolPath;
@@ -26,4 +26,3 @@ namespace APIViewWeb
         }
     }
 }
-

--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_ReviewUploadHelp.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_ReviewUploadHelp.cshtml
@@ -101,10 +101,10 @@
             <p class="card-text">
                 <ol>
                     <li>
-                        In the root of your azure-sdk-for-rust clone, run: <code>cargo run --manifest-path eng/tools/generate_api_report/Cargo.toml -- --package {package-name}</code>
+                        In the root of your azure-sdk-for-rust clone, run: <code>cargo run --manifest-path eng/tools/Cargo.toml -p generate_api -- --manifest-path sdk/{service-name}/{package-name}/Cargo.toml --format apiview --output target/generate_api/{package-name}</code>
                     </li>
                     <li>
-                        Upload <code>sdk/{service-name}/{package-name}/review/{package-name}.rust.json</code> using the <code>Create Review</code> link.
+                        Rename <code>target/generate_api/{package-name}/apiview.json</code> to <code>{package-name}_rust.json</code> and upload the renamed file using the <code>Create Review</code> link.
                     </li>
                 </ol>
             </p>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_ReviewUploadHelp.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_ReviewUploadHelp.cshtml
@@ -104,7 +104,7 @@
                         In the root of your azure-sdk-for-rust clone, run: <code>cargo run --manifest-path eng/tools/Cargo.toml -p generate_api -- --manifest-path sdk/{service-name}/{package-name}/Cargo.toml --format apiview --output target/generate_api/{package-name}</code>
                     </li>
                     <li>
-                        Rename <code>target/generate_api/{package-name}/apiview.json</code> to <code>{package-name}_rust.json</code> and upload the renamed file using the <code>Create Review</code> link.
+                        Rename <code>target/generate_api/{package-name}/apiview.json</code> to <code>{package-name}.rust.json</code> and upload the renamed file using the <code>Create Review</code> link.
                     </li>
                 </ol>
             </p>

--- a/src/dotnet/APIView/APIViewWeb/README.md
+++ b/src/dotnet/APIView/APIViewWeb/README.md
@@ -45,7 +45,7 @@ Run `dotnet pack` for the required package to generate Nuget file. Upload the re
 
 ### Rust
 1. In the root of your azure-sdk-for-rust clone, run: `cargo run --manifest-path eng/tools/Cargo.toml -p generate_api -- --manifest-path sdk/{service-name}/{package-name}/Cargo.toml --format apiview --output target/generate_api/{package-name}`
-2. Rename `target/generate_api/{package-name}/apiview.json` to `{package-name}_rust.json`, then upload the renamed file using the `Create Review` link.
+2. Rename `target/generate_api/{package-name}/apiview.json` to `{package-name}.rust.json`, then upload the renamed file using the `Create Review` link.
 
 ### Swagger
 Swagger API revisions can be generated manually by uploading swagger file to APIView if you are trying to generate API revision for a single swagger file. Swagger API revision is automatically generated when swagger files are modified in a pull request and pull request comment shows a link to generated APIView. Automatically generated API revision from pull request creates a diff using existing swagger files in the target branch as baseline to show API level changes in pull request.

--- a/src/dotnet/APIView/APIViewWeb/README.md
+++ b/src/dotnet/APIView/APIViewWeb/README.md
@@ -44,8 +44,8 @@ Run `dotnet pack` for the required package to generate Nuget file. Upload the re
 2. Upload generated whl file
 
 ### Rust
-1. In the root of your azure-sdk-for-rust clone, run: `cargo run --manifest-path eng/tools/generate_api_report/Cargo.toml -- --package {package-name}`
-2. Upload `sdk/{service-name}/{package-name}/review/{package-name}.rust.json` using the `Create Review` link.
+1. In the root of your azure-sdk-for-rust clone, run: `cargo run --manifest-path eng/tools/Cargo.toml -p generate_api -- --manifest-path sdk/{service-name}/{package-name}/Cargo.toml --format apiview --output target/generate_api/{package-name}`
+2. Rename `target/generate_api/{package-name}/apiview.json` to `{package-name}_rust.json`, then upload the renamed file using the `Create Review` link.
 
 ### Swagger
 Swagger API revisions can be generated manually by uploading swagger file to APIView if you are trying to generate API revision for a single swagger file. Swagger API revision is automatically generated when swagger files are modified in a pull request and pull request comment shows a link to generated APIView. Automatically generated API revision from pull request creates a diff using existing swagger files in the target branch as baseline to show API level changes in pull request.

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/revisions-list/revisions-list.component.html
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/revisions-list/revisions-list.component.html
@@ -196,7 +196,7 @@
                 <div *ngIf="!revisionUploadFile" class="drop-zone-content">
                     <i class="pi pi-file-arrow-up drop-zone-icon"></i>
                     <p class="drop-zone-title">Drag and drop files here</p>
-                    <p class="drop-zone-subtitle">Accepted: {{ acceptedFilesForReviewUploadLabel ?? acceptedFilesForReviewUpload }}</p>
+                    <p class="drop-zone-subtitle">Accepted: {{ acceptedFilesForReviewUpload }}</p>
                     <label class="btn btn-outline-secondary btn-sm drop-zone-browse">
                         Browse files
                         <input type="file" [accept]="acceptedFilesForReviewUpload" (change)="onRevisionFileInputChange($event)" hidden />

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/revisions-list/revisions-list.component.html
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/revisions-list/revisions-list.component.html
@@ -196,7 +196,7 @@
                 <div *ngIf="!revisionUploadFile" class="drop-zone-content">
                     <i class="pi pi-file-arrow-up drop-zone-icon"></i>
                     <p class="drop-zone-title">Drag and drop files here</p>
-                    <p class="drop-zone-subtitle">Accepted: {{ acceptedFilesForReviewUpload }}</p>
+                    <p class="drop-zone-subtitle">Accepted: {{ acceptedFilesForReviewUploadLabel ?? acceptedFilesForReviewUpload }}</p>
                     <label class="btn btn-outline-secondary btn-sm drop-zone-browse">
                         Browse files
                         <input type="file" [accept]="acceptedFilesForReviewUpload" (change)="onRevisionFileInputChange($event)" hidden />

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/revisions-list/revisions-list.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/revisions-list/revisions-list.component.ts
@@ -82,6 +82,7 @@ export class RevisionsListComponent implements OnInit, OnChanges {
   // Review Upload Instructions
   createRevisionInstruction : string[] | undefined;
   acceptedFilesForReviewUpload : string | undefined;
+  acceptedFilesForReviewUploadLabel : string | undefined;
 
   // Filters
   details: any[] = [];
@@ -473,7 +474,7 @@ export class RevisionsListComponent implements OnInit, OnChanges {
         severity: 'error',
         icon: 'bi bi-exclamation-triangle',
         summary: 'Invalid file type',
-        detail: `Only ${this.acceptedFilesForReviewUpload} files are accepted.`,
+        detail: `Only ${this.acceptedFilesForReviewUploadLabel ?? this.acceptedFilesForReviewUpload} files are accepted.`,
         key: 'bc',
         life: 3000
       });
@@ -493,7 +494,7 @@ export class RevisionsListComponent implements OnInit, OnChanges {
         severity: 'error',
         icon: 'bi bi-exclamation-triangle',
         summary: 'Invalid file type',
-        detail: `Only ${this.acceptedFilesForReviewUpload} files are accepted.`,
+        detail: `Only ${this.acceptedFilesForReviewUploadLabel ?? this.acceptedFilesForReviewUpload} files are accepted.`,
         key: 'bc',
         life: 3000
       });
@@ -502,8 +503,12 @@ export class RevisionsListComponent implements OnInit, OnChanges {
 
   private isAcceptedRevisionFile(fileName: string): boolean {
     if (!this.acceptedFilesForReviewUpload) return true;
-    const extensions = this.acceptedFilesForReviewUpload.split(',').map(ext => ext.trim().toLowerCase());
     const lowerName = fileName.toLowerCase();
+    if (this.createRevisionForm.get('selectedCRLanguage')?.value?.data === "Rust") {
+      return lowerName.endsWith(".rust.json") || lowerName.endsWith("_rust.json");
+    }
+
+    const extensions = this.acceptedFilesForReviewUpload.split(',').map(ext => ext.trim().toLowerCase());
     return extensions.some(ext => lowerName.endsWith(ext));
   }
 
@@ -554,6 +559,7 @@ export class RevisionsListComponent implements OnInit, OnChanges {
   }
 
   onCRLanguageSelectChange() {
+    this.acceptedFilesForReviewUploadLabel = undefined;
     switch(this.createRevisionForm.get('selectedCRLanguage')?.value?.data){
       case "C":
         this.createRevisionInstruction = [
@@ -622,10 +628,11 @@ export class RevisionsListComponent implements OnInit, OnChanges {
         break;
       case "Rust":
         this.createRevisionInstruction = [
-          `In the root of your azure-sdk-for-rust clone, run: <code>cargo run --manifest-path eng/tools/generate_api_report/Cargo.toml -- --package {package-name}</code>`,
-          `Upload <code>sdk/{service-name}/{package-name}/review/{package-name}.rust.json</code> using the file picker in this drawer.`
+          `In the root of your azure-sdk-for-rust clone, run: <code>cargo run --manifest-path eng/tools/Cargo.toml -p generate_api -- --manifest-path sdk/{service-name}/{package-name}/Cargo.toml --format apiview --output target/generate_api/{package-name}</code>`,
+          `Rename <code>target/generate_api/{package-name}/apiview.json</code> to <code>{package-name}_rust.json</code> and upload the renamed file using the file picker in this drawer.`
         ];
-        this.acceptedFilesForReviewUpload = ".rust.json";
+        this.acceptedFilesForReviewUpload = ".json";
+        this.acceptedFilesForReviewUploadLabel = "_rust.json";
         this.createRevisionForm.get('selectedFile')?.enable();
         this.createRevisionForm.get('filePath')?.disable();
         break;
@@ -667,7 +674,10 @@ export class RevisionsListComponent implements OnInit, OnChanges {
       default:
         this.createRevisionInstruction = [];
         this.acceptedFilesForReviewUpload = undefined;
+        this.acceptedFilesForReviewUploadLabel = undefined;
     }
+
+    this.acceptedFilesForReviewUploadLabel ??= this.acceptedFilesForReviewUpload;
 
     this.revisionUploadFile = undefined;
 

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/revisions-list/revisions-list.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/revisions-list/revisions-list.component.ts
@@ -82,7 +82,6 @@ export class RevisionsListComponent implements OnInit, OnChanges {
   // Review Upload Instructions
   createRevisionInstruction : string[] | undefined;
   acceptedFilesForReviewUpload : string | undefined;
-  acceptedFilesForReviewUploadLabel : string | undefined;
 
   // Filters
   details: any[] = [];
@@ -474,7 +473,7 @@ export class RevisionsListComponent implements OnInit, OnChanges {
         severity: 'error',
         icon: 'bi bi-exclamation-triangle',
         summary: 'Invalid file type',
-        detail: `Only ${this.acceptedFilesForReviewUploadLabel ?? this.acceptedFilesForReviewUpload} files are accepted.`,
+        detail: `Only ${this.acceptedFilesForReviewUpload} files are accepted.`,
         key: 'bc',
         life: 3000
       });
@@ -494,7 +493,7 @@ export class RevisionsListComponent implements OnInit, OnChanges {
         severity: 'error',
         icon: 'bi bi-exclamation-triangle',
         summary: 'Invalid file type',
-        detail: `Only ${this.acceptedFilesForReviewUploadLabel ?? this.acceptedFilesForReviewUpload} files are accepted.`,
+        detail: `Only ${this.acceptedFilesForReviewUpload} files are accepted.`,
         key: 'bc',
         life: 3000
       });
@@ -559,7 +558,6 @@ export class RevisionsListComponent implements OnInit, OnChanges {
   }
 
   onCRLanguageSelectChange() {
-    this.acceptedFilesForReviewUploadLabel = undefined;
     switch(this.createRevisionForm.get('selectedCRLanguage')?.value?.data){
       case "C":
         this.createRevisionInstruction = [
@@ -629,10 +627,9 @@ export class RevisionsListComponent implements OnInit, OnChanges {
       case "Rust":
         this.createRevisionInstruction = [
           `In the root of your azure-sdk-for-rust clone, run: <code>cargo run --manifest-path eng/tools/Cargo.toml -p generate_api -- --manifest-path sdk/{service-name}/{package-name}/Cargo.toml --format apiview --output target/generate_api/{package-name}</code>`,
-          `Rename <code>target/generate_api/{package-name}/apiview.json</code> to <code>{package-name}_rust.json</code> and upload the renamed file using the file picker in this drawer.`
+          `Rename <code>target/generate_api/{package-name}/apiview.json</code> to <code>{package-name}.rust.json</code> and upload the renamed file using the file picker in this drawer.`
         ];
         this.acceptedFilesForReviewUpload = ".json";
-        this.acceptedFilesForReviewUploadLabel = "_rust.json";
         this.createRevisionForm.get('selectedFile')?.enable();
         this.createRevisionForm.get('filePath')?.disable();
         break;
@@ -674,10 +671,7 @@ export class RevisionsListComponent implements OnInit, OnChanges {
       default:
         this.createRevisionInstruction = [];
         this.acceptedFilesForReviewUpload = undefined;
-        this.acceptedFilesForReviewUploadLabel = undefined;
     }
-
-    this.acceptedFilesForReviewUploadLabel ??= this.acceptedFilesForReviewUpload;
 
     this.revisionUploadFile = undefined;
 

--- a/src/dotnet/APIView/docs/overview.md
+++ b/src/dotnet/APIView/docs/overview.md
@@ -312,7 +312,7 @@ Parsers live in various locations across the `azure-sdk-tools` repo.
 | JavaScript/TypeScript | `tools/apiview/parsers/js-api-parser` | `.api.json` | Tree | Yes |
 | Go | `src/go` | `.gosource` (zip) | Tree | Yes |
 | TypeSpec | `tools/apiview/emitters/typespec-apiview` | `.tsp`, `.cadl` | Tree | No  |
-| Rust | `tools/apiview/parsers/rust-api-parser` | `_rust.json` | Tree | Yes |
+| Rust | `tools/apiview/parsers/rust-api-parser` | `.rust.json` | Tree | Yes |
 | Swift | `src/swift/SwiftAPIView` | `.json` | Tree | No |
 | Swagger/OpenAPI | `tools/apiview/parsers/swagger-api-parser` | `.swagger` | Flat (legacy) | No  |
 | C++ | `tools/apiview/parsers/cpp-api-parser` | `.cppast` | Flat (legacy) | Yes |
@@ -333,9 +333,9 @@ There are three ways API revisions reach APIView: **CI Automatic** (the persiste
 A key variable across all workflows is **where the language parser runs**. This is determined by whether the CI build produces a pre-parsed token file (`{packageName}_{languageShort}.json`) alongside the build artifact. The shared scripts (`Create-APIReview.ps1`, `Detect-Api-Changes.ps1`) check for this file and branch accordingly:
 
 - **No token file present** (C#, Java, Go): The build artifact (`.nupkg`, `sources.jar`, `.gosource`) is sent to APIView. APIView invokes the language parser as an external process on the server.
-- **Token file present** (Python, JavaScript, Rust): The CI pipeline runs the parser or generator to produce a `_python.json`, `_js.json`, or `_rust.json` token file. Both the token file and the original artifact are sent to APIView, which stores the token file directly without running a parser. See [sandboxing.md](sandboxing.md) for rationale.
+- **Token file present** (Python, JavaScript, Rust): The CI pipeline runs the parser or generator to produce a `_python.json`, `_js.json`, or Rust token file. Both the token file and the original artifact are sent to APIView, which stores the token file directly without running a parser. See [sandboxing.md](sandboxing.md) for rationale.
 
-> **Note:** Go still uses CI-side preprocessing by zipping source into `.gosource` archives, and APIView runs the Go parser on the server. Rust now uses `generate_api` to produce `apiview.json`, stages that file as `_rust.json`, and uploads the token file directly.
+> **Note:** Go still uses CI-side preprocessing by zipping source into `.gosource` archives, and APIView runs the Go parser on the server. Rust now uses `generate_api` to produce `apiview.json`, then uploads a pre-generated Rust token file instead of invoking the parser on the server.
 
 ### Workflow A — CI Automatic (non-PR internal builds)
 
@@ -385,7 +385,7 @@ Query approval status
 | Python | `.whl` + `_python.json` | **Yes** (mandatory) | `/autoreview/create` |
 | JavaScript | `.api.json` + `_js.json` | **Yes** | `/autoreview/create` |
 | Go | `.gosource` | No | `/autoreview/upload` |
-| Rust | `_rust.json` | **Yes** | `/autoreview/create` |
+| Rust | `.rust.json` | **Yes** | `/autoreview/create` |
 
 ### Workflow B — CI Pull Request
 

--- a/src/dotnet/APIView/docs/overview.md
+++ b/src/dotnet/APIView/docs/overview.md
@@ -6,7 +6,7 @@ APIView is the Azure SDK team's **API review platform**. It ingests SDK artifact
 
 It supports **16+ languages** (C#, Java, Python, JavaScript/TypeScript, Go, Rust, C, C++, Swift, Protocol Buffers, Swagger/OpenAPI, TypeSpec, and more) through a common token model that normalizes every language into the same reviewable format.
 
-> **Development policy:** New features should target the Angular SPA and tree-token model only. The legacy Razor Pages frontend and flat-token parser are not receiving new investment. See [legacy.md](legacy.md) for details on what remains and the migration path.
+> **Development policy:** New features should target the Angular SPA and tree-token model only. The legacy Razor Pages frontend and flat-token parser are not receiving new investment. See [legacy.md](https://github.com/Azure/azure-sdk-tools/blob/main/src/dotnet/APIView/docs/legacy.md) for details on what remains and the migration path.
 
 ### a. What APIView Does
 
@@ -182,7 +182,7 @@ A separate set of controllers use **token authentication** (`RequireTokenAuthent
 
 The Angular SPA is the **primary UI**. It is built separately (`npm run build`) and output to `APIViewWeb/wwwroot/spa/`. The ASP.NET backend serves it as static files and acts purely as an API host.
 
-> **Note:** There is a legacy Razor Pages frontend (`Pages/Assemblies/`) that predates the SPA. It is being phased out; see [legacy.md](legacy.md) for details.
+> **Note:** There is a legacy Razor Pages frontend (`Pages/Assemblies/`) that predates the SPA. It is being phased out; see [legacy.md](https://github.com/Azure/azure-sdk-tools/blob/main/src/dotnet/APIView/docs/legacy.md) for details.
 
 ### a. Routes
 
@@ -249,7 +249,7 @@ APIView's core abstraction is a **language-agnostic token model**. Every languag
 | **Flat (legacy)** | `CodeFileToken[]` — linear stream with `Newline` tokens as line separators | Deprecated; auto-converted on read |
 | **Tree (modern)** | `ReviewLine[]` — hierarchical lines with `ReviewToken[]` per line and `Children[]` for nesting | Active; all modern parsers emit this |
 
-> For a full list of which languages use which format and the migration path, see [legacy.md](legacy.md).
+> For a full list of which languages use which format and the migration path, see [legacy.md](https://github.com/Azure/azure-sdk-tools/blob/main/src/dotnet/APIView/docs/legacy.md).
 
 ### b. Key Fields on CodeFile
 
@@ -277,7 +277,7 @@ Modern (`ReviewToken.Kind`): `Text`, `Punctuation`, `Keyword`, `TypeName`, `Memb
 
 ### e. Content Hashing
 
-Each CodeFile gets a **SHA-256 hash** of its API surface (excluding package version, documentation, and `SkipDiff` regions). This enables O(1) comparison between revisions. See [release-approval.md](release-approval.md#5-automatic-approval-carry-forward) for how content hashing drives automatic approval carry-forward.
+Each CodeFile gets a **SHA-256 hash** of its API surface (excluding package version, documentation, and `SkipDiff` regions). This enables O(1) comparison between revisions. See [release-approval.md](https://github.com/Azure/azure-sdk-tools/blob/main/src/dotnet/APIView/docs/release-approval.md#5-automatic-approval-carry-forward) for how content hashing drives automatic approval carry-forward.
 
 ---
 
@@ -296,7 +296,7 @@ Each CodeFile gets a **SHA-256 hash** of its API surface (excluding package vers
 
 APIView supports manual approval by reviewers, automatic carry-forward of approvals when the API surface is unchanged between revisions, and release tagging when a release pipeline marks a revision as shipped.
 
-For the complete approval workflow — including prerequisites, toggle flow, carry-forward mechanics, release gating endpoints, and HTTP response codes — see [release-approval.md](release-approval.md). For the user-facing approval process and who can approve, see [user-guide.md](user-guide.md#api-approvals).
+For the complete approval workflow — including prerequisites, toggle flow, carry-forward mechanics, release gating endpoints, and HTTP response codes — see [release-approval.md](https://github.com/Azure/azure-sdk-tools/blob/main/src/dotnet/APIView/docs/release-approval.md). For the user-facing approval process and who can approve, see [user-guide.md](https://github.com/Azure/azure-sdk-tools/blob/main/src/dotnet/APIView/docs/user-guide.md#api-approvals).
 
 ---
 
@@ -324,7 +324,7 @@ Parsers live in various locations across the `azure-sdk-tools` repo.
 
 ## 10. Core Workflows
 
-> For a higher-level explanation of when revisions are created, when approvals are required, and how release enforcement works, see [ci-integration.md](ci-integration.md).
+> For a higher-level explanation of when revisions are created, when approvals are required, and how release enforcement works, see [ci-integration.md](https://github.com/Azure/azure-sdk-tools/blob/main/src/dotnet/APIView/docs/ci-integration.md).
 
 There are three ways API revisions reach APIView: **CI Automatic** (the persistent review created on merges to `main`), **CI Pull Request** (the ephemeral revision created for PR review), and **Manual** (a user uploads a file through the web UI). The first two are automated; they share the same build step that produces the artifact but diverge in how that artifact reaches the server.
 
@@ -333,7 +333,7 @@ There are three ways API revisions reach APIView: **CI Automatic** (the persiste
 A key variable across all workflows is **where the language parser runs**. This is determined by whether the CI build produces a pre-parsed token file (`{packageName}_{languageShort}.json`) alongside the build artifact. The shared scripts (`Create-APIReview.ps1`, `Detect-Api-Changes.ps1`) check for this file and branch accordingly:
 
 - **No token file present** (C#, Java, Go): The build artifact (`.nupkg`, `sources.jar`, `.gosource`) is sent to APIView. APIView invokes the language parser as an external process on the server.
-- **Token file present** (Python, JavaScript, Rust): The CI pipeline runs the parser or generator to produce a `_python.json`, `_js.json`, or Rust token file. Both the token file and the original artifact are sent to APIView, which stores the token file directly without running a parser. See [sandboxing.md](sandboxing.md) for rationale.
+- **Token file present** (Python, JavaScript, Rust): The CI pipeline runs the parser or generator to produce a `_python.json`, `_js.json`, or Rust token file. Both the token file and the original artifact are sent to APIView, which stores the token file directly without running a parser. See [sandboxing.md](https://github.com/Azure/azure-sdk-tools/blob/main/src/dotnet/APIView/docs/sandboxing.md) for rationale.
 
 > **Note:** Go still uses CI-side preprocessing by zipping source into `.gosource` archives, and APIView runs the Go parser on the server. Rust now uses `generate_api` to produce `apiview.json`, then uploads a pre-generated Rust token file instead of invoking the parser on the server.
 
@@ -489,8 +489,8 @@ Each language repo follows a similar pattern: `ci.yml` → archetype stage → j
 | C++ | `Azure/azure-sdk-for-cpp` | [`eng/pipelines/templates/jobs/archetype-sdk-client.yml`](https://github.com/Azure/azure-sdk-for-cpp/blob/main/eng/pipelines/templates/jobs/archetype-sdk-client.yml) | `GenerateReleaseArtifacts` job downloads `ParseAzureSdkCpp.exe`, runs `Generate-APIReview-Token-Files.ps1`, then calls `create-apireview.yml` + `detect-api-changes.yml` |
 | Rust | `Azure/azure-sdk-for-rust` | [`eng/pipelines/templates/jobs/pack.yml`](https://github.com/Azure/azure-sdk-for-rust/blob/main/eng/pipelines/templates/jobs/pack.yml) | Pack job calls `create-apireview.yml` + `detect-api-changes.yml` after crate packing |
 | Swift | `Azure/azure-sdk-for-ios` | *(none — manual upload)* | No automated CI → APIView integration; JSON token files are uploaded manually |
-| TypeSpec | *(this repo)* | [`eng/pipelines/apiview-review-gen-typespec.yml`](../../eng/pipelines/apiview-review-gen-typespec.yml) | Manual-trigger pipeline; not per-service CI |
-| Swagger/OpenAPI | *(this repo)* | [`eng/pipelines/apiview-review-gen-swagger.yml`](../../eng/pipelines/apiview-review-gen-swagger.yml) | Manual-trigger pipeline; not per-service CI |
+| TypeSpec | *(this repo)* | [`eng/pipelines/apiview-review-gen-typespec.yml`](https://github.com/Azure/azure-sdk-tools/blob/main/eng/pipelines/apiview-review-gen-typespec.yml) | Manual-trigger pipeline; not per-service CI |
+| Swagger/OpenAPI | *(this repo)* | [`eng/pipelines/apiview-review-gen-swagger.yml`](https://github.com/Azure/azure-sdk-tools/blob/main/eng/pipelines/apiview-review-gen-swagger.yml) | Manual-trigger pipeline; not per-service CI |
 
 ---
 

--- a/src/dotnet/APIView/docs/overview.md
+++ b/src/dotnet/APIView/docs/overview.md
@@ -312,7 +312,7 @@ Parsers live in various locations across the `azure-sdk-tools` repo.
 | JavaScript/TypeScript | `tools/apiview/parsers/js-api-parser` | `.api.json` | Tree | Yes |
 | Go | `src/go` | `.gosource` (zip) | Tree | Yes |
 | TypeSpec | `tools/apiview/emitters/typespec-apiview` | `.tsp`, `.cadl` | Tree | No  |
-| Rust | `tools/apiview/parsers/rust-api-parser` | `.rust.json` | Tree | Yes |
+| Rust | `tools/apiview/parsers/rust-api-parser` | `_rust.json` | Tree | Yes |
 | Swift | `src/swift/SwiftAPIView` | `.json` | Tree | No |
 | Swagger/OpenAPI | `tools/apiview/parsers/swagger-api-parser` | `.swagger` | Flat (legacy) | No  |
 | C++ | `tools/apiview/parsers/cpp-api-parser` | `.cppast` | Flat (legacy) | Yes |
@@ -332,10 +332,10 @@ There are three ways API revisions reach APIView: **CI Automatic** (the persiste
 
 A key variable across all workflows is **where the language parser runs**. This is determined by whether the CI build produces a pre-parsed token file (`{packageName}_{languageShort}.json`) alongside the build artifact. The shared scripts (`Create-APIReview.ps1`, `Detect-Api-Changes.ps1`) check for this file and branch accordingly:
 
-- **No token file present** (C#, Java, Go, Rust): The build artifact (`.nupkg`, `sources.jar`, `.gosource`, `.rust.json`) is sent to APIView. APIView invokes the language parser as an external process on the server.
-- **Token file present** (Python, JavaScript): The CI pipeline runs the parser to produce a `_python.json` or `_js.json` token file. Both the token file and the original artifact are sent to APIView, which stores them directly without running a parser. See [sandboxing.md](sandboxing.md) for rationale.
+- **No token file present** (C#, Java, Go): The build artifact (`.nupkg`, `sources.jar`, `.gosource`) is sent to APIView. APIView invokes the language parser as an external process on the server.
+- **Token file present** (Python, JavaScript, Rust): The CI pipeline runs the parser or generator to produce a `_python.json`, `_js.json`, or `_rust.json` token file. Both the token file and the original artifact are sent to APIView, which stores the token file directly without running a parser. See [sandboxing.md](sandboxing.md) for rationale.
 
-> **Note:** Go and Rust do CI-side *preprocessing* (zipping source into `.gosource` archives, generating `.rust.json` intermediate files), but the APIView server still runs the actual parser on those intermediate artifacts. Python and JavaScript are the only languages where the full APIView parser runs in CI.
+> **Note:** Go still uses CI-side preprocessing by zipping source into `.gosource` archives, and APIView runs the Go parser on the server. Rust now uses `generate_api` to produce `apiview.json`, stages that file as `_rust.json`, and uploads the token file directly.
 
 ### Workflow A — CI Automatic (non-PR internal builds)
 
@@ -352,12 +352,12 @@ Build artifact + (optionally) run parser
         │
         ├── Token file exists?
         │       │
-        │       ├── YES (Python, JS)
+        │       ├── YES (Python, JS, Rust)
         │       │   POST /autoreview/create ─────────► Download token file + original
         │       │   (build coordinates only)           artifact from DevOps
         │       │                                      Store both in Blob Storage
         │       │
-        │       └── NO (C#, Java, Go, Rust)
+        │       └── NO (C#, Java, Go)
         │           POST /autoreview/upload ─────────► Save original artifact to
         │           (multipart, binary artifact)       Blob Storage
         │                                              Invoke language parser on server
@@ -385,7 +385,7 @@ Query approval status
 | Python | `.whl` + `_python.json` | **Yes** (mandatory) | `/autoreview/create` |
 | JavaScript | `.api.json` + `_js.json` | **Yes** | `/autoreview/create` |
 | Go | `.gosource` | No | `/autoreview/upload` |
-| Rust | `.rust.json` | No | `/autoreview/upload` |
+| Rust | `_rust.json` | **Yes** | `/autoreview/create` |
 
 ### Workflow B — CI Pull Request
 
@@ -423,8 +423,8 @@ GET /api/PullRequests/                    ───────────► D
 
 1. The CI pipeline builds the artifact and publishes it (and optionally a token file) as a pipeline artifact — the same steps as Workflow A.
 2. `Detect-Api-Changes.ps1` iterates packages that have changes in the PR. For each, it calls `GET /api/PullRequests/CreateAPIRevisionIfAPIHasChanges` with DevOps build coordinates (`buildId`, `artifactName`, `filePath`), PR metadata (`pullRequestNumber`, `commitSha`, `repoName`), and package info (`packageName`, `language`).
-   - **If a token file exists** (Python, JS): The `codeFile` query param is added. APIView downloads the parent directory as a zip, extracting both the token file and original artifact.
-   - **If no token file** (C#, Java, Go, Rust): APIView downloads only the artifact file and runs the language parser on the server.
+   - **If a token file exists** (Python, JS, Rust): The `codeFile` query param is added. APIView downloads the parent directory as a zip, extracting both the token file and original artifact.
+   - **If no token file** (C#, Java, Go): APIView downloads only the artifact file and runs the language parser on the server.
 3. APIView creates a **PullRequest-type** API revision linked to the PR. It asynchronously posts a comment on the GitHub PR with a link to the review.
 
 > **Key difference from Workflow A:** The PR flow always uses DevOps build coordinates for artifact retrieval — even for languages like C# where Workflow A does a direct multipart upload. There is no direct file upload in the PR flow.

--- a/tools/apiview/parsers/rust-api-parser/README.md
+++ b/tools/apiview/parsers/rust-api-parser/README.md
@@ -7,9 +7,8 @@ Compatibility parser for Rust APIView inputs.
 The **current** Rust APIView design lives in `Azure/azure-sdk-for-rust` under
 `eng/tools/generate_api`. That tool now generates the complete APIView tree-style
 `CodeFile` JSON itself and sets `ParserVersion` from the tool version
-(`2.0.0` or newer). The resulting token file is staged as
-`<package>/<package>_rust.json` and uploaded straight to APIView, which treats it
-as an already-generated review token file.
+(`2.0.0` or newer). The resulting token file is uploaded to APIView as an
+already-generated review token file.
 
 This repository's TypeScript parser is now primarily a **compatibility bridge**:
 
@@ -30,16 +29,12 @@ cargo run --manifest-path eng/tools/Cargo.toml -p generate_api -- \
 
 That writes `apiview.json`, whose top-level shape already matches APIView's
 tree-style schema (`PackageName`, `PackageVersion`, `ParserVersion`, `Language`,
-`ReviewLines`). In the Rust repo's pack flow, the file is then copied to the
-artifact layout expected by `create-apireview` as `<package>_rust.json`.
+`ReviewLines`).
 
-For manual website uploads, rename `apiview.json` to `<package>_rust.json` so it
-matches the shared APIView artifact convention.
+For manual website uploads, rename `apiview.json` to `<package>.rust.json`.
 
 For the new design, this parser does not transform the file; it only preserves
-pass-through behavior if APIView still invokes it. APIView still accepts older
-`<package>.rust.json` names for compatibility, but `_rust.json` is the canonical
-suffix for current flows.
+pass-through behavior if APIView still invokes it.
 
 ## Legacy compatibility
 

--- a/tools/apiview/parsers/rust-api-parser/README.md
+++ b/tools/apiview/parsers/rust-api-parser/README.md
@@ -33,8 +33,13 @@ tree-style schema (`PackageName`, `PackageVersion`, `ParserVersion`, `Language`,
 `ReviewLines`). In the Rust repo's pack flow, the file is then copied to the
 artifact layout expected by `create-apireview` as `<package>_rust.json`.
 
+For manual website uploads, rename `apiview.json` to `<package>_rust.json` so it
+matches the shared APIView artifact convention.
+
 For the new design, this parser does not transform the file; it only preserves
-pass-through behavior if APIView still invokes it.
+pass-through behavior if APIView still invokes it. APIView still accepts older
+`<package>.rust.json` names for compatibility, but `_rust.json` is the canonical
+suffix for current flows.
 
 ## Legacy compatibility
 

--- a/tools/apiview/parsers/rust-api-parser/design.md
+++ b/tools/apiview/parsers/rust-api-parser/design.md
@@ -59,12 +59,12 @@ The Rust repo's current API review caller chain remains:
 5. `eng/scripts/Pack-Crates.ps1`
 
 `Pack-Crates.ps1` runs `generate_api --format apiview`, copies the produced
-`apiview.json` into the staged artifact as `<package>_rust.json`, and the shared
-`create-apireview` step uploads that token file directly. `Create-APIReview.ps1`
-already has a separate upload path for pre-generated review token files.
+`apiview.json` into the staged artifact for the shared `create-apireview` step,
+which uploads that token file directly. `Create-APIReview.ps1` already has a
+separate upload path for pre-generated review token files.
 
-For consistency with that shared artifact contract, manual uploads should also
-rename `apiview.json` to `<package>_rust.json` before sending it to APIView.
+For manual uploads, rename `apiview.json` to `<package>.rust.json` before
+sending it to APIView.
 
 ## Role of this parser now
 

--- a/tools/apiview/parsers/rust-api-parser/design.md
+++ b/tools/apiview/parsers/rust-api-parser/design.md
@@ -63,6 +63,9 @@ The Rust repo's current API review caller chain remains:
 `create-apireview` step uploads that token file directly. `Create-APIReview.ps1`
 already has a separate upload path for pre-generated review token files.
 
+For consistency with that shared artifact contract, manual uploads should also
+rename `apiview.json` to `<package>_rust.json` before sending it to APIView.
+
 ## Role of this parser now
 
 This repository is no longer the primary renderer for current Rust SDK APIView


### PR DESCRIPTION
Standardize Rust APIView docs and website help on the generate_api flow and the _rust.json artifact name while keeping legacy .rust.json uploads supported for compatibility.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 393c42cc-3505-4169-9d15-6c8d090e391e
