### PR TITLE
Add NextSteps chaining to package workflow tools

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/PackageCheckTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/PackageCheckTool.cs
@@ -246,8 +246,10 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
             var nextSteps = new List<string>();
             if (overallSuccess)
             {
-                nextSteps.Add("All package validation checks passed! Your package is ready for the next steps in the development process.");
-                nextSteps.Add("Consider running package release readiness checks if preparing for release.");
+                nextSteps.Add("All package validation checks passed.");
+                nextSteps.Add("Update changelog content using azsdk_package_update_changelog_content if not already done.");
+                nextSteps.Add("Update package metadata using azsdk_package_update_metadata.");
+                nextSteps.Add("Update version using azsdk_package_update_version when preparing for release.");
             }
             else
             {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkBuildTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkBuildTool.cs
@@ -92,9 +92,13 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
                         return PackageOperationResponse.CreateSuccess(
                             "Python SDK project detected. Skipping build step as Python SDKs do not require a build process.",
                             packageInfo,
+                            nextSteps: ["Run package validation checks using azsdk_package_run_check", "Run tests using azsdk_package_run_tests"],
                             result: "noop");
                     }
-                    return PackageOperationResponse.CreateSuccess("Build completed successfully.", packageInfo);
+                    return PackageOperationResponse.CreateSuccess(
+                        "Build completed successfully.",
+                        packageInfo,
+                        nextSteps: ["Run package validation checks using azsdk_package_run_check", "Run tests using azsdk_package_run_tests"]);
                 }
 
                 return PackageOperationResponse.CreateFailure(

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkReleaseTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkReleaseTool.cs
@@ -197,6 +197,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
                         response.PipelineBuildId = releasePipelineRun.Id;
                         response.ReleasePipelineStatus = releasePipelineRun.Status?.ToString() ?? "";
                         response.ReleaseStatusDetails = $"Release pipeline triggered successfully for package '{packageName}' in language '{language}'. Check the status of the pipeline after some time and approve the SDK release using the link to the pipeline run. You can find more information about release approval in https://aka.ms/azsdk/publishsdk";
+                        response.NextSteps = ["Approve the release stage in the pipeline run", "After release completes, verify package is published to the registry"];
                         logger.LogInformation("{details}", response.ReleaseStatusDetails);
                     }
                     else

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkReleaseTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/SdkReleaseTool.cs
@@ -197,7 +197,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
                         response.PipelineBuildId = releasePipelineRun.Id;
                         response.ReleasePipelineStatus = releasePipelineRun.Status?.ToString() ?? "";
                         response.ReleaseStatusDetails = $"Release pipeline triggered successfully for package '{packageName}' in language '{language}'. Check the status of the pipeline after some time and approve the SDK release using the link to the pipeline run. You can find more information about release approval in https://aka.ms/azsdk/publishsdk";
-                        response.NextSteps = ["Approve the release stage in the pipeline run", "After release completes, verify package is published to the registry"];
+                        response.NextSteps = ["Prompt the user to approve the release stage in the pipeline run using the pipeline link", "After release completes, prompt the user to verify the package is published to the registry"];
                         logger.LogInformation("{details}", response.ReleaseStatusDetails);
                     }
                     else

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/TestTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/TestTool.cs
@@ -144,6 +144,11 @@ namespace Azure.Sdk.Tools.Cli.Tools.Package
                 var timeout = timeoutSeconds.HasValue ? TimeSpan.FromSeconds(timeoutSeconds.Value) : (TimeSpan?)null;
                 var testResponse = await languageService.RunAllTests(packagePath, testMode, liveTestEnvironment, timeout, ct);
 
+                if (testResponse.ExitCode == 0 && (testResponse.NextSteps == null || testResponse.NextSteps.Count == 0))
+                {
+                    testResponse.NextSteps = ["Tests passed. Run package validation checks using azsdk_package_run_check if not already done.", "Update changelog, metadata, and version when preparing for release."];
+                }
+
                 await AddPackageDetailsInResponse(testResponse, packagePath, ct);
                 return testResponse;
             }


### PR DESCRIPTION
## What

Adds success-path `NextSteps` to 4 package workflow tools so agents can follow the workflow chain without requiring a skill to be loaded.

## Why

Today, when a tool completes successfully, it returns no guidance on what to do next. The agent only knows the workflow order if it has loaded a skill (e.g., `azsdk-common-generate-sdk-locally`). Without the skill, the workflow dead-ends.

This was the only cross-tool chain that existed before this PR:
- `ReleasePlanTool` -> "Run SDK generation using `azsdk_run_generate_sdk`"

## Changes

| Tool | Success NextSteps added |
|------|------------------------|
| `SdkBuildTool` | "Run package validation checks using `azsdk_package_run_check`", "Run tests using `azsdk_package_run_tests`" |
| `TestTool` | "Run package validation checks if not already done", "Update changelog, metadata, and version when preparing for release" |
| `PackageCheckTool` | "Update changelog using `azsdk_package_update_changelog_content`", "Update metadata", "Update version" |
| `SdkReleaseTool` | "Approve the release stage in the pipeline run", "Verify package is published" |

## Workflow chain covered

```
generate -> build -> check/test -> changelog/metadata/version -> release -> approve
```

`SdkGenerationTool` already had: "If the SDK is not Python, build the code"

## What is NOT in scope

- Cross-skill transitions (e.g., "generation done, now resolve APIView") - those need design discussion
- `ChangelogContentUpdateTool` and `MetadataUpdateTool` already have NextSteps via their script execution paths
- `VersionUpdateTool` already chains to "Review the updated version and release date", "Run validation checks"

Fixes #16612