### PR TITLE
Bump Vally CLI to 0.12.0 for azure-typespec-author eval

### DIFF
--- a/.github/skills/azure-typespec-author/evaluate/.vally.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/.vally.yaml
@@ -6,7 +6,7 @@
 # behave as teammates expect.
 #
 # The benchmark pipelines invoke suite branches from this file directly with --suite.
-# Vally 0.6.0 supports parallel execution across multiple eval files, so pipeline
+# Vally 0.12.0 supports parallel execution across multiple eval files, so pipeline
 # runs do not need consolidated suite eval files plus tag filtering.
 
 paths:

--- a/.github/skills/azure-typespec-author/evaluate/.vally.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/.vally.yaml
@@ -24,6 +24,7 @@ environments:
       azure-sdk-mcp:
         type: stdio
         command: dotnet
+        cwd: .
         args:
           [
             "run",
@@ -53,6 +54,7 @@ environments:
       azure-sdk-mcp:
         type: stdio
         command: dotnet
+        cwd: .
         args:
           [
             "run",
@@ -74,6 +76,7 @@ environments:
       azure-sdk-mcp:
         type: stdio
         command: dotnet
+        cwd: .
         args:
           [
             "run",

--- a/.github/skills/azure-typespec-author/evaluate/README.md
+++ b/.github/skills/azure-typespec-author/evaluate/README.md
@@ -4,7 +4,8 @@ This directory contains [Vally](https://aka.ms/vally) evaluation cases for the `
 
 ## Prerequisites
 
-- [Vally CLI](https://aka.ms/vally) installed globally: `npm install -g @microsoft/vally-cli@0.6.0`
+- Node.js `>=22.12.0` and npm `>=11.11.1`
+- [Vally CLI](https://aka.ms/vally) 0.12.0 (the benchmark pipeline installs the pinned local package)
 - The `azsdk-cli` MCP server built: `dotnet build tools/azsdk-cli/Azure.Sdk.Tools.Cli`
 - An API key for the model configured (e.g., Anthropic or OpenAI key via environment variable)
 
@@ -35,7 +36,7 @@ Why each piece matters:
 - **`FIXTURE_NODE_MODULES`** lets the agent symlink a prebuilt `node_modules` instead of running
   `npm install` on every case. Without it evals still work, just slower.
 - **`copilot-instructions.md`** is copied into each run's `.github/` by the `azsdk-mcp` environments
-  in `.vally.yaml`, so evals exercise the *real* spec-repo authoring guidance. It is intentionally
+  in `.vally.yaml`, so evals exercise the _real_ spec-repo authoring guidance. It is intentionally
   **not** checked in (it is git-ignored) and always refreshed from `main`, so the eval reflects what
   authors actually see today.
 
@@ -72,8 +73,8 @@ vally eval --eval-spec evals/001001.eval.yaml --tag mode=no-skill --skill-dir /t
 
 Use different entry files depending on your goal:
 
-| File                     | When to use                            | Example command                                                                                                   |
-| ------------------------ | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| File                     | When to use                            | Example command                                                                                                                  |
+| ------------------------ | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `.vally.yaml`            | Default local entry; run by suite name | `vally eval --suite versioning-forced --skill-dir .. --output-dir ./result --workspace ./debug --verbose`                        |
 | `evals/00xxxx.eval.yaml` | Debug one specific case file           | `vally eval --eval-spec evals/003001.eval.yaml --skill-dir .. --output-dir ./result-003001 --workspace ./debug-003001 --verbose` |
 
@@ -86,29 +87,29 @@ Notes:
 
 Test suites are defined in `.vally.yaml` under the `suites` key. Available suites:
 
-| Suite                           | Description                                     |
-| ------------------------------- | ----------------------------------------------- |
-| `versioning-forced`             | Versioning cases (001xxx) — forced mode         |
-| `armtemplate-forced`            | ARM template cases (002xxx) — forced mode       |
-| `longrunningoperation-forced`   | Long-running operation cases (003xxx) — forced  |
-| `decorators-forced`             | Decorator cases (004xxx) — forced mode          |
-| `warning-forced`                | Warning cases (005xxx) — forced mode            |
-| `dataplane-forced`              | Data-plane cases (006xxx) — forced mode         |
-| `versioning-trigger`            | Versioning cases — trigger mode                 |
-| `armtemplate-trigger`           | ARM template cases — trigger mode               |
-| `longrunningoperation-trigger`  | LRO cases — trigger mode                        |
-| `decorators-trigger`            | Decorator cases — trigger mode                  |
-| `warning-trigger`               | Warning cases — trigger mode                    |
-| `dataplane-trigger`             | Data-plane cases — trigger mode                 |
-| `versioning-no-skill`           | Versioning cases — no-skill baseline            |
-| `armtemplate-no-skill`          | ARM template cases — no-skill baseline          |
-| `longrunningoperation-no-skill` | LRO cases — no-skill baseline                   |
-| `decorators-no-skill`           | Decorator cases — no-skill baseline             |
-| `warning-no-skill`              | Warning cases — no-skill baseline               |
-| `dataplane-no-skill`            | Data-plane cases — no-skill baseline            |
-| `forced`                        | All cases — forced mode                         |
-| `trigger`                       | All cases — trigger mode                        |
-| `no-skill`                      | All cases — no-skill baseline                   |
+| Suite                           | Description                                    |
+| ------------------------------- | ---------------------------------------------- |
+| `versioning-forced`             | Versioning cases (001xxx) — forced mode        |
+| `armtemplate-forced`            | ARM template cases (002xxx) — forced mode      |
+| `longrunningoperation-forced`   | Long-running operation cases (003xxx) — forced |
+| `decorators-forced`             | Decorator cases (004xxx) — forced mode         |
+| `warning-forced`                | Warning cases (005xxx) — forced mode           |
+| `dataplane-forced`              | Data-plane cases (006xxx) — forced mode        |
+| `versioning-trigger`            | Versioning cases — trigger mode                |
+| `armtemplate-trigger`           | ARM template cases — trigger mode              |
+| `longrunningoperation-trigger`  | LRO cases — trigger mode                       |
+| `decorators-trigger`            | Decorator cases — trigger mode                 |
+| `warning-trigger`               | Warning cases — trigger mode                   |
+| `dataplane-trigger`             | Data-plane cases — trigger mode                |
+| `versioning-no-skill`           | Versioning cases — no-skill baseline           |
+| `armtemplate-no-skill`          | ARM template cases — no-skill baseline         |
+| `longrunningoperation-no-skill` | LRO cases — no-skill baseline                  |
+| `decorators-no-skill`           | Decorator cases — no-skill baseline            |
+| `warning-no-skill`              | Warning cases — no-skill baseline              |
+| `dataplane-no-skill`            | Data-plane cases — no-skill baseline           |
+| `forced`                        | All cases — forced mode                        |
+| `trigger`                       | All cases — trigger mode                       |
+| `no-skill`                      | All cases — no-skill baseline                  |
 
 Run a suite by name:
 
@@ -136,20 +137,20 @@ vally eval --suite longrunningoperation-forced --skill-dir .. --output-dir ./res
 vally eval --suite versioning-trigger --skill-dir .. --output-dir ./result --workspace ./debug --verbose
 ```
 
-### Vally 0.6.0 local runs
+### Vally 0.12.0 local runs
 
-Vally 0.6.0 uses the `copilot-sdk` executor and records skill/tool calls differently from 0.5.0.
-For local forced and trigger runs, pass `--skill-dir ..` explicitly so Vally discovers the
+Vally 0.12.0 uses the `copilot-sdk` executor and does not auto-discover skills.
+For local forced and trigger runs, pass `--skill-dir ..` explicitly so Vally loads the
 `azure-typespec-author` skill directory that contains `SKILL.md`. The prompts still include the
 `@azure-typespec-author` prefix, and the evals still use `skill-invocation` graders to verify that
 the skill was invoked.
 
-Compared with 0.5.0, 0.6.0 result output includes additional run metadata such as `Turns`,
-`Tool Calls`, `Executor: copilot-sdk`, and richer JSONL fields (`type`, `itemId`, `stimulus`,
-`durationMs`, `workspacePath`). Because tool-call tracking is stricter, forced-mode failures often
-mean the agent did not call a required tool such as `azure-sdk-mcp-azsdk_run_typespec_validation`.
-When debugging local runs, keep `--verbose` enabled and inspect the `Tool Calls` column in
-`eval-results.md` or the trial entries in `results.jsonl`.
+Before running an eval, execute `node scripts/setup-environment.js`, then validate the relevant
+spec with `vally lint -e evals/<case>.eval.yaml --strict`. Vally validates referenced fixture
+files and every named environment at load time. Scoring weights are keyed by grader type and must
+form a normalized distribution totaling `1.0`; a type assigned `0` is intentionally excluded.
+When debugging local runs, keep `--verbose` enabled and inspect `eval-results.md`, `results.jsonl`,
+and the automatically preserved per-trial session directory.
 
 Do not add `--skill-dir ..` to no-skill baseline runs. Those runs intentionally use an empty skill
 directory, for example `--skill-dir /tmp/no-skills`, to measure behavior without loading the skill.
@@ -171,11 +172,14 @@ vally eval --suite trigger --skill-dir ..
 
 ### Useful flags
 
-| Flag                           | Purpose                                                        |
-| ------------------------------ | -------------------------------------------------------------- |
-| `--keep-executor-session-logs` | Preserve agent session logs under `--output-dir` for debugging |
-| `--verbose`                    | Show full agent output during the run                          |
-| `--workers <n>`                | Run multiple stimuli in parallel (default: 5)                  |
+| Flag            | Purpose                                       |
+| --------------- | --------------------------------------------- |
+| Flag            | Purpose                                       |
+| --------------- | --------------------------------------------- |
+| `--verbose`     | Show full agent output during the run         |
+| `--workers <n>` | Run multiple stimuli in parallel (default: 5) |
+
+Executor session logs are preserved automatically under the run output directory.
 
 ### Parallel run the environment
 
@@ -220,15 +224,15 @@ evaluate/
 The CI runs in three mode groups (forced, trigger, no-skill), and each group is split into
 five suite steps. Each step runs the corresponding `.vally.yaml` suite branch directly,
 for example `--suite versioning-forced`, `--suite versioning-trigger`, or
-`--suite versioning-no-skill`. Vally 0.6.0 supports parallel execution across multiple
+`--suite versioning-no-skill`. Vally 0.12.0 supports parallel execution across multiple
 eval files, so the pipelines no longer need consolidated suite eval files plus
 `--tag suite=...` filtering.
 
-| Pipeline           | Command/source              | Purpose                                                               |
-| ------------------ | --------------------------- | --------------------------------------------------------------------- |
-| benchmark          | `--suite *-forced`          | Forced skill invocation + code-quality graders (real MCP environment) |
-| benchmark          | `--suite *-trigger`         | Skill trigger detection (mock MCP environment)                        |
-| benchmark-no-skill | `--suite *-no-skill`        | Baseline run without loading the skill (`--skill-dir /tmp/no-skills`) |
+| Pipeline           | Command/source       | Purpose                                                               |
+| ------------------ | -------------------- | --------------------------------------------------------------------- |
+| benchmark          | `--suite *-forced`   | Forced skill invocation + code-quality graders (real MCP environment) |
+| benchmark          | `--suite *-trigger`  | Skill trigger detection (mock MCP environment)                        |
+| benchmark-no-skill | `--suite *-no-skill` | Baseline run without loading the skill (`--skill-dir /tmp/no-skills`) |
 
 Each stimulus has dual tags: `suite` and `mode`, for example
 `{ suite: versioning, mode: forced }`.

--- a/.github/skills/azure-typespec-author/evaluate/evals/001001.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001001.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -133,8 +133,9 @@ stimuli:
 
 scoring:
   weights:
-    prompt: 1
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 3
+    prompt: 0.166667
+    run-command: 0.166667
+    skill-invocation: 0.166667
+    file-matches: 0.499999
+    tool-calls: 0
   threshold: 0.97

--- a/.github/skills/azure-typespec-author/evaluate/evals/001002.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001002.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -137,8 +137,9 @@ stimuli:
 
 scoring:
   weights:
-    prompt: 1
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 4
+    prompt: 0.142857
+    run-command: 0.142857
+    skill-invocation: 0.142857
+    file-matches: 0.571429
+    tool-calls: 0
   threshold: 0.98

--- a/.github/skills/azure-typespec-author/evaluate/evals/001003.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001003.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -129,8 +129,9 @@ stimuli:
 
 scoring:
   weights:
-    prompt: 1
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 2
+    prompt: 0.2
+    run-command: 0.2
+    skill-invocation: 0.2
+    file-matches: 0.4
+    tool-calls: 0
   threshold: 0.96

--- a/.github/skills/azure-typespec-author/evaluate/evals/001004.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001004.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -121,8 +121,9 @@ stimuli:
 
 scoring:
   weights:
-    prompt: 1
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 2
+    prompt: 0.2
+    run-command: 0.2
+    skill-invocation: 0.2
+    file-matches: 0.4
+    tool-calls: 0
   threshold: 0.95

--- a/.github/skills/azure-typespec-author/evaluate/evals/001005.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001005.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -207,10 +207,11 @@ stimuli:
 
 scoring:
   weights:
-    file-not-matches: 3
-    skill-invocation: 1
-    file-exists: 1
-    file-matches: 4
-    run-command: 1
-    file-not-exists: 1
+    file-not-matches: 0.272727
+    skill-invocation: 0.090909
+    file-exists: 0.090909
+    file-matches: 0.363636
+    run-command: 0.090909
+    file-not-exists: 0.09091
+    tool-calls: 0
   threshold: 1

--- a/.github/skills/azure-typespec-author/evaluate/evals/001006.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001006.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -173,9 +173,10 @@ stimuli:
 
 scoring:
   weights:
-    prompt: 1
-    file-exists: 2
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 2
+    prompt: 0.142857
+    file-exists: 0.285714
+    run-command: 0.142857
+    skill-invocation: 0.142857
+    file-matches: 0.285715
+    tool-calls: 0
   threshold: 0.97

--- a/.github/skills/azure-typespec-author/evaluate/evals/001007.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001007.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -205,10 +205,11 @@ stimuli:
 
 scoring:
   weights:
-    file-not-matches: 3
-    skill-invocation: 1
-    file-exists: 1
-    file-matches: 2
-    run-command: 1
-    file-not-exists: 1
+    file-not-matches: 0.333333
+    skill-invocation: 0.111111
+    file-exists: 0.111111
+    file-matches: 0.222222
+    run-command: 0.111111
+    file-not-exists: 0.111112
+    tool-calls: 0
   threshold: 1

--- a/.github/skills/azure-typespec-author/evaluate/evals/001008.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001008.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -187,9 +187,10 @@ stimuli:
 
 scoring:
   weights:
-    prompt: 1
-    file-exists: 2
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 3
+    prompt: 0.125
+    file-exists: 0.25
+    run-command: 0.125
+    skill-invocation: 0.125
+    file-matches: 0.375
+    tool-calls: 0
   threshold: 0.97

--- a/.github/skills/azure-typespec-author/evaluate/evals/001009.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001009.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -136,8 +136,9 @@ stimuli:
 
 scoring:
   weights:
-    prompt: 1
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 3
+    prompt: 0.166667
+    run-command: 0.166667
+    skill-invocation: 0.166667
+    file-matches: 0.499999
+    tool-calls: 0
   threshold: 0.97

--- a/.github/skills/azure-typespec-author/evaluate/evals/001010.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001010.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -124,7 +124,8 @@ stimuli:
 
 scoring:
   weights:
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 3
+    run-command: 0.2
+    skill-invocation: 0.2
+    file-matches: 0.6
+    tool-calls: 0
   threshold: 1

--- a/.github/skills/azure-typespec-author/evaluate/evals/001011.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001011.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -124,7 +124,8 @@ stimuli:
 
 scoring:
   weights:
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 3
+    run-command: 0.2
+    skill-invocation: 0.2
+    file-matches: 0.6
+    tool-calls: 0
   threshold: 1

--- a/.github/skills/azure-typespec-author/evaluate/evals/001013.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/001013.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -136,8 +136,9 @@ stimuli:
 
 scoring:
   weights:
-    prompt: 1
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 3
+    prompt: 0.166667
+    run-command: 0.166667
+    skill-invocation: 0.166667
+    file-matches: 0.499999
+    tool-calls: 0
   threshold: 0.97

--- a/.github/skills/azure-typespec-author/evaluate/evals/002001.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002001.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -133,9 +133,10 @@ stimuli:
 
 scoring:
   weights:
-    prompt: 1
-    file-not-matches: 1
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 2
+    prompt: 0.166667
+    file-not-matches: 0.166667
+    run-command: 0.166667
+    skill-invocation: 0.166667
+    file-matches: 0.333332
+    tool-calls: 0
   threshold: 0.96

--- a/.github/skills/azure-typespec-author/evaluate/evals/002002.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002002.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -123,7 +123,8 @@ stimuli:
 
 scoring:
   weights:
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 3
+    run-command: 0.2
+    skill-invocation: 0.2
+    file-matches: 0.6
+    tool-calls: 0
   threshold: 1

--- a/.github/skills/azure-typespec-author/evaluate/evals/002003.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002003.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -107,7 +107,8 @@ stimuli:
 
 scoring:
   weights:
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 1
+    run-command: 0.333333
+    skill-invocation: 0.333333
+    file-matches: 0.333334
+    tool-calls: 0
   threshold: 1

--- a/.github/skills/azure-typespec-author/evaluate/evals/002004.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002004.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -139,8 +139,9 @@ stimuli:
 
 scoring:
   weights:
-    prompt: 1
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 4
+    prompt: 0.142857
+    run-command: 0.142857
+    skill-invocation: 0.142857
+    file-matches: 0.571429
+    tool-calls: 0
   threshold: 0.98

--- a/.github/skills/azure-typespec-author/evaluate/evals/002005.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002005.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -167,8 +167,9 @@ stimuli:
 
 scoring:
   weights:
-    prompt: 1
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 7
+    prompt: 0.1
+    run-command: 0.1
+    skill-invocation: 0.1
+    file-matches: 0.7
+    tool-calls: 0
   threshold: 0.99

--- a/.github/skills/azure-typespec-author/evaluate/evals/002006.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002006.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -237,8 +237,9 @@ stimuli:
 
 scoring:
   weights:
-    prompt: 1
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 16
+    prompt: 0.052632
+    run-command: 0.052632
+    skill-invocation: 0.052632
+    file-matches: 0.842104
+    tool-calls: 0
   threshold: 0.99

--- a/.github/skills/azure-typespec-author/evaluate/evals/002007.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002007.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -203,8 +203,9 @@ stimuli:
 
 scoring:
   weights:
-    prompt: 1
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 11
+    prompt: 0.071429
+    run-command: 0.071429
+    skill-invocation: 0.071429
+    file-matches: 0.785713
+    tool-calls: 0
   threshold: 0.99

--- a/.github/skills/azure-typespec-author/evaluate/evals/002008.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002008.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -121,7 +121,9 @@ stimuli:
 
 scoring:
   weights:
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 1
+    run-command: 0.333333
+    skill-invocation: 0.333333
+    file-matches: 0.333334
+    tool-calls: 0
+    file-not-matches: 0
   threshold: 1

--- a/.github/skills/azure-typespec-author/evaluate/evals/002009.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002009.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -113,8 +113,9 @@ stimuli:
 
 scoring:
   weights:
-    prompt: 1
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 1
+    prompt: 0.25
+    run-command: 0.25
+    skill-invocation: 0.25
+    file-matches: 0.25
+    tool-calls: 0
   threshold: 0.91

--- a/.github/skills/azure-typespec-author/evaluate/evals/002010.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002010.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -113,8 +113,9 @@ stimuli:
 
 scoring:
   weights:
-    prompt: 1
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 2
+    prompt: 0.2
+    run-command: 0.2
+    skill-invocation: 0.2
+    file-matches: 0.4
+    tool-calls: 0
   threshold: 0.96

--- a/.github/skills/azure-typespec-author/evaluate/evals/002011.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/002011.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -119,8 +119,9 @@ stimuli:
 
 scoring:
   weights:
-    run-command: 1
-    skill-invocation: 1
-    prompt: 1
-    file-matches: 1
+    run-command: 0.25
+    skill-invocation: 0.25
+    prompt: 0.25
+    file-matches: 0.25
+    tool-calls: 0
   threshold: 0.91

--- a/.github/skills/azure-typespec-author/evaluate/evals/003001.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/003001.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -127,8 +127,9 @@ stimuli:
 
 scoring:
   weights:
-    prompt: 1
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 2
+    prompt: 0.2
+    run-command: 0.2
+    skill-invocation: 0.2
+    file-matches: 0.4
+    tool-calls: 0
   threshold: 0.95

--- a/.github/skills/azure-typespec-author/evaluate/evals/003002.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/003002.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -141,8 +141,9 @@ stimuli:
 
 scoring:
   weights:
-    prompt: 1
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 5
+    prompt: 0.125
+    run-command: 0.125
+    skill-invocation: 0.125
+    file-matches: 0.625
+    tool-calls: 0
   threshold: 0.98

--- a/.github/skills/azure-typespec-author/evaluate/evals/004001.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/004001.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -123,8 +123,9 @@ stimuli:
 
 scoring:
   weights:
-    prompt: 1
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 2
+    prompt: 0.2
+    run-command: 0.2
+    skill-invocation: 0.2
+    file-matches: 0.4
+    tool-calls: 0
   threshold: 0.93

--- a/.github/skills/azure-typespec-author/evaluate/evals/004002.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/004002.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -137,8 +137,10 @@ stimuli:
 
 scoring:
   weights:
-    prompt: 1
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 4
+    prompt: 0.142857
+    run-command: 0.142857
+    skill-invocation: 0.142857
+    file-matches: 0.571429
+    tool-calls: 0
+    file-not-matches: 0
   threshold: 0.97

--- a/.github/skills/azure-typespec-author/evaluate/evals/004003.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/004003.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -223,8 +223,9 @@ stimuli:
 
 scoring:
   weights:
-    run-command: 1
-    file-not-matches: 3
-    skill-invocation: 1
-    file-matches: 4
+    run-command: 0.111111
+    file-not-matches: 0.333333
+    skill-invocation: 0.111111
+    file-matches: 0.444445
+    tool-calls: 0
   threshold: 1

--- a/.github/skills/azure-typespec-author/evaluate/evals/005001.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/005001.eval.yaml
@@ -7,7 +7,7 @@ type: capability # capability | regression
 environment: azsdk-mcp
 
 # Execution configuration
-config:
+defaults:
   runs: 1 # Trials per stimulus
   timeout: "660s" # Seconds per trial
   model: claude-opus-4.6 #gpt-4o #claude-sonnet-4.6 # Model for agent execution
@@ -113,7 +113,8 @@ stimuli:
 
 scoring:
   weights:
-    run-command: 1
-    skill-invocation: 1
-    file-matches: 2
+    run-command: 0.25
+    skill-invocation: 0.25
+    file-matches: 0.5
+    tool-calls: 0
   threshold: 1

--- a/.github/skills/azure-typespec-author/evaluate/evals/006001.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/006001.eval.yaml
@@ -3,7 +3,7 @@ description: Evaluation suite for azure-typespec-author.
 version: '1.0'
 type: capability
 environment: azsdk-mcp
-config:
+defaults:
   runs: 1
   timeout: 660s
   model: claude-opus-4.6
@@ -93,9 +93,9 @@ stimuli:
     max_tokens: 100000
 scoring:
   weights:
-    tool-calls: 1
-    skill-invocation: 1
-    run-command: 1
-    file-matches: 3
-    prompt: 2
+    tool-calls: 0.125
+    skill-invocation: 0.125
+    run-command: 0.125
+    file-matches: 0.375
+    prompt: 0.25
   threshold: 0.95

--- a/.github/skills/azure-typespec-author/evaluate/evals/006002.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/006002.eval.yaml
@@ -3,7 +3,7 @@ description: Evaluation suite for azure-typespec-author.
 version: '1.0'
 type: capability
 environment: azsdk-mcp
-config:
+defaults:
   runs: 1
   timeout: 660s
   model: claude-opus-4.6
@@ -93,9 +93,9 @@ stimuli:
     max_tokens: 100000
 scoring:
   weights:
-    tool-calls: 1
-    skill-invocation: 1
-    run-command: 1
-    file-matches: 3
-    prompt: 2
+    tool-calls: 0.125
+    skill-invocation: 0.125
+    run-command: 0.125
+    file-matches: 0.375
+    prompt: 0.25
   threshold: 0.95

--- a/.github/skills/azure-typespec-author/evaluate/evals/006003.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/006003.eval.yaml
@@ -3,7 +3,7 @@ description: Evaluation suite for azure-typespec-author.
 version: '1.0'
 type: capability
 environment: azsdk-mcp
-config:
+defaults:
   runs: 1
   timeout: 660s
   model: claude-opus-4.6
@@ -93,9 +93,9 @@ stimuli:
     max_tokens: 100000
 scoring:
   weights:
-    tool-calls: 1
-    skill-invocation: 1
-    run-command: 1
-    file-matches: 3
-    prompt: 2
+    tool-calls: 0.125
+    skill-invocation: 0.125
+    run-command: 0.125
+    file-matches: 0.375
+    prompt: 0.25
   threshold: 0.95

--- a/.github/skills/azure-typespec-author/evaluate/evals/006004.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/006004.eval.yaml
@@ -3,7 +3,7 @@ description: Evaluation suite for azure-typespec-author.
 version: '1.0'
 type: capability
 environment: azsdk-mcp
-config:
+defaults:
   runs: 1
   timeout: 660s
   model: claude-opus-4.6
@@ -118,9 +118,9 @@ stimuli:
     max_tokens: 100000
 scoring:
   weights:
-    tool-calls: 1
-    skill-invocation: 1
-    run-command: 1
-    file-matches: 3
-    prompt: 2
+    tool-calls: 0.125
+    skill-invocation: 0.125
+    run-command: 0.125
+    file-matches: 0.375
+    prompt: 0.25
   threshold: 0.95

--- a/.github/skills/azure-typespec-author/evaluate/evals/006005.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/006005.eval.yaml
@@ -3,7 +3,7 @@ description: Evaluation suite for azure-typespec-author.
 version: '1.0'
 type: capability
 environment: azsdk-mcp
-config:
+defaults:
   runs: 1
   timeout: 660s
   model: claude-opus-4.6
@@ -85,8 +85,8 @@ stimuli:
     max_tokens: 100000
 scoring:
   weights:
-    tool-calls: 1
-    skill-invocation: 1
-    run-command: 1
-    file-matches: 3
+    tool-calls: 0.166667
+    skill-invocation: 0.166667
+    run-command: 0.166667
+    file-matches: 0.499999
   threshold: 0.95

--- a/.github/skills/azure-typespec-author/evaluate/evals/006006.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/006006.eval.yaml
@@ -3,7 +3,7 @@ description: Evaluation suite for azure-typespec-author.
 version: '1.0'
 type: capability
 environment: azsdk-mcp
-config:
+defaults:
   runs: 1
   timeout: 660s
   model: claude-opus-4.6
@@ -91,9 +91,9 @@ stimuli:
     max_tokens: 100000
 scoring:
   weights:
-    tool-calls: 1
-    skill-invocation: 1
-    run-command: 1
-    file-matches: 3
-    file-not-matches: 2
+    tool-calls: 0.125
+    skill-invocation: 0.125
+    run-command: 0.125
+    file-matches: 0.375
+    file-not-matches: 0.25
   threshold: 0.95

--- a/.github/skills/azure-typespec-author/evaluate/evals/006007.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/006007.eval.yaml
@@ -3,7 +3,7 @@ description: Evaluation suite for azure-typespec-author.
 version: '1.0'
 type: capability
 environment: azsdk-mcp
-config:
+defaults:
   runs: 1
   timeout: 660s
   model: claude-opus-4.6
@@ -99,9 +99,9 @@ stimuli:
     max_tokens: 100000
 scoring:
   weights:
-    tool-calls: 1
-    skill-invocation: 1
-    run-command: 1
-    file-matches: 3
-    prompt: 2
+    tool-calls: 0.125
+    skill-invocation: 0.125
+    run-command: 0.125
+    file-matches: 0.375
+    prompt: 0.25
   threshold: 0.95

--- a/.github/skills/azure-typespec-author/evaluate/evals/006008.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/006008.eval.yaml
@@ -3,7 +3,7 @@ description: Evaluation suite for azure-typespec-author.
 version: '1.0'
 type: capability
 environment: azsdk-mcp
-config:
+defaults:
   runs: 1
   timeout: 660s
   model: claude-opus-4.6
@@ -100,9 +100,9 @@ stimuli:
     max_tokens: 100000
 scoring:
   weights:
-    tool-calls: 1
-    skill-invocation: 1
-    run-command: 1
-    file-matches: 3
-    prompt: 2
+    tool-calls: 0.125
+    skill-invocation: 0.125
+    run-command: 0.125
+    file-matches: 0.375
+    prompt: 0.25
   threshold: 0.95

--- a/.github/skills/azure-typespec-author/evaluate/evals/006009.eval.yaml
+++ b/.github/skills/azure-typespec-author/evaluate/evals/006009.eval.yaml
@@ -3,7 +3,7 @@ description: Evaluation suite for azure-typespec-author.
 version: '1.0'
 type: capability
 environment: azsdk-mcp
-config:
+defaults:
   runs: 1
   timeout: 660s
   model: claude-opus-4.6
@@ -100,9 +100,9 @@ stimuli:
     max_tokens: 100000
 scoring:
   weights:
-    tool-calls: 1
-    skill-invocation: 1
-    run-command: 1
-    file-matches: 3
-    prompt: 2
+    tool-calls: 0.125
+    skill-invocation: 0.125
+    run-command: 0.125
+    file-matches: 0.375
+    prompt: 0.25
   threshold: 0.95

--- a/eng/pipelines/azure-typespec-author-benchmark.yml
+++ b/eng/pipelines/azure-typespec-author-benchmark.yml
@@ -22,13 +22,13 @@ trigger: none
 pr: none
 
 parameters:
-- name: PythonVersion
-  type: string
-  default: '3.10'
-- name: SkillBranch
-  displayName: Branch containing the azure-typespec-author skill source (SKILL.md + references/) to evaluate. Defaults to the branch this pipeline was triggered from.
-  type: string
-  default: $(Build.SourceBranchName)
+  - name: PythonVersion
+    type: string
+    default: "3.10"
+  - name: SkillBranch
+    displayName: Branch containing the azure-typespec-author skill source (SKILL.md + references/) to evaluate. Defaults to the branch this pipeline was triggered from.
+    type: string
+    default: $(Build.SourceBranchName)
 
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
@@ -46,7 +46,7 @@ extends:
           os: linux
         jobs:
           # Forced mode: each .vally.yaml suite branch runs in an independent step.
-          # Vally 0.6.0 supports parallel execution across multiple eval files, so
+          # Vally 0.12.0 supports parallel execution across multiple eval files, so
           # this no longer needs suites/forced.eval.yaml plus tag filtering.
           - job: RunEvalsForCodeQuality
             displayName: Run Vally Evaluations for Code Quality
@@ -68,42 +68,42 @@ extends:
                   SuiteName: versioning-forced
                   DisplayName: Run force invokation suite - versioning
                   TimeoutMinutes: 50
-                  AzureSubscription: 'azuresdkqabot-dev'
+                  AzureSubscription: "azuresdkqabot-dev"
               - template: /eng/pipelines/templates/steps/typespec-author-eval-run-suite.yml
                 parameters:
                   Suite: armtemplate-forced
                   SuiteName: armtemplate-forced
                   DisplayName: Run force invokation suite - armtemplate
                   TimeoutMinutes: 40
-                  AzureSubscription: 'azuresdkqabot-dev'
+                  AzureSubscription: "azuresdkqabot-dev"
               - template: /eng/pipelines/templates/steps/typespec-author-eval-run-suite.yml
                 parameters:
                   Suite: longrunningoperation-forced
                   SuiteName: longrunningoperation-forced
                   DisplayName: Run force invokation suite - longrunningoperation
                   TimeoutMinutes: 25
-                  AzureSubscription: 'azuresdkqabot-dev'
+                  AzureSubscription: "azuresdkqabot-dev"
               - template: /eng/pipelines/templates/steps/typespec-author-eval-run-suite.yml
                 parameters:
                   Suite: decorators-forced
                   SuiteName: decorators-forced
                   DisplayName: Run force invokation suite - decorators
                   TimeoutMinutes: 15
-                  AzureSubscription: 'azuresdkqabot-dev'
+                  AzureSubscription: "azuresdkqabot-dev"
               - template: /eng/pipelines/templates/steps/typespec-author-eval-run-suite.yml
                 parameters:
                   Suite: warning-forced
                   SuiteName: warning-forced
                   DisplayName: Run force invokation suite - warning
                   TimeoutMinutes: 25
-                  AzureSubscription: 'azuresdkqabot-dev'
+                  AzureSubscription: "azuresdkqabot-dev"
               - template: /eng/pipelines/templates/steps/typespec-author-eval-run-suite.yml
                 parameters:
                   Suite: dataplane-forced
                   SuiteName: dataplane-forced
                   DisplayName: Run force invocation suite - dataplane
                   TimeoutMinutes: 50
-                  AzureSubscription: 'azuresdkqabot-dev'
+                  AzureSubscription: "azuresdkqabot-dev"
 
             templateContext:
               outputs:
@@ -138,42 +138,42 @@ extends:
                   SuiteName: versioning-trigger
                   DisplayName: Run suite - versioning
                   TimeoutMinutes: 50
-                  AzureSubscription: 'azuresdkqabot-dev'
+                  AzureSubscription: "azuresdkqabot-dev"
               - template: /eng/pipelines/templates/steps/typespec-author-eval-run-suite.yml
                 parameters:
                   Suite: armtemplate-trigger
                   SuiteName: armtemplate-trigger
                   DisplayName: Run suite - armtemplate
                   TimeoutMinutes: 40
-                  AzureSubscription: 'azuresdkqabot-dev'
+                  AzureSubscription: "azuresdkqabot-dev"
               - template: /eng/pipelines/templates/steps/typespec-author-eval-run-suite.yml
                 parameters:
                   Suite: longrunningoperation-trigger
                   SuiteName: longrunningoperation-trigger
                   DisplayName: Run suite - longrunningoperation
                   TimeoutMinutes: 25
-                  AzureSubscription: 'azuresdkqabot-dev'
+                  AzureSubscription: "azuresdkqabot-dev"
               - template: /eng/pipelines/templates/steps/typespec-author-eval-run-suite.yml
                 parameters:
                   Suite: decorators-trigger
                   SuiteName: decorators-trigger
                   DisplayName: Run suite - decorators
                   TimeoutMinutes: 15
-                  AzureSubscription: 'azuresdkqabot-dev'
+                  AzureSubscription: "azuresdkqabot-dev"
               - template: /eng/pipelines/templates/steps/typespec-author-eval-run-suite.yml
                 parameters:
                   Suite: warning-trigger
                   SuiteName: warning-trigger
                   DisplayName: Run suite - warning
                   TimeoutMinutes: 25
-                  AzureSubscription: 'azuresdkqabot-dev'
+                  AzureSubscription: "azuresdkqabot-dev"
               - template: /eng/pipelines/templates/steps/typespec-author-eval-run-suite.yml
                 parameters:
                   Suite: dataplane-trigger
                   SuiteName: dataplane-trigger
                   DisplayName: Run suite - dataplane
                   TimeoutMinutes: 50
-                  AzureSubscription: 'azuresdkqabot-dev'
+                  AzureSubscription: "azuresdkqabot-dev"
 
             templateContext:
               outputs:

--- a/eng/pipelines/azure-typespec-author-eval/package-lock.json
+++ b/eng/pipelines/azure-typespec-author-eval/package-lock.json
@@ -6,9 +6,145 @@
     "": {
       "name": "azure-typespec-author-benchmark",
       "devDependencies": {
-        "@github/copilot-sdk": "1.0.0-beta.5",
-        "@microsoft/vally-cli": "0.6.0",
+        "@github/copilot-sdk": "1.0.7",
+        "@microsoft/vally-cli": "0.12.0",
         "@typespec/compiler": "1.13.0"
+      },
+      "engines": {
+        "node": ">=22.12.0",
+        "npm": ">=11.11.1"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-fNAjWnA/nZ2jz31kxR/AqRaUT8ewHBw/WuBIosK0moMy1C9e5ValbDfFdIxJzVOOYaYkV/b2F1S4H/aHiqfVQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.11.0.tgz",
+      "integrity": "sha512-IUZydyTUkDnYdstOW9pFOOUQlBjAepK5teihDE3x6yxsPJs/hsAaaYpeGxdxrgtOiJbBKSjKW7MDk7AEhb4LRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.11.0.tgz",
+      "integrity": "sha512-JjQWO6akOck45PH/XBrxzsQGAiKrfFl4m5iggJ0ItMIz5omRufOXWpqCPpdjKN3vKDzlSUvFjaMb7Zwf0gvAdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.25.0.tgz",
+      "integrity": "sha512-bMs8ekJLjX8wPV+9IPBges1SLPyuDtE9g5gLDWOpxzKcoOFQnpLGkbcT1tdw3FaAmDS1gnPmMmJ6y/T5B96kIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.4.0.tgz",
+      "integrity": "sha512-eGwxD0AtncrxeBM4tG8R55Pc3rdX1hNW2WibJAgYpCVA6E93mvvVH+LcssoVjOBrSKWS55yEIHsk0X8ctHmfOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.14.0.tgz",
+      "integrity": "sha512-9n2pWK61veAuN0V20t9lOuoV4CFMdyAZ1ygZzvBGk/pBBJRib/PjL9PLXa/aI2CcPpyHfqVsxxqLCYl6uZlfDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.4.0.tgz",
+      "integrity": "sha512-rbAE25KUfjU/s3XHUdJgceoCP5dEOpMx85J04kF+QMdta73XkuG9JGHHinch+XIoKpBdqljin+KqURpJriSzLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/monitor-opentelemetry-exporter": {
+      "version": "1.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@azure/monitor-opentelemetry-exporter/-/monitor-opentelemetry-exporter-1.0.0-beta.32.tgz",
+      "integrity": "sha512-Tk5Tv8KwHhKCQlXET/7ZLtjBv1Zi4lmPTadKTQ9KCURRJWdt+6hu5ze52Tlp2pVeg3mg+MRQ9vhWvVNXMZAp/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.19.0",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.200.0",
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/resources": "^2.0.0",
+        "@opentelemetry/sdk-logs": "^0.200.0",
+        "@opentelemetry/sdk-metrics": "^2.0.0",
+        "@opentelemetry/sdk-trace-base": "^2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.32.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -37,9 +173,9 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.65",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.65.tgz",
-      "integrity": "sha512-J1XvLuOiVpiAi/E1MBICBymszCgdGLnZxokosXzGcmcjEVZd+QSDoW/kPRHq6oEyBT9SDASPcjCEZ9Q0rLJllg==",
+      "version": "1.0.78",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.78.tgz",
+      "integrity": "sha512-jn+8HLZC3R7d6K1/1g9L1iWNKzBVS3JdVcx40r3aWyS5r+MLV1OPNp0fo5OfRMCDIm3NmEaaoqypi9sQkCXuiQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
@@ -49,20 +185,20 @@
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.65",
-        "@github/copilot-darwin-x64": "1.0.65",
-        "@github/copilot-linux-arm64": "1.0.65",
-        "@github/copilot-linux-x64": "1.0.65",
-        "@github/copilot-linuxmusl-arm64": "1.0.65",
-        "@github/copilot-linuxmusl-x64": "1.0.65",
-        "@github/copilot-win32-arm64": "1.0.65",
-        "@github/copilot-win32-x64": "1.0.65"
+        "@github/copilot-darwin-arm64": "1.0.78",
+        "@github/copilot-darwin-x64": "1.0.78",
+        "@github/copilot-linux-arm64": "1.0.78",
+        "@github/copilot-linux-x64": "1.0.78",
+        "@github/copilot-linuxmusl-arm64": "1.0.78",
+        "@github/copilot-linuxmusl-x64": "1.0.78",
+        "@github/copilot-win32-arm64": "1.0.78",
+        "@github/copilot-win32-x64": "1.0.78"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.65",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.65.tgz",
-      "integrity": "sha512-NFc4xIstZNiIuAYkurQT5DVtbZjBoZ/z6yt/Ffcom7Y5QGjfpN4BFuekv9k+OADRioxxR99NgmhjbuNPWtQhNQ==",
+      "version": "1.0.78",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.78.tgz",
+      "integrity": "sha512-P11+VyWg8ad0WlywGtO2d7AxqTLJv4hkUicFg6Ycth5lfk00aCu/74YOOZSPO6C2bBBJhAza7oAdmauM6KEojw==",
       "cpu": [
         "arm64"
       ],
@@ -77,9 +213,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.65",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.65.tgz",
-      "integrity": "sha512-0wtV22KmTa12VbqWRRkgvJcBz/oIbszfcIpyDWGc4MzbCVksajQ3TWVQ6c7Sdzj5RifCaYdkHAX2zuIYXYlLoQ==",
+      "version": "1.0.78",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.78.tgz",
+      "integrity": "sha512-stimP3WDFs2GU8nJzTJbtRpZViV4bsf80yg7QrFq+G4RISQ3Nihg/3/H0U6UQF1+txMJ/Ohmb5RFYxSw1Hj2sw==",
       "cpu": [
         "x64"
       ],
@@ -94,9 +230,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.65",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.65.tgz",
-      "integrity": "sha512-dOwdy/YbTXQN/+x2v4ZgiDycdRtWElyHxPuA6ail3yJDt0nagwn8OYAA/diBLPMAJuuBXiOZGvvb9fGRuh7Xgg==",
+      "version": "1.0.78",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.78.tgz",
+      "integrity": "sha512-K31PRKGTm252V1Lof7ypjg283R2QSm3BgoCvZfX2taos4wqC3SaTozSQKwW3dgrAx7A3G3SGEoilVCNqfigdZA==",
       "cpu": [
         "arm64"
       ],
@@ -114,9 +250,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.65",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.65.tgz",
-      "integrity": "sha512-al/1a/l/GrpHtygTxt7PZspmv0eHBPdAZ5B31J7Hv/GRdVZM4STCC9dCIOSUFsOX2fhaKD8yLfz4HureSYs23g==",
+      "version": "1.0.78",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.78.tgz",
+      "integrity": "sha512-QK3oMtAn9dIv+1u1kx0xNpZNtZxdI+uZVIyLl7myp+Oh2Uj8BLagVv6a7uP0cDphO3TgfIdlvpepCe5MIcx0fw==",
       "cpu": [
         "x64"
       ],
@@ -134,9 +270,9 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-arm64": {
-      "version": "1.0.65",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.65.tgz",
-      "integrity": "sha512-xccQeJSR45xyoaL7J5mZjtU++dmte+ZCDQkIlrpTn2yuMl2LWriBvorQ1P2MwVnXmIiW/GHi93B+lNtsybA9yw==",
+      "version": "1.0.78",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.78.tgz",
+      "integrity": "sha512-F/0cTMsz6ug4yiXn3RKaCAMsLR261U5Njb6G9Y/HeAI7ES/tKEo2t5SHuvgXaIH4mYiZsRvfDKdX7c0WgBX/Jg==",
       "cpu": [
         "arm64"
       ],
@@ -154,9 +290,9 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-x64": {
-      "version": "1.0.65",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.65.tgz",
-      "integrity": "sha512-RHPVUaqjSrhKHQ2EpfGKWErnV+R5elGIZaHXPKO10zpSaQD9b/C9u6nLigZnBuT/8sCaJpVrazPMwOYvYA62aw==",
+      "version": "1.0.78",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.78.tgz",
+      "integrity": "sha512-YMaJaeBGbArGAFYel+yFaFW/0rFgh0Oqki2f2mUtlonTX/xHr8EB4+mTnMJkHYMFy4gOTC3OtSEEe1NaW/cBXQ==",
       "cpu": [
         "x64"
       ],
@@ -174,24 +310,25 @@
       }
     },
     "node_modules/@github/copilot-sdk": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.0-beta.5.tgz",
-      "integrity": "sha512-WT/JZXkLi4mZKjyQakqBEv4lU8zHOSERicEB75KN1oLVIvKRvL8WyfP6dqIjeO1xmCKd6/qKVGlQxJChCIzJ1w==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.7.tgz",
+      "integrity": "sha512-dgCFCPfxWUkrgclQbrm7WCFzTf5RnJHsK1Lqsc3KjPBbDLPutJT0qIGg3xJ0ZELLyX0icg3TOmVczhR4HdwHxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "^1.0.51",
+        "@github/copilot": "^1.0.71",
+        "koffi": "^3.1.0",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.65",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.65.tgz",
-      "integrity": "sha512-/vSE/t9Wm3eFSWpxlKyn/oL8OAVOB0yFO7ECxhgbtiqNrBd1tgpYh1k7IXBIWa/saxlV1+de6DEmPuQfx3Z0bg==",
+      "version": "1.0.78",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.78.tgz",
+      "integrity": "sha512-ktDkFXaaecEKD3hpM6ydM9lKOdoCfsQsXCmzLzE7DCmSpbbMCdfPfWfZ7MOclmKmpZ5/MNfr4U2l8CUqGerzYA==",
       "cpu": [
         "arm64"
       ],
@@ -206,9 +343,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.65",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.65.tgz",
-      "integrity": "sha512-wjVWXepET+SpFg8z8V43ZiTy6X1OerCb7yu3QZKNNJ3zY9z20goihPXQCDWkiJpGzszNSgfrsiqUzpUsC9qS0A==",
+      "version": "1.0.78",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.78.tgz",
+      "integrity": "sha512-Gd8l2T4eqYEWlOEPd0SZznQ+YYgYrwOkE0QXodMkhCBbPdgu/uTzb7mnISWwnVAgqs7pONdF1GOpHkTo+ay8CQ==",
       "cpu": [
         "x64"
       ],
@@ -223,9 +360,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
-      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -592,59 +729,649 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@microsoft/vally": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/vally/-/vally-0.6.0.tgz",
-      "integrity": "sha512-b283YRDFZXUkKNKY3+1EfMBVbHrBLIs5jfUi7lIQ8N0Y10lVsNnNGkRbtTbd7tLYZajr6AhtnpIroc4RFzo1cQ==",
+    "node_modules/@koromix/koffi-darwin-arm64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.1.4.tgz",
+      "integrity": "sha512-/9o0uahf25sNXz7CczfMAsgdHrrrkDK3/d1W5ygJUC7QnpWo80103yTYpYahWP3vTABK5yjzKtURgssv1paskA==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-x64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.1.4.tgz",
+      "integrity": "sha512-6IOhfAHbrySr6lYRU720Hg+IMQvtMpN08k9Ppf9WF8NxYRdHLnW1FJm7zCbClfrwudtjhS/piwDYwgAkO5u8cg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-arm64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.1.4.tgz",
+      "integrity": "sha512-JKCWC0awdVvq7Nd/etn4PXFTa7uvyHn7IzqtaOZ3r4dJRdwQVby7Ai/wsQo8UUrJfAYlALkLYgFgU8wgsnAE/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-ia32": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.1.4.tgz",
+      "integrity": "sha512-gU9pShDRLMZzftdGW+mTzyL8Cpa/7nzHPHe5vFakjGgtIzVFzdFBqwli4oB+tFsx44W1VqMMlvMMVlnz54ERiQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-x64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.1.4.tgz",
+      "integrity": "sha512-2kppLX97xBM3WoQET6noN4W02zT2fkFRXHYluAwcCcmkEax8AVJ1CYs6hxcZ3kaNPc+5P7yMw3V/b1lg2v3aMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-arm64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.1.4.tgz",
+      "integrity": "sha512-yYbypuGVGqrNchkAMY59kj+7TZ1c1u9lXRG1+74X9T8G4rOaushoVONNYLuu+ygpbwsKzz/NvEDtRioRU/dQlQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-ia32": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.1.4.tgz",
+      "integrity": "sha512-IoA/8Qfc6ZEmwMw2Nf4aSp9RfJnxh0UHhdqD4FsVXm0vC797kLMuzj744vv5tll+waVfjrU10jREqjtnMVFoQw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-loong64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.1.4.tgz",
+      "integrity": "sha512-ZUTdea+9dg6CV9J9CIGbhTh0FtSBgvcGKqDrlp9BVQF71jEDKOri1by/TrDe8yQUyC5kzWN8vWnkzES5wT0xDg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-riscv64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.1.4.tgz",
+      "integrity": "sha512-CINyyhNYV/8MX52MGhYcik2G6PXH+KEU2JEO7dOONlsGol4lSGyW40RvYA4RQgNYk8q8imGSEScL08X8eOXnaA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-x64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.1.4.tgz",
+      "integrity": "sha512-x3XnAy/tUTTCX/gMpV7VJNpOQIVQvzNhNYDrpyIeS9Q8/f1qLsE0vp0tj7A/YEDIfMVLqoJtyamfRJc04+vk4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-ia32": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.1.4.tgz",
+      "integrity": "sha512-r9p/fffvmBm7+iT5BZ+c17gZJ280jvmbinrPZqjG14rF9I4lk7xrlV79YfsexkeN4mcPjF2hSPtbMNFBoQU3Dw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-x64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.1.4.tgz",
+      "integrity": "sha512-SNp5AxOzheC2YaWPu3Y86wxRHHWf6V9NMl5Ot5nu9OpnP61Yinzug7JwsCeXtcZZTbKLsfsWoT7y4n17UYpOVA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-arm64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.1.4.tgz",
+      "integrity": "sha512-oS8ETU35AelOD6DY7xmmz9qq26Xl38upXWiZbsdxbtH9UEIY0QpenQOuCK/0+q4CtfiLorRUlglGkO9YgPAIeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-ia32": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.1.4.tgz",
+      "integrity": "sha512-zd7Qh8s4fzblD9zzuDf44XCbujYg3QrffhgcNJg79/YC6ABT2m0CUtX4yFic9EWm2ps8NPAM25kCTCXPpt3eaw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-x64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.1.4.tgz",
+      "integrity": "sha512-BPeQXc1bRd0QBOklvsP+AjoRnUzKbPNE6rfx7VNxrebhh09MKld2ibstgKWn6ejQLEcfKEoUJ+WAWIhX4AOsIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@microsoft/vally": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/vally/-/vally-0.12.0.tgz",
+      "integrity": "sha512-6/zyjQBGkhCuZeUe4rMeD841xIGQX9PW0u5FBEkXOZOhhqjecnCDB0zxSd0cQEIF2TqVOacLiHSwxbhCNwpFEg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@github/copilot-sdk": "^1.0.0",
+        "@github/copilot-sdk": "^1.0.7",
+        "@opentelemetry/api": "^1.9.1",
         "js-tiktoken": "^1.0.21",
-        "picomatch": "^4.0.4",
+        "mdast-util-from-markdown": "^2.0.3",
+        "picomatch": "^4.0.5",
         "yaml": "^2.9.0",
         "zod": "^4.4.3"
+      },
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=11.11.1"
       }
     },
     "node_modules/@microsoft/vally-cli": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/vally-cli/-/vally-cli-0.6.0.tgz",
-      "integrity": "sha512-6JzbuB2EpQTuA9snexb7xsos1oLiB8JhWY6Xe2JCOd4clsv1fj3WFhv/jxiU6OMmSC2vQQ3hsM/LDuyAoEUJyw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/vally-cli/-/vally-cli-0.12.0.tgz",
+      "integrity": "sha512-qH20bcwLUHCsenSLZ+vqQw0r5yj5tBLSs+fzjzuE4/JgZJcTlG3ARY2iN0rB5UIWKl04m6CkDAEfMaBFNi8Vvg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@microsoft/vally": "^0.6.0",
-        "@microsoft/vally-server": "^0.6.0",
+        "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.32",
+        "@microsoft/vally": "^0.12.0",
+        "@microsoft/vally-server": "^0.12.0",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
+        "@opentelemetry/resources": "^2.10.0",
+        "@opentelemetry/sdk-trace-base": "^2.10.0",
+        "@opentelemetry/sdk-trace-node": "^2.10.0",
         "commander": "^15.0.0"
       },
       "bin": {
         "vally": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=11.11.1"
+      },
+      "optionalDependencies": {
+        "@vscode/deviceid": "~0.1.5"
       }
     },
     "node_modules/@microsoft/vally-server": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/vally-server/-/vally-server-0.6.0.tgz",
-      "integrity": "sha512-8LPB/NtJo/vYwiNYQdU6oc/f4W08QwQtEiE+M+g5O/dpJQsM9RmPINZrb/DQJl7yngBZQ8VShe1HtqeuwX1wvw==",
-      "dev": true,
-      "dependencies": {
-        "@hono/node-server": "^2.0.4",
-        "@microsoft/vally": "^0.6.0",
-        "better-sqlite3": "^12.10.0",
-        "hono": "^4.12.25"
-      }
-    },
-    "node_modules/@microsoft/vally/node_modules/@github/copilot-sdk": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.4.tgz",
-      "integrity": "sha512-c6/gpatP7LAuP9stlc2uXXOrB+TJMFSs3Jrzu9FG8lJJYFGmdzbBvGz2UdL1jww84fp6D7cohEZa4UGq1+iuyA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/vally-server/-/vally-server-0.12.0.tgz",
+      "integrity": "sha512-oYR1nDplTD2KjSU1lEh484jqMy5bSSweeRTf/yosCeCjkJn/Vjir4GdLSuKOe21V9623Xs9rg9omwXenHm2B7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "^1.0.65",
-        "vscode-jsonrpc": "^8.2.1",
-        "zod": "^4.3.6"
+        "@hono/node-server": "^2.0.11",
+        "@microsoft/vally": "^0.12.0",
+        "better-sqlite3": "^13.0.1",
+        "hono": "^4.12.31"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": ">=22.0.0",
+        "npm": ">=11.11.1"
       }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.200.0.tgz",
+      "integrity": "sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.10.0.tgz",
+      "integrity": "sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.221.0.tgz",
+      "integrity": "sha512-AySXiKoC+meiWm6zdVj5T2LnPDZuatveBby1cMOeQteIWsYXAUxs8Sru13G2pVSPrUXz6vF+og7QVBX6GdC/oQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.221.0.tgz",
+      "integrity": "sha512-UFPIq80OH3Ns/oPFHRj14d4DTOxUo+MUFU8hUiCq5jTqFhdeJnfVSANHT+xp92409cA+oxzvlZCe6NM1wvCuBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/otlp-transformer": "0.221.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.221.0.tgz",
+      "integrity": "sha512-lg6lkOU08Az23jVcn/0Els9HP+V8PnR4Km6p0KgpTggS0n/WuhnmY64rSh83Of9iR9nD+dpWr6adlcX8KzAwjg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.221.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-logs": "0.221.0",
+        "@opentelemetry/sdk-metrics": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-logs": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
+      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.221.0.tgz",
+      "integrity": "sha512-FaDcazjyMp7TZZZAsqbo4IkovP0UegoCu0EBkiNt+qCqvUf7FPAsfcrZ3+ZEkKgXZ/jHafop+JoGPDk3A0SmLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.221.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.200.0.tgz",
+      "integrity": "sha512-VZG870063NLfObmQQNtCVcdXXLzI3vOjjrRENmU37HYiPFa0ZXpXVDsTD02Nh3AT3xYJzQaWKl2X2lQ2l7TWJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.200.0",
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.10.0.tgz",
+      "integrity": "sha512-t6r1VSvXNtSDnPXU1FbZeetJb7yyovHmgu0wRSoftxtE0g2rSNhQZQUy69sRUCL+iioJpX8SN/S6wq6ZtvLySQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.10.0.tgz",
+      "integrity": "sha512-GZK/G6oZyBLGlH1pUgeDch7D91KoHd2uotUGIkWCPi9GI5T9X0p4L7nNAMDR1BQjkRYoDqo+ddfVx9t5Uhys+Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.10.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/sdk-trace-base": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typespec/compiler": {
       "version": "1.13.0",
@@ -676,6 +1403,44 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.8.tgz",
+      "integrity": "sha512-bLMpVcWZNzq6lYOybwFwOAR1IXKcHnhUNqYeHjl1bET/qE3jFPFH+p8Wrh3rU4xwdnifPxmKNESBYnvnmc75aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@vscode/deviceid": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@vscode/deviceid/-/deviceid-0.1.5.tgz",
+      "integrity": "sha512-D0be67wWo7WyyBqHnRkL2bK7lp7CDH/EMN4kMV6INoKc7kxRL3nsTtngt9JZrOcZdnW59gquGRk+6KFIDyD3QA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fs-extra": "^11.2.0",
+        "uuid": "^14.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -743,65 +1508,16 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.11.1",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
-      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
+      "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
+        "node-addon-api": "^8.0.0"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "node": ">=22"
       }
     },
     "node_modules/change-case": {
@@ -810,6 +1526,17 @@
       "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/chardet": {
       "version": "2.1.1",
@@ -863,30 +1590,46 @@
         "node": ">=22.12.0"
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mimic-response": "^3.1.0"
+        "ms": "^2.1.3"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=6.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -899,22 +1642,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
     },
     "node_modules/env-paths": {
       "version": "4.0.0",
@@ -938,16 +1685,6 @@
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "dev": true,
-      "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
       }
@@ -1003,19 +1740,21 @@
         "fast-string-width": "^3.0.2"
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+    "node_modules/fs-extra": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -1040,21 +1779,50 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -1073,41 +1841,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/is-safe-filename": {
       "version": "0.1.1",
@@ -1159,28 +1892,549 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=10"
+      "optional": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+    "node_modules/koffi": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-3.1.4.tgz",
+      "integrity": "sha512-KHX39XIg7afe8ds+0MHPoLiKR9dCzsVK4oAmBUSaeJlcX0xur22f15C2DILbZ6GJ9eyqC+e6Sb1cTG7M17z+Tg==",
       "dev": true,
+      "hasInstallScript": true,
       "license": "MIT",
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "url": "https://liberapay.com/Koromix"
+      },
+      "optionalDependencies": {
+        "@koromix/koffi-darwin-arm64": "3.1.4",
+        "@koromix/koffi-darwin-x64": "3.1.4",
+        "@koromix/koffi-freebsd-arm64": "3.1.4",
+        "@koromix/koffi-freebsd-ia32": "3.1.4",
+        "@koromix/koffi-freebsd-x64": "3.1.4",
+        "@koromix/koffi-linux-arm64": "3.1.4",
+        "@koromix/koffi-linux-ia32": "3.1.4",
+        "@koromix/koffi-linux-loong64": "3.1.4",
+        "@koromix/koffi-linux-riscv64": "3.1.4",
+        "@koromix/koffi-linux-x64": "3.1.4",
+        "@koromix/koffi-openbsd-ia32": "3.1.4",
+        "@koromix/koffi-openbsd-x64": "3.1.4",
+        "@koromix/koffi-win32-arm64": "3.1.4",
+        "@koromix/koffi-win32-ia32": "3.1.4",
+        "@koromix/koffi-win32-x64": "3.1.4"
       }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/minipass": {
       "version": "7.1.3",
@@ -1205,10 +2459,10 @@
         "node": ">= 18"
       }
     },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1232,34 +2486,14 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/node-abi": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
-      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+    "node_modules/node-addon-api": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.1.tgz",
+      "integrity": "sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/picocolors": {
@@ -1270,9 +2504,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1280,34 +2514,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/prettier": {
@@ -1326,48 +2532,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -1377,27 +2541,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1430,63 +2573,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -1523,16 +2609,6 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/tar": {
       "version": "7.5.22",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
@@ -1548,43 +2624,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
-      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-fs/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/temporal-polyfill": {
@@ -1604,25 +2643,52 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "Apache-2.0",
+      "license": "0BSD"
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "safe-buffer": "^5.0.1"
+        "@types/unist": "^3.0.0"
       },
-      "engines": {
-        "node": "*"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.1",
@@ -1699,13 +2765,6 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/eng/pipelines/azure-typespec-author-eval/package.json
+++ b/eng/pipelines/azure-typespec-author-eval/package.json
@@ -2,9 +2,13 @@
   "name": "azure-typespec-author-benchmark",
   "private": true,
   "description": "CI-only npm project that pins @microsoft/vally-cli, @github/copilot-sdk and @typespec/compiler via the committed lockfile for reproducible benchmark pipeline runs; not published.",
+  "engines": {
+    "node": ">=22.12.0",
+    "npm": ">=11.11.1"
+  },
   "devDependencies": {
-    "@github/copilot-sdk": "1.0.0-beta.5",
-    "@microsoft/vally-cli": "0.6.0",
+    "@github/copilot-sdk": "1.0.7",
+    "@microsoft/vally-cli": "0.12.0",
     "@typespec/compiler": "1.13.0"
   }
 }

--- a/eng/pipelines/templates/steps/typespec-author-eval-setup.yml
+++ b/eng/pipelines/templates/steps/typespec-author-eval-setup.yml
@@ -126,6 +126,9 @@ steps:
       npmrcPath: $(Build.SourcesDirectory)/.npmrc
       registryUrl: https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-tools/npm/registry/
 
+  - script: npm install --global npm@11.11.1 --userconfig $(Build.SourcesDirectory)/.npmrc
+    displayName: Use npm 11.11.1
+
   - script: |
       npm ci --userconfig $(Build.SourcesDirectory)/.npmrc
       echo "##vso[task.prependpath]$(Build.SourcesDirectory)/eng/pipelines/azure-typespec-author-eval/node_modules/.bin"


### PR DESCRIPTION
## Bump Vally CLI to 0.12.0 (azure-typespec-author eval)

Upgrades the `azure-typespec-author` benchmark evaluation from Vally 0.6–0.7 to **0.12.0** and migrates its eval specs to the 0.12 schema.

### Changes
- Bump `@microsoft/vally` to `0.12.0` for the azure-typespec-author eval (`eng/pipelines/azure-typespec-author-eval` package.json + lockfile, `eng/pipelines/azure-typespec-author-benchmark.yml`, `eng/pipelines/templates/steps/typespec-author-eval-setup.yml`).
- Migrate the 38 benchmark eval specs (001001–006009) to the 0.12 schema.
- Update the `azure-typespec-author/evaluate` README for the new schema.
- **MCP path fix for 0.12:** Vally 0.12 runs the agent from an ephemeral temp workspace, so the stdio MCP server relative `--project` args no longer resolve against the `.vally.yaml` directory. Added `cwd: .` to each stdio server in `evaluate/.vally.yaml` so Vally resolves it to the config dir before launching `dotnet`.

Split out from the broader Vally 0.12 upgrade so the typespec-owned files can be reviewed by their owners separately.
