### PR TITLE
configure npm to use `azure-sdk-for-js` registry for TypeSpec generation

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/NpmOptionsTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/NpmOptionsTests.cs
@@ -3,8 +3,6 @@
 
 using System.Runtime.InteropServices;
 using Azure.Sdk.Tools.Cli.Helpers;
-using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Helpers
 {
@@ -249,83 +247,4 @@ namespace Azure.Sdk.Tools.Cli.Tests.Helpers
         }
     }
 
-    [TestFixture]
-    public class TspClientHelperTests
-    {
-        private const string AzureSdkNpmRegistry = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/";
-
-        private Mock<INpmHelper> _npmHelper = null!;
-        private Mock<ITypeSpecHelper> _typeSpecHelper = null!;
-        private Mock<IGitHelper> _gitHelper = null!;
-        private TspClientHelper _helper = null!;
-        private string _tempDirectory = null!;
-
-        [SetUp]
-        public void SetUp()
-        {
-            _tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-            Directory.CreateDirectory(_tempDirectory);
-
-            _npmHelper = new Mock<INpmHelper>();
-            _typeSpecHelper = new Mock<ITypeSpecHelper>();
-            _gitHelper = new Mock<IGitHelper>();
-
-            _gitHelper
-                .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(_tempDirectory);
-            _typeSpecHelper
-                .Setup(x => x.IsRepoPathForSpecRepoAsync(_tempDirectory, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(false);
-
-            _helper = new TspClientHelper(
-                _npmHelper.Object,
-                _typeSpecHelper.Object,
-                _gitHelper.Object,
-                NullLogger<TspClientHelper>.Instance);
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            Directory.Delete(_tempDirectory, recursive: true);
-        }
-
-        [Test]
-        public async Task UpdateGenerationAsync_SetsAzureSdkNpmRegistry()
-        {
-            File.WriteAllText(Path.Combine(_tempDirectory, "tsp-location.yaml"), "directory: specification/test");
-            NpmOptions? capturedOptions = null;
-            _npmHelper
-                .Setup(x => x.Run(It.IsAny<NpmOptions>(), It.IsAny<CancellationToken>()))
-                .Callback<NpmOptions, CancellationToken>((options, _) => capturedOptions = options)
-                .ReturnsAsync(new ProcessResult { ExitCode = 0 });
-
-            var result = await _helper.UpdateGenerationAsync(_tempDirectory);
-
-            Assert.That(result.IsSuccessful, Is.True);
-            AssertRegistry(capturedOptions);
-        }
-
-        [Test]
-        public async Task InitializeGenerationAsync_SetsAzureSdkNpmRegistry()
-        {
-            NpmOptions? capturedOptions = null;
-            _npmHelper
-                .Setup(x => x.Run(It.IsAny<NpmOptions>(), It.IsAny<CancellationToken>()))
-                .Callback<NpmOptions, CancellationToken>((options, _) => capturedOptions = options)
-                .ReturnsAsync(new ProcessResult { ExitCode = 0 });
-
-            var result = await _helper.InitializeGenerationAsync(_tempDirectory, "tspconfig.yaml");
-
-            Assert.That(result.IsSuccessful, Is.True);
-            AssertRegistry(capturedOptions);
-        }
-
-        private static void AssertRegistry(NpmOptions? options)
-        {
-            Assert.That(options, Is.Not.Null);
-            Assert.That(options!.EnvironmentVariables, Is.Not.Null);
-            Assert.That(options.EnvironmentVariables!["npm_config_registry"], Is.EqualTo(AzureSdkNpmRegistry));
-        }
-    }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/NpmOptionsTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/NpmOptionsTests.cs
@@ -3,6 +3,8 @@
 
 using System.Runtime.InteropServices;
 using Azure.Sdk.Tools.Cli.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Helpers
 {
@@ -244,6 +246,86 @@ namespace Azure.Sdk.Tools.Cli.Tests.Helpers
             // Only the binary name was provided, so remaining args should be empty
             Assert.That(options.Args, Has.No.Member("my-tool"));
             Assert.That(options.Args, Has.No.Member("exec"));
+        }
+    }
+
+    [TestFixture]
+    public class TspClientHelperTests
+    {
+        private const string AzureSdkNpmRegistry = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/";
+
+        private Mock<INpmHelper> _npmHelper = null!;
+        private Mock<ITypeSpecHelper> _typeSpecHelper = null!;
+        private Mock<IGitHelper> _gitHelper = null!;
+        private TspClientHelper _helper = null!;
+        private string _tempDirectory = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(_tempDirectory);
+
+            _npmHelper = new Mock<INpmHelper>();
+            _typeSpecHelper = new Mock<ITypeSpecHelper>();
+            _gitHelper = new Mock<IGitHelper>();
+
+            _gitHelper
+                .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_tempDirectory);
+            _typeSpecHelper
+                .Setup(x => x.IsRepoPathForSpecRepoAsync(_tempDirectory, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+
+            _helper = new TspClientHelper(
+                _npmHelper.Object,
+                _typeSpecHelper.Object,
+                _gitHelper.Object,
+                NullLogger<TspClientHelper>.Instance);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+
+        [Test]
+        public async Task UpdateGenerationAsync_SetsAzureSdkNpmRegistry()
+        {
+            File.WriteAllText(Path.Combine(_tempDirectory, "tsp-location.yaml"), "directory: specification/test");
+            NpmOptions? capturedOptions = null;
+            _npmHelper
+                .Setup(x => x.Run(It.IsAny<NpmOptions>(), It.IsAny<CancellationToken>()))
+                .Callback<NpmOptions, CancellationToken>((options, _) => capturedOptions = options)
+                .ReturnsAsync(new ProcessResult { ExitCode = 0 });
+
+            var result = await _helper.UpdateGenerationAsync(_tempDirectory);
+
+            Assert.That(result.IsSuccessful, Is.True);
+            AssertRegistry(capturedOptions);
+        }
+
+        [Test]
+        public async Task InitializeGenerationAsync_SetsAzureSdkNpmRegistry()
+        {
+            NpmOptions? capturedOptions = null;
+            _npmHelper
+                .Setup(x => x.Run(It.IsAny<NpmOptions>(), It.IsAny<CancellationToken>()))
+                .Callback<NpmOptions, CancellationToken>((options, _) => capturedOptions = options)
+                .ReturnsAsync(new ProcessResult { ExitCode = 0 });
+
+            var result = await _helper.InitializeGenerationAsync(_tempDirectory, "tspconfig.yaml");
+
+            Assert.That(result.IsSuccessful, Is.True);
+            AssertRegistry(capturedOptions);
+        }
+
+        private static void AssertRegistry(NpmOptions? options)
+        {
+            Assert.That(options, Is.Not.Null);
+            Assert.That(options!.EnvironmentVariables, Is.Not.Null);
+            Assert.That(options.EnvironmentVariables!["npm_config_registry"], Is.EqualTo(AzureSdkNpmRegistry));
         }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/TspClientHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/TspClientHelperTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Azure.Sdk.Tools.Cli.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Azure.Sdk.Tools.Cli.Tests.Helpers;
+
+[TestFixture]
+public class TspClientHelperTests
+{
+    private const string AzureSdkNpmRegistry = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/";
+
+    private Mock<INpmHelper> _npmHelper = null!;
+    private Mock<ITypeSpecHelper> _typeSpecHelper = null!;
+    private Mock<IGitHelper> _gitHelper = null!;
+    private TspClientHelper _helper = null!;
+    private string _tempDirectory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(_tempDirectory);
+
+        _npmHelper = new Mock<INpmHelper>();
+        _typeSpecHelper = new Mock<ITypeSpecHelper>();
+        _gitHelper = new Mock<IGitHelper>();
+
+        _gitHelper
+            .Setup(x => x.DiscoverRepoRootAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_tempDirectory);
+        _typeSpecHelper
+            .Setup(x => x.IsRepoPathForSpecRepoAsync(_tempDirectory, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _helper = new TspClientHelper(
+            _npmHelper.Object,
+            _typeSpecHelper.Object,
+            _gitHelper.Object,
+            NullLogger<TspClientHelper>.Instance);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task UpdateGenerationAsync_SetsAzureSdkNpmRegistry()
+    {
+        File.WriteAllText(Path.Combine(_tempDirectory, "tsp-location.yaml"), "directory: specification/test");
+        NpmOptions? capturedOptions = null;
+        _npmHelper
+            .Setup(x => x.Run(It.IsAny<NpmOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<NpmOptions, CancellationToken>((options, _) => capturedOptions = options)
+            .ReturnsAsync(new ProcessResult { ExitCode = 0 });
+
+        var result = await _helper.UpdateGenerationAsync(_tempDirectory);
+
+        Assert.That(result.IsSuccessful, Is.True);
+        AssertRegistry(capturedOptions);
+    }
+
+    [Test]
+    public async Task InitializeGenerationAsync_SetsAzureSdkNpmRegistry()
+    {
+        NpmOptions? capturedOptions = null;
+        _npmHelper
+            .Setup(x => x.Run(It.IsAny<NpmOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<NpmOptions, CancellationToken>((options, _) => capturedOptions = options)
+            .ReturnsAsync(new ProcessResult { ExitCode = 0 });
+
+        var result = await _helper.InitializeGenerationAsync(_tempDirectory, "tspconfig.yaml");
+
+        Assert.That(result.IsSuccessful, Is.True);
+        AssertRegistry(capturedOptions);
+    }
+
+    private static void AssertRegistry(NpmOptions? options)
+    {
+        Assert.That(options, Is.Not.Null);
+        Assert.That(options!.EnvironmentVariables, Is.Not.Null);
+        Assert.That(options.EnvironmentVariables!["npm_config_registry"], Is.EqualTo(AzureSdkNpmRegistry));
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Process/Options/NpmOptions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/Process/Options/NpmOptions.cs
@@ -31,18 +31,21 @@ public class NpmOptions : ProcessOptions, IProcessOptions
     /// <param name="logOutputStream">Whether to log the output stream. Defaults to true.</param>
     /// <param name="workingDirectory">The working directory for the command. Defaults to current directory.</param>
     /// <param name="timeout">The timeout for the command. Defaults to 2 minutes.</param>
+    /// <param name="environmentVariables">Optional environment variables for the npm process and its child processes.</param>
     public NpmOptions(
         string? prefix,
         string[] args,
         bool logOutputStream = true,
         string? workingDirectory = null,
-        TimeSpan? timeout = null
+        TimeSpan? timeout = null,
+        IDictionary<string, string>? environmentVariables = null
     ) : base(
         ResolveBinCommand(prefix, args) ?? NPM,
         ResolveBinArgs(prefix, args),
         logOutputStream,
         workingDirectory,
-        timeout)
+        timeout,
+        environmentVariables)
     {
         Prefix = prefix;
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TspClientHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TspClientHelper.cs
@@ -13,6 +13,8 @@ public class TspClientHelper : ITspClientHelper
     private readonly IGitHelper gitHelper;
     private readonly ILogger<TspClientHelper> logger;
     private const int CommandTimeoutInMinutes = 30;
+    // Public Azure Artifacts feed containing the latest @azure-tools TypeSpec packages and upstreaming npmjs.org.
+    private const string AzureSdkNpmRegistry = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/";
 
     public TspClientHelper(INpmHelper npmHelper, ITypeSpecHelper typeSpecHelper, IGitHelper gitHelper, ILogger<TspClientHelper> logger)
     {
@@ -113,7 +115,8 @@ public class TspClientHelper : ITspClientHelper
             args.ToArray(),
             logOutputStream: true,
             workingDirectory: tspLocationDirectory,
-            timeout: TimeSpan.FromMinutes(CommandTimeoutInMinutes)
+            timeout: TimeSpan.FromMinutes(CommandTimeoutInMinutes),
+            environmentVariables: CreateNpmEnvironmentVariables()
         );
 
         var result = await npmHelper.Run(npmOptions, ct);
@@ -154,7 +157,8 @@ public class TspClientHelper : ITspClientHelper
             arguments.ToArray(),
             logOutputStream: true,
             workingDirectory: workingDirectory,
-            timeout: TimeSpan.FromMinutes(CommandTimeoutInMinutes)
+            timeout: TimeSpan.FromMinutes(CommandTimeoutInMinutes),
+            environmentVariables: CreateNpmEnvironmentVariables()
         );
 
         var result = await npmHelper.Run(npmOptions, ct);
@@ -173,4 +177,12 @@ public class TspClientHelper : ITspClientHelper
             TypeSpecProject = workingDirectory
         };
     }
+
+    private static Dictionary<string, string> CreateNpmEnvironmentVariables() =>
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            // Always use the central Azure Artifacts feed for secure, compliant packages and immediate access to new
+            // @azure-tools releases, avoiding the seven-day delay imposed by the internal package feed proxy.
+            ["npm_config_registry"] = AzureSdkNpmRegistry
+        };
 }


### PR DESCRIPTION
Pin `tsp-client init` and `tsp-client update` to leverage the public `azure-sdk-for-js` npm feed. This fixes an issue where generate SDK fails on a current local run.

For corp-managed machines, `tsp-client update` uses the package feed proxy (`packagefeedproxy.microsoft.io`). The package feed in this case, returned a 404 for `@azure-tools/typespec-go` because newly published `@azure-tools` packages can take up to seven days to become available.

To address this, we pin the npm feed used to `azure-sdk-for-js` (without modifying the user's `~/.npmrc` file). Using the public hosted Azure Artifacts feed is also more secure and compliant.