### PR TITLE
Move a few large inline scripts to checked in files

### DIFF
--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -32,9 +32,8 @@ steps:
       - task: Powershell@2
         displayName: Generate PR Diff
         inputs:
-          targetType: inline
-          script: >
-            ${{ parameters.ScriptDirectory }}/Generate-PR-Diff.ps1
+          filePath: ${{ parameters.ScriptDirectory }}/Generate-PR-Diff.ps1
+          arguments: >
             -TargetPath '${{ parameters.TargetPath }}'
             -ArtifactPath '${{ parameters.DiffDirectory }}'
             -ExcludePaths ('${{ convertToJson(parameters.ExcludePaths) }}' | ConvertFrom-Json)

--- a/eng/common/pipelines/templates/steps/upload-llm-artifacts.yml
+++ b/eng/common/pipelines/templates/steps/upload-llm-artifacts.yml
@@ -37,60 +37,14 @@ parameters:
     default: '$(Build.SourcesDirectory)'
 
 steps:
-  - pwsh: |
-      $artifactsDirectory = "$(Build.ArtifactStagingDirectory)/llm-artifacts"
-      New-Item $artifactsDirectory -ItemType Directory -Force | Out-Null
-
-      $searchFolder = "${{ parameters.SearchFolder }}"
-      $patterns = "${{ parameters.TestResultsGlob }}".Split(",", [StringSplitOptions]::RemoveEmptyEntries) `
-        | ForEach-Object { $_.Trim() } | Where-Object { $_ }
-
-      $testResultsFiles = @(Get-ChildItem -Path $searchFolder -Include $patterns -Recurse -File -ErrorAction SilentlyContinue)
-
-      Write-Host "================="
-      Write-Host "Found $($testResultsFiles.Count) test result file(s) under '$searchFolder' matching: $($patterns -join ', ')"
-      $testResultsFiles | ForEach-Object { Write-Host $_.FullName }
-      Write-Host "================="
-
-      $stagedCount = 0
-      foreach ($testResultsFile in $testResultsFiles)
-      {
-        $fileFullName = $testResultsFile.FullName
-
-        # Build a unique, traceable artifact name from the file's location. Prefer the path
-        # relative to the language repo's "sdk" directory, for example:
-        #   <sources>/sdk/template/Azure.Template/tests/TestResults/net8.0.trx
-        #     -> template-Azure.Template-tests-TestResults-net8.0.trx
-        #   <sources>/sdk/storage/report.xml
-        #     -> storage-report.xml
-        # Fall back to a sources-relative path for repos without an "sdk" directory.
-        if ($fileFullName -match "[\\/]sdk[\\/]")
-        {
-          $relativePath = ($fileFullName -split "[\\/]sdk[\\/]", 2)[-1]
-        }
-        else
-        {
-          $relativePath = [System.IO.Path]::GetRelativePath("$(Build.SourcesDirectory)", $fileFullName)
-        }
-        $fileName = $relativePath -replace "^[\\/]+", "" -replace "[\\/]+", "-"
-
-        $destination = "$artifactsDirectory/$fileName"
-        Move-Item -Path $fileFullName -Destination $destination -ErrorAction Continue
-        if (Test-Path -Path $destination)
-        {
-          $stagedCount++
-        }
-      }
-
-      # Only signal an upload when test result files were actually staged.
-      if ($stagedCount -gt 0)
-      {
-        Write-Host "Staged $stagedCount test result file(s) into '$artifactsDirectory'."
-        Write-Host "##vso[task.setvariable variable=uploadLlmArtifacts]true"
-      }
-      else
-      {
-        Write-Host "No test result files were staged; skipping llm-artifacts upload."
-      }
+  - task: PowerShell@2
+    inputs:
+      pwsh: true
+      filePath: eng/common/scripts/Copy-TestResultsToLlmStaging.ps1
+      arguments: >
+        -ArtifactStagingDirectory $(Build.ArtifactStagingDirectory)
+        -SearchFolder ${{ parameters.SearchFolder }}
+        -TestResultsGlob ${{ parameters.TestResultsGlob }}
+        -SourcesDirectory $(Build.SourcesDirectory)
     condition: succeededOrFailed()
     displayName: Copy test result files to llm artifacts staging directory

--- a/eng/common/scripts/Copy-TestResultsToLlmStaging.ps1
+++ b/eng/common/scripts/Copy-TestResultsToLlmStaging.ps1
@@ -1,0 +1,93 @@
+<#
+.SYNOPSIS
+Copies the test result files to the llm-artifacts directory for further processing.
+
+.DESCRIPTION
+This script stages test result files into an "llm-artifacts" directory so they can be
+uploaded as a pipeline artifact and consumed by LLM tooling (for example GitHub Copilot)
+to analyze a test run.
+
+It is language agnostic. Every Azure SDK language repo emits test results in a different
+format (.NET produces TRX, the other languages produce JUnit XML) and with a different
+file name, so callers pass the appropriate leaf-name glob via TestResultsGlob:
+
+- .NET    (TRX):       TestResultsGlob: '$(TestTargetFramework)*.trx'
+- Python  (JUnit XML): TestResultsGlob: '*test*.xml'
+- JS      (JUnit XML): TestResultsGlob: 'test-results*.xml', SearchFolder: '$(System.DefaultWorkingDirectory)/sdk'
+- Java    (JUnit XML): TestResultsGlob: 'TEST-*.xml',        SearchFolder: '$(System.DefaultWorkingDirectory)/sdk'
+- Go      (JUnit XML): TestResultsGlob: 'report.xml'
+
+The staging step does not care about the file format; it only moves files. Each file is
+renamed using its location relative to the repo's "sdk" directory so results from different
+services/packages do not collide once flattened into a single directory.
+
+.PARAMETER ArtifactStagingDirectory
+The folder in which the llm-artifacts directory will be created. Passed from DevOps as a string.
+
+.PARAMETER SearchFolder
+The folder under which test result files will be searched for. Passed from DevOps as a string.
+
+.PARAMETER TestResultsGlob
+The glob pattern to match test result files. Passed from DevOps as a string.
+
+.PARAMETER SourcesDirectory
+The root folder of the repo. Passed from DevOps as a string.
+#>
+Param(
+    [Parameter(Mandatory = $True)]
+    [string] $ArtifactStagingDirectory,
+    [Parameter(Mandatory = $True)]
+    [string] $SearchFolder,
+    [Parameter(Mandatory = $True)]
+    [string] $TestResultsGlob,
+    [Parameter(Mandatory = $True)]
+    [string] $SourcesDirectory
+)
+
+$artifactsDirectory = "$ArtifactStagingDirectory/llm-artifacts"
+New-Item $artifactsDirectory -ItemType Directory -Force | Out-Null
+
+$patterns = $TestResultsGlob.Split(",", [StringSplitOptions]::RemoveEmptyEntries) `
+| ForEach-Object { $_.Trim() } | Where-Object { $_ }
+
+$testResultsFiles = @(Get-ChildItem -Path $SearchFolder -Include $patterns -Recurse -File -ErrorAction SilentlyContinue)
+
+Write-Host "================="
+Write-Host "Found $($testResultsFiles.Count) test result file(s) under '$SearchFolder' matching: $($patterns -join ', ')"
+$testResultsFiles | ForEach-Object { Write-Host $_.FullName }
+Write-Host "================="
+
+$stagedCount = 0
+foreach ($testResultsFile in $testResultsFiles) {
+    $fileFullName = $testResultsFile.FullName
+
+    # Build a unique, traceable artifact name from the file's location. Prefer the path
+    # relative to the language repo's "sdk" directory, for example:
+    #   <sources>/sdk/template/Azure.Template/tests/TestResults/net8.0.trx
+    #     -> template-Azure.Template-tests-TestResults-net8.0.trx
+    #   <sources>/sdk/storage/report.xml
+    #     -> storage-report.xml
+    # Fall back to a sources-relative path for repos without an "sdk" directory.
+    if ($fileFullName -match "[\\/]sdk[\\/]") {
+        $relativePath = ($fileFullName -split "[\\/]sdk[\\/]", 2)[-1]
+    }
+    else {
+        $relativePath = [System.IO.Path]::GetRelativePath($SourcesDirectory, $fileFullName)
+    }
+    $fileName = $relativePath -replace "^[\\/]+", "" -replace "[\\/]+", "-"
+
+    $destination = "$artifactsDirectory/$fileName"
+    Move-Item -Path $fileFullName -Destination $destination -ErrorAction Continue
+    if (Test-Path -Path $destination) {
+        $stagedCount++
+    }
+}
+
+# Only signal an upload when test result files were actually staged.
+if ($stagedCount -gt 0) {
+    Write-Host "Staged $stagedCount test result file(s) into '$artifactsDirectory'."
+    Write-Host "##vso[task.setvariable variable=uploadLlmArtifacts]true"
+}
+else {
+    Write-Host "No test result files were staged; skipping llm-artifacts upload."
+}

