### PR TITLE
Adding the pipeline-fix prefix to scheduled branch cleanup

### DIFF
--- a/eng/pipelines/branch-cleanup.yml
+++ b/eng/pipelines/branch-cleanup.yml
@@ -121,7 +121,7 @@ jobs:
             filePath: $(System.DefaultWorkingDirectory)/eng/common/scripts/Delete-RemoteBranches.ps1
             arguments: >
               -RepoId "${{ repo }}"
-              -BranchRegex "^(increment-package-version-|fluent-lite-generation-|auto-update-|version-increment-build-|post-release-automation-|restapi_auto_|t2-).*$"
+              -BranchRegex "^(increment-package-version-|fluent-lite-generation-|auto-update-|version-increment-build-|post-release-automation-|restapi_auto_|t2-|pipeline-fix/).*$"
               -LastCommitOlderThan ((Get-Date).AddDays(-1))
               -AuthToken $(GH_TOKEN_azure-sdk)
               -WhatIf:$${{parameters.WhatIfPreference}}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/EngSys/PipelineFixEvaluatorHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/EngSys/PipelineFixEvaluatorHelperTests.cs
@@ -14,7 +14,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Helpers.EngSys;
 /// Seam: <see cref="PipelineFixEvaluatorHelper.EvaluatePipelineFixesAsync"/> turns a repository and a
 /// time window into one telemetry row per Copilot pipeline-fix attempt, given <see cref="IGitHubService"/>
 /// and <see cref="IPipelineFixSurvivalJudge"/>. Two delivery paths feed it: an @copilot mention that pushes
-/// commits onto the pull request, and the auto-fix workflow that opens a separate copilot-pipeline-fix/ pull
+/// commits onto the pull request, and the auto-fix workflow that opens a separate pipeline-fix/ pull
 /// request.
 /// </summary>
 [TestFixture]
@@ -23,7 +23,7 @@ public class PipelineFixEvaluatorHelperTests
     private const string Owner = "ReilleyMilne";
     private const string Repo = "azure-sdk-for-python";
     private const string CheckName = "ReilleyMilne.azure-sdk-for-python - pullrequest (Analyze Analyze)";
-    private const string FixBranchPrefix = "copilot-pipeline-fix/";
+    private const string FixBranchPrefix = "pipeline-fix/";
 
     // Real shapes captured from ReilleyMilne/azure-sdk-for-python#36, the auto-fix pull request opened for #35.
     private const int OriginalPrNumber = 35;
@@ -31,7 +31,7 @@ public class PipelineFixEvaluatorHelperTests
     private const string FailingSha = "f8eedcaef0bed15bc45b7b620d28461958311c95";
     private const string FixHeadSha = "e7f1ea3de721a53bd3e0c0f83173e2b83455ac75";
     private const string FixBranchRef =
-        "copilot-pipeline-fix/pr-35-f8eedcaef0bed15bc45b7b620d28461958311c95/run-30861672656/copilot-pipeline-fix/fix-analyze-pr35-68fe750a7ab81983";
+        "pipeline-fix/pr-35-f8eedcaef0bed15bc45b7b620d28461958311c95/run-30861672656/pipeline-fix/fix-analyze-pr35-68fe750a7ab81983";
 
     private static readonly DateTimeOffset Since = new(2026, 8, 1, 0, 0, 0, TimeSpan.Zero);
     private static readonly DateTimeOffset Until = new(2026, 8, 4, 0, 0, 0, TimeSpan.Zero);
@@ -235,7 +235,7 @@ public class PipelineFixEvaluatorHelperTests
             Times.Never);
     }
 
-    // A copilot-pipeline-fix/ head belongs to the workflow path; treating it as a mention too would count the
+    // A pipeline-fix/ head belongs to the workflow path; treating it as a mention too would count the
     // same fix twice.
     [Test]
     public async Task MentionFix_HeadIsFixBranch_IsSkippedBeforeFetchingComments()

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 0.6.36 (Unreleased)
+## 0.6.36 (2026-08-18)
 
 ### Features Added
 
 - Added `eng evaluate` CLI command to evaluate whether Copilot's fixes for failing pipelines took the pipeline from failure to success and survived into the merged pull request. Accepts a repository owner and name. Optional parameters: `--since-days`, `--model`.
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 0.6.35 (2026-08-14)
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.6.36 (2026-08-18)
+## 0.6.36 (2026-08-19)
 
 ### Features Added
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/EngSys/PipelineFixEvaluatorHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/EngSys/PipelineFixEvaluatorHelper.cs
@@ -39,10 +39,10 @@ public class PipelineFixEvaluatorHelper(
     private const string BotLoginSuffix = "[bot]";
     private const string GitHubCommitterName = "GitHub";
     private const string ActionsBotName = "github-actions[bot]";
-    private const string FixBranchPrefix = "copilot-pipeline-fix/";
+    private const string FixBranchPrefix = "pipeline-fix/";
     private static readonly string[] CopilotAuthors = ["Copilot", "copilot-swe-agent[bot]"];
     private static readonly Regex FixBranch =
-        new(@"^copilot-pipeline-fix/pr-(\d+)-([0-9a-f]{40})/", RegexOptions.IgnoreCase);
+        new(@"^pipeline-fix/pr-(\d+)-([0-9a-f]{40})/", RegexOptions.IgnoreCase);
 
     private const string EvidenceMarker = "<!-- pipeline-analysis-ci-evidence -->";
     private static readonly Regex EvidenceCommit = new(@"Commit `([0-9a-f]{40})`", RegexOptions.IgnoreCase);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Pipeline/EvaluationEnums.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Pipeline/EvaluationEnums.cs
@@ -13,7 +13,7 @@ namespace Azure.Sdk.Tools.Cli.Models.Pipeline;
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum CopilotFixTrigger
 {
-    /// The pipeline-analysis auto-fix workflow produced the commit on a copilot-pipeline-fix/pr-N branch.
+    /// The pipeline-analysis auto-fix workflow produced the commit on a pipeline-fix/pr-N branch.
     GitHubActionsWorkflow,
 
     /// Somebody directed Copilot at the pull request with an @copilot mention.


### PR DESCRIPTION
- The new pipeline analysis and fix workflow will automatically create branches for suggested changes. Adds the branch prefix created by the fix workflow to the `branch-cleanup.yml` pipeline.
- Updates the references to the branch prefix in the evaluation tool.
- Removes unnecessary `CHANGELOG.md` sections and update release date.

Fix workflow: https://github.com/Azure/azure-sdk-for-python/pull/48554