### PR TITLE
Exclude service root files from auto-release package detection

### DIFF
--- a/eng/common-tests/scripts/AutoRelease-Operations.Tests.ps1
+++ b/eng/common-tests/scripts/AutoRelease-Operations.Tests.ps1
@@ -203,4 +203,37 @@ Describe "New-GitHubPullRequestDiffObject" -Tag "UnitTest", "AutoRelease-Operati
         $diff.ExcludePaths | Should -Contain 'sdk/foo/'
         $diff.PRNumber | Should -BeExactly '5'
     }
+
+    It "excludes service-root files when requested" {
+      $files = @(
+        [PSCustomObject]@{ filename = "sdk/storage/ci.yml"; status = "modified" },
+        [PSCustomObject]@{ filename = "sdk/storage/README.md"; status = "removed" },
+        [PSCustomObject]@{ filename = "sdk\storage\swagger_to_sdk_config.json"; status = "renamed"; previous_filename = "sdk\storage\ci.storage.yml" },
+        [PSCustomObject]@{ filename = "sdk/storage/azure-storage-blob/pom.xml"; status = "modified" },
+        [PSCustomObject]@{ filename = "eng/common/file.txt"; status = "modified" }
+      )
+
+      $diff = New-GitHubPullRequestDiffObject `
+        -PullRequestNumber 123 `
+        -PullRequestFiles $files `
+        -ExcludeServiceRootFiles
+
+      $diff.ChangedFiles | Should -Be @(
+        "eng/common/file.txt"
+        "sdk/storage/azure-storage-blob/pom.xml"
+      )
+      $diff.DeletedFiles | Should -BeNullOrEmpty
+      $diff.ChangedServices | Should -Be @("storage")
+  }
+
+  It "retains service-root files by default" {
+      $files = @(
+        [PSCustomObject]@{ filename = "sdk/storage/ci.yml"; status = "modified" }
+      )
+
+      $diff = New-GitHubPullRequestDiffObject -PullRequestNumber 123 -PullRequestFiles $files
+
+      $diff.ChangedFiles | Should -Be @("sdk/storage/ci.yml")
+      $diff.ChangedServices | Should -Be @("storage")
+  }
 }

--- a/eng/common-tests/scripts/AutoRelease-Operations.Tests.ps1
+++ b/eng/common-tests/scripts/AutoRelease-Operations.Tests.ps1
@@ -205,35 +205,35 @@ Describe "New-GitHubPullRequestDiffObject" -Tag "UnitTest", "AutoRelease-Operati
     }
 
     It "excludes service-root files when requested" {
-      $files = @(
-        [PSCustomObject]@{ filename = "sdk/storage/ci.yml"; status = "modified" },
-        [PSCustomObject]@{ filename = "sdk/storage/README.md"; status = "removed" },
-        [PSCustomObject]@{ filename = "sdk\storage\swagger_to_sdk_config.json"; status = "renamed"; previous_filename = "sdk\storage\ci.storage.yml" },
-        [PSCustomObject]@{ filename = "sdk/storage/azure-storage-blob/pom.xml"; status = "modified" },
-        [PSCustomObject]@{ filename = "eng/common/file.txt"; status = "modified" }
-      )
+        $files = @(
+            [pscustomobject]@{ filename = "sdk/storage/ci.yml"; status = "modified" },
+            [pscustomobject]@{ filename = "sdk/storage/README.md"; status = "removed" },
+            [pscustomobject]@{ filename = "sdk\storage\swagger_to_sdk_config.json"; status = "renamed"; previous_filename = "sdk\storage\ci.storage.yml" },
+            [pscustomobject]@{ filename = "sdk/storage/azure-storage-blob/pom.xml"; status = "modified" },
+            [pscustomobject]@{ filename = "eng/common/file.txt"; status = "modified" }
+        )
 
-      $diff = New-GitHubPullRequestDiffObject `
-        -PullRequestNumber 123 `
-        -PullRequestFiles $files `
-        -ExcludeServiceRootFiles
+        $diff = New-GitHubPullRequestDiffObject `
+            -PullRequestNumber 123 `
+            -PullRequestFiles $files `
+            -ExcludeServiceRootFiles
 
-      $diff.ChangedFiles | Should -Be @(
-        "eng/common/file.txt"
-        "sdk/storage/azure-storage-blob/pom.xml"
-      )
-      $diff.DeletedFiles | Should -BeNullOrEmpty
-      $diff.ChangedServices | Should -Be @("storage")
-  }
+        $diff.ChangedFiles | Should -Be @(
+            "eng/common/file.txt"
+            "sdk/storage/azure-storage-blob/pom.xml"
+        )
+        $diff.DeletedFiles | Should -BeNullOrEmpty
+        $diff.ChangedServices | Should -Be @("storage")
+    }
 
-  It "retains service-root files by default" {
-      $files = @(
-        [PSCustomObject]@{ filename = "sdk/storage/ci.yml"; status = "modified" }
-      )
+    It "retains service-root files by default" {
+        $files = @(
+            [pscustomobject]@{ filename = "sdk/storage/ci.yml"; status = "modified" }
+        )
 
-      $diff = New-GitHubPullRequestDiffObject -PullRequestNumber 123 -PullRequestFiles $files
+        $diff = New-GitHubPullRequestDiffObject -PullRequestNumber 123 -PullRequestFiles $files
 
-      $diff.ChangedFiles | Should -Be @("sdk/storage/ci.yml")
-      $diff.ChangedServices | Should -Be @("storage")
-  }
+        $diff.ChangedFiles | Should -Be @("sdk/storage/ci.yml")
+        $diff.ChangedServices | Should -Be @("storage")
+    }
 }

--- a/eng/common/scripts/AutoRelease-Operations.ps1
+++ b/eng/common/scripts/AutoRelease-Operations.ps1
@@ -87,6 +87,8 @@ function Get-GitHubAutoReleasePullRequestForCommit {
 #   PullRequestNumber : the PR number recorded in the diff object.
 #   PullRequestFiles  : the file entries returned by Get-GitHubPullRequestFiles.
 #   ExcludePaths      : optional paths to record on the diff object.
+#   ExcludeServiceRootFiles : excludes files directly under sdk/<service> so they do not resolve every
+#                             package in that service.
 #
 # Returns a PSCustomObject with ChangedFiles, ChangedServices, ExcludePaths, DeletedFiles, PRNumber.
 function New-GitHubPullRequestDiffObject {
@@ -97,7 +99,8 @@ function New-GitHubPullRequestDiffObject {
     [AllowEmptyCollection()]
     [array] $PullRequestFiles,
     [AllowEmptyCollection()]
-    [array] $ExcludePaths = @()
+    [array] $ExcludePaths = @(),
+    [switch] $ExcludeServiceRootFiles
   )
 
   $changedFiles = @()
@@ -117,6 +120,12 @@ function New-GitHubPullRequestDiffObject {
     if ($file.status -eq 'renamed' -and $file.previous_filename) {
       $deletedFiles += ("$($file.previous_filename)" -replace '\\', '/')
     }
+  }
+
+  if ($ExcludeServiceRootFiles) {
+    $serviceRootFilePattern = '^sdk/[^/]+/[^/]+$'
+    $changedFiles = @($changedFiles | Where-Object { $_ -notmatch $serviceRootFilePattern })
+    $deletedFiles = @($deletedFiles | Where-Object { $_ -notmatch $serviceRootFilePattern })
   }
 
   $changedFiles = @($changedFiles | Where-Object { $_ } | Sort-Object -Unique)

--- a/eng/common/scripts/Resolve-AutoReleasePackages.ps1
+++ b/eng/common/scripts/Resolve-AutoReleasePackages.ps1
@@ -10,8 +10,8 @@ commit, this script:
      'auto-release' label.
   2. Builds a PR diff object (New-GitHubPullRequestDiffObject) from the PR's changed files and reuses
      the repo's existing package-detection logic (Get-PrPkgProperties) to identify the changed packages
-     (honoring triggering paths, deleted files and service-level changes), excluding
-     validation-only packages. Get-PrPkgProperties delegates to each repo's own
+      (honoring triggering paths and deleted files while ignoring files directly under service folders),
+      excluding validation-only packages. Get-PrPkgProperties delegates to each repo's own
      Get-AllPackageInfoFromRepo (language-settings.ps1), so this script works for any language repo.
   3. Intersects those packages with this pipeline's declared artifacts and emits Azure DevOps output
      variables consumed by the release stages. Both consumption styles are emitted:
@@ -135,7 +135,10 @@ function Invoke-AutoReleaseResolution {
   # package-detection logic to identify the changed packages.
   Write-Host "Fetching changed files for PR $prLink..."
   $files = @(Get-GitHubPullRequestFiles -RepoId $RepoId -PullRequestNumber $pr.number -AuthToken $AuthToken)
-  $diff = New-GitHubPullRequestDiffObject -PullRequestNumber $pr.number -PullRequestFiles $files
+  $diff = New-GitHubPullRequestDiffObject `
+    -PullRequestNumber $pr.number `
+    -PullRequestFiles $files `
+    -ExcludeServiceRootFiles
   Write-Host "PR $prLink changed $($diff.ChangedFiles.Count) file(s) and deleted $($diff.DeletedFiles.Count) file(s)."
 
   $diffPath = Join-Path ([System.IO.Path]::GetTempPath()) ("autorelease-diff-" + [System.Guid]::NewGuid().ToString('N') + ".json")

--- a/eng/common/scripts/Resolve-AutoReleasePackages.ps1
+++ b/eng/common/scripts/Resolve-AutoReleasePackages.ps1
@@ -10,8 +10,9 @@ commit, this script:
      'auto-release' label.
   2. Builds a PR diff object (New-GitHubPullRequestDiffObject) from the PR's changed files and reuses
      the repo's existing package-detection logic (Get-PrPkgProperties) to identify the changed packages
-      (honoring triggering paths and deleted files while ignoring files directly under service folders),
-      excluding validation-only packages. Get-PrPkgProperties delegates to each repo's own
+      (honoring triggering paths and deleted files while ignoring only files directly under
+      sdk/<service>/, not files in package subdirectories), excluding validation-only packages.
+      Get-PrPkgProperties delegates to each repo's own
      Get-AllPackageInfoFromRepo (language-settings.ps1), so this script works for any language repo.
   3. Intersects those packages with this pipeline's declared artifacts and emits Azure DevOps output
      variables consumed by the release stages. Both consumption styles are emitted:


### PR DESCRIPTION
## Summary
- exclude files directly under `sdk/<service>` when resolving auto-release packages
- preserve nested package file changes and deleted-file handling
- add coverage for the opt-in filtering behavior

## Why
Service-folder root files can affect an entire service in general package detection, but should not cause every package in that service to be selected for auto-release.

## Testing
- Added Pester coverage in `AutoRelease-Operations.Tests.ps1`