### PR TITLE
Fix Python 3.10 generic API stub crash

### DIFF
--- a/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
@@ -5,6 +5,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+import ast
 import importlib.metadata
 import sys
 import os
@@ -308,22 +309,25 @@ class StubGenerator:
         return sorted(modules)
 
     def _set_root_namespace(self, init_file_path, module_name):
-        with open(init_file_path, "r") as f:
-            in_docstring = False
-            content = []
-            for line in f:
-                stripped_line = line.strip()
-                # If in multi-line docstring, skip following lines until end of docstring.
-                # If single-line docstring, skip the docstring line.
-                if stripped_line.startswith(('"""', "'''")) and not stripped_line.endswith(('"""', "'''")):
-                    in_docstring = not in_docstring
-                # If comment, skip line. Otherwise, add to content.
-                if not in_docstring and not stripped_line.startswith("#"):
-                    content.append(line)
-            if len(content) > 1 or (
-                len(content) == 1 and not INIT_EXTENSION_SUBSTRING in content[0]
+        with open(init_file_path, "r", encoding="utf-8") as f:
+            source = f.read()
+
+        content = []
+        for node in ast.parse(source).body:
+            # String expressions are documentation, not package content.
+            if (
+                isinstance(node, ast.Expr)
+                and isinstance(node.value, ast.Constant)
+                and isinstance(node.value.value, str)
             ):
-                self.namespace = module_name
+                continue
+            node_source = ast.get_source_segment(source, node) or ""
+            if INIT_EXTENSION_SUBSTRING in node_source:
+                continue
+            content.append(node)
+
+        if content:
+            self.namespace = module_name
 
     def _generate_tokens(
         self, pkg_root_path, package_name, package_version, *, source_url

--- a/packages/python-packages/apiview-stub-generator/apistub/nodes/_function_node.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/nodes/_function_node.py
@@ -101,7 +101,7 @@ class FunctionNode(NodeEntityBase):
                             self.name,
                         )
                         candidate = None
-                except OSError:
+                except (OSError, TypeError):
                     candidate = None
                 if obj_id is not None:
                     _FUNC_ASTROID_CACHE[obj_id] = candidate

--- a/packages/python-packages/apiview-stub-generator/apistub/nodes/_module_node.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/nodes/_module_node.py
@@ -1,7 +1,7 @@
 import astroid
 import logging
 import inspect
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, get_origin
 
 from ._base_node import NodeEntityBase
 from ._data_class_node import DataClassNode
@@ -51,6 +51,11 @@ class ModuleNode(NodeEntityBase):
         # find class and function nodes in module
         for name, member_obj in inspect.getmembers(self.obj):
             if self._should_skip_parsing(name, member_obj, public_entities):
+                continue
+            # Python 3.10 reports parameterized collections.abc aliases such as
+            # Callable[[str], T] as classes. They are type aliases, not class APIs.
+            if get_origin(member_obj) is not None:
+                logging.debug("Skipping parameterized type alias in module: %s", name)
                 continue
             if inspect.isclass(member_obj):
                 class_type = ClassNode

--- a/packages/python-packages/apiview-stub-generator/tests/function_parsing_test.py
+++ b/packages/python-packages/apiview-stub-generator/tests/function_parsing_test.py
@@ -4,6 +4,8 @@
 # license information.
 # --------------------------------------------------------------------------
 
+from collections.abc import Callable
+
 from apistub.nodes import FunctionNode
 from apiview_stub_generator_test import (
     Python2TypeHintClient,
@@ -29,6 +31,18 @@ def _test_return(node, _type):
 
 class TestTypeHints:
     """Ensure simple typehints render correctly."""
+
+    def test_getsource_type_error_falls_back_to_annotations(self):
+        callable_alias = Callable[[str], int]
+        node = FunctionNode(
+            "test",
+            None,
+            apiview=MockApiView,
+            obj=callable_alias.__class_getitem__,
+        )
+
+        assert node.node is None
+        assert node.name == "_CallableGenericAlias"
 
     def test_simple_typehints(self):
         clients = [Python2TypeHintClient, Python3TypeHintClient, DocstringTypeHintClient]

--- a/packages/python-packages/apiview-stub-generator/tests/init_files/__init__.content_w_multiline_docs.py
+++ b/packages/python-packages/apiview-stub-generator/tests/init_files/__init__.content_w_multiline_docs.py
@@ -1,0 +1,8 @@
+"""A package with a multiline module docstring.
+
+The first executable statement must still identify this as a package root.
+"""
+
+from typing import Any
+
+__all__ = ["Any"]

--- a/packages/python-packages/apiview-stub-generator/tests/module_parsing_test.py
+++ b/packages/python-packages/apiview-stub-generator/tests/module_parsing_test.py
@@ -4,18 +4,52 @@
 # license information.
 # --------------------------------------------------------------------------
 
+from collections.abc import Callable
 import importlib
+from types import ModuleType
+from typing import Generic, TypeVar
 
-from apistub.nodes import ModuleNode
+from apistub import ApiView
+from apistub.nodes import ClassNode, ModuleNode
 
 from pytest import fail
 
 from ._test_util import _check, _tokenize, _render_lines, MockApiView, _count_review_line_metadata
 
 
+Input = TypeVar("Input")
+Output = TypeVar("Output")
+
+
+class GenericTask(Generic[Input, Output]):
+    pass
+
+
 class TestModuleParsing:
 
     pkg_namespace = "apiview_stub_generator_test"
+
+    def test_parameterized_callable_alias_is_not_parsed_as_class(self):
+        module = ModuleType(__name__)
+        module.__all__ = ["GenericTask", "GenericTaskFactory"]
+        module.GenericTask = GenericTask
+        module.GenericTaskFactory = Callable[[str], GenericTask[Input, Output]]
+
+        module_node = ModuleNode(
+            namespace=module.__name__,
+            module=module,
+            # Reproduce the empty namespace caused by a multiline package docstring.
+            pkg_root_namespace="",
+            apiview=ApiView(pkg_name="test", namespace=module.__name__),
+        )
+
+        class_names = [
+            node.name
+            for node in module_node.child_nodes
+            if isinstance(node, ClassNode)
+        ]
+        assert class_names == ["GenericTask"]
+        assert module_node.child_nodes[0].base_class_names == ["Generic[Input, Output]"]
 
     # Validates that there are no repeat defintion IDs and that each line has only one definition ID.
     def _validate_line_ids(self, review_lines):


### PR DESCRIPTION
## Summary
- correctly detect package roots whose `__init__.py` starts with a multiline docstring
- skip parameterized type aliases that Python 3.10 misclassifies as classes
- fall back to annotation-based parsing when `inspect.getsource` rejects a synthetic callable
- add focused regression coverage for `Generic[Input, Output]`, parameterized `Callable`, and multiline package docs

## Validation
- reproduced the original `azure-ai-agentserver-core` failure on Python 3.10.20
- generated `azure-ai-agentserver-core_python.json` successfully after the fix
- focused regressions: 2 passed
- namespace tests: 6 passed
- broader non-Azure package tests: 105 passed