### PR TITLE
Add npm userconfig to typespec emitter template

### DIFF
--- a/eng/common/pipelines/templates/archetype-typespec-emitter.yml
+++ b/eng/common/pipelines/templates/archetype-typespec-emitter.yml
@@ -632,3 +632,5 @@ extends:
                   scriptLocation: "inlineScript"
                   inlineScript: npx tsp-spector upload-coverage --coverageFile $(Build.ArtifactStagingDirectory)/tsp-spector-coverage-azure.json --generatorName @azure-typespec/$(SpectorName) --storageAccountName typespec --containerName coverages --generatorVersion $(node -p -e "require('./package.json').version") --generatorMode azure
                   workingDirectory: $(Build.SourcesDirectory)/eng/packages/$(SpectorName)
+                env:
+                  npm_config_userconfig: $(emitterNpmrcPath)


### PR DESCRIPTION
Fixed the CFSClean compliance issue:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6716715&view=logs&j=5c952eb6-394a-5f6b-81c4-fd6e00460747&t=736dcc2e-9b84-59a7-5cdd-b2688910569e