### PR TITLE
[ARH] Update `handle-apireview-hub-request.yml` to generate baseline artifacts on update

### DIFF
--- a/eng/common/pipelines/templates/steps/create-apireview-hub-artifacts-base.yml
+++ b/eng/common/pipelines/templates/steps/create-apireview-hub-artifacts-base.yml
@@ -45,10 +45,10 @@ steps:
         exit 1
       fi
 
-      # API Review Hub must provide a fully-qualified Git ref (for example refs/heads/* or refs/tags/*).
-      # Keeping this explicit avoids ambiguous fetch behavior across remote refspec configurations.
-      if [[ -z "$ref" || "$ref" != refs/* ]]; then
-        echo "Expected a fully-qualified git ref (refs/*), but received: '$ref'" >&2
+      # API Review Hub must provide a fully-qualified Git ref in the form refs/heads/<branch>
+      # or refs/tags/<tag>. A bare "refs/tags" or "refs/heads" is not a valid remote ref.
+      if [[ -z "$ref" || ! "$ref" =~ ^refs/(heads|tags)/.+$ ]]; then
+        echo "Expected a fully-qualified git ref in the form refs/heads/<branch> or refs/tags/<tag>, but received: '$ref'" >&2
         exit 1
       fi
 

--- a/eng/pipelines/handle-apireview-hub-request.yml
+++ b/eng/pipelines/handle-apireview-hub-request.yml
@@ -121,15 +121,19 @@ jobs:
           if ([string]::IsNullOrWhiteSpace('${{ parameters.targetRef }}')) {
             throw 'targetRef is required.'
           }
+          if ('${{ parameters.requestMode }}' -eq 'update' -and [string]::IsNullOrWhiteSpace('${{ parameters.baseRef }}')) {
+            throw 'baseRef is required for update requests.'
+          }
 
           New-Item -ItemType Directory -Force -Path '$(Build.ArtifactStagingDirectory)/base' | Out-Null
           New-Item -ItemType Directory -Force -Path '$(Build.ArtifactStagingDirectory)/target' | Out-Null
           New-Item -ItemType Directory -Force -Path '$(Build.ArtifactStagingDirectory)/result' | Out-Null
         displayName: 'Validate request parameters'
 
-      # Create requests with a baseline need the baseline bundle first. Empty
-      # baseRef values intentionally generate a target-only review.
-      - ${{ if and(eq(parameters.requestMode, 'create'), ne(trim(parameters.baseRef), '')) }}:
+      # Create and update requests with a baseline generate it with the same
+      # pipeline and tooling inputs as the target. Create requests may omit
+      # baseRef to intentionally generate a target-only review.
+      - ${{ if ne(trim(parameters.baseRef), '') }}:
         - template: ${{ format('/eng/pipelines/templates/steps/create-apireview-hub-artifacts-{0}.yml@{0}-repo', parameters.language) }}
           parameters:
             requestMode: ${{ parameters.requestMode }}
@@ -140,8 +144,7 @@ jobs:
             outputDir: $(Build.ArtifactStagingDirectory)/base
             workingDir: $(Pipeline.Workspace)/apireview/base
 
-      # Always generate the target bundle. Update requests only generate this
-      # artifact; create requests generate it after the base bundle above.
+      # Always generate the target bundle after any requested baseline bundle.
       - template: ${{ format('/eng/pipelines/templates/steps/create-apireview-hub-artifacts-{0}.yml@{0}-repo', parameters.language) }}
         parameters:
           requestMode: ${{ parameters.requestMode }}
@@ -170,7 +173,7 @@ jobs:
             $baseRef = ''
           }
 
-          $hasBaseline = '${{ parameters.requestMode }}' -eq 'create' -and -not [string]::IsNullOrWhiteSpace($baseRef)
+          $hasBaseline = -not [string]::IsNullOrWhiteSpace($baseRef)
           $baseVersion = ''
           $changed = $null
           if ($hasBaseline) {
@@ -233,7 +236,7 @@ jobs:
         displayName: 'Write failure result summary'
         condition: failed()
 
-      - ${{ if and(eq(parameters.requestMode, 'create'), ne(trim(parameters.baseRef), '')) }}:
+      - ${{ if ne(trim(parameters.baseRef), '') }}:
         - task: PublishBuildArtifacts@1
           displayName: 'Publish base API review bundle'
           condition: succeeded()
@@ -312,7 +315,7 @@ jobs:
             }
 
             $baseRef = '${{ parameters.baseRef }}'
-            $hasBaseline = '${{ parameters.requestMode }}' -eq 'create' -and -not [string]::IsNullOrWhiteSpace($baseRef)
+            $hasBaseline = -not [string]::IsNullOrWhiteSpace($baseRef)
             if ($hasBaseline -and ('$(Agent.JobStatus)' -eq 'Succeeded' -or '$(Agent.JobStatus)' -eq 'SucceededWithIssues')) {
               $body.artifacts.base = '${{ parameters.baseArtifactName }}'
             }

--- a/eng/pipelines/handle-apireview-hub-request.yml
+++ b/eng/pipelines/handle-apireview-hub-request.yml
@@ -121,9 +121,6 @@ jobs:
           if ([string]::IsNullOrWhiteSpace('${{ parameters.targetRef }}')) {
             throw 'targetRef is required.'
           }
-          if ('${{ parameters.requestMode }}' -eq 'update' -and [string]::IsNullOrWhiteSpace('${{ parameters.baseRef }}')) {
-            throw 'baseRef is required for update requests.'
-          }
 
           New-Item -ItemType Directory -Force -Path '$(Build.ArtifactStagingDirectory)/base' | Out-Null
           New-Item -ItemType Directory -Force -Path '$(Build.ArtifactStagingDirectory)/target' | Out-Null
@@ -131,8 +128,8 @@ jobs:
         displayName: 'Validate request parameters'
 
       # Create and update requests with a baseline generate it with the same
-      # pipeline and tooling inputs as the target. Create requests may omit
-      # baseRef to intentionally generate a target-only review.
+      # pipeline and tooling inputs as the target. Either mode may omit baseRef
+      # to intentionally generate a target-only review.
       - ${{ if ne(trim(parameters.baseRef), '') }}:
         - template: ${{ format('/eng/pipelines/templates/steps/create-apireview-hub-artifacts-{0}.yml@{0}-repo', parameters.language) }}
           parameters:


### PR DESCRIPTION
We need to generate artifacts for create and update scenarios to cover the situation where the pipelines or tooling change after a review is created. 