### PR TITLE
Fix Attention Required release plan filtering

### DIFF
--- a/tools/release-plan-dashboard/public/app.js
+++ b/tools/release-plan-dashboard/public/app.js
@@ -1807,7 +1807,8 @@
         : `WI ${esc(String(p.id))}`;
       if (currentUserIsPM) {
         const dashboardUrl = `/?releasePlan=${encodeURIComponent(planId)}`;
-        html += `<div class="detail-row"><strong>Release Plan:</strong> <a href="${esc(dashboardUrl)}" target="_blank" rel="noopener">${label}</a> <span class="wi-warning">⚠️ Do not modify directly — use the <a href="https://aka.ms/azsdk/agent" target="_blank" rel="noopener">azsdk agent</a></span></div>`;
+        const wiUrl = `https://dev.azure.com/azure-sdk/Release/_workitems/edit/${p.id}`;
+        html += `<div class="detail-row"><strong>Release Plan:</strong> <a href="${esc(dashboardUrl)}" target="_blank" rel="noopener">${label}</a> (<a href="${esc(wiUrl)}" target="_blank" rel="noopener">ADO work item ${esc(String(p.id))}</a>) <span class="wi-warning">⚠️ Do not modify directly — use the <a href="https://aka.ms/azsdk/agent" target="_blank" rel="noopener">azsdk agent</a></span></div>`;
       } else {
         html += `<div class="detail-row"><strong>Release Plan:</strong> ${label}</div>`;
       }

--- a/tools/release-plan-dashboard/public/app.js
+++ b/tools/release-plan-dashboard/public/app.js
@@ -1799,14 +1799,15 @@
     }
     if (specPath)
       html += `<div class="detail-row"><strong>Spec Project Path:</strong> ${esc(specPath)}</div>`;
-    // Work item link — show as link for PMs, plain text for others
+    // Release plan link — show as link for PMs, plain text for others
     {
+      const planId = p.releasePlanId || p.id;
       const label = p.releasePlanId
         ? `#${esc(String(p.releasePlanId))}`
         : `WI ${esc(String(p.id))}`;
       if (currentUserIsPM) {
-        const wiUrl = `https://dev.azure.com/azure-sdk/Release/_workitems/edit/${p.id}`;
-        html += `<div class="detail-row"><strong>Release Plan:</strong> <a href="${esc(wiUrl)}" target="_blank" rel="noopener">${label}</a> <span class="wi-warning">⚠️ Do not modify directly — use the <a href="https://aka.ms/azsdk/agent" target="_blank" rel="noopener">azsdk agent</a></span></div>`;
+        const dashboardUrl = `/?releasePlan=${encodeURIComponent(planId)}`;
+        html += `<div class="detail-row"><strong>Release Plan:</strong> <a href="${esc(dashboardUrl)}" target="_blank" rel="noopener">${label}</a> <span class="wi-warning">⚠️ Do not modify directly — use the <a href="https://aka.ms/azsdk/agent" target="_blank" rel="noopener">azsdk agent</a></span></div>`;
       } else {
         html += `<div class="detail-row"><strong>Release Plan:</strong> ${label}</div>`;
       }
@@ -2724,9 +2725,12 @@
 
     const planeFilter = getGlobalPlaneFilter();
     const monthFilter = getMonthFilter();
-    let filtered = planeFilter
-      ? plans.filter((p) => classifyPlane(p) === planeFilter)
+    const filter = store().filters.search.toLowerCase();
+    let filtered = filter
+      ? plans.filter((p) => matchesFilter(p, filter))
       : plans;
+    if (planeFilter)
+      filtered = filtered.filter((p) => classifyPlane(p) === planeFilter);
     if (monthFilter)
       filtered = filtered.filter(
         (p) =>

--- a/tools/release-plan-dashboard/tests/pm-view-layout.test.js
+++ b/tools/release-plan-dashboard/tests/pm-view-layout.test.js
@@ -8,6 +8,7 @@ const indexHtml = readFileSync(
   path.join(__dirname, "../public/index.html"),
   "utf8",
 );
+const appJs = readFileSync(path.join(__dirname, "../public/app.js"), "utf8");
 
 function expectOrdered(block, labels) {
   let lastIndex = -1;
@@ -22,6 +23,21 @@ function expectOrdered(block, labels) {
 }
 
 describe("PM View Attention Required layout", () => {
+  test("applies the search filter to Attention Needed plans", () => {
+    expect(appJs).toMatch(
+      /function renderPMView\(plans\)[\s\S]*?const filter = store\(\)\.filters\.search\.toLowerCase\(\);[\s\S]*?plans\.filter\(\(p\) => matchesFilter\(p, filter\)\)/,
+    );
+  });
+
+  test("links release plan IDs to the filtered dashboard", () => {
+    expect(appJs).toContain(
+      "const dashboardUrl = `/?releasePlan=${encodeURIComponent(planId)}`;",
+    );
+    expect(appJs).toContain(
+      '<a href="${esc(dashboardUrl)}" target="_blank" rel="noopener">${label}</a>',
+    );
+  });
+
   test("groups informational and action sections in the expected order", () => {
     const informationalIndex = indexHtml.indexOf('id="pm-informational"');
     const needsAttentionIndex = indexHtml.indexOf('id="pm-needs-attention"');

--- a/tools/release-plan-dashboard/tests/pm-view-layout.test.js
+++ b/tools/release-plan-dashboard/tests/pm-view-layout.test.js
@@ -29,12 +29,18 @@ describe("PM View Attention Required layout", () => {
     );
   });
 
-  test("links release plan IDs to the filtered dashboard", () => {
+  test("links release plan IDs to the dashboard and ADO work item", () => {
     expect(appJs).toContain(
       "const dashboardUrl = `/?releasePlan=${encodeURIComponent(planId)}`;",
     );
     expect(appJs).toContain(
       '<a href="${esc(dashboardUrl)}" target="_blank" rel="noopener">${label}</a>',
+    );
+    expect(appJs).toContain(
+      "const wiUrl = `https://dev.azure.com/azure-sdk/Release/_workitems/edit/${p.id}`;",
+    );
+    expect(appJs).toContain(
+      '<a href="${esc(wiUrl)}" target="_blank" rel="noopener">ADO work item ${esc(String(p.id))}</a>',
     );
   });
 


### PR DESCRIPTION
## Summary

- apply the shared release-plan search filter to the **Attention Required** view
- link the release plan number back to the dashboard filtered by release plan ID
- preserve a separate, clearly labeled link to the ADO work item
- add regression coverage for the filter and both link destinations

Fixes Azure/azure-sdk-pr#2755

## Validation

- `npm --prefix tools/release-plan-dashboard run check`
  - 15 test files passed
  - 434 tests passed
  - ESLint passed
  - Prettier check passed
- local dashboard with `ENVIRONMENT=test` and PM development authentication
  - filtering Attention Required by release plan `35681` reduced Missing Product Details from 10 plans to 1
  
<img width="3693" height="1835" alt="image" src="https://github.com/user-attachments/assets/93f24fa3-32c5-40f9-bb53-f558362c3a85" />
  
  - release plan `#35681` links to `/?releasePlan=35681`
  - `ADO work item 35681` links to the corresponding DevOps work item
  

<img width="2953" height="1794" alt="image" src="https://github.com/user-attachments/assets/ee2d6632-9e96-4858-b3c8-f091aba33a49" />
