### PR TITLE
Point vcpkg asset cache at the Terrapin mirror

### DIFF
--- a/eng/common/pipelines/templates/steps/set-vcpkg-cache-vars.yml
+++ b/eng/common/pipelines/templates/steps/set-vcpkg-cache-vars.yml
@@ -6,9 +6,10 @@ parameters:
 
 steps:
   - pwsh: |
-      Write-Host "Setting vcpkg cache variables for read only access to vcpkg binary and asset caches"
+      Write-Host "Setting vcpkg cache variables for read only access to the vcpkg binary cache"
       Write-Host '##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azcopy,https://azuresdkartifacts.blob.core.windows.net/public-vcpkg-container,read'
-      Write-Host '##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES_SECRET;issecret=true;]clear;x-azurl,https://azuresdkartifacts.blob.core.windows.net/public-vcpkg-container,,read'
+      Write-Host "Setting Terrapin asset source for read only access to the vcpkg source mirror"
+      Write-Host '##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES]clear;x-azurl,https://vcpkg.storage.devpackages.microsoft.io/artifacts/;x-block-origin'
     displayName: Set vcpkg variables
 
   - ${{if eq(variables['System.TeamProject'], 'internal') }}:

--- a/eng/common/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/common/scripts/Set-VcpkgWriteModeCache.ps1
@@ -20,4 +20,3 @@ Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SAS_TOKEN;issecret=true
 
 Write-Host "Setting vcpkg binary cache to read and write"
 Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azcopy-sas,https://$StorageAccountName.blob.core.windows.net/$StorageContainerName,$vcpkgBinarySourceSas,readwrite"
-Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES_SECRET;issecret=true;]clear;x-azurl,https://$StorageAccountName.blob.core.windows.net/$StorageContainerName,$vcpkgBinarySourceSas,readwrite"


### PR DESCRIPTION
Routes vcpkg asset (source tarball) downloads through the Microsoft-hosted Terrapin mirror instead of the `azuresdkartifacts` storage account, so vcpkg builds fetch upstream sources from an approved mirror under 1ES Network Isolation.

- `set-vcpkg-cache-vars.yml` — sets `X_VCPKG_ASSET_SOURCES` to the Terrapin mirror with `x-block-origin`, so a source missing from the mirror fails the build instead of silently falling back to the public internet. The value carries no SAS token, so it no longer needs `X_VCPKG_ASSET_SOURCES_SECRET`.
- `Set-VcpkgWriteModeCache.ps1` — drops the write-mode asset source, which overrode the read-only mirror in internal builds. The binary cache is unchanged and stays read/write.

Unblocks Azure/azure-sdk-for-cpp#7214, which currently has to touch `eng/common` directly.

C++ is the only language repo using vcpkg meaningfully. The tools-local `eng/scripts/Set-VcpkgWriteModeCache.ps1` is not synced and is intentionally left alone.