### PR TITLE
[APIView] Add `reviews/mark-released` endpoint

### DIFF
--- a/src/dotnet/APIView/APIViewUnitTests/APIRevisionsManagerTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/APIRevisionsManagerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Security.Claims;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -132,6 +133,67 @@ public class APIRevisionsManagerTests
             _mockApiVersionsManager.Object,
             _mockConfiguration.Object
         );
+    }
+
+    [Fact]
+    public async Task MarkAPIRevisionReleasedAsync_MarksAndPersistsRevision()
+    {
+        const string revisionId = "revision-1";
+        var revision = new APIRevisionListItemModel
+        {
+            Id = revisionId,
+            IsReleased = false
+        };
+        _mockAPIRevisionsRepository.Setup(r => r.GetAPIRevisionAsync(revisionId)).ReturnsAsync(revision);
+
+        APIRevisionListItemModel result = await _manager.MarkAPIRevisionReleasedAsync(revisionId);
+
+        Assert.True(result.IsReleased);
+        Assert.True(result.ReleasedOn <= DateTime.UtcNow);
+        _mockAPIRevisionsRepository.Verify(r => r.UpsertAPIRevisionAsync(revision), Times.Once);
+    }
+
+    [Fact]
+    public async Task MarkAPIRevisionReleasedAsync_WhenAlreadyReleased_DoesNotPersistAgain()
+    {
+        const string revisionId = "revision-1";
+        var revision = new APIRevisionListItemModel
+        {
+            Id = revisionId,
+            IsReleased = true,
+            ReleasedOn = DateTime.UtcNow.AddDays(-1)
+        };
+        _mockAPIRevisionsRepository.Setup(r => r.GetAPIRevisionAsync(revisionId)).ReturnsAsync(revision);
+
+        APIRevisionListItemModel result = await _manager.MarkAPIRevisionReleasedAsync(revisionId);
+
+        Assert.Same(revision, result);
+        _mockAPIRevisionsRepository.Verify(r => r.UpsertAPIRevisionAsync(It.IsAny<APIRevisionListItemModel>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetAPIRevisionsAsync_WithMultipleExactVersionMatches_ReturnsNewestFirst()
+    {
+        const string reviewId = "review-1";
+        var olderRevision = new APIRevisionListItemModel
+        {
+            Id = "older",
+            CreatedOn = DateTime.UtcNow.AddDays(-1),
+            Files = [new APICodeFileModel { PackageVersion = "1.2.3" }]
+        };
+        var newerRevision = new APIRevisionListItemModel
+        {
+            Id = "newer",
+            CreatedOn = DateTime.UtcNow,
+            Files = [new APICodeFileModel { PackageVersion = "1.2.3" }]
+        };
+        _mockAPIRevisionsRepository
+            .Setup(r => r.GetAPIRevisionsAsync(reviewId))
+            .ReturnsAsync([olderRevision, newerRevision]);
+
+        IEnumerable<APIRevisionListItemModel> result = await _manager.GetAPIRevisionsAsync(reviewId, "1.2.3");
+
+        Assert.Equal(["newer", "older"], result.Select(revision => revision.Id));
     }
 
     [Fact]

--- a/src/dotnet/APIView/APIViewUnitTests/APIRevisionsManagerTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/APIRevisionsManagerTests.cs
@@ -146,10 +146,12 @@ public class APIRevisionsManagerTests
         };
         _mockAPIRevisionsRepository.Setup(r => r.GetAPIRevisionAsync(revisionId)).ReturnsAsync(revision);
 
+        DateTime before = DateTime.UtcNow;
         APIRevisionListItemModel result = await _manager.MarkAPIRevisionReleasedAsync(revisionId);
+        DateTime after = DateTime.UtcNow;
 
         Assert.True(result.IsReleased);
-        Assert.True(result.ReleasedOn <= DateTime.UtcNow);
+        Assert.InRange(result.ReleasedOn, before, after);
         _mockAPIRevisionsRepository.Verify(r => r.UpsertAPIRevisionAsync(revision), Times.Once);
     }
 

--- a/src/dotnet/APIView/APIViewUnitTests/ReviewSearchTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/ReviewSearchTests.cs
@@ -251,6 +251,51 @@ public class ReviewSearchTests
 
     #endregion
 
+    #region ResolveAutomaticRevisionForRelease Tests
+
+    [Fact]
+    public async Task ResolveAutomaticRevisionForRelease_SelectsNewestExactAutomaticRevision()
+    {
+        ReviewListItemModel review = CreateMockReview("review123", "Azure.Storage.Blobs", "C#");
+        APIRevisionListItemModel older = CreateMockRevision("older", review.Id, "12.0.0");
+        older.APIRevisionType = APIRevisionType.Automatic;
+        older.CreatedOn = DateTime.UtcNow.AddDays(-2);
+        APIRevisionListItemModel newer = CreateMockRevision("newer", review.Id, "12.0.0");
+        newer.APIRevisionType = APIRevisionType.Automatic;
+        APIRevisionListItemModel manual = CreateMockRevision("manual", review.Id, "12.0.0");
+        manual.APIRevisionType = APIRevisionType.Manual;
+        manual.CreatedOn = DateTime.UtcNow;
+
+        _mockReviewManager.Setup(x => x.GetReviewAsync("C#", "Azure.Storage.Blobs", null)).ReturnsAsync(review);
+        _mockApiRevisionsManager.Setup(x => x.GetAPIRevisionsAsync(review.Id, "", APIRevisionType.All))
+            .ReturnsAsync([older, manual, newer]);
+
+        ResolvePackageResponse result = await package.ResolveAutomaticRevisionForRelease(
+            "Azure.Storage.Blobs", "C#", "12.0.0");
+
+        Assert.NotNull(result);
+        Assert.Equal("newer", result.RevisionId);
+    }
+
+    [Fact]
+    public async Task ResolveAutomaticRevisionForRelease_ReturnsNullWithoutExactVersion()
+    {
+        ReviewListItemModel review = CreateMockReview("review123", "Azure.Storage.Blobs", "C#");
+        APIRevisionListItemModel fallback = CreateMockRevision("fallback", review.Id, "12.0.1");
+        fallback.APIRevisionType = APIRevisionType.Automatic;
+
+        _mockReviewManager.Setup(x => x.GetReviewAsync("C#", "Azure.Storage.Blobs", null)).ReturnsAsync(review);
+        _mockApiRevisionsManager.Setup(x => x.GetAPIRevisionsAsync(review.Id, "", APIRevisionType.All))
+            .ReturnsAsync([fallback]);
+
+        ResolvePackageResponse result = await package.ResolveAutomaticRevisionForRelease(
+            "Azure.Storage.Blobs", "C#", "12.0.0");
+
+        Assert.Null(result);
+    }
+
+    #endregion
+
     #region ResolvePackageLink Tests
 
     [Fact]

--- a/src/dotnet/APIView/APIViewUnitTests/ReviewSearchTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/ReviewSearchTests.cs
@@ -265,10 +265,14 @@ public class ReviewSearchTests
         APIRevisionListItemModel manual = CreateMockRevision("manual", review.Id, "12.0.0");
         manual.APIRevisionType = APIRevisionType.Manual;
         manual.CreatedOn = DateTime.UtcNow;
+        APIRevisionListItemModel deleted = CreateMockRevision("deleted", review.Id, "12.0.0");
+        deleted.APIRevisionType = APIRevisionType.Automatic;
+        deleted.IsDeleted = true;
+        deleted.CreatedOn = DateTime.UtcNow.AddDays(1);
 
         _mockReviewManager.Setup(x => x.GetReviewAsync("C#", "Azure.Storage.Blobs", null)).ReturnsAsync(review);
         _mockApiRevisionsManager.Setup(x => x.GetAPIRevisionsAsync(review.Id, "", APIRevisionType.All))
-            .ReturnsAsync([older, manual, newer]);
+            .ReturnsAsync([older, manual, newer, deleted]);
 
         ResolvePackageResponse result = await package.ResolveAutomaticRevisionForRelease(
             "Azure.Storage.Blobs", "C#", "12.0.0");

--- a/src/dotnet/APIView/APIViewUnitTests/ReviewsTokenAuthControllerTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/ReviewsTokenAuthControllerTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using APIViewWeb;
 using APIViewWeb.Helpers;
 using APIViewWeb.LeanControllers;
+using APIViewWeb.LeanModels;
 using APIViewWeb.Managers;
 using APIViewWeb.Managers.Interfaces;
 using APIViewWeb.Models;
@@ -140,6 +141,82 @@ public class ReviewsTokenAuthControllerTests
         notFoundResult.Value?.ToString().Should().Contain("Could not find an APIView review");
         notFoundResult.Value?.ToString().Should().Contain(package);
         notFoundResult.Value?.ToString().Should().Contain(language);
+    }
+
+    #endregion
+
+    #region MarkReleased Tests
+
+    [Fact]
+    public async Task MarkReleased_WithExactVersion_MarksResolvedRevisionReleased()
+    {
+        var resolved = new ResolvePackageResponse
+        {
+            PackageName = "Azure.Storage.Blobs",
+            Language = "C#",
+            ReviewId = "review123",
+            RevisionId = "revision456",
+            Version = "12.0.0"
+        };
+        _mockReviewSearch
+            .Setup(x => x.ResolveAutomaticRevisionForRelease("Azure.Storage.Blobs", "C#", "12.0.0"))
+            .ReturnsAsync(resolved);
+        _mockApiRevisionsManager
+            .Setup(x => x.MarkAPIRevisionReleasedAsync("revision456"))
+            .ReturnsAsync(new APIRevisionListItemModel { Id = "revision456", IsReleased = true });
+
+        ActionResult<ResolvePackageResponse> result = await _controller.MarkReleased("Azure.Storage.Blobs", "C#", "12.0.0");
+
+        Assert.IsType<LeanJsonResult>(result.Result);
+        _mockApiRevisionsManager.Verify(x => x.MarkAPIRevisionReleasedAsync("revision456"), Times.Once);
+    }
+
+    [Fact]
+    public async Task MarkReleased_WithDryRun_ReturnsResolvedRevisionWithoutMarkingReleased()
+    {
+        var resolved = new ResolvePackageResponse
+        {
+            PackageName = "Azure.Storage.Blobs",
+            Language = "C#",
+            ReviewId = "review123",
+            RevisionId = "revision456",
+            Version = "12.0.0"
+        };
+        _mockReviewSearch
+            .Setup(x => x.ResolveAutomaticRevisionForRelease("Azure.Storage.Blobs", "C#", "12.0.0"))
+            .ReturnsAsync(resolved);
+
+        ActionResult<ResolvePackageResponse> result = await _controller.MarkReleased(
+            "Azure.Storage.Blobs", "C#", "12.0.0", dryRun: true);
+
+        LeanJsonResult jsonResult = Assert.IsType<LeanJsonResult>(result.Result);
+        Assert.Same(resolved, jsonResult.Value);
+        _mockApiRevisionsManager.Verify(x => x.MarkAPIRevisionReleasedAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(null, "C#", "12.0.0")]
+    [InlineData("Azure.Storage.Blobs", null, "12.0.0")]
+    [InlineData("Azure.Storage.Blobs", "C#", null)]
+    public async Task MarkReleased_WithMissingParameter_ReturnsBadRequest(string package, string language, string version)
+    {
+        ActionResult<ResolvePackageResponse> result = await _controller.MarkReleased(package, language, version);
+
+        Assert.IsType<BadRequestObjectResult>(result.Result);
+        _mockApiRevisionsManager.Verify(x => x.MarkAPIRevisionReleasedAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task MarkReleased_WithMajorMinorFallback_ReturnsNotFound()
+    {
+        _mockReviewSearch
+            .Setup(x => x.ResolveAutomaticRevisionForRelease("Azure.Storage.Blobs", "C#", "12.0.0"))
+            .ReturnsAsync((ResolvePackageResponse)null);
+
+        ActionResult<ResolvePackageResponse> result = await _controller.MarkReleased("Azure.Storage.Blobs", "C#", "12.0.0");
+
+        Assert.IsType<NotFoundObjectResult>(result.Result);
+        _mockApiRevisionsManager.Verify(x => x.MarkAPIRevisionReleasedAsync(It.IsAny<string>()), Times.Never);
     }
 
     #endregion

--- a/src/dotnet/APIView/APIViewUnitTests/ReviewsTokenAuthControllerTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/ReviewsTokenAuthControllerTests.cs
@@ -202,7 +202,8 @@ public class ReviewsTokenAuthControllerTests
     {
         ActionResult<ResolvePackageResponse> result = await _controller.MarkReleased(package, language, version);
 
-        Assert.IsType<BadRequestObjectResult>(result.Result);
+        BadRequestObjectResult badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
+        System.Text.Json.JsonSerializer.Serialize(badRequest.Value).Should().Contain("\"message\"");
         _mockApiRevisionsManager.Verify(x => x.MarkAPIRevisionReleasedAsync(It.IsAny<string>()), Times.Never);
     }
 
@@ -215,8 +216,39 @@ public class ReviewsTokenAuthControllerTests
 
         ActionResult<ResolvePackageResponse> result = await _controller.MarkReleased("Azure.Storage.Blobs", "C#", "12.0.0");
 
-        Assert.IsType<NotFoundObjectResult>(result.Result);
+        NotFoundObjectResult notFound = Assert.IsType<NotFoundObjectResult>(result.Result);
+        System.Text.Json.JsonSerializer.Serialize(notFound.Value).Should().Contain("\"message\"");
         _mockApiRevisionsManager.Verify(x => x.MarkAPIRevisionReleasedAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task MarkReleased_WhenResolvedRevisionDisappears_ReturnsStructuredNotFound()
+    {
+        _mockReviewSearch
+            .Setup(x => x.ResolveAutomaticRevisionForRelease("Azure.Storage.Blobs", "C#", "12.0.0"))
+            .ReturnsAsync(new ResolvePackageResponse { RevisionId = "revision456" });
+        _mockApiRevisionsManager
+            .Setup(x => x.MarkAPIRevisionReleasedAsync("revision456"))
+            .ReturnsAsync((APIRevisionListItemModel)null);
+
+        ActionResult<ResolvePackageResponse> result = await _controller.MarkReleased("Azure.Storage.Blobs", "C#", "12.0.0");
+
+        NotFoundObjectResult notFound = Assert.IsType<NotFoundObjectResult>(result.Result);
+        System.Text.Json.JsonSerializer.Serialize(notFound.Value).Should().Contain("\"message\"");
+    }
+
+    [Fact]
+    public async Task MarkReleased_WhenResolutionThrows_ReturnsStructuredInternalServerError()
+    {
+        _mockReviewSearch
+            .Setup(x => x.ResolveAutomaticRevisionForRelease("Azure.Storage.Blobs", "C#", "12.0.0"))
+            .ThrowsAsync(new InvalidOperationException("failure"));
+
+        ActionResult<ResolvePackageResponse> result = await _controller.MarkReleased("Azure.Storage.Blobs", "C#", "12.0.0");
+
+        ObjectResult internalServerError = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status500InternalServerError, internalServerError.StatusCode);
+        System.Text.Json.JsonSerializer.Serialize(internalServerError.Value).Should().Contain("\"message\"");
     }
 
     #endregion

--- a/src/dotnet/APIView/APIViewWeb/LeanControllers/ReviewsTokenAuthController.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanControllers/ReviewsTokenAuthController.cs
@@ -111,7 +111,7 @@ public class ReviewsTokenAuthController : ControllerBase
     {
         if (string.IsNullOrWhiteSpace(packageName) || string.IsNullOrWhiteSpace(language) || string.IsNullOrWhiteSpace(version))
         {
-            return BadRequest("'packageName', 'language', and 'version' are required.");
+            return BadRequest(new { message = "'packageName', 'language', and 'version' are required." });
         }
 
         try
@@ -119,7 +119,7 @@ public class ReviewsTokenAuthController : ControllerBase
             ResolvePackageResponse result = await reviewSearch.ResolveAutomaticRevisionForRelease(packageName, language, version);
             if (result == null)
             {
-                return NotFound($"Could not find an APIView revision for package '{packageName}' in language '{language}' with version '{version}'.");
+                return NotFound(new { message = $"Could not find an APIView revision for package '{packageName}' in language '{language}' with version '{version}'." });
             }
 
             if (dryRun)
@@ -130,7 +130,7 @@ public class ReviewsTokenAuthController : ControllerBase
             APIRevisionListItemModel revision = await _apiRevisionsManager.MarkAPIRevisionReleasedAsync(result.RevisionId);
             if (revision == null)
             {
-                return NotFound($"APIView revision '{result.RevisionId}' was not found.");
+                return NotFound(new { message = $"APIView revision '{result.RevisionId}' was not found." });
             }
 
             return new LeanJsonResult(result, StatusCodes.Status200OK);
@@ -138,7 +138,7 @@ public class ReviewsTokenAuthController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error marking package {Package} {Version} released for {Language}", packageName, version, language);
-            return StatusCode(StatusCodes.Status500InternalServerError, "An error occurred while marking the package released.");
+            return StatusCode(StatusCodes.Status500InternalServerError, new { message = "An error occurred while marking the package released." });
         }
     }
 

--- a/src/dotnet/APIView/APIViewWeb/LeanControllers/ReviewsTokenAuthController.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanControllers/ReviewsTokenAuthController.cs
@@ -102,6 +102,46 @@ public class ReviewsTokenAuthController : ControllerBase
         }
     }
 
