### PR TITLE
[AzSdkCli] Update `api-review get-approval-status` and `api-review create` commands

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/ApiReviewHubServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/ApiReviewHubServiceTests.cs
@@ -71,7 +71,7 @@ public class ApiReviewHubServiceTests
             .Setup(x => x.CreateClient(It.IsAny<string>()))
             .Returns(new HttpClient(mockHandler.Object));
 
-        var result = await service.GetReleaseGateStatusAsync("https://api-review-hub-test.azurewebsites.net", language, "pkg", packageVersion, "hash", CancellationToken.None);
+        var result = await service.GetReleaseGateStatusAsync("https://api-review-hub-test.azurewebsites.net", language, "pkg", packageVersion, "hash", "", CancellationToken.None);
 
         Assert.That(result.IsApproved, Is.False);
         Assert.That(result.StatusCode, Is.EqualTo(200));
@@ -121,7 +121,7 @@ public class ApiReviewHubServiceTests
             .Setup(x => x.CreateClient(It.IsAny<string>()))
             .Returns(new HttpClient(mockHandler.Object));
 
-        var result = await service.GetReleaseGateStatusAsync("https://api-review-hub-test.azurewebsites.net", "python", "pkg", "4.12.0b3", "hash", CancellationToken.None);
+        var result = await service.GetReleaseGateStatusAsync("https://api-review-hub-test.azurewebsites.net", "python", "pkg", "4.12.0b3", "hash", "", CancellationToken.None);
 
         Assert.That(result.AppliedInheritanceRule, Is.EqualTo("prereleaseToStable"));
         Assert.That(result.Approvals, Is.Not.Null);
@@ -158,7 +158,7 @@ public class ApiReviewHubServiceTests
             .Setup(x => x.CreateClient(It.IsAny<string>()))
             .Returns(new HttpClient(mockHandler.Object));
 
-        var result = await service.GetReleaseGateStatusAsync("https://api-review-hub-test.azurewebsites.net", "python", "pkg", "1.0.0", "hash", CancellationToken.None);
+        var result = await service.GetReleaseGateStatusAsync("https://api-review-hub-test.azurewebsites.net", "python", "pkg", "1.0.0", "hash", "", CancellationToken.None);
 
         Assert.That(result.StatusCode, Is.EqualTo(202));
     }
@@ -194,7 +194,7 @@ public class ApiReviewHubServiceTests
             .Setup(x => x.CreateClient(It.IsAny<string>()))
             .Returns(new HttpClient(mockHandler.Object));
 
-        _ = await service.GetReleaseGateStatusAsync("https://api-review-hub-test.azurewebsites.net", "python", "pkg", "1.0.0", "hash", CancellationToken.None);
+        _ = await service.GetReleaseGateStatusAsync("https://api-review-hub-test.azurewebsites.net", "python", "pkg", "1.0.0", "hash", "", CancellationToken.None);
 
         Assert.That(capturedRequest, Is.Not.Null);
         Assert.That(capturedRequest!.Headers.Authorization, Is.Not.Null);
@@ -231,7 +231,7 @@ public class ApiReviewHubServiceTests
             .Setup(x => x.CreateClient(It.IsAny<string>()))
             .Returns(new HttpClient(mockHandler.Object));
 
-        var result = await service.GetReleaseGateStatusAsync("https://api-review-hub-test.azurewebsites.net", "python", "pkg", "1.0.0", "hash", CancellationToken.None);
+        var result = await service.GetReleaseGateStatusAsync("https://api-review-hub-test.azurewebsites.net", "python", "pkg", "1.0.0", "hash", "", CancellationToken.None);
 
         Assert.That(result.StatusCode, Is.EqualTo(200));
         Assert.That(result.Reason, Is.EqualTo("repositoryNotSupported"));
