### PR TITLE
Fix Go release plan status write-back

### DIFF
--- a/eng/common/scripts/Mark-ReleasePlanCompletion.ps1
+++ b/eng/common/scripts/Mark-ReleasePlanCompletion.ps1
@@ -44,7 +44,7 @@ function Process-Package([string]$packageInfoPath)
     if (!$PackageName)
     {
         Write-Host "Package name is not available in the package information file. Skipping the release plan status update for the package."
-        return
+        return $true
     } 
 
     Write-Host "Marking release completion for package, name: $PackageName"
@@ -53,7 +53,7 @@ function Process-Package([string]$packageInfoPath)
     if (!$version)
     {
         Write-Host "Failed to parse version string '$($PackageVersion)' for package '$PackageName'. Skipping the release plan status update."
-        return
+        return $true
     }
 
     $sdkReleaseType = ""
@@ -72,17 +72,28 @@ function Process-Package([string]$packageInfoPath)
         $releaseArgs += @("--package-version", $PackageVersion)
     }
     $releaseInfo = & $AzsdkExePath @releaseArgs
-    if ($LASTEXITCODE -ne 0)
-    {
-        ## Not all releases have a release plan. So we should not fail the script even if a release plan is missing.
-        Write-Host "Failed to mark release completion for package '$PackageName' using azsdk. Exit code: $LASTEXITCODE"
-    }
+    $releaseExitCode = $LASTEXITCODE
     Write-Host "Details: $releaseInfo"
+    if ($releaseExitCode -ne 0)
+    {
+        Write-Warning "Failed to mark release completion for package '$PackageName' using azsdk. Exit code: $releaseExitCode"
+        return $false
+    }
+    return $true
 }
 
 Write-Host "Finding all package info files in the path: $PackageInfoFilePath"
+$hasFailures = $false
 # Get all package info file under the directory given in input param and process
 Get-ChildItem -Path $PackageInfoFilePath -Filter "*.json" | ForEach-Object {
     Write-Host "Processing package info file: $_"
-    Process-Package $_.FullName
+    if (!(Process-Package $_.FullName))
+    {
+        $hasFailures = $true
+    }
+}
+
+if ($hasFailures)
+{
+    exit 1
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/DevOpsServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/DevOpsServiceTests.cs
@@ -487,6 +487,23 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services
         }
 
         [Test]
+        public async Task GetReleasePlansForPackageAsync_GoQueryIncludesPackageNameAliases()
+        {
+            // Arrange
+            const string packageName = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v4";
+
+            // Act
+            await _devOpsService.GetReleasePlansForPackageAsync(packageName, "go", false, CancellationToken.None);
+
+            // Assert
+            var capturedQuery = _connection.LastCapturedQuery;
+            Assert.That(capturedQuery, Does.Contain($"[Custom.GoPackageName] = '{packageName}'"));
+            Assert.That(capturedQuery, Does.Contain("[Custom.GoPackageName] = 'sdk/resourcemanager/cosmos/armcosmos/v4'"));
+            Assert.That(capturedQuery, Does.Contain("[Custom.GoPackageName] = 'sdk/resourcemanager/cosmos/armcosmos'"));
+            Assert.That(capturedQuery, Does.Contain("[Custom.GoPackageName] = 'armcosmos'"));
+        }
+
+        [Test]
         public async Task GetReleasePlansForPackageAsync_QueryIncludesInProgressStateFilter()
         {
             // Arrange

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/PackageReleaseStatusToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/PackageReleaseStatusToolTests.cs
@@ -123,7 +123,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             // Assert
             Assert.That(result.Message, Does.Contain("No in-progress release plans found"));
             Assert.That(result.Message, Does.Contain("azure-test-package"));
-            Assert.That(result.ResponseError, Is.Null);
+            Assert.That(result.ResponseError, Is.EqualTo(result.Message));
             Assert.That(result.ReleaseStatus, Is.EqualTo("Released"));
         }
 
