### PR TITLE
Use shallow checkout for SDK regeneration jobs

### DIFF
--- a/eng/common/pipelines/templates/archetype-typespec-emitter.yml
+++ b/eng/common/pipelines/templates/archetype-typespec-emitter.yml
@@ -303,7 +303,11 @@ extends:
         jobs:
         - job: Initialize
           steps:
+          # Regeneration does not read repository history. Avoid fetching the full
+          # history and tags for this large repository.
           - checkout: self
+            fetchDepth: 1
+            fetchTags: false
 
           - template: /eng/common/pipelines/templates/steps/login-to-github.yml
             parameters:
@@ -399,6 +403,8 @@ extends:
             emitterNpmrcPath: $(Agent.TempDirectory)/${{ parameters.EmitterPackagePath }}/.npmrc
           steps:
           - checkout: self
+            fetchDepth: 1
+            fetchTags: false
 
           - template: /eng/common/pipelines/templates/steps/login-to-github.yml
             parameters:

--- a/eng/common/pipelines/templates/archetype-typespec-emitter.yml
+++ b/eng/common/pipelines/templates/archetype-typespec-emitter.yml
@@ -303,8 +303,9 @@ extends:
         jobs:
         - job: Initialize
           steps:
-          # Regeneration does not read repository history. Avoid fetching the full
-          # history and tags for this large repository.
+          # Regeneration does not read repository history, so fetch only the
+          # checked-out commit. git-branch-push.ps1's retry path diffs the branch
+          # tip against its parent, which stays inside the depth-1 boundary.
           - checkout: self
             fetchDepth: 1
             fetchTags: false


### PR DESCRIPTION
## Change

Use `fetchDepth: 1` and `fetchTags: false` for the `Initialize` and matrix `Generate` checkouts in the TypeSpec emitter regeneration stage.

These jobs do not read repository history. A full .NET management SDK regeneration also exercised concurrent push-conflict retries successfully, confirming that the local commit parent used by `git-branch-push.ps1` remains available at depth 1.

## Measured result

Verified in [Azure/azure-sdk-for-net#61512](https://github.com/Azure/azure-sdk-for-net/pull/61512), internal build 6633135:

| Metric | Baseline | Shallow/tagless | Change |
|---|---:|---:|---:|
| Initialize checkout | 4.08 min | 0.70 min | **-83%** |
| Average Generate checkout | 4.21 min | 0.66 min | **-84%** |
| Aggregate Generate checkout | 75.7 min | 11.9 min | **-63.8 agent-min** |
| Aggregate non-generation work | 115.1 min | 63.8 min | **-51.3 agent-min** |
| Slowest Generate job | 23.86 min | 21.77 min | **-2.09 min** |

The critical Network group was an apples-to-apples comparison: its regeneration task was essentially unchanged (`17.58 -> 17.70 min`), while its complete job fell `23.86 -> 21.77 min` because checkout was shorter.

Overall stage time was flat in that run because Azure DevOps orchestration gaps between dependent jobs increased by 3.99 minutes, offsetting the measured 4.24-minute critical-path execution saving. Those gaps contain no user tasks and occur after checkout, so they are scheduler variance rather than work introduced by this change.

The .NET repository has approximately 4.8 GB of Git history versus 119 MB at depth 1, plus 7,345 tags and 53,104 remote refs.

## Validation

- Full management SDK regeneration completed successfully.
- Concurrent branch push retries completed without shallow-history errors.
- Pipeline template parses successfully as YAML.
