### PR TITLE
Support pool-specific PR job batch sizes

### DIFF
--- a/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+++ b/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
@@ -53,9 +53,16 @@ parameters:
 - name: PRMatrixKey
   type: string
   default: 'ArtifactName'
+# Default number of PackageInfo entries assigned to each PR job.
+# Used when a pool-specific override is absent or its runtime variable is unset.
 - name: PRJobBatchSize
   type: number
   default: 10
+# Optional map of pool names to per-job batch-size overrides.
+# Values may be numbers or runtime variables populated by PreGenerationSteps.
+- name: PRJobBatchSizeByPool
+  type: object
+  default: {}
 - name: PRMatrixIndirectFilters
   type: object
   default: []
@@ -142,6 +149,20 @@ jobs:
         - pwsh: |
             '${{ convertToJson(parameters.MatrixConfigs) }}' | Set-Content matrix.json
 
+            $batchSize = ${{ parameters.PRJobBatchSize }}
+            $overrides = '${{ convertToJson(parameters.PRJobBatchSizeByPool) }}' | ConvertFrom-Json
+            $poolOverride = $overrides.PSObject.Properties |
+              Where-Object { $_.Name -eq '${{ pool.name }}' } |
+              Select-Object -First 1
+            # An unset runtime macro remains in $(Name) form; retain the default in that case.
+            if ($poolOverride -and [string]$poolOverride.Value -notmatch '^\$\(.+\)$') {
+              $batchSize = [int]$poolOverride.Value
+              Write-Host "Using batch size override for ${{ pool.name }}: $batchSize"
+            }
+            if ($batchSize -le 0) {
+              throw "PR job batch size for ${{ pool.name }} must be greater than zero."
+            }
+
             ./eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1 `
               -PackagePropertiesFolder $(Build.ArtifactStagingDirectory)/PackageInfo `
               -PRMatrixFile matrix.json `
@@ -151,7 +172,7 @@ jobs:
               -Filters '${{ join(''',''', parameters.MatrixFilters) }}', 'container=^$', 'SupportedClouds=^$|${{ parameters.CloudConfig.Cloud }}', 'Pool=${{ pool.filter }}' `
               -IndirectFilters '${{ join(''',''', parameters.PRMatrixIndirectFilters) }}' `
               -Replace '${{ join(''',''', parameters.MatrixReplace) }}' `
-              -PackagesPerPRJob ${{ parameters.PRJobBatchSize }} `
+              -PackagesPerPRJob $batchSize `
               -SparseIndirect $${{ parameters.PRMatrixSparseIndirect }}
           displayName: Create ${{ pool.name }} PR Matrix
           name: vm_job_matrix_pr_${{ pool.name }}

--- a/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+++ b/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
@@ -155,9 +155,17 @@ jobs:
               Where-Object { $_.Name -eq '${{ pool.name }}' } |
               Select-Object -First 1
             # An unset runtime macro remains in $(Name) form; retain the default in that case.
-            if ($poolOverride -and [string]$poolOverride.Value -notmatch '^\$\(.+\)$') {
-              $batchSize = [int]$poolOverride.Value
-              Write-Host "Using batch size override for ${{ pool.name }}: $batchSize"
+            if ($poolOverride) {
+              $overrideValue = [string]$poolOverride.Value
+              if (-not [string]::IsNullOrWhiteSpace($overrideValue) -and $overrideValue -notmatch '^\$\(.+\)$') {
+                try {
+                  $batchSize = [int]$overrideValue
+                }
+                catch {
+                  throw "PR job batch size override for ${{ pool.name }} must be an integer, got '$overrideValue'."
+                }
+                Write-Host "Using batch size override for ${{ pool.name }}: $batchSize"
+              }
             }
             if ($batchSize -le 0) {
               throw "PR job batch size for ${{ pool.name }} must be greater than zero."


### PR DESCRIPTION
Add an optional `PRJobBatchSizeByPool` map to `generate-job-matrix.yml` to configure batch sizes per-pool.

We allow override values of `PRJobBatchSizeByPool` to come from runtime variables populated by `PreGenerationSteps` (which is useful). In cases where no override exists or a runtime macro remains unset, we use the default `PRJobBatchSize` value.

## Motivation

Some consumers preprocess `PackageInfo` entries into scheduling buckets whose optimal grouping differs by agent pool. For example, [Azure/azure-sdk-for-net#57798](https://github.com/Azure/azure-sdk-for-net/pull/57798) combines three weighted buckets per Linux and Windows job while using one per slower macOS job. This keeps that policy in the consuming repository while exposing only a generic per-pool batch-size capability from the centrally owned template.

Existing callers are unchanged because the new map defaults to empty and the current `PRJobBatchSize` remains the fallback.