+    [HttpPost("mark-released", Name = "MarkPackageReleased")]
+    public async Task<ActionResult<ResolvePackageResponse>> MarkReleased(
+        [FromQuery, Required] string packageName,
+        [FromQuery, Required] string language,
+        [FromQuery, Required] string version,
+        [FromQuery] bool dryRun = false)
+    {
+        if (string.IsNullOrWhiteSpace(packageName) || string.IsNullOrWhiteSpace(language) || string.IsNullOrWhiteSpace(version))
+        {
+            return BadRequest("'packageName', 'language', and 'version' are required.");
+        }
+
+        try
+        {
+            ResolvePackageResponse result = await reviewSearch.ResolveAutomaticRevisionForRelease(packageName, language, version);
+            if (result == null)
+            {
+                return NotFound($"Could not find an APIView revision for package '{packageName}' in language '{language}' with version '{version}'.");
+            }
+
+            if (dryRun)
+            {
+                return new LeanJsonResult(result, StatusCodes.Status200OK);
+            }
+
+            APIRevisionListItemModel revision = await _apiRevisionsManager.MarkAPIRevisionReleasedAsync(result.RevisionId);
+            if (revision == null)
+            {
+                return NotFound($"APIView revision '{result.RevisionId}' was not found.");
+            }
+
+            return new LeanJsonResult(result, StatusCodes.Status200OK);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error marking package {Package} {Version} released for {Language}", packageName, version, language);
+            return StatusCode(StatusCodes.Status500InternalServerError, "An error occurred while marking the package released.");
+        }
+    }
+
     /// <summary>
     ///     Returns the canonical APIView review URL for a given package and language.
     ///     By default redirects to the review page. Use redirect=false to get JSON response instead.