@@ -243,7 +243,7 @@ public class ApiReviewHubServiceTests
     public void GetReleaseGateStatusAsync_WithDisallowedHost_ThrowsInvalidOperationException()
     {
         var exception = Assert.ThrowsAsync<InvalidOperationException>(async () =>
-            await service.GetReleaseGateStatusAsync("https://api-review-hub.evil.example", "python", "pkg", "1.0.0", "hash", CancellationToken.None));
+            await service.GetReleaseGateStatusAsync("https://api-review-hub.evil.example", "python", "pkg", "1.0.0", "hash", "", CancellationToken.None));
 
         Assert.That(exception!.Message, Does.Contain("endpoint host is not allowed"));
     }
@@ -442,6 +442,51 @@ public class ApiReviewHubServiceTests
 
         Assert.That(exception!.StatusCode, Is.EqualTo(HttpStatusCode.Conflict));
         Assert.That(exception.Message, Does.Contain("operationConflict"));
+    }
+
+    [Test]
+    public async Task GetReleaseGateStatusAsync_IncludesRepoOwnerInQuery_WhenProvided()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        var mockHandler = new Mock<HttpMessageHandler>();
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((request, _) => capturedRequest = request)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    {
+                      "isApproved": true,
+                      "reason": "approved",
+                      "details": [],
+                      "approvals": []
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/json")
+            });
+
+        httpClientFactoryMock
+            .Setup(x => x.CreateClient(It.IsAny<string>()))
+            .Returns(new HttpClient(mockHandler.Object));
+
+        _ = await service.GetReleaseGateStatusAsync(
+            "https://api-review-hub-test.azurewebsites.net",
+            "python",
+            "pkg",
+            "1.0.0",
+            "hash",
+            "Contoso",
+            CancellationToken.None);
+
+        Assert.That(capturedRequest, Is.Not.Null);
+        Assert.That(capturedRequest!.RequestUri, Is.Not.Null);
+        Assert.That(capturedRequest.RequestUri!.Query, Does.Contain("repoOwner=Contoso"));
     }
 
     private sealed class SteppingTimeProvider(DateTimeOffset initial, TimeSpan step) : TimeProvider

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/ApiReviewHubServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/ApiReviewHubServiceTests.cs
@@ -324,6 +324,58 @@ public class ApiReviewHubServiceTests
     }
 
     [Test]