@@ -142,7 +142,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             // Assert
             Assert.That(result.Message, Does.Contain("No in-progress release plans found"));
             Assert.That(result.Message, Does.Contain("azure-resourcemanager-containerservice"));
-            Assert.That(result.ResponseError, Is.Null);
+            Assert.That(result.ResponseError, Is.EqualTo(result.Message));
             Assert.That(result.ReleaseStatus, Is.EqualTo("Released"));
         }
 
@@ -190,7 +190,41 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         }
 
         [Test]
-        public async Task UpdatePackageReleaseStatus_WithMultipleReleasePlans_SelectsMergedPullRequest()
+        public async Task UpdatePackageReleaseStatus_WithSingleReleasePlanAndWrongReleaseType_ReturnsError()
+        {
+            // Arrange
+            var releasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 12345,
+                ReleasePlanId = 100,
+                SDKReleaseType = "beta",
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo
+                    {
+                        Language = "go",
+                        PackageName = "sdk/resourcemanager/cosmos/armcosmos"
+                    }
+                }
+            };
+
+            mockDevOpsService
+                .Setup(x => x.GetReleasePlansForPackageAsync("sdk/resourcemanager/cosmos/armcosmos/v4", "go", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem> { releasePlan });
+
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus(
+                "sdk/resourcemanager/cosmos/armcosmos/v4", "go", "Released", "4.0.0", 0, "stable", null, null, CancellationToken.None);
+
+            // Assert
+            Assert.That(result.ResponseError, Does.Contain("SDK release type 'stable'"));
+            mockDevOpsService.Verify(
+                x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_WithMultipleReleasePlansAndMergedPullRequestStatus_ReturnsError()
         {
             // Arrange
             var releasePlanWithMergedPR = new ReleasePlanWorkItem
@@ -227,32 +261,25 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .Setup(x => x.GetReleasePlansForPackageAsync("azure-test-package", "python", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<ReleasePlanWorkItem> { releasePlanWithOpenPR, releasePlanWithMergedPR });
 
-            mockDevOpsService
-                .Setup(x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 11111 });
-
             // Act
             var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
-            Assert.That(result.ResponseError, Is.Null);
-            Assert.That(result.ReleaseStatus, Is.EqualTo("Released"));
-
-            // Verify the one with merged PR was selected (work item 11111)
+            Assert.That(result.ResponseError, Does.Contain("Multiple in-progress release plans"));
             mockDevOpsService.Verify(
-                x => x.UpdateWorkItemAsync(11111, It.Is<Dictionary<string, string>>(d =>
-                    d.ContainsKey("Custom.ReleaseStatusForPython")), It.IsAny<CancellationToken>()),
-                Times.Once);
+                x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()),
+                Times.Never);
         }
 
         [Test]
