### PR TITLE
Update eng/common to encompass mcp

### DIFF
--- a/eng/pipelines/sync-eng-common.yml
+++ b/eng/pipelines/sync-eng-common.yml
@@ -29,9 +29,8 @@ parameters:
       RepoName: azure-sdk-for-rust
     - RepoOwner: Azure
       RepoName: azure-rest-api-specs
-    # TODO: Enable mcp syncing once the repo is updated to latest
-    # - RepoOwner: Microsoft
-    #   RepoName: mcp
+    - RepoOwner: Microsoft
+      RepoName: mcp
 - name: RepoOwners
   type: object
   default:


### PR DESCRIPTION
This pull request makes a minor update to the pipeline configuration by enabling synchronization for the `mcp` repository now that it has been updated.

* Pipeline configuration:
  * Enabled syncing for the `mcp` repository by uncommenting and activating its entry in the `parameters` section of `eng/pipelines/sync-eng-common.yml`.