### PR TITLE
[APIView] Fix issue where filters were not applied

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Repositories/CosmosAPIRevisionsRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/CosmosAPIRevisionsRepository.cs
@@ -105,47 +105,38 @@ namespace APIViewWeb
 
             if (filterAndSortParams.Details != null && filterAndSortParams.Details.Count() > 0)
             {
-                queryStringBuilder.Append(" AND (");
-
                 var approvalFilters = filterAndSortParams.Details.Where(x => x == "Approved" || x == "Pending").ToList();
                 var apiRevisionTypeFilters = filterAndSortParams.Details.Where(x => x == "Manual" || x == "Automatic" || x == "PullRequest").ToList();
+                var detailClauses = new List<string>();
 
                 if (approvalFilters.Count() == 2)
                 {
-                    queryStringBuilder.Append($"c.IsApproved = true OR c.IsApproved = false");
+                    detailClauses.Add("(c.IsApproved = true OR c.IsApproved = false)");
                 }
                 else if (approvalFilters.Contains("Approved"))
                 {
-                    queryStringBuilder.Append($"c.IsApproved = true");
+                    detailClauses.Add("c.IsApproved = true");
                 }
                 else if (approvalFilters.Contains("Pending"))
                 {
-                    queryStringBuilder.Append($"c.IsApproved = false");
+                    detailClauses.Add("c.IsApproved = false");
                 }
 
-                if (approvalFilters.Count > 0 && apiRevisionTypeFilters.Count() > 0)
-                    queryStringBuilder.Append(" AND ");
-
-                foreach (var item in apiRevisionTypeFilters)
+                if (apiRevisionTypeFilters.Count > 0)
                 {
-                    switch (item)
-                    {
-                        case "Manual":
-                            queryStringBuilder.Append($"c.APIRevisionType = 'Manual'");
-                            break;
-                        case "Automatic":
-                            queryStringBuilder.Append($"c.APIRevisionType = 'Automatic'");
-                            break;
-                        case "PullRequest":
-                            queryStringBuilder.Append($"c.APIRevisionType = 'PullRequest'");
-                            break;
-                    }
-                    if (item != apiRevisionTypeFilters.Last())
-                    {
-                        queryStringBuilder.Append(" OR ");
-                    }
+                    var apiRevisionTypeClauses = apiRevisionTypeFilters.Select(item => $"c.APIRevisionType = '{item}'");
+                    detailClauses.Add($"({string.Join(" OR ", apiRevisionTypeClauses)})");
                 }
-                queryStringBuilder.Append(")");
+
+                if (filterAndSortParams.Details.Contains("Released"))
+                {
+                    detailClauses.Add("c.IsReleased = true");
+                }
+
+                if (detailClauses.Count > 0)
+                {
+                    queryStringBuilder.Append($" AND ({string.Join(" AND ", detailClauses)})");
+                }
             }
 
             int totalCount = 0;

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-page/review-page.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-page/review-page.component.ts
@@ -97,7 +97,7 @@ export class ReviewPageComponent implements OnInit, OnDestroy {
   crossLanguageRowData: CrossLanguageContentDto[] = [];
 
   private codePanelIsLoading: boolean = true;
-  apiRevisionPageSize = 200;
+  apiRevisionPageSize = 100;
   lastNodeIdUnhashedDiscarded = '';
 
   codeLineSearchText: string | undefined = undefined;

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-toolbar/review-toolbar.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-toolbar/review-toolbar.component.ts
@@ -21,6 +21,7 @@ import { CodeLineRowNavigationDirection, FULL_DIFF_STYLE, getTypeClass, TREE_DIF
 import { DIFF_API_REVISION_ID_QUERY_PARAM, DIFF_STYLE_QUERY_PARAM, getQueryParams } from 'src/app/_helpers/router-helpers';
 import { AzureEngSemanticVersion } from 'src/app/_models/azureEngSemanticVersion';
 import { LastUpdatedOnPipe } from 'src/app/_pipes/last-updated-on.pipe';
+import { APIRevisionsService } from 'src/app/_services/revisions/revisions.service';
 
 @Component({
   selector: 'app-review-toolbar',
@@ -76,6 +77,8 @@ export class ReviewToolbarComponent implements OnInit, OnChanges {
   selectedDiffAPIRevision: any = null;
   diffApiRevisionsSearchValue: string = '';
   diffApiRevisionsFilterValue: string | undefined = '';
+  private queriedRevisionFilters = new Set<string>();
+  private queriedReviewId: string | undefined;
 
   DIFF_API_REVISION_SELECT: string = 'diff-api';
 
@@ -119,7 +122,7 @@ export class ReviewToolbarComponent implements OnInit, OnChanges {
   totalMatchCountValue: number = 0;
   showSearchControls: boolean = false;
 
-  constructor(private route: ActivatedRoute, private router: Router) {}
+  constructor(private route: ActivatedRoute, private router: Router, private apiRevisionsService: APIRevisionsService) {}
 
   ngOnInit() {
     // Initialize settings from user profile
@@ -169,7 +172,10 @@ export class ReviewToolbarComponent implements OnInit, OnChanges {
 
     if (changes['apiRevisions'] || changes['activeApiRevisionId'] || changes['diffApiRevisionId']) {
       if (this.apiRevisions.length > 0) {
-        this.mappedApiRevisions = this.mapRevisionToMenu(this.apiRevisions);
+        const mappedApiRevisions = this.mapRevisionToMenu(this.apiRevisions);
+        this.mappedApiRevisions = Array.from(new Map(
+          [...this.mappedApiRevisions, ...mappedApiRevisions].map(apiRevision => [apiRevision.id, apiRevision])
+        ).values());
         this.tagSpecialRevisions(this.mappedApiRevisions);
 
         this.diffApiRevisionsMenu = this.mappedApiRevisions.filter((apiRevision: any) => apiRevision.id !== this.activeApiRevisionId);
@@ -221,6 +227,53 @@ export class ReviewToolbarComponent implements OnInit, OnChanges {
   }
 
   searchAndFilterDropdown(searchValue: string, filterValue: string | undefined) {
+    if (searchValue || filterValue) {
+      this.queryFilteredAPIRevisions(searchValue, filterValue);
+    }
+
+    this.applyDropdownFilter(searchValue, filterValue);
+  }
+
+  private queryFilteredAPIRevisions(searchValue: string, filterValue: string | undefined) {
+    const detailsByFilter: Record<string, string> = {
+      approved: 'Approved',
+      released: 'Released',
+      automatic: 'Automatic',
+      pullRequest: 'PullRequest',
+      manual: 'Manual'
+    };
+    const details = filterValue && detailsByFilter[filterValue] ? [detailsByFilter[filterValue]] : [];
+    const reviewId = this.apiRevisions[0]?.reviewId;
+    if (!reviewId) {
+      return;
+    }
+
+    if (this.queriedReviewId !== reviewId) {
+      this.queriedRevisionFilters.clear();
+      this.queriedReviewId = reviewId;
+    }
+    const queryKey = `${searchValue.trim().toLowerCase()}\u0000${filterValue || ''}`;
+    if (this.queriedRevisionFilters.has(queryKey)) {
+      return;
+    }
+    this.queriedRevisionFilters.add(queryKey);
+
+    this.apiRevisionsService.getAPIRevisions(
+      0, 100, reviewId, searchValue || undefined, undefined, details, 'createdOn', 1, false, false, true
+    ).subscribe({
+      next: (response) => {
+        const mappedResults = this.mapRevisionToMenu(response.result ?? []);
+        this.mappedApiRevisions = Array.from(new Map(
+          [...this.mappedApiRevisions, ...mappedResults].map(apiRevision => [apiRevision.id, apiRevision])
+        ).values());
+        this.tagSpecialRevisions(this.mappedApiRevisions);
+        this.applyDropdownFilter(searchValue, filterValue);
+      },
+      error: () => this.queriedRevisionFilters.delete(queryKey)
+    });
+  }
+
+  private applyDropdownFilter(searchValue: string, filterValue: string | undefined) {
     let filtered = this.mappedApiRevisions.filter((apiRevision: APIRevision) => {
       switch (filterValue) {
         case 'pullRequest':

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-toolbar/review-toolbar.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-toolbar/review-toolbar.component.ts
@@ -252,14 +252,15 @@ export class ReviewToolbarComponent implements OnInit, OnChanges {
       this.queriedRevisionFilters.clear();
       this.queriedReviewId = reviewId;
     }
-    const queryKey = `${searchValue.trim().toLowerCase()}\u0000${filterValue || ''}`;
+    const normalizedSearchValue = searchValue.trim();
+    const queryKey = `${normalizedSearchValue}\u0000${filterValue || ''}`;
     if (this.queriedRevisionFilters.has(queryKey)) {
       return;
     }
     this.queriedRevisionFilters.add(queryKey);
 
     this.apiRevisionsService.getAPIRevisions(
-      0, 100, reviewId, searchValue || undefined, undefined, details, 'createdOn', 1, false, false, true
+      0, 100, reviewId, normalizedSearchValue || undefined, undefined, details, 'createdOn', 1, false, false, true
     ).subscribe({
       next: (response) => {
         const mappedResults = this.mapRevisionToMenu(response.result ?? []);
@@ -267,7 +268,10 @@ export class ReviewToolbarComponent implements OnInit, OnChanges {
           [...this.mappedApiRevisions, ...mappedResults].map(apiRevision => [apiRevision.id, apiRevision])
         ).values());
         this.tagSpecialRevisions(this.mappedApiRevisions);
-        this.applyDropdownFilter(searchValue, filterValue);
+        const currentQueryKey = `${this.diffApiRevisionsSearchValue.trim()}\u0000${this.diffApiRevisionsFilterValue || ''}`;
+        if (currentQueryKey === queryKey) {
+          this.applyDropdownFilter(this.diffApiRevisionsSearchValue, this.diffApiRevisionsFilterValue);
+        }
       },
       error: () => this.queriedRevisionFilters.delete(queryKey)
     });

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/revision-options/revision-options.component.spec.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/revision-options/revision-options.component.spec.ts
@@ -65,8 +65,10 @@ vi.mock('ngx-simplemde', () => {
 
 // All imports AFTER vi.mock() calls
 import { NotificationsService } from 'src/app/_services/notifications/notifications.service';
+import { APIRevisionsService } from 'src/app/_services/revisions/revisions.service';
 import { SignalRService } from 'src/app/_services/signal-r/signal-r.service';
 import { WorkerService } from 'src/app/_services/worker/worker.service';
+import { APIRevision } from 'src/app/_models/revision';
 import { createMockSignalRService, createMockNotificationsService, createMockWorkerService } from 'src/test-helpers/mock-services';
 import { RevisionOptionsComponent } from './revision-options.component';
 
@@ -110,6 +112,37 @@ describe('ApiRevisionOptionsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should query and cache released revisions when the Released filter is selected', () => {
+    const initialRevision = {
+      id: 'initial',
+      reviewId: 'review-id',
+      resolvedLabel: 'Initial revision',
+      isReleased: false
+    } as APIRevision;
+    const releasedRevision = {
+      id: 'released',
+      reviewId: 'review-id',
+      resolvedLabel: 'Older released revision',
+      isReleased: true
+    } as APIRevision;
+    component.apiRevisions = [initialRevision];
+    component.mappedApiRevisions = component.mapRevisionToMenu([initialRevision]);
+    const apiRevisionsService = TestBed.inject(APIRevisionsService);
+    const getAPIRevisionsSpy = vi.spyOn(apiRevisionsService, 'getAPIRevisions').mockReturnValue(of({
+      result: [releasedRevision]
+    }));
+
+    component.activeApiRevisionFilterFunction({ value: 'released' });
+    component.activeApiRevisionFilterFunction({ value: 'released' });
+
+    expect(getAPIRevisionsSpy).toHaveBeenCalledOnce();
+    expect(getAPIRevisionsSpy).toHaveBeenCalledWith(
+      0, 100, 'review-id', undefined, undefined, ['Released'], 'createdOn', 1, false, false, true
+    );
+    expect(component.mappedApiRevisions.some(revision => revision.id === releasedRevision.id)).toBeTruthy();
+    expect(component.activeApiRevisionsMenu.some(revision => revision.id === releasedRevision.id)).toBeTruthy();
   });
 
   describe('Tag APIRevision appropriately based on date and/or status', () => {

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/revision-options/revision-options.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/revision-options/revision-options.component.ts
@@ -153,13 +153,13 @@ export class RevisionOptionsComponent implements OnChanges {
   searchAndFilterDropdown(searchValue : string, filterValue  : string | undefined, dropDownMenu : string) {
     if ((searchValue || filterValue) &&
         (dropDownMenu === this.ACTIVE_API_REVISION_SELECT || dropDownMenu === this.DIFF_API_REVISION_SELECT)) {
-      this.queryFilteredAPIRevisions(searchValue, filterValue, dropDownMenu);
+      this.queryFilteredAPIRevisions(searchValue, filterValue);
     }
 
     this.applyDropdownFilter(searchValue, filterValue, dropDownMenu);
   }
 
-  private queryFilteredAPIRevisions(searchValue: string, filterValue: string | undefined, dropDownMenu: string) {
+  private queryFilteredAPIRevisions(searchValue: string, filterValue: string | undefined) {
     const detailsByFilter: Record<string, string> = {
       approved: 'Approved',
       released: 'Released',
@@ -177,14 +177,15 @@ export class RevisionOptionsComponent implements OnChanges {
       this.queriedRevisionFilters.clear();
       this.queriedReviewId = reviewId;
     }
-    const queryKey = `${searchValue.trim().toLowerCase()}\u0000${filterValue || ''}`;
+    const normalizedSearchValue = searchValue.trim();
+    const queryKey = `${normalizedSearchValue}\u0000${filterValue || ''}`;
     if (this.queriedRevisionFilters.has(queryKey)) {
       return;
     }
     this.queriedRevisionFilters.add(queryKey);
 
     this.apiRevisionsService.getAPIRevisions(
-      0, 100, reviewId, searchValue || undefined, undefined, details, 'createdOn', 1, false, false, true
+      0, 100, reviewId, normalizedSearchValue || undefined, undefined, details, 'createdOn', 1, false, false, true
     ).subscribe({
       next: (response) => {
         const results = Array.isArray(response.result) ? response.result : [];
@@ -193,7 +194,16 @@ export class RevisionOptionsComponent implements OnChanges {
           [...this.mappedApiRevisions, ...mappedResults].map(apiRevision => [apiRevision.id, apiRevision])
         ).values());
         this.tagSpecialRevisions(this.mappedApiRevisions);
-        this.applyDropdownFilter(searchValue, filterValue, dropDownMenu);
+        const dropdownStates = [
+          [this.activeApiRevisionsSearchValue, this.activeApiRevisionsFilterValue, this.ACTIVE_API_REVISION_SELECT],
+          [this.diffApiRevisionsSearchValue, this.diffApiRevisionsFilterValue, this.DIFF_API_REVISION_SELECT]
+        ] as const;
+        for (const [currentSearchValue, currentFilterValue, currentDropDownMenu] of dropdownStates) {
+          const currentQueryKey = `${currentSearchValue.trim()}\u0000${currentFilterValue || ''}`;
+          if (currentQueryKey === queryKey) {
+            this.applyDropdownFilter(currentSearchValue, currentFilterValue, currentDropDownMenu);
+          }
+        }
       },
       error: () => this.queriedRevisionFilters.delete(queryKey)
     });

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/revision-options/revision-options.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/revision-options/revision-options.component.ts
@@ -10,6 +10,7 @@ import { AUTOMATIC_ICON, getTypeClass, MANUAL_ICON, PR_ICON, TREE_DIFF_STYLE } f
 import { ACTIVE_API_REVISION_ID_QUERY_PARAM, DIFF_API_REVISION_ID_QUERY_PARAM, DIFF_STYLE_QUERY_PARAM, getQueryParams } from 'src/app/_helpers/router-helpers';
 import { AzureEngSemanticVersion } from 'src/app/_models/azureEngSemanticVersion';
 import { APIRevision } from 'src/app/_models/revision';
+import { APIRevisionsService } from 'src/app/_services/revisions/revisions.service';
 
 @Component({
     selector: 'app-revision-options',
@@ -55,6 +56,8 @@ export class RevisionOptionsComponent implements OnChanges {
 
   activeApiRevisionsFilterValue: string | undefined = '';
   diffApiRevisionsFilterValue: string | undefined = '';
+  private queriedRevisionFilters = new Set<string>();
+  private queriedReviewId: string | undefined;
 
   filterOptions: any[] = [
     { label: 'Approved', value: 'approved' },
@@ -64,12 +67,15 @@ export class RevisionOptionsComponent implements OnChanges {
     { label: 'Manual', icon: this.manualIcon, value: 'manual' }
   ];
 
-  constructor(private route: ActivatedRoute, private router: Router) {}
+  constructor(private route: ActivatedRoute, private router: Router, private apiRevisionsService: APIRevisionsService) {}
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes['apiRevisions'] || changes['activeApiRevisionId'] || changes['diffApiRevisionId']) {
       if (this.apiRevisions.length > 0) {
-        this.mappedApiRevisions = this.mapRevisionToMenu(this.apiRevisions);
+        const mappedApiRevisions = this.mapRevisionToMenu(this.apiRevisions);
+        this.mappedApiRevisions = Array.from(new Map(
+          [...this.mappedApiRevisions, ...mappedApiRevisions].map(apiRevision => [apiRevision.id, apiRevision])
+        ).values());
         this.tagSpecialRevisions(this.mappedApiRevisions);
 
         this.activeApiRevisionsMenu = this.mappedApiRevisions.filter((apiRevision: any) => apiRevision.id !== this.diffApiRevisionId);
@@ -145,6 +151,55 @@ export class RevisionOptionsComponent implements OnChanges {
   }
 
   searchAndFilterDropdown(searchValue : string, filterValue  : string | undefined, dropDownMenu : string) {
+    if ((searchValue || filterValue) &&
+        (dropDownMenu === this.ACTIVE_API_REVISION_SELECT || dropDownMenu === this.DIFF_API_REVISION_SELECT)) {
+      this.queryFilteredAPIRevisions(searchValue, filterValue, dropDownMenu);
+    }
+
+    this.applyDropdownFilter(searchValue, filterValue, dropDownMenu);
+  }
+
+  private queryFilteredAPIRevisions(searchValue: string, filterValue: string | undefined, dropDownMenu: string) {
+    const detailsByFilter: Record<string, string> = {
+      approved: 'Approved',
+      released: 'Released',
+      automatic: 'Automatic',
+      pullRequest: 'PullRequest',
+      manual: 'Manual'
+    };
+    const details = filterValue && detailsByFilter[filterValue] ? [detailsByFilter[filterValue]] : [];
+    const reviewId = this.apiRevisions[0]?.reviewId;
+    if (!reviewId) {
+      return;
+    }
+
+    if (this.queriedReviewId !== reviewId) {
+      this.queriedRevisionFilters.clear();
+      this.queriedReviewId = reviewId;
+    }
+    const queryKey = `${searchValue.trim().toLowerCase()}\u0000${filterValue || ''}`;
+    if (this.queriedRevisionFilters.has(queryKey)) {
+      return;
+    }
+    this.queriedRevisionFilters.add(queryKey);
+
+    this.apiRevisionsService.getAPIRevisions(
+      0, 100, reviewId, searchValue || undefined, undefined, details, 'createdOn', 1, false, false, true
+    ).subscribe({
+      next: (response) => {
+        const results = Array.isArray(response.result) ? response.result : [];
+        const mappedResults = this.mapRevisionToMenu(results);
+        this.mappedApiRevisions = Array.from(new Map(
+          [...this.mappedApiRevisions, ...mappedResults].map(apiRevision => [apiRevision.id, apiRevision])
+        ).values());
+        this.tagSpecialRevisions(this.mappedApiRevisions);
+        this.applyDropdownFilter(searchValue, filterValue, dropDownMenu);
+      },
+      error: () => this.queriedRevisionFilters.delete(queryKey)
+    });
+  }
+
+  private applyDropdownFilter(searchValue : string, filterValue  : string | undefined, dropDownMenu : string) {
     let filtered = [];
     if (dropDownMenu === this.ACTIVE_API_REVISION_SELECT || dropDownMenu === this.DIFF_API_REVISION_SELECT) {
       filtered = this.mappedApiRevisions.filter((apiRevision: APIRevision) => {


### PR DESCRIPTION
Currently, APIView fetches the 200 most recently created revisions for the revision selection dropdown. If you use the filter buttons, it only does client-side filtering of that set of 200 revisions.

This PR changes it so that using filters sends a server-side query the first time it is selected, fetching any missing data, before applying the client-side filter. Subsequent selections of the same filter will not re-fetch the data.

Reloading the page will invalidate the cache. 