### PR TITLE
[Teams Chatbot] Add TypeSpec suppression doc and ARM lease doc to  azure_rest_api_specs_docs

### DIFF
--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/config/knowledge-config.json
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/config/knowledge-config.json
@@ -624,6 +624,24 @@
           "metadata": {
             "scope": "branded"
           }
+        },
+        {
+          "description": "TypeSpec suppressions CLI and CI approval workflow documentation for Azure REST API specs",
+          "path": "/eng/tools/typespec-suppressions/README.md",
+          "folder": "azure_rest_api_specs_docs",
+          "relativeByRepoPath": true,
+          "metadata": {
+            "scope": "branded"
+          }
+        },
+        {
+          "description": "ARM lease design discussion period, lease.yaml validation, and automation guidance for Azure REST API specs",
+          "path": "/.github/arm-leases/README.md",
+          "folder": "azure_rest_api_specs_docs",
+          "relativeByRepoPath": true,
+          "metadata": {
+            "scope": "branded"
+          }
         }
       ]
     },


### PR DESCRIPTION
This PR add TypeSpec suppression doc and ARM lease doc to  azure_rest_api_specs_docs

- docs:
    https://github.com/Azure/azure-rest-api-specs/blob/main/eng/tools/typespec-suppressions/README.md
    https://github.com/Azure/azure-rest-api-specs/blob/main/.github/arm-leases/README.md

- test in dev:
<img width="616" height="322" alt="image" src="https://github.com/user-attachments/assets/9749802b-907f-4599-8b02-567b7ab1adc0" />

<img width="545" height="399" alt="image" src="https://github.com/user-attachments/assets/5dc04bfc-e5f3-42ac-9ab2-34460d2b3d80" />


