### PR TITLE
[AzSdkCli] Skip ARH when apiHash is not provided

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/TestData/TestPrompts.json
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/TestData/TestPrompts.json
@@ -35,6 +35,10 @@
     { "toolName": "azsdk_engsys_codeowner_update_cache", "prompt": "Run the codeowner cache update pipeline to unblock releases", "category": "all" },
     { "toolName": "azsdk_engsys_codeowner_update_cache", "prompt": "Update the owners cache", "category": "all" },
 
+    { "toolName": "azsdk_sync_product_onboarding", "prompt": "Sync the product onboarding status for my service", "category": "all" },
+    { "toolName": "azsdk_sync_product_onboarding", "prompt": "Create a product onboarding work item for this service", "category": "all" },
+    { "toolName": "azsdk_sync_product_onboarding", "prompt": "Update the existing product onboarding details", "category": "all" },
+
     { "toolName": "azsdk_analyze_log_file", "prompt": "Analyze this log file for errors", "category": "all" },
     { "toolName": "azsdk_analyze_log_file", "prompt": "What errors are in this build log?", "category": "all" },
     { "toolName": "azsdk_cleanup_ai_agents", "prompt": "Clean up AI agents in my project", "category": "all" },

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackageMarkReleasedToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackageMarkReleasedToolTests.cs
@@ -104,10 +104,11 @@ public class PackageMarkReleasedToolTests
 
         var response = await MarkReleasedAsync();
 
-        Assert.That(response.ExitCode, Is.EqualTo(1));
+        Assert.That(response.ExitCode, Is.Zero);
         Assert.That(response.ApiReviewHubSucceeded, Is.False);
         Assert.That(response.ApiReviewHub, Is.Null);
         Assert.That(response.ApiViewSucceeded, Is.True);
+        Assert.That(response.ResponseErrors, Is.Empty);
         Assert.That(response.ToString(), Does.Contain("API Review Hub: FAILED - ARH failed"));
         Assert.That(response.ToString(), Does.Contain("APIView: SUCCEEDED - Release request resolved revision revision456 (review review123); revision is not released."));
         apiViewService.Verify(x => x.MarkPackageReleasedAsync(
@@ -124,10 +125,11 @@ public class PackageMarkReleasedToolTests
 
         var response = await MarkReleasedAsync();
 
-        Assert.That(response.ExitCode, Is.EqualTo(1));
+        Assert.That(response.ExitCode, Is.Zero);
         Assert.That(response.ApiReviewHubSucceeded, Is.True);
         Assert.That(response.ApiViewSucceeded, Is.False);
         Assert.That(response.ApiView, Is.Null);
+        Assert.That(response.ResponseErrors, Is.Empty);
         apiReviewHubService.Verify(x => x.MarkPackageReleasedAsync(
             It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), false), Times.Once);
     }
@@ -150,7 +152,7 @@ public class PackageMarkReleasedToolTests
     }
 
     [Test]