--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -1463,6 +1463,18 @@ namespace APIViewWeb.Managers
             return revision;
         }
 
+        public async Task<APIRevisionListItemModel> MarkAPIRevisionReleasedAsync(string apiRevisionId)
+        {
+            APIRevisionListItemModel revision = await _apiRevisionsRepository.GetAPIRevisionAsync(apiRevisionId);
+            if (revision == null || revision.IsReleased)
+                return revision;
+
+            revision.IsReleased = true;
+            revision.ReleasedOn = DateTime.UtcNow;
+            await _apiRevisionsRepository.UpsertAPIRevisionAsync(revision);
+            return revision;
+        }
+
         /// <summary>
         /// Get ReviewIds of Language corresponding Review linked by CrossLanguagePackageId
         /// </summary>

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
@@ -47,6 +47,7 @@ namespace APIViewWeb.Managers.Interfaces
         public Task AssignReviewersToAPIRevisionAsync(ClaimsPrincipal User, string apiRevisionId, HashSet<string> reviewers);
         public Task<IEnumerable<APIRevisionListItemModel>> GetAPIRevisionsAssignedToUser(string userName);
         public Task<APIRevisionListItemModel> UpdateRevisionMetadataAsync(APIRevisionListItemModel revision, string packageVersion, string label, bool setReleaseTag = false);