-        public async Task UpdatePackageReleaseStatus_WithMultipleReleasePlans_NoMergedPR_SelectsFirst()
+        public async Task UpdatePackageReleaseStatus_WithMultipleSameReleaseType_ReturnsError()
         {
             // Arrange
             var firstReleasePlan = new ReleasePlanWorkItem
             {
                 WorkItemId = 11111,
                 ReleasePlanId = 101,
+                SDKReleaseType = "stable",
                 SDKInfo = new List<SDKInfo>
                 {
                     new SDKInfo
@@ -268,6 +295,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             {
                 WorkItemId = 22222,
                 ReleasePlanId = 102,
+                SDKReleaseType = "stable",
                 SDKInfo = new List<SDKInfo>
                 {
                     new SDKInfo
@@ -283,21 +311,57 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                 .Setup(x => x.GetReleasePlansForPackageAsync("azure-test-package", "python", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<ReleasePlanWorkItem> { firstReleasePlan, secondReleasePlan });
 
+            // Act
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", null, 0, "stable", null, null, CancellationToken.None);
+
+            // Assert
+            Assert.That(result.ResponseError, Does.Contain("Multiple in-progress release plans"));
+            mockDevOpsService.Verify(
+                x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Test]
+        public async Task UpdatePackageReleaseStatus_WithUniqueReleaseType_SelectsMatchingReleasePlan()
+        {
+            // Arrange
+            var betaReleasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 11111,
+                ReleasePlanId = 101,
+                SDKReleaseType = "beta",
+                SDKInfo = new List<SDKInfo>()
+            };
+            var stableReleasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 22222,
+                ReleasePlanId = 102,
+                SDKReleaseType = "stable",
+                SDKInfo = new List<SDKInfo>()
+            };
+
             mockDevOpsService
-                .Setup(x => x.UpdateWorkItemAsync(It.IsAny<int>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 11111 });
+                .Setup(x => x.GetReleasePlansForPackageAsync("sdk/resourcemanager/cosmos/armcosmos/v4", "go", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ReleasePlanWorkItem> { betaReleasePlan, stableReleasePlan });
+            mockDevOpsService
+                .Setup(x => x.UpdateWorkItemAsync(22222, It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 22222 });
 
             // Act
-            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", null, 0, null, null, null, CancellationToken.None);
+            var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus(
+                "sdk/resourcemanager/cosmos/armcosmos/v4", "go", "Released", "4.0.0", 0, "stable", null, null, CancellationToken.None);
 
             // Assert
             Assert.That(result.ResponseError, Is.Null);
-
-            // Verify the first one was selected (work item 11111)
+            Assert.That(result.ReleasePlanId, Is.EqualTo(102));
             mockDevOpsService.Verify(
-                x => x.UpdateWorkItemAsync(11111, It.Is<Dictionary<string, string>>(d =>
-                    d.ContainsKey("Custom.ReleaseStatusForPython")), It.IsAny<CancellationToken>()),
+                x => x.UpdateWorkItemAsync(22222, It.Is<Dictionary<string, string>>(fields =>
+                    fields["Custom.ReleaseStatusForGo"] == "Released"
+                    && fields["Custom.ReleasedVersionForGo"] == "4.0.0"), It.IsAny<CancellationToken>()),
                 Times.Once);
+            mockDevOpsService.Verify(
+                x => x.UpdateWorkItemAsync(11111, It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()),
+                Times.Never);
         }
 
         [Test]
@@ -547,7 +611,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus(packageName, language, "Released", null, 0, null, null, null, CancellationToken.None);
 
             // Assert
-            Assert.That(result.ResponseError, Is.Null);
+            Assert.That(result.ResponseError, Is.EqualTo(result.Message));
             Assert.That(result.Message, Does.Contain("No in-progress release plans found"));
             Assert.That(result.Message, Does.Contain(packageName));
             Assert.That(result.Message, Does.Contain(language));
@@ -813,11 +877,10 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus(
                 "azure-test-package", "python", "Released", null, 999, null, null, null, CancellationToken.None);
 
-            // Assert - returns message, does not update any work item
-            Assert.That(result.ResponseError, Is.Null);
-            Assert.That(result.Message, Does.Contain("999"));
-            Assert.That(result.Message, Does.Contain("azure-test-package"));
-            Assert.That(result.Message, Does.Contain("python"));
+            // Assert - returns an error and does not update any work item
+            Assert.That(result.ResponseError, Does.Contain("999"));
+            Assert.That(result.ResponseError, Does.Contain("azure-test-package"));
+            Assert.That(result.ResponseError, Does.Contain("python"));
 
             // Verify it searched by package name but did NOT update any work item
             mockDevOpsService.Verify(
@@ -1194,7 +1257,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             var result = await packageReleaseStatusTool.UpdatePackageReleaseStatus("azure-test-package", "python", "Released", "2.0.0", 0, null, null, null, CancellationToken.None);
 
             // Assert - The tool should report no in-progress release plans found
-            Assert.That(result.ResponseError, Is.Null);
+            Assert.That(result.ResponseError, Is.EqualTo(result.Message));
             Assert.That(result.Message, Does.Contain("No in-progress release plans found"));
             Assert.That(result.Message, Does.Contain("azure-test-package"));
             Assert.That(result.Message, Does.Contain("python"));

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -354,10 +354,11 @@ namespace Azure.Sdk.Tools.Cli.Services
             try
             {
                 var languageId = MapLanguageToId(language);
-                var escapedPackageName = packageName?.Replace("'", "''");
+                var packageNameConditions = GetPackageNameSearchValues(packageName, language)
+                    .Select(name => $"[Custom.{languageId}PackageName] = '{name.Replace("'", "''")}'");
                 var query = $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{Constants.AZURE_SDK_DEVOPS_RELEASE_PROJECT}'";
                 query += $" AND [System.Tags] {(isTestReleasePlan ? "CONTAINS" : "NOT CONTAINS")} '{RELEASE_PLANNER_APP_TEST}'";
-                query += $" AND [Custom.{languageId}PackageName] = '{escapedPackageName}'";
+                query += $" AND ({string.Join(" OR ", packageNameConditions)})";
                 query += $" AND [Custom.ReleaseStatusFor{languageId}] <> 'Released'";
                 query += " AND [System.WorkItemType] = 'Release Plan'";
                 query += " AND [System.State] = 'In Progress'";
@@ -382,6 +383,39 @@ namespace Azure.Sdk.Tools.Cli.Services
                 logger.LogError(ex, "Failed to get release plans for package {packageName} in {language}", packageName, language);
                 throw new Exception($"Failed to get release plans for package {packageName} in {language}. Error: {ex.Message}", ex);
             }
+        }
+
+        private static IReadOnlyCollection<string> GetPackageNameSearchValues(string packageName, string language)
+        {
+            var packageNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { packageName };
+            if (!string.Equals(language, "go", StringComparison.OrdinalIgnoreCase))
+            {
+                return packageNames;
+            }
+
+            const string goModulePrefix = "github.com/Azure/azure-sdk-for-go/";
+            var repositoryPath = packageName.Replace('\\', '/').Trim('/');
+            if (repositoryPath.StartsWith(goModulePrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                repositoryPath = repositoryPath[goModulePrefix.Length..];
+                packageNames.Add(repositoryPath);
+            }
+
+            var lastSeparator = repositoryPath.LastIndexOf('/');
+            var lastSegment = repositoryPath[(lastSeparator + 1)..];
+            if (lastSeparator >= 0
+                && lastSegment.Length > 1
+                && (lastSegment[0] == 'v' || lastSegment[0] == 'V')
+                && int.TryParse(lastSegment[1..], out var majorVersion)
+                && majorVersion >= 2)
+            {
+                repositoryPath = repositoryPath[..lastSeparator];
+                packageNames.Add(repositoryPath);
+            }
+
+            lastSeparator = repositoryPath.LastIndexOf('/');
+            packageNames.Add(repositoryPath[(lastSeparator + 1)..]);
+            return packageNames;
         }
 
         private async Task<ReleasePlanWorkItem> MapWorkItemToReleasePlanAsync(WorkItem workItem, CancellationToken ct)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/PackageReleaseStatusTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/PackageReleaseStatusTool.cs
@@ -156,29 +156,15 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 if (releasePlans.Count == 0)
                 {
                     response.Message = $"No in-progress release plans found for package '{packageName}' in language '{language}'.";
+                    response.ResponseError = response.Message;
                     return response;
                 }
 
-                ReleasePlanWorkItem releasePlan;
-
-                // If release plan ID is provided, use it to select the matching release plan from the results
-                if (releasePlanId > 0)
+                var (releasePlan, selectionError) = SelectReleasePlan(releasePlans, packageName, language, releasePlanId, sdkReleaseType, sdkPullRequest);
+                if (releasePlan == null)
                 {
-                    var matchingPlan = releasePlans.FirstOrDefault(rp => rp.ReleasePlanId == releasePlanId);
-                    if (matchingPlan != null)
-                    {
-                        logger.LogInformation("Found release plan {releasePlanId} matching the provided ID for package {packageName}.", releasePlanId, packageName);
-                        releasePlan = matchingPlan;
-                    }
-                    else
-                    {
-                        response.Message = $"Release plan with ID '{releasePlanId}' not found among in-progress release plans for package '{packageName}' in language '{language}'.";
-                        return response;
-                    }
-                }
-                else
-                {
-                    releasePlan = SelectReleasePlan(releasePlans, packageName, sdkReleaseType, sdkPullRequest);
+                    response.ResponseError = selectionError;
+                    return response;
                 }
 
                 response.ReleasePlanId = releasePlan.ReleasePlanId;
@@ -245,57 +231,53 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             }
         }
 
-        private ReleasePlanWorkItem SelectReleasePlan(List<ReleasePlanWorkItem> releasePlans, string packageName, string? sdkReleaseType, string? sdkPullRequest)
+        private (ReleasePlanWorkItem? ReleasePlan, string? Error) SelectReleasePlan(
+            List<ReleasePlanWorkItem> releasePlans,
+            string packageName,
+            string language,
+            int releasePlanId,
+            string? sdkReleaseType,
+            string? sdkPullRequest)
         {
-            var releasePlan = releasePlans[0];
-            if (releasePlans.Count > 1)
+            IEnumerable<ReleasePlanWorkItem> candidates = releasePlans;
+            var criteria = new List<string>();
+
+            if (releasePlanId > 0)
             {
-                logger.LogInformation("Multiple active release plans are found for '{packageName}'", packageName);
-                // If an SDK pull request URL is provided, try to select the release plan that matches it.
-                if (!string.IsNullOrWhiteSpace(sdkPullRequest))
-                {
-                    var releasePlanWithSdkPullRequest = releasePlans.FirstOrDefault(rp =>
-                        rp.SDKInfo.Any(s =>
-                            string.Equals(s.PackageName, packageName, StringComparison.OrdinalIgnoreCase)
-                            && !string.IsNullOrWhiteSpace(s.SdkPullRequestUrl)
-                            && string.Equals(s.SdkPullRequestUrl, sdkPullRequest, StringComparison.OrdinalIgnoreCase)));
-                    if (releasePlanWithSdkPullRequest != null)
-                    {
-                        logger.LogInformation("Selected release plan {releasePlanId} with SDK pull request {sdkPullRequest}.", releasePlanWithSdkPullRequest.ReleasePlanId, sdkPullRequest);
-                        releasePlan = releasePlanWithSdkPullRequest;
-                        return releasePlan;
-                    }
-                    logger.LogInformation("No release plan matched the SDK pull request {sdkPullRequest}.", sdkPullRequest);
-                }
-                // If an SDK release type is provided, try to select the release plan that matches it.
-                if (!string.IsNullOrWhiteSpace(sdkReleaseType))
-                {
-                    var releasePlanWithSdkReleaseType = releasePlans.FirstOrDefault(rp => string.Equals(rp.SDKReleaseType, sdkReleaseType, StringComparison.OrdinalIgnoreCase));
-                    if (releasePlanWithSdkReleaseType != null)
-                    {
-                        logger.LogInformation("Selected release plan {releasePlanId} with SDK release type {sdkReleaseType}.", releasePlanWithSdkReleaseType.ReleasePlanId, sdkReleaseType);
-                        releasePlan = releasePlanWithSdkReleaseType;
-                        return releasePlan;
-                    }
-                    logger.LogInformation("No release plan matched the SDK release type {sdkReleaseType}.", sdkReleaseType);
-                }
-                // If no release plan was selected by SDK pull request or SDK release type, try to select the release plan with a merged pull request.
-                var releasePlanWithPrMerged = releasePlans.FirstOrDefault(rp => rp.SDKInfo.Any(s => string.Equals(s.PackageName, packageName, StringComparison.OrdinalIgnoreCase) && s.PullRequestStatus.Equals("Merged")));
-                if (releasePlanWithPrMerged != null)
-                {
-                    logger.LogInformation("Selected first release plan {releasePlanId} with pull request as merged.", releasePlanWithPrMerged.ReleasePlanId);
-                    releasePlan = releasePlanWithPrMerged;
-                }
-                else
-                {
-                    logger.LogInformation("No release plan with merged pull request status found. Defaulting to first release plan {releasePlanId}.", releasePlan.ReleasePlanId);
-                }
+                candidates = candidates.Where(rp => rp.ReleasePlanId == releasePlanId);
+                criteria.Add($"release plan ID '{releasePlanId}'");
             }
-            else
+
+            if (!string.IsNullOrWhiteSpace(sdkPullRequest))
             {
-                logger.LogInformation("Found release plan work item {workItemId} for package {packageName}", releasePlan.WorkItemId, packageName);
+                candidates = candidates.Where(rp => rp.SDKInfo.Any(s =>
+                    !string.IsNullOrWhiteSpace(s.SdkPullRequestUrl)
+                    && string.Equals(s.SdkPullRequestUrl, sdkPullRequest, StringComparison.OrdinalIgnoreCase)));
+                criteria.Add($"SDK pull request '{sdkPullRequest}'");
             }
-            return releasePlan;
+
+            if (!string.IsNullOrWhiteSpace(sdkReleaseType))
+            {
+                candidates = candidates.Where(rp => string.Equals(rp.SDKReleaseType, sdkReleaseType, StringComparison.OrdinalIgnoreCase));
+                criteria.Add($"SDK release type '{sdkReleaseType}'");
+            }
+
+            var matchingPlans = candidates.ToList();
+            var criteriaDescription = criteria.Count > 0 ? $" with {string.Join(" and ", criteria)}" : string.Empty;
+            if (matchingPlans.Count == 0)
+            {
+                return (null, $"No in-progress release plans matched package '{packageName}' in language '{language}'{criteriaDescription}.");
+            }
+
+            if (matchingPlans.Count > 1)
+            {
+                var matchingIds = string.Join(", ", matchingPlans.Select(rp => rp.ReleasePlanId));
+                return (null, $"Multiple in-progress release plans matched package '{packageName}' in language '{language}'{criteriaDescription}. Matching release plan IDs: {matchingIds}. Provide --release-plan-id or --sdk-pull-request to select one.");
+            }
+
+            var releasePlan = matchingPlans[0];
+            logger.LogInformation("Selected release plan {releasePlanId} for package {packageName}.", releasePlan.ReleasePlanId, packageName);
+            return (releasePlan, null);
         }
 
         internal static bool IsReleasePlanComplete(ReleasePlanWorkItem releasePlan)


### PR DESCRIPTION
## Summary

- match Go release plans across full module paths, repository-relative paths, semantic major suffixes such as `/v4`, and legacy leaf-only package names
- require release-plan ID, SDK PR, and release type filters to resolve to exactly one active plan instead of falling back to the first result
- return CLI errors for missing or ambiguous plans and surface write-back failures as nonblocking pipeline warnings
- add regression coverage for Go aliases, stable/beta selection, ambiguity, wrong release type, and missing plans

Tracking: release-planner issue 2756.
https://github.com/Azure/azure-sdk-pr/issues/2756


## Testing

- focused release-status and package-query tests: 71 passed, 0 failed
- full `Azure.Sdk.Tools.Cli.Tests` suite: 1,834 total, 0 failed, 1 environment-dependent test skipped
- PowerShell syntax and `git diff --check`
- fake-CLI smoke test confirming write-back failure returns exit code 1