### PR TITLE
[AzSdkCli] Prepare 0.6.34 for Release

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
@@ -13,7 +13,7 @@
     <WarningsAsErrors>CA2254</WarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AssemblyName>azsdk</AssemblyName>
-    <VersionPrefix>0.6.33</VersionPrefix>
+    <VersionPrefix>0.6.34</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <!-- Package metadata -->

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,17 +1,25 @@
 # Release History
 
+## 0.6.34 (2026-08-07)
+
+### Features Added
+
+- Added optional `--repo-owner` support to `api-review get-approval-status` (and `azsdk_apireview_get_approval_status`) so approval checks can target a specific repository owner when needed.
+
+### Bugs Fixed
+
+- `api-review create` now surfaces an already-existing API Review Hub review PR as a success rather than an error.
+- `api-review create` no longer requires `--base-tag`; when omitted, API Review Hub will construct an "all-green" review.
+
 ## 0.6.33 (2026-07-29)
 
 ### Features Added
 
 - Added `AZSDK_COPILOT_GITHUB_TOKEN` support for authenticating Copilot-backed commands in non-interactive environments.
-- Added optional `--repo-owner` support to `api-review get-approval-status` (and `azsdk_apireview_get_approval_status`) so approval checks can target a specific repository owner when needed.
 
 ### Bugs Fixed
 
 - Removed the unavailable `claude-sonnet-4.5` default from Copilot-backed commands.
-- `api-review create` now surfaces an already-existing API Review Hub review PR as a success rather than an error.
-- `api-review create` no longer requires `--base-tag`; when omitted, API Review Hub will construct an "all-green" review.
 
 ## 0.6.32 (2026-07-28)
 


### PR DESCRIPTION
Moves changelogs mistakenly merged under 0.6.33 (which has already been released!) to 0.6.34, for release tomorrow.