### PR TITLE
[Service Label] Add service label: Discovery

### DIFF
--- a/tools/github/data/common-labels.csv
+++ b/tools/github/data/common-labels.csv
@@ -135,6 +135,7 @@ Device Update,,e99695
 Devtestlab,,e99695
 DigitalAssets,,e99695
 Digital Twins,,e99695
+Discovery,,e99695
 Do Not Merge,,b60205
 Docs,,e99695
 Document Intelligence,,e99695


### PR DESCRIPTION
This PR adds the service label 'Discovery' to the repository. Documentation link: https://learn.microsoft.com/en-us/azure/microsoft-discovery/