### PR TITLE
Remove mcp repo from eng/common sync

### DIFF
--- a/eng/pipelines/sync-eng-common.yml
+++ b/eng/pipelines/sync-eng-common.yml
@@ -29,8 +29,9 @@ parameters:
       RepoName: azure-sdk-for-rust
     - RepoOwner: Azure
       RepoName: azure-rest-api-specs
-    - RepoOwner: Microsoft
-      RepoName: mcp
+    # TODO: Enable mcp syncing once the repo is updated to latest
+    # - RepoOwner: Microsoft
+    #   RepoName: mcp
 - name: RepoOwners
   type: object
   default:


### PR DESCRIPTION
Disabling mcp repo syncing temporarily because it's CI scripts are out of date and blocking changes to eng/common from the sync pipeline.