+        public Task<APIRevisionListItemModel> MarkAPIRevisionReleasedAsync(string apiRevisionId);
         public Task<IEnumerable<string>> GetReviewIdsOfLanguageCorrespondingReviewAsync(string crossLanguagePackageId);
         public Task<APIRevisionListItemModel> UpdateAPIRevisionReviewersAsync(ClaimsPrincipal User, string apiRevisionId, HashSet<string> reviewers);
         public Task<string> GetOutlineAPIRevisionsAsync(string activeApiRevisionId);

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IReviewSearch.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IReviewSearch.cs
@@ -9,6 +9,10 @@ namespace APIViewWeb.Managers.Interfaces
             string packageQuery,
             string language,
             string version = null);
+        Task<ResolvePackageResponse> ResolveAutomaticRevisionForRelease(
+            string packageName,
+            string language,
+            string version);
         Task<ResolvePackageResponse> ResolvePackageLink(string link);
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Managers/ReviewSearch.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/ReviewSearch.cs
@@ -111,6 +111,54 @@ public class ReviewSearch : IReviewSearch
         };
     }
 
+    public async Task<ResolvePackageResponse> ResolveAutomaticRevisionForRelease(
+        string packageName,
+        string language,
+        string version)
+    {
+        if (string.IsNullOrEmpty(packageName))
+        {
+            throw new ArgumentException("Package name is required.", nameof(packageName));
+        }
+
+        if (string.IsNullOrEmpty(language))
+        {
+            throw new ArgumentException("Language is required.", nameof(language));
+        }
+
+        if (string.IsNullOrEmpty(version))
+        {
+            throw new ArgumentException("Version is required.", nameof(version));
+        }
+
+        ReviewListItemModel review = await _reviewManager.GetReviewAsync(language, packageName, null);
+        if (review == null)
+        {
+            return null;
+        }
+
+        IEnumerable<APIRevisionListItemModel> revisions = await _apiRevisionsManager.GetAPIRevisionsAsync(review.Id);
+        APIRevisionListItemModel revision = revisions
+            .Where(r => r.APIRevisionType == APIRevisionType.Automatic && r.PackageVersion == version)
+            .OrderByDescending(r => r.CreatedOn)
+            .FirstOrDefault();
+
+        if (revision == null)
+        {
+            return null;
+        }
+
+        return new ResolvePackageResponse
+        {
+            PackageName = review.PackageName,
+            Language = review.Language,
+            ReviewId = review.Id,
+            Version = revision.PackageVersion,
+            RevisionId = revision.Id,
+            RevisionLabel = revision.Label
+        };
+    }
+
     public async Task<ResolvePackageResponse> ResolvePackageLink(string link)
     {
         if (string.IsNullOrEmpty(link))

--- a/src/dotnet/APIView/APIViewWeb/Managers/ReviewSearch.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/ReviewSearch.cs
@@ -139,7 +139,7 @@ public class ReviewSearch : IReviewSearch
 
         IEnumerable<APIRevisionListItemModel> revisions = await _apiRevisionsManager.GetAPIRevisionsAsync(review.Id);
         APIRevisionListItemModel revision = revisions
-            .Where(r => r.APIRevisionType == APIRevisionType.Automatic && r.PackageVersion == version)
+            .Where(r => !r.IsDeleted && r.APIRevisionType == APIRevisionType.Automatic && r.PackageVersion == version)
             .OrderByDescending(r => r.CreatedOn)
             .FirstOrDefault();
 

--- a/src/dotnet/APIView/APIViewWeb/typespec/operations.tsp
+++ b/src/dotnet/APIView/APIViewWeb/typespec/operations.tsp
@@ -230,6 +230,27 @@ namespace Reviews {
     } | BadRequestErrorResponse | NotFoundErrorResponse | InternalServerErrorResponse;
 
     /**
+     * Mark the newest revision matching an exact package version as released.
+     *
+    * @param packageName Exact package name (e.g., "Azure.Storage.Blobs").
+     * @param language Programming language (e.g., "C#", "Python").
+     * @param version Exact package version to mark as released.
+    * @param dryRun Whether to resolve and return the matching revision without marking it released.
+    * @returns IDs of the resolved review and revision.
+     */
+    @post
+    @route("/mark-released")
+    op markReleased(
+        @query packageName: string,
+        @query language: string,
+        @query version: string,
+        @query dryRun?: boolean = false
+    ): {
+        @statusCode statusCode: 200;
+        @body result: RevisionResolveResult;
+    } | BadRequestErrorResponse | UnauthorizedErrorResponse | NotFoundErrorResponse | InternalServerErrorResponse;
+
+    /**
      * Get full metadata for a review and revision.
      * Requires a revisionId (obtained from the /resolve endpoint).
      * 


### PR DESCRIPTION
This PR adds a new endpoint to mark a package as released rather than relying on the existing, convoluted logic built into `auto-review/create` and `auto-review/upload`.

This endpoint will be used by the `azsdk package mark-released` command and will allow a greatly simplified command surface. 