### PR TITLE
Revert go.mod/go.sum changes from commit add4af2285 (part of #16431)

### DIFF
--- a/src/go/cmd/testdata/test_external_alias_exporter/go.mod
+++ b/src/go/cmd/testdata/test_external_alias_exporter/go.mod
@@ -2,4 +2,4 @@ module github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_external_alias_
 
 go 1.18
 
-require github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_external_alias_source v0.0.0-20260729090047-e9df8483316a
+require github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_external_alias_source v1.0.0

--- a/src/go/cmd/testdata/test_external_alias_exporter/go.sum
+++ b/src/go/cmd/testdata/test_external_alias_exporter/go.sum
@@ -1,2 +1,0 @@
-github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_external_alias_source v0.0.0-20260729090047-e9df8483316a h1:DQqLrxq02E66gTDXG/Kg2MnL/F9L/2v4hjDOcp93b4s=
-github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_external_alias_source v0.0.0-20260729090047-e9df8483316a/go.mod h1:z93m+Ekiuqy54PlAzRt4pwdVheIJkSJxyAFhGwKSUcI=

--- a/src/go/cmd/testdata/test_external_module/go.mod
+++ b/src/go/cmd/testdata/test_external_module/go.mod
@@ -3,5 +3,3 @@ module test_external_module
 go 1.18
 
 require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.1.0
-
-require github.com/Azure/azure-sdk-for-go/sdk/internal v0.1.0 // indirect

--- a/src/go/cmd/testdata/test_external_module/go.sum
+++ b/src/go/cmd/testdata/test_external_module/go.sum
@@ -1,4 +1,0 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.1.0 h1:EKsq8iuP38DMwX6x3Ue15E8Sg97lnrKCf7G+tI3hhTA=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.1.0/go.mod h1:UKq2za3CMGx75vfPM9tPSuTBNODR4hX1qAeb+GRoDkc=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.1.0 h1:sgOdyT1ZAW3nErwCuvlGrkeP03pTtbRBW5MGCXWGZws=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.1.0/go.mod h1:Q+TCQnSr+clUU0JU+xrHZ3slYCxw17AOFdvWFpQXjAY=

--- a/src/go/cmd/testdata/test_service_group/group/test_alias_export/go.mod
+++ b/src/go/cmd/testdata/test_service_group/group/test_alias_export/go.mod
@@ -2,4 +2,4 @@ module github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_service_group/g
 
 go 1.18
 
-require github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_service_group/group/internal v0.0.0-20260729090047-e9df8483316a
+require github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_service_group/group/internal v0.0.0

--- a/src/go/cmd/testdata/test_service_group/group/test_alias_export/go.sum
+++ b/src/go/cmd/testdata/test_service_group/group/test_alias_export/go.sum
@@ -1,2 +1,0 @@
-github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_service_group/group/internal v0.0.0-20260729090047-e9df8483316a h1:nK/I13UkcGHQZJmLRAO/dl1N4MS3wG1tsf1Uzg4frs0=
-github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_service_group/group/internal v0.0.0-20260729090047-e9df8483316a/go.mod h1:iSrKJNEzaabU2gTijPUWLprgUbOVGRhzN0ekUzeVvyE=

--- a/src/go/go.sum
+++ b/src/go/go.sum
@@ -16,8 +16,6 @@ golang.org/x/exp v0.0.0-20240604190554-fc45aab8b7f8 h1:LoYXNGAShUG3m/ehNk4iFctuh
 golang.org/x/exp v0.0.0-20240604190554-fc45aab8b7f8/go.mod h1:jj3sYF3dwk5D+ghuXyeI3r5MFf+NT2An6/9dOA95KSI=
 golang.org/x/mod v0.18.0 h1:5+9lSbEzPSdWkH32vYPBwEpX8KwDbM52Ud9xBUvNlb0=
 golang.org/x/mod v0.18.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
-golang.org/x/tools v0.22.0 h1:gqSGLZqv+AI9lIQzniJ0nZDRG5GBPsSi+DRNHWNz6yA=
-golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Reverts a single commit from #16431: https://github.com/Azure/azure-sdk-tools/pull/16431/changes/add4af2285d606c3627e547ed6c8baf4970ebbec

This reverts commit add4af2285d606c3627e547ed6c8baf4970ebbec ("Merge origin/main and resolve README merge conflicts"), which only touched go.mod/go.sum files under src/go.