--- a/eng/common/scripts/Copy-TestResultsToLlmStaging.ps1
+++ b/eng/common/scripts/Copy-TestResultsToLlmStaging.ps1
@@ -33,6 +33,7 @@ The glob pattern to match test result files. Passed from DevOps as a string.
 .PARAMETER SourcesDirectory
 The root folder of the repo. Passed from DevOps as a string.
 #>
+[CmdletBinding()]
 Param(
     [Parameter(Mandatory = $True)]
     [string] $ArtifactStagingDirectory,
@@ -43,6 +44,9 @@ Param(
     [Parameter(Mandatory = $True)]
     [string] $SourcesDirectory
 )
+
+Set-StrictMode -Version 4
+$ErrorActionPreference = 'Stop'
 
 $artifactsDirectory = "$ArtifactStagingDirectory/llm-artifacts"
 New-Item $artifactsDirectory -ItemType Directory -Force | Out-Null

--- a/eng/common/scripts/Install-TestProxy.ps1
+++ b/eng/common/scripts/Install-TestProxy.ps1
@@ -1,0 +1,62 @@
+<#
+.SYNOPSIS
+Installs Test Proxy.
+
+.DESCRIPTION
+Installs Test Proxy, which is a tool used to record and playback HTTP requests for testing purposes.
+
+.PARAMETER TemplateRoot
+The root directory where the Test Proxy templates are located. Passed from DevOps as a string.
+
+.PARAMETER BinariesDirectory
+The directory where the Test Proxy binaries will be installed. Passed from DevOps as a string.
+
+.PARAMETER RunProxy
+Whether to run the Test Proxy after installation. Passed from DevOps as a boolean.
+#>
+Param(
+    [Parameter(Mandatory = $True)]
+    [string] $TemplateRoot,
+    [Parameter(Mandatory = $True)]
+    [string] $BinariesDirectory,
+    [Parameter(Mandatory = $False)]
+    [bool] $RunProxy = $true
+)
+
+$standardVersion = "$TemplateRoot/eng/common/testproxy/target_version.txt"
+$overrideVersion = "$TemplateRoot/eng/target_proxy_version.txt"
+
+$version = $(Get-Content $standardVersion -Raw).Trim()
+
+if (Test-Path $overrideVersion) {
+    $version = $(Get-Content $overrideVersion -Raw).Trim()
+}
+
+Write-Host "Installing test-proxy version $version"
+
+$invocation = @"
+dotnet tool install azure.sdk.tools.testproxy `
+    --tool-path $BinariesDirectory/test-proxy `
+    --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json `
+    --version $version
+"@
+Write-Host $invocation
+
+dotnet tool install azure.sdk.tools.testproxy `
+    --tool-path $BinariesDirectory/test-proxy `
+    --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json `
+    --version $version
+
+Write-Host "Prepending path with the test proxy tool install location: '$BinariesDirectory/test-proxy'"
+Write-Host "##vso[task.prependpath]$BinariesDirectory/test-proxy"
+
+if ($runProxy) {
+    Write-Host "Configuring Kestrel and PROXY_MANUAL_START environment variables for Test Proxy"
+
+    Write-Host "Setting ASPNETCORE_Kestrel__Certificates__Default__Path to '$TemplateRoot/eng/common/testproxy/dotnet-devcert.pfx'"
+    Write-Host "##vso[task.setvariable variable=ASPNETCORE_Kestrel__Certificates__Default__Path]$TemplateRoot/eng/common/testproxy/dotnet-devcert.pfx"
+    Write-Host "Setting ASPNETCORE_Kestrel__Certificates__Default__Password to 'password'"
+    Write-Host "##vso[task.setvariable variable=ASPNETCORE_Kestrel__Certificates__Default__Password]password"
+    Write-Host "Setting PROXY_MANUAL_START to 'true'"
+    Write-Host "##vso[task.setvariable variable=PROXY_MANUAL_START]true"
+}

--- a/eng/common/scripts/Install-TestProxy.ps1
+++ b/eng/common/scripts/Install-TestProxy.ps1
@@ -14,6 +14,7 @@ The directory where the Test Proxy binaries will be installed. Passed from DevOp
 .PARAMETER RunProxy
 Whether to run the Test Proxy after installation. Passed from DevOps as a boolean.
 #>
+[CmdletBinding()]
 Param(
     [Parameter(Mandatory = $True)]
     [string] $TemplateRoot,
@@ -22,6 +23,9 @@ Param(
     [Parameter(Mandatory = $False)]
     [bool] $RunProxy = $true
 )
+
+Set-StrictMode -Version 4
+$ErrorActionPreference = 'Stop'
 
 $standardVersion = "$TemplateRoot/eng/common/testproxy/target_version.txt"
 $overrideVersion = "$TemplateRoot/eng/target_proxy_version.txt"

--- a/eng/common/scripts/Start-TestProxy.ps1
+++ b/eng/common/scripts/Start-TestProxy.ps1
@@ -1,0 +1,40 @@
+<#
+.SYNOPSIS
+Starts Test Proxy.
+
+.DESCRIPTION
+Starts Test Proxy, which is a tool used to record and playback HTTP requests for testing purposes.
+
+.PARAMETER RootFolder
+The root folder where the Test Proxy will store its recordings. Passed from DevOps as a string.
+
+.PARAMETER ProxyUrl
+The URL of the Test Proxy to start. Passed from DevOps as a string.
+
+.PARAMETER BinariesDirectory
+The directory where the Test Proxy binaries were installed. Passed from DevOps as a string.
+#>
+Param(
+    [Parameter(Mandatory = $True)]
+    [string] $RootFolder,
+    [Parameter(Mandatory = $True)]
+    [string] $ProxyUrl,
+    [Parameter(Mandatory = $True)]
+    [string] $BinariesDirectory
+)
+
+$invocation = @"
+Start-Process $BinariesDirectory/test-proxy/test-proxy.exe
+    -ArgumentList `"start -u --storage-location $RootFolder -- --urls $ProxyUrl`"
+    -NoNewWindow -PassThru -RedirectStandardOutput $RootFolder/test-proxy.log
+    -RedirectStandardError $RootFolder/test-proxy-error.log
+"@
+Write-Host $invocation
+
+$Process = Start-Process $BinariesDirectory/test-proxy/test-proxy.exe `
+    -ArgumentList "start -u --storage-location $RootFolder -- --urls $ProxyUrl" `
+    -NoNewWindow -PassThru -RedirectStandardOutput $RootFolder/test-proxy.log `
+    -RedirectStandardError $RootFolder/test-proxy-error.log
+
+Write-Host "Setting PROXY_PID to $($Process.Id)"
+Write-Host "##vso[task.setvariable variable=PROXY_PID]$($Process.Id)"

--- a/eng/common/scripts/Start-TestProxy.ps1
+++ b/eng/common/scripts/Start-TestProxy.ps1
@@ -14,6 +14,7 @@ The URL of the Test Proxy to start. Passed from DevOps as a string.
 .PARAMETER BinariesDirectory
 The directory where the Test Proxy binaries were installed. Passed from DevOps as a string.
 #>
+[CmdletBinding()]
 Param(
     [Parameter(Mandatory = $True)]
     [string] $RootFolder,
@@ -22,6 +23,9 @@ Param(
     [Parameter(Mandatory = $True)]
     [string] $BinariesDirectory
 )
+
+Set-StrictMode -Version 4
+$ErrorActionPreference = 'Stop'
 
 $invocation = @"
 Start-Process $BinariesDirectory/test-proxy/test-proxy.exe

--- a/eng/common/scripts/Test-TestProxyIsAlive.ps1
+++ b/eng/common/scripts/Test-TestProxyIsAlive.ps1
@@ -9,16 +9,20 @@ If the Test Proxy is not responding, the script will retry up to 10 times with a
 .PARAMETER ProxyUrl
 The URL of the Test Proxy to test. Passed from DevOps as a string.
 #>
+[CmdletBinding()]
 Param(
     [Parameter(Mandatory = $True)]
     [string] $ProxyUrl
 )
 
+Set-StrictMode -Version 4
+$ErrorActionPreference = 'Stop'
+
 for ($i = 0; $i -lt 10; $i++) {
     try {
         Write-Host "Invoke-WebRequest -Uri `"$ProxyUrl/Admin/IsAlive`" | Out-Null"
         Invoke-WebRequest -Uri "$ProxyUrl/Admin/IsAlive" | Out-Null
-        Write-Host "Successfully connected to the test proxy on port 5000."
+        Write-Host "Successfully connected to the test proxy at '$ProxyUrl'."
         exit 0
     }
     catch {

--- a/eng/common/scripts/Test-TestProxyIsAlive.ps1
+++ b/eng/common/scripts/Test-TestProxyIsAlive.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+Tests if the Test Proxy is alive and responding to requests.
+
+.DESCRIPTION
+Tests if the Test Proxy is alive and responding to requests by sending a request to the /Admin/IsAlive endpoint.
+If the Test Proxy is not responding, the script will retry up to 10 times with a 6 second delay between attempts.
+
+.PARAMETER ProxyUrl
+The URL of the Test Proxy to test. Passed from DevOps as a string.
+#>
+Param(
+    [Parameter(Mandatory = $True)]
+    [string] $ProxyUrl
+)
+
+for ($i = 0; $i -lt 10; $i++) {
+    try {
+        Write-Host "Invoke-WebRequest -Uri `"$ProxyUrl/Admin/IsAlive`" | Out-Null"
+        Invoke-WebRequest -Uri "$ProxyUrl/Admin/IsAlive" | Out-Null
+        Write-Host "Successfully connected to the test proxy on port 5000."
+        exit 0
+    }
+    catch {
+        Write-Warning "Failed to successfully connect to test proxy. Retrying..."
+        Start-Sleep 6
+    }
+}
+Write-Error "Could not connect to test proxy."
+exit 1

--- a/eng/common/testproxy/test-proxy-tool.yml
+++ b/eng/common/testproxy/test-proxy-tool.yml
@@ -8,8 +8,10 @@ parameters:
   proxyUrl: 'http://localhost:5000'
 
 steps:
-  - pwsh: |
-        ${{ parameters.templateRoot }}/eng/common/scripts/trust-proxy-certificate.ps1
+  - task: PowerShell@2
+    inputs:
+      pwsh: true
+      filePath: ${{ parameters.templateRoot }}/eng/common/scripts/trust-proxy-certificate.ps1
     displayName: 'Language Specific Certificate Trust'
     condition: and(succeeded(), ${{ parameters.condition }})
 
@@ -22,71 +24,32 @@ steps:
       arguments: '-TargetVersion "${{ parameters.targetVersion }}"'
       pwsh: true
 
-  - pwsh: |
-      $standardVersion = "${{ parameters.templateRoot }}/eng/common/testproxy/target_version.txt"
-      $overrideVersion = "${{ parameters.templateRoot }}/eng/target_proxy_version.txt"
-
-      $version = $(Get-Content $standardVersion -Raw).Trim()
-
-      if (Test-Path $overrideVersion) {
-        $version = $(Get-Content $overrideVersion -Raw).Trim()
-      }
-
-      Write-Host "Installing test-proxy version $version"
-
-      $invocation = @"
-      dotnet tool install azure.sdk.tools.testproxy `
-        --tool-path $(Build.BinariesDirectory)/test-proxy `
-        --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json `
-        --version $version
-      "@
-      Write-Host $invocation
-
-      dotnet tool install azure.sdk.tools.testproxy `
-        --tool-path $(Build.BinariesDirectory)/test-proxy `
-        --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json `
-        --version $version
-    displayName: "Install test-proxy"
+  - task: PowerShell@2
+    inputs:
+      filePath: '${{ parameters.templateRoot }}/eng/common/scripts/Install-TestProxy.ps1'
+      arguments: >
+        -TemplateRoot "${{ parameters.templateRoot }}"
+        -BinariesDirectory $(Build.BinariesDirectory)
+        -RunProxy $${{ parameters.runProxy }}
+      pwsh: true
+    displayName: "Install and configure test-proxy"
     condition: and(succeeded(), ${{ parameters.condition }})
 
-  - pwsh: |
-      Write-Host "Prepending path with the test proxy tool install location: '$(Build.BinariesDirectory)/test-proxy'"
-      Write-Host "##vso[task.prependpath]$(Build.BinariesDirectory)/test-proxy"
-    displayName: "Prepend path with test-proxy tool install location"
-
   - ${{ if eq(parameters.runProxy, 'true') }}:
-    - pwsh: |
-        Write-Host "Setting ASPNETCORE_Kestrel__Certificates__Default__Path to '${{ parameters.templateRoot }}/eng/common/testproxy/dotnet-devcert.pfx'"
-        Write-Host "##vso[task.setvariable variable=ASPNETCORE_Kestrel__Certificates__Default__Path]${{ parameters.templateRoot }}/eng/common/testproxy/dotnet-devcert.pfx"
-        Write-Host "Setting ASPNETCORE_Kestrel__Certificates__Default__Password to 'password'"
-        Write-Host "##vso[task.setvariable variable=ASPNETCORE_Kestrel__Certificates__Default__Password]password"
-        Write-Host "Setting PROXY_MANUAL_START to 'true'"
-        Write-Host "##vso[task.setvariable variable=PROXY_MANUAL_START]true"
-      displayName: 'Configure Kestrel and PROXY_MANUAL_START Variables'
-      condition: and(succeeded(), ${{ parameters.condition }})
-
-    - pwsh: |
-        $invocation = @"
-        Start-Process $(Build.BinariesDirectory)/test-proxy/test-proxy.exe
-          -ArgumentList `"start -u --storage-location ${{ parameters.rootFolder }} -- --urls ${{ parameters.proxyUrl }}`"
-          -NoNewWindow -PassThru -RedirectStandardOutput ${{ parameters.rootFolder }}/test-proxy.log
-          -RedirectStandardError ${{ parameters.rootFolder }}/test-proxy-error.log
-        "@
-        Write-Host $invocation
-
-        $Process = Start-Process $(Build.BinariesDirectory)/test-proxy/test-proxy.exe `
-          -ArgumentList "start -u --storage-location ${{ parameters.rootFolder }} -- --urls ${{ parameters.proxyUrl }}" `
-          -NoNewWindow -PassThru -RedirectStandardOutput ${{ parameters.rootFolder }}/test-proxy.log `
-          -RedirectStandardError ${{ parameters.rootFolder }}/test-proxy-error.log
-
-        Write-Host "Setting PROXY_PID to $($Process.Id)"
-        Write-Host "##vso[task.setvariable variable=PROXY_PID]$($Process.Id)"
-      displayName: 'Run the testproxy - windows'
+    - task: PowerShell@2
+      inputs:
+        filePath: '${{ parameters.templateRoot }}/eng/common/scripts/Start-TestProxy.ps1'
+        arguments: >
+          -RootFolder ${{ parameters.rootFolder }}
+          -ProxyUrl ${{ parameters.proxyUrl }}
+          -BinariesDirectory $(Build.BinariesDirectory)
+        pwsh: true
+      displayName: 'Run test-proxy - Windows'
       condition: and(succeeded(), eq(variables['Agent.OS'],'Windows_NT'), ${{ parameters.condition }})
       env:
         DOTNET_ROLL_FORWARD: 'Major'
 
-    # nohup does NOT continue beyond the current session if you use it within powershell
+    # nohup does NOT continue beyond the current session if you use it within PowerShell
     - bash: |
         if [[ "$(uname)" == "Darwin" ]]; then
           export DOTNET_ROOT="$HOME/.dotnet"
@@ -97,25 +60,17 @@ steps:
 
         echo "Setting PROXY_PID to $(cat $(Build.SourcesDirectory)/test-proxy.pid)"
         echo "##vso[task.setvariable variable=PROXY_PID]$(cat $(Build.SourcesDirectory)/test-proxy.pid)"
-      displayName: "Run the testproxy - linux/mac"
+      displayName: "Run test-proxy - Linux/Mac"
       condition: and(succeeded(), ne(variables['Agent.OS'],'Windows_NT'), ${{ parameters.condition }})
       workingDirectory: "${{ parameters.rootFolder }}"
       env:
         DOTNET_ROLL_FORWARD: 'Major'
 
-    - pwsh: |
-        for ($i = 0; $i -lt 10; $i++) {
-            try {
-                Write-Host "Invoke-WebRequest -Uri `"${{ parameters.proxyUrl }}/Admin/IsAlive`" | Out-Null"
-                Invoke-WebRequest -Uri "${{ parameters.proxyUrl }}/Admin/IsAlive" | Out-Null
-                Write-Host "Successfully connected to the test proxy on port 5000."
-                exit 0
-            } catch {
-                Write-Warning "Failed to successfully connect to test proxy. Retrying..."
-                Start-Sleep 6
-            }
-        }
-        Write-Error "Could not connect to test proxy."
-        exit 1
-      displayName: Test Proxy IsAlive
+    - task: PowerShell@2
+      inputs:
+        filePath: '${{ parameters.templateRoot }}/eng/common/scripts/Test-TestProxyIsAlive.ps1'
+        arguments: >
+          -ProxyUrl ${{ parameters.proxyUrl }}
+        pwsh: true
+      displayName: "Test Proxy IsAlive"
       condition: and(succeeded(), ${{ parameters.condition }})


### PR DESCRIPTION
Moves a handful of commonly used and large inline scripts into checked in files to reduce overall YAML size in DevOps. Currently, in some pipeline runs the azure-sdk-for-java repository is seeing failures due to YAML sizes and a testing PR (https://github.com/Azure/azure-sdk-for-java/pull/50085) verified that moving these few large inline scripts, as well as some in the azure-sdk-for-java repository, to checked in files alleviates the issue.

Further investigation should be done to see where else we can trim YAML sizes to further prevent this issue from appearing again in the future.