+    public async Task RequestReviewPullRequestAsync_WithoutBaseTag_SendsEmptyString()
+    {
+        string? requestBody = null;
+        var mockHandler = new Mock<HttpMessageHandler>();
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(request => request.Method == HttpMethod.Post),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) =>
+                requestBody = request.Content!.ReadAsStringAsync(cancellationToken).GetAwaiter().GetResult())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Accepted)
+            {
+                Content = new StringContent(
+                    """
+                    {
+                      "operationId": "op-accepted",
+                      "status": "accepted"
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/json")
+            });
+
+        httpClientFactoryMock
+            .Setup(x => x.CreateClient(It.IsAny<string>()))
+            .Returns(new HttpClient(mockHandler.Object));
+
+        var request = new ReviewPullRequestCreationRequest
+        {
+            Language = "python",
+            PackageName = "pkg",
+            TargetBranch = new GitBranchReference
+            {
+                Owner = "Azure",
+                Repo = "azure-sdk-for-python",
+                Name = "main"
+            }
+        };
+
+        await service.RequestReviewPullRequestAsync(
+            request,
+            "https://api-review-hub-test.azurewebsites.net",
+            waitForCompletion: false,
+            pollInterval: TimeSpan.Zero,
+            CancellationToken.None);
+
+        Assert.That(requestBody, Does.Contain("\"baseTag\":\"\""));
+    }
+
+    [Test]
     public async Task RequestReviewPullRequestAsync_WhenReviewPullRequestAlreadyExists_ReturnsExpectedStatus()
     {
         var mockHandler = new Mock<HttpMessageHandler>();

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/ApiReviewReleaseStatusServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/ApiReviewReleaseStatusServiceTests.cs
@@ -26,14 +26,14 @@ public class ApiReviewReleaseStatusServiceTests
     public async Task GetApprovalStatusAsync_UsesReviewHubResult_WhenReviewHubQuerySucceeds()
     {
         reviewHubServiceMock
-            .Setup(x => x.GetReleaseGateStatusAsync("https://endpoint", "python", "pkg", "1.0.0", "hash", It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetReleaseGateStatusAsync("https://endpoint", "python", "pkg", "1.0.0", "hash", "", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ApiReviewHubReleaseGateResult
             {
                 IsApproved = true,
                 Reason = "approved"
             });
 
-        var result = await service.GetApprovalStatusAsync("https://endpoint", "python", "pkg", "1.0.0", "hash", CancellationToken.None);
+        var result = await service.GetApprovalStatusAsync("https://endpoint", "python", "pkg", "1.0.0", "hash", "", CancellationToken.None);
 
         Assert.That(result.IsApproved, Is.True);
         Assert.That(result.FinalSource, Is.EqualTo("ApiReviewHub"));
@@ -47,7 +47,7 @@ public class ApiReviewReleaseStatusServiceTests
     public async Task GetApprovalStatusAsync_QueriesApiView_WhenReviewHubResultIsNotApproved()
     {
         reviewHubServiceMock
-            .Setup(x => x.GetReleaseGateStatusAsync("https://endpoint", "python", "pkg", "1.0.0", "hash", It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetReleaseGateStatusAsync("https://endpoint", "python", "pkg", "1.0.0", "hash", "", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ApiReviewHubReleaseGateResult
             {
                 IsApproved = false,
@@ -64,7 +64,7 @@ public class ApiReviewReleaseStatusServiceTests
                 Details = ["APIView secondary result"]
             });
 
-        var result = await service.GetApprovalStatusAsync("https://endpoint", "python", "pkg", "1.0.0", "hash", CancellationToken.None);
+        var result = await service.GetApprovalStatusAsync("https://endpoint", "python", "pkg", "1.0.0", "hash", "", CancellationToken.None);
 
         Assert.That(result.IsApproved, Is.False);
         Assert.That(result.FinalSource, Is.EqualTo("ApiReviewHub"));
@@ -78,7 +78,7 @@ public class ApiReviewReleaseStatusServiceTests
     public async Task GetApprovalStatusAsync_FallsBackToApiView_WhenReviewHubQueryFails()
     {
         reviewHubServiceMock
-            .Setup(x => x.GetReleaseGateStatusAsync("https://endpoint", "python", "pkg", "1.0.0", "hash", It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetReleaseGateStatusAsync("https://endpoint", "python", "pkg", "1.0.0", "hash", "", It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("hub failed", null, HttpStatusCode.InternalServerError));
         apiViewServiceMock
             .Setup(x => x.GetApprovalStatusAsync("python", "pkg", "1.0.0", It.IsAny<CancellationToken>()))
@@ -91,7 +91,7 @@ public class ApiReviewReleaseStatusServiceTests
                 Details = ["APIView fallback result"]
             });
 
-        var result = await service.GetApprovalStatusAsync("https://endpoint", "python", "pkg", "1.0.0", "hash", CancellationToken.None);
+        var result = await service.GetApprovalStatusAsync("https://endpoint", "python", "pkg", "1.0.0", "hash", "", CancellationToken.None);
 
         Assert.That(result.IsApproved, Is.False);
         Assert.That(result.FinalSource, Is.EqualTo("APIView"));
@@ -106,7 +106,7 @@ public class ApiReviewReleaseStatusServiceTests
     public async Task GetApprovalStatusAsync_UsesApiViewResult_WhenReviewHubRepositoryIsNotSupported()
     {
         reviewHubServiceMock
-            .Setup(x => x.GetReleaseGateStatusAsync("https://endpoint", "python", "pkg", "1.0.0", "hash", It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetReleaseGateStatusAsync("https://endpoint", "python", "pkg", "1.0.0", "hash", "", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ApiReviewHubReleaseGateResult
             {
                 IsApproved = false,
@@ -123,7 +123,7 @@ public class ApiReviewReleaseStatusServiceTests
                 Details = ["APIView fallback result"]
             });
 
-        var result = await service.GetApprovalStatusAsync("https://endpoint", "python", "pkg", "1.0.0", "hash", CancellationToken.None);
+        var result = await service.GetApprovalStatusAsync("https://endpoint", "python", "pkg", "1.0.0", "hash", "", CancellationToken.None);
 
         Assert.That(result.IsApproved, Is.False);
         Assert.That(result.FinalSource, Is.EqualTo("APIView"));
@@ -136,7 +136,7 @@ public class ApiReviewReleaseStatusServiceTests
     public async Task GetApprovalStatusAsync_ReturnsReviewNotFound_WhenReviewHubRepositoryIsNotSupported_AndApiViewReturns404()
     {
         reviewHubServiceMock
-            .Setup(x => x.GetReleaseGateStatusAsync("https://endpoint", "java", "azure-keyvault-keys", "4.12.0b3", "hash", It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetReleaseGateStatusAsync("https://endpoint", "java", "azure-keyvault-keys", "4.12.0b3", "hash", "", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ApiReviewHubReleaseGateResult
             {
                 IsApproved = false,
@@ -146,7 +146,7 @@ public class ApiReviewReleaseStatusServiceTests
             .Setup(x => x.GetApprovalStatusAsync("java", "azure-keyvault-keys", "4.12.0b3", It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("review not found", null, HttpStatusCode.NotFound));
 
-        var result = await service.GetApprovalStatusAsync("https://endpoint", "java", "azure-keyvault-keys", "4.12.0b3", "hash", CancellationToken.None);
+        var result = await service.GetApprovalStatusAsync("https://endpoint", "java", "azure-keyvault-keys", "4.12.0b3", "hash", "", CancellationToken.None);
 
         Assert.That(result.IsApproved, Is.False);
         Assert.That(result.FinalSource, Is.EqualTo("APIView"));
@@ -160,14 +160,14 @@ public class ApiReviewReleaseStatusServiceTests
     public async Task GetApprovalStatusAsync_SkipsApiViewFallback_WhenLanguageIsNotSupportedByApiView()
     {
         reviewHubServiceMock
-            .Setup(x => x.GetReleaseGateStatusAsync("https://endpoint", "cpp", "pkg", "1.0.0", "hash", It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetReleaseGateStatusAsync("https://endpoint", "cpp", "pkg", "1.0.0", "hash", "", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ApiReviewHubReleaseGateResult
             {
                 IsApproved = false,
                 Reason = "repositoryNotSupported"
             });
 
-        var result = await service.GetApprovalStatusAsync("https://endpoint", "cpp", "pkg", "1.0.0", "hash", CancellationToken.None);
+        var result = await service.GetApprovalStatusAsync("https://endpoint", "cpp", "pkg", "1.0.0", "hash", "", CancellationToken.None);
 
         Assert.That(result.IsApproved, Is.False);
         Assert.That(result.FinalSource, Is.EqualTo("None"));

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -10,7 +10,8 @@
 ### Bugs Fixed
 
 - Removed the unavailable `claude-sonnet-4.5` default from Copilot-backed commands.
-- `api-review create` now surfaces the API Review Hub server response for an already-existing review PR as a success rather than an error.
+- `api-review create` now surfaces an already-existing API Review Hub review PR as a success rather than an error.
+- `api-review create` no longer requires `--base-tag`; when omitted, API Review Hub will construct an "all-green" review.
 
 ## 0.6.32 (2026-07-28)
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Added `AZSDK_COPILOT_GITHUB_TOKEN` support for authenticating Copilot-backed commands in non-interactive environments.
+- Added optional `--repo-owner` support to `api-review get-approval-status` (and `azsdk_apireview_get_approval_status`) so approval checks can target a specific repository owner when needed.
 
 ### Bugs Fixed
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ApiReviewHub/ApiReviewHubModels.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ApiReviewHub/ApiReviewHubModels.cs
@@ -26,7 +26,7 @@ public class ReviewPullRequestCreationRequest
     public required string PackageName { get; set; }
 
     [JsonPropertyName("baseTag")]
-    public required string BaseTag { get; set; }
+    public string BaseTag { get; set; } = string.Empty;
 
     [JsonPropertyName("targetBranch")]
     public required GitBranchReference TargetBranch { get; set; }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ApiReviewHub/ApiReviewHubService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ApiReviewHub/ApiReviewHubService.cs
@@ -62,16 +62,15 @@ public class ApiReviewHubService(
         }
         catch (ApiReviewHubRequestException ex) when (string.Equals(ex.ErrorCode, "reviewPullRequestAlreadyExists", StringComparison.Ordinal))
         {
-            var serverMessage = TryGetMessage(ex.Content) ?? $"An API Review Hub review PR already exists for {request.PackageName}.";
+            var serverMessage = TryGetErrorMessage(ex.Content) ?? $"An API Review Hub review PR already exists for {request.PackageName}.";
             logger.LogDebug("{message}", serverMessage);
 
-            var reviewPullRequest = TryGetReviewPullRequest(ex.Content);
             return new OperationStatus
             {
                 Status = "succeeded",
                 PackageName = request.PackageName,
                 Message = serverMessage,
-                ReviewPullRequest = reviewPullRequest
+                ReviewPullRequest = TryGetErrorReviewPullRequest(ex.Content)
             };
         }
 
@@ -245,82 +244,45 @@ public class ApiReviewHubService(
         }
     }
 
-    private static string? TryGetMessage(string content)
+    private static string? TryGetErrorMessage(string? content)
     {
+        return TryGetErrorProperty(content, "message", out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+    }
+
+    private static JsonElement? TryGetErrorReviewPullRequest(string? content)
+    {
+        return TryGetErrorProperty(content, "reviewPullRequest", out var property)
+            ? property.Clone()
+            : null;
+    }
+
+    private static bool TryGetErrorProperty(string? content, string propertyName, out JsonElement property)
+    {
+        property = default;
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return false;
+        }
+
         try
         {
             using var document = JsonDocument.Parse(content);
-            var root = document.RootElement;
-
-            if (TryGetStringProperty(root, "message", out var message))
+            if (!document.RootElement.TryGetProperty("error", out var error)
+                || error.ValueKind != JsonValueKind.Object
+                || !error.TryGetProperty(propertyName, out var parsedProperty))
             {
-                return message;
+                return false;
             }
 
-            if (root.TryGetProperty("error", out var error) && TryGetStringProperty(error, "message", out message))
-            {
-                return message;
-            }
-
-            return null;
+            property = parsedProperty.Clone();
+            return true;
         }
         catch (JsonException)
         {
-            return null;
+            return false;
         }
-        catch (InvalidOperationException)
-        {
-            return null;
-        }
-        catch (KeyNotFoundException)
-        {
-            return null;
-        }
-    }
-
-    private static JsonElement? TryGetReviewPullRequest(string content)
-    {
-        try
-        {
-            using var document = JsonDocument.Parse(content);
-            return TryGetReviewPullRequest(document.RootElement);
-        }
-        catch (JsonException)
-        {
-            return null;
-        }
-        catch (InvalidOperationException)
-        {
-            return null;
-        }
-        catch (KeyNotFoundException)
-        {
-            return null;
-        }
-    }
-
-    private static JsonElement? TryGetReviewPullRequest(JsonElement element)
-    {
-        if (element.ValueKind != JsonValueKind.Object)
-        {
-            return null;
-        }
-
-        if (element.TryGetProperty("reviewPullRequest", out var reviewPullRequest))
-        {
-            return reviewPullRequest.Clone();
-        }
-
-        if (element.TryGetProperty("error", out var error))
-        {
-            var nestedReviewPullRequest = TryGetReviewPullRequest(error);
-            if (nestedReviewPullRequest != null)
-            {
-                return nestedReviewPullRequest;
-            }
-        }
-
-        return null;
     }
 
     private static bool TryGetStringProperty(JsonElement element, string propertyName, out string? value)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ApiReviewHub/ApiReviewHubService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ApiReviewHub/ApiReviewHubService.cs
@@ -21,6 +21,7 @@ public interface IApiReviewHubService
         string packageName,
         string packageVersion,
         string apiHash,
+        string repoOwner,
         CancellationToken ct);
 }
 
@@ -111,6 +112,7 @@ public class ApiReviewHubService(
         string packageName,
         string packageVersion,
         string apiHash,
+        string repoOwner,
         CancellationToken ct)
     {
         endpoint = endpoint.TrimEnd('/');
@@ -127,6 +129,11 @@ public class ApiReviewHubService(
         if (!string.IsNullOrWhiteSpace(apiHash))
         {
             query.Add($"apiHash={Uri.EscapeDataString(apiHash)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(repoOwner))
+        {
+            query.Add($"repoOwner={Uri.EscapeDataString(repoOwner)}");
         }
 
         uriBuilder.Query = string.Join("&", query);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ApiReviewHub/ApiReviewReleaseStatusService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ApiReviewHub/ApiReviewReleaseStatusService.cs
@@ -6,7 +6,7 @@ namespace Azure.Sdk.Tools.Cli.Services.ApiReviewHub;
 
 public interface IApiReviewReleaseStatusService
 {
-    Task<ApiReviewReleaseStatusResult> GetApprovalStatusAsync(string endpoint, string language, string packageName, string packageVersion, string apiHash, CancellationToken ct);
+    Task<ApiReviewReleaseStatusResult> GetApprovalStatusAsync(string endpoint, string language, string packageName, string packageVersion, string apiHash, string repoOwner, CancellationToken ct);
 }
 
 public class ApiReviewReleaseStatusService(
@@ -14,13 +14,13 @@ public class ApiReviewReleaseStatusService(
     IAPIViewReleaseStatusService apiViewReleaseStatusService,
     ILogger<ApiReviewReleaseStatusService> logger) : IApiReviewReleaseStatusService
 {
-    public async Task<ApiReviewReleaseStatusResult> GetApprovalStatusAsync(string endpoint, string language, string packageName, string packageVersion, string apiHash, CancellationToken ct)
+    public async Task<ApiReviewReleaseStatusResult> GetApprovalStatusAsync(string endpoint, string language, string packageName, string packageVersion, string apiHash, string repoOwner, CancellationToken ct)
     {
         var result = new ApiReviewReleaseStatusResult();
 
         try
         {
-            var reviewHubResult = await apiReviewHubService.GetReleaseGateStatusAsync(endpoint, language, packageName, packageVersion, apiHash, ct);
+            var reviewHubResult = await apiReviewHubService.GetReleaseGateStatusAsync(endpoint, language, packageName, packageVersion, apiHash, repoOwner, ct);
             reviewHubResult.StatusCode ??= (int)HttpStatusCode.OK;
             result.ReviewHub = reviewHubResult;
             result.IsApproved = reviewHubResult.IsApproved;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ApiReviewHub/ApiReviewHubTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ApiReviewHub/ApiReviewHubTool.cs
@@ -67,8 +67,7 @@ public class ApiReviewHubTool(
 
     private readonly Option<string> baseTagOption = new("--base-tag")
     {
-        Description = "The release tag or ref used as the base API surface.",
-        Required = true
+        Description = "The optional release tag or ref used as the base API surface."
     };
 
     private readonly Option<string> targetOwnerOption = new("--target-owner")
@@ -138,10 +137,10 @@ public class ApiReviewHubTool(
         return await RequestReviewPullRequest(
             parseResult.GetValue(languageOption) ?? string.Empty,
             parseResult.GetValue(packageNameOption) ?? string.Empty,
-            parseResult.GetValue(baseTagOption) ?? string.Empty,
             parseResult.GetValue(targetOwnerOption) ?? string.Empty,
             ResolveTargetRepo(parseResult.GetValue(languageOption), parseResult.GetValue(targetRepoOption)),
             parseResult.GetValue(targetBranchOption) ?? string.Empty,
+            parseResult.GetValue(baseTagOption),
             !parseResult.GetValue(noWaitOption),
             parseResult.GetValue(pollIntervalSecondsOption),
             ct);
@@ -175,10 +174,10 @@ public class ApiReviewHubTool(
     public async Task<ApiReviewHubResponse> RequestReviewPullRequest(
         [Description("The SDK language for the review PR request.")] string language,
         [Description("The package name to review.")] string packageName,
-        [Description("The release tag or ref used as the base API surface.")] string baseTag,
         [Description("The GitHub owner for the target working branch.")] string targetOwner,
         [Description("The GitHub repository for the target working branch. By default, the command selects the appropriate repo based on the language.")] string targetRepo,
         [Description("The target working branch name.")] string targetBranch,
+        [Description("The optional release tag or ref used as the base API surface.")] string? baseTag = null,
         [Description("Poll API Review Hub until the operation completes.")] bool waitForCompletion = true,
         [Description("Seconds to wait between API Review Hub operation status polls.")] int pollIntervalSeconds = 10,
         CancellationToken ct = default)
@@ -189,7 +188,7 @@ public class ApiReviewHubTool(
             {
                 Language = language,
                 PackageName = packageName,
-                BaseTag = baseTag,
+                BaseTag = baseTag ?? string.Empty,
                 TargetBranch = new GitBranchReference
                 {
                     Owner = targetOwner,

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ApiReviewHub/ApiReviewHubTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ApiReviewHub/ApiReviewHubTool.cs
@@ -60,6 +60,11 @@ public class ApiReviewHubTool(
         Description = "The API Review Hub API hash to check. When omitted, the release gate cannot be approved but current approval status is returned."
     };
 
+    private readonly Option<string> repoOwnerOption = new("--repo-owner")
+    {
+        Description = "The GitHub repository owner to query in API Review Hub. Optional; when omitted, the service default is used."
+    };
+
     private readonly Option<string> baseTagOption = new("--base-tag")
     {
         Description = "The release tag or ref used as the base API surface.",
@@ -113,7 +118,8 @@ public class ApiReviewHubTool(
             languageOption,
             packageNameOption,
             packageVersionOption,
-            apiHashOption
+            apiHashOption,
+            repoOwnerOption
         }
     ];
 
@@ -148,6 +154,7 @@ public class ApiReviewHubTool(
             parseResult.GetValue(packageNameOption) ?? string.Empty,
             parseResult.GetValue(packageVersionOption) ?? string.Empty,
             parseResult.GetValue(apiHashOption) ?? string.Empty,
+            parseResult.GetValue(repoOwnerOption) ?? string.Empty,
             ct);
 
         if (IsJsonOutput(parseResult))
@@ -259,11 +266,12 @@ public class ApiReviewHubTool(
         [Description("The package name.")] string packageName,
         [Description("The package version to check.")] string packageVersion,
         [Description("The API Review Hub API hash to check. When omitted, the release gate cannot be approved but current approval status is returned.")] string apiHash = "",
+        [Description("The GitHub repository owner to query in API Review Hub. Optional; when omitted, the service default is used.")] string repoOwner = "",
         CancellationToken ct = default)
     {
         try
         {
-            var result = await apiReviewReleaseStatusService.GetApprovalStatusAsync(DefaultEndpoint, language, packageName, packageVersion, apiHash, ct);
+            var result = await apiReviewReleaseStatusService.GetApprovalStatusAsync(DefaultEndpoint, language, packageName, packageVersion, apiHash, repoOwner, ct);
             var response = new ApiReviewReleaseStatusResponse
             {
                 Result = result,


### PR DESCRIPTION
- Add `--repo-owner` param to `azsdk api-review get-approval-status` command. This is optional and if not provided defaults to the service default ("Azure"). This is useful for testing (for example, on a fork).
- Makes `--base-tag` optional on `azsdk api-review create` command. This allows creating an "all-green" PR for initial reviews.