-    public async Task MarkReleasedAsync_WhenAPIViewReturnsServerError_Fails()
+    public async Task MarkReleasedAsync_WhenAPIViewReturnsServerError_ReviewHubSuccessPreventsFailure()
     {
         apiViewService
             .Setup(x => x.MarkPackageReleasedAsync(
@@ -159,9 +161,33 @@ public class PackageMarkReleasedToolTests
 
         var response = await MarkReleasedAsync();
 
-        Assert.That(response.ExitCode, Is.EqualTo(1));
+        Assert.That(response.ExitCode, Is.Zero);
         Assert.That(response.ApiViewSucceeded, Is.False);
-        Assert.That(response.ResponseErrors, Has.One.EqualTo("APIView: APIView server error"));
+        Assert.That(response.ResponseErrors, Is.Empty);
+    }
+
+    [Test]
+    public async Task MarkReleasedAsync_WhenBothBackendsFail_Fails()
+    {
+        apiReviewHubService
+            .Setup(x => x.MarkPackageReleasedAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+            .ThrowsAsync(new InvalidOperationException("ARH failed"));
+        apiViewService
+            .Setup(x => x.MarkPackageReleasedAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+            .ThrowsAsync(new HttpRequestException("APIView failed"));
+
+        var response = await MarkReleasedAsync();
+
+        Assert.That(response.ExitCode, Is.EqualTo(1));
+        Assert.That(response.ApiReviewHubSucceeded, Is.False);
+        Assert.That(response.ApiViewSucceeded, Is.False);
+        Assert.That(response.ResponseErrors, Is.EquivalentTo(new[]
+        {
+            "API Review Hub: ARH failed",
+            "APIView: APIView failed"
+        }));
     }
 
     [Test]
@@ -183,6 +209,58 @@ public class PackageMarkReleasedToolTests
     }
 
     [Test]
+    public async Task MarkReleasedAsync_WithoutApiHash_SkipsReviewHubWithoutFailing()
+    {
+        var response = await tool.MarkReleasedAsync(
+            "python",
+            "azure-test",
+            "1.0.0",
+            string.Empty,
+            "tjprescott");
+        var output = new OutputHelper(OutputHelper.OutputModes.Json).Format(response);
+
+        using var document = System.Text.Json.JsonDocument.Parse(output);
+        var reviewHub = document.RootElement.GetProperty("api_review_hub");
+
+        Assert.That(response.ExitCode, Is.Zero);
+        Assert.That(response.ApiReviewHubSucceeded, Is.False);
+        Assert.That(response.ApiReviewHubSkipped, Is.True);
+        Assert.That(response.ResponseErrors, Is.Empty);
+        Assert.That(response.ToString(), Does.Contain("API Review Hub: SKIPPED - Skipped because apiHash is required."));
+        Assert.That(reviewHub.GetProperty("skipped").GetBoolean(), Is.True);
+        Assert.That(reviewHub.GetProperty("message").GetString(), Is.EqualTo("Skipped because apiHash is required."));
+        Assert.That(document.RootElement.GetProperty("operation_status").GetString(), Is.EqualTo("Succeeded"));
+        Assert.That(document.RootElement.GetProperty("response_errors").GetArrayLength(), Is.Zero);
+        apiReviewHubService.Verify(x => x.MarkPackageReleasedAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Never);
+        apiViewService.Verify(x => x.MarkPackageReleasedAsync(
+            "azure-test", "python", "1.0.0", It.IsAny<CancellationToken>(), false), Times.Once);
+    }
+
+    [Test]
+    public async Task MarkReleasedAsync_WithoutApiHash_WhenAPIViewReturnsNotFound_Fails()
+    {
+        apiViewService
+            .Setup(x => x.MarkPackageReleasedAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+            .ThrowsAsync(new HttpRequestException("APIView revision not found", null, HttpStatusCode.NotFound));
+
+        var response = await tool.MarkReleasedAsync(
+            "python",
+            "azure-test",
+            "1.0.0",
+            string.Empty,
+            "tjprescott");
+
+        Assert.That(response.ExitCode, Is.EqualTo(1));
+        Assert.That(response.ApiReviewHubSkipped, Is.True);
+        Assert.That(response.ApiViewSucceeded, Is.False);
+        Assert.That(response.ResponseErrors, Has.One.EqualTo("APIView: APIView revision not found"));
+        apiReviewHubService.Verify(x => x.MarkPackageReleasedAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Never);
+    }
+
+    [Test]
     public void Command_AcceptsRepoOwner()
     {
         var command = tool.GetCommandInstances().Single();
@@ -196,14 +274,14 @@ public class PackageMarkReleasedToolTests
     public async Task Command_DryRun_PassesTrueToBothBackends()
     {
         var command = tool.GetCommandInstances().Single();
-        var parseResult = command.Parse("--language python --package-name azure-test --package-version 1.0.0 --dry-run");
+        var parseResult = command.Parse("--language python --package-name azure-test --package-version 1.0.0 --api-hash hash --dry-run");
 
         var response = await tool.HandleCommand(parseResult, CancellationToken.None);
 
         Assert.That(response.ToString(), Does.Contain("API Review Hub: SUCCEEDED - Dry run resolved package version"));
         Assert.That(response.ToString(), Does.Contain("APIView: SUCCEEDED - Dry run resolved revision revision456"));
         apiReviewHubService.Verify(x => x.MarkPackageReleasedAsync(
-            "python", "azure-test", "1.0.0", string.Empty, string.Empty, It.IsAny<CancellationToken>(), true), Times.Once);
+            "python", "azure-test", "1.0.0", "hash", string.Empty, It.IsAny<CancellationToken>(), true), Times.Once);
         apiViewService.Verify(x => x.MarkPackageReleasedAsync(
             "azure-test", "python", "1.0.0", It.IsAny<CancellationToken>(), true), Times.Once);
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.6.37 (Unreleased)
+## 0.6.37 (2026-08-21)
 
 ### Features Added
 
@@ -9,6 +9,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+
+- `package mark-released` now skips API Review Hub when `--api-hash` is omitted and succeeds when either API Review Hub or APIView succeeds, failing only when neither backend succeeds.
 
 ### Other Changes
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -6,13 +6,9 @@
 
 - Added `product-onboarding sync` CLI command to create or update product onboarding work items.
 
-### Breaking Changes
-
 ### Bugs Fixed
 
 - `package mark-released` now skips API Review Hub when `--api-hash` is omitted and succeeds when either API Review Hub or APIView succeeds, failing only when neither backend succeeds.
-
-### Other Changes
 
 ## 0.6.36 (2026-08-19)
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageMarkReleasedResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageMarkReleasedResponse.cs
@@ -22,6 +22,9 @@ public class PackageMarkReleasedResponse : CommandResponse
     public bool ApiReviewHubSucceeded { get; set; }
 
     [JsonIgnore]
+    public bool ApiReviewHubSkipped { get; set; }
+
+    [JsonIgnore]
     public string ApiReviewHubMessage { get; set; } = string.Empty;
 
     [JsonIgnore]
@@ -34,7 +37,8 @@ public class PackageMarkReleasedResponse : CommandResponse
     {
         StringBuilder output = new();
         output.AppendLine($"Package: {PackageName} {Version}");
-        output.AppendLine($"API Review Hub: {(ApiReviewHubSucceeded ? "SUCCEEDED" : "FAILED")} - {ApiReviewHubMessage}");
+        string apiReviewHubStatus = ApiReviewHubSkipped ? "SKIPPED" : ApiReviewHubSucceeded ? "SUCCEEDED" : "FAILED";
+        output.AppendLine($"API Review Hub: {apiReviewHubStatus} - {ApiReviewHubMessage}");
         output.AppendLine($"APIView: {(ApiViewSucceeded ? "SUCCEEDED" : "FAILED")} - {ApiViewMessage}");
         return output.ToString();
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/PackageMarkReleasedTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/PackageMarkReleasedTool.cs
@@ -73,20 +73,34 @@ public class PackageMarkReleasedTool(
         {
             JsonElement? reviewHubResponse = null;
             bool reviewHubSucceeded = false;
+            bool reviewHubSkipped = false;
             string reviewHubMessage;
-            try
+            if (string.IsNullOrWhiteSpace(apiHash))
             {
-                var result = await apiReviewHubService.MarkPackageReleasedAsync(language, packageName, packageVersion, apiHash, repoOwner, ct, dryRun);
-                reviewHubResponse = JsonSerializer.SerializeToElement(result, responseSerializerOptions);
-                reviewHubSucceeded = true;
-                string reviewHubAction = dryRun ? "Dry run resolved" : "Release request resolved";
-                reviewHubMessage = $"{reviewHubAction} package version {result.PackageVersionId}; approval is {result.ApprovalStatus}, release state is {(result.IsReleased ? "released" : "not released")}.";
+                reviewHubSkipped = true;
+                reviewHubMessage = "Skipped because apiHash is required.";
+                reviewHubResponse = JsonSerializer.SerializeToElement(new
+                {
+                    Skipped = true,
+                    Message = reviewHubMessage
+                }, responseSerializerOptions);
             }
-            catch (Exception ex)
+            else
             {
-                logger.LogError(ex, "Failed to mark {packageName} {packageVersion} released in API Review Hub", packageName, packageVersion);
-                reviewHubResponse = GetRawErrorResponse(ex);
-                reviewHubMessage = ex.Message;
+                try
+                {
+                    var result = await apiReviewHubService.MarkPackageReleasedAsync(language, packageName, packageVersion, apiHash, repoOwner, ct, dryRun);
+                    reviewHubResponse = JsonSerializer.SerializeToElement(result, responseSerializerOptions);
+                    reviewHubSucceeded = true;
+                    string reviewHubAction = dryRun ? "Dry run resolved" : "Release request resolved";
+                    reviewHubMessage = $"{reviewHubAction} package version {result.PackageVersionId}; approval is {result.ApprovalStatus}, release state is {(result.IsReleased ? "released" : "not released")}.";
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to mark {packageName} {packageVersion} released in API Review Hub", packageName, packageVersion);
+                    reviewHubResponse = GetRawErrorResponse(ex);
+                    reviewHubMessage = ex.Message;
+                }
             }
 
             JsonElement? apiViewResponse = null;
@@ -120,12 +134,12 @@ public class PackageMarkReleasedTool(
             }
 
             List<string> errors = [];
-            if (!reviewHubSucceeded)
+            if (!reviewHubSucceeded && !apiViewSucceeded)
             {
-                errors.Add($"API Review Hub: {reviewHubMessage}");
-            }
-            if (!apiViewSucceeded && apiViewFailureIsFatal)
-            {
+                if (!reviewHubSkipped)
+                {
+                    errors.Add($"API Review Hub: {reviewHubMessage}");
+                }
                 errors.Add($"APIView: {apiViewMessage}");
             }
 
@@ -135,6 +149,7 @@ public class PackageMarkReleasedTool(
                 Version = packageVersion,
                 ApiReviewHub = reviewHubResponse,
                 ApiReviewHubSucceeded = reviewHubSucceeded,
+                ApiReviewHubSkipped = reviewHubSkipped,
                 ApiReviewHubMessage = reviewHubMessage,
                 ApiView = apiViewResponse,
                 ApiViewSucceeded = apiViewSucceeded,

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ProductOnboarding/ProductOnboardingTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ProductOnboarding/ProductOnboardingTool.cs
@@ -145,6 +145,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ProductOnboarding
             }
         }
 
+        [McpServerTool(Name = SyncProductOnboardingToolName), Description("Create or update a product onboarding work item.")]
         public async Task<ProductOnboardingResponse> SyncProductOnboarding(
             Guid productId,
             string productName,


### PR DESCRIPTION
Previously, if you call this command without `--api-hash` it will still attempt to call ARH and fail (because the value is required). This would propagate to a command failure which would propagate to a CI failure.

The command should only fail is neither APIView nor ARH are able to mark the package released. If either succeeds, the command should succeed (so that the CI will succeed).