### PR TITLE
[APIView] Use shared revision filter cache

### DIFF
--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-toolbar/review-toolbar.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-toolbar/review-toolbar.component.ts
@@ -77,8 +77,6 @@ export class ReviewToolbarComponent implements OnInit, OnChanges {
   selectedDiffAPIRevision: any = null;
   diffApiRevisionsSearchValue: string = '';
   diffApiRevisionsFilterValue: string | undefined = '';
-  private queriedRevisionFilters = new Set<string>();
-  private queriedReviewId: string | undefined;
 
   DIFF_API_REVISION_SELECT: string = 'diff-api';
 
@@ -172,10 +170,9 @@ export class ReviewToolbarComponent implements OnInit, OnChanges {
 
     if (changes['apiRevisions'] || changes['activeApiRevisionId'] || changes['diffApiRevisionId']) {
       if (this.apiRevisions.length > 0) {
-        const mappedApiRevisions = this.mapRevisionToMenu(this.apiRevisions);
-        this.mappedApiRevisions = Array.from(new Map(
-          [...this.mappedApiRevisions, ...mappedApiRevisions].map(apiRevision => [apiRevision.id, apiRevision])
-        ).values());
+        const reviewId = this.apiRevisions[0].reviewId;
+        this.apiRevisionsService.cacheAPIRevisionOptions(reviewId, this.apiRevisions);
+        this.mappedApiRevisions = this.mapRevisionToMenu(this.apiRevisionsService.getCachedAPIRevisionOptions(reviewId));
         this.tagSpecialRevisions(this.mappedApiRevisions);
 
         this.diffApiRevisionsMenu = this.mappedApiRevisions.filter((apiRevision: any) => apiRevision.id !== this.activeApiRevisionId);
@@ -229,6 +226,7 @@ export class ReviewToolbarComponent implements OnInit, OnChanges {
   searchAndFilterDropdown(searchValue: string, filterValue: string | undefined) {
     if (searchValue || filterValue) {
       this.queryFilteredAPIRevisions(searchValue, filterValue);
+      return;
     }
 
     this.applyDropdownFilter(searchValue, filterValue);
@@ -248,32 +246,19 @@ export class ReviewToolbarComponent implements OnInit, OnChanges {
       return;
     }
 
-    if (this.queriedReviewId !== reviewId) {
-      this.queriedRevisionFilters.clear();
-      this.queriedReviewId = reviewId;
-    }
     const normalizedSearchValue = searchValue.trim();
     const queryKey = `${normalizedSearchValue}\u0000${filterValue || ''}`;
-    if (this.queriedRevisionFilters.has(queryKey)) {
-      return;
-    }
-    this.queriedRevisionFilters.add(queryKey);
-
-    this.apiRevisionsService.getAPIRevisions(
-      0, 100, reviewId, normalizedSearchValue || undefined, undefined, details, 'createdOn', 1, false, false, true
+    this.apiRevisionsService.getFilteredAPIRevisionOptions(
+      reviewId, normalizedSearchValue || undefined, details
     ).subscribe({
-      next: (response) => {
-        const mappedResults = this.mapRevisionToMenu(response.result ?? []);
-        this.mappedApiRevisions = Array.from(new Map(
-          [...this.mappedApiRevisions, ...mappedResults].map(apiRevision => [apiRevision.id, apiRevision])
-        ).values());
+      next: () => {
+        this.mappedApiRevisions = this.mapRevisionToMenu(this.apiRevisionsService.getCachedAPIRevisionOptions(reviewId));
         this.tagSpecialRevisions(this.mappedApiRevisions);
         const currentQueryKey = `${this.diffApiRevisionsSearchValue.trim()}\u0000${this.diffApiRevisionsFilterValue || ''}`;
         if (currentQueryKey === queryKey) {
           this.applyDropdownFilter(this.diffApiRevisionsSearchValue, this.diffApiRevisionsFilterValue);
         }
-      },
-      error: () => this.queriedRevisionFilters.delete(queryKey)
+      }
     });
   }
 

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-toolbar/review-toolbar.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-toolbar/review-toolbar.component.ts
@@ -249,7 +249,7 @@ export class ReviewToolbarComponent implements OnInit, OnChanges {
     const normalizedSearchValue = searchValue.trim();
     const queryKey = `${normalizedSearchValue}\u0000${filterValue || ''}`;
     this.apiRevisionsService.getFilteredAPIRevisionOptions(
-      reviewId, normalizedSearchValue || undefined, details
+      reviewId, details
     ).subscribe({
       next: () => {
         this.mappedApiRevisions = this.mapRevisionToMenu(this.apiRevisionsService.getCachedAPIRevisionOptions(reviewId));

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/revision-options/revision-options.component.spec.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/revision-options/revision-options.component.spec.ts
@@ -4,8 +4,9 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ActivatedRoute, convertToParamMap } from '@angular/router';
-import { of } from 'rxjs';
-import { vi } from 'vitest';
+import { of, Subject } from 'rxjs';
+import { PaginatedResult } from 'src/app/_models/pagination';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { initializeTestBed } from '../../../test-setup';
 
 // Mock ngx-ui-scroll to avoid vscroll dependency error
@@ -143,6 +144,35 @@ describe('ApiRevisionOptionsComponent', () => {
     );
     expect(component.mappedApiRevisions.some(revision => revision.id === releasedRevision.id)).toBeTruthy();
     expect(component.activeApiRevisionsMenu.some(revision => revision.id === releasedRevision.id)).toBeTruthy();
+  });
+
+  it('should keep existing options until a filtered revision query completes', () => {
+    const initialRevision = {
+      id: 'initial',
+      reviewId: 'pending-review-id',
+      resolvedLabel: 'Initial revision',
+      isReleased: false
+    } as APIRevision;
+    const releasedRevision = {
+      id: 'released',
+      reviewId: 'pending-review-id',
+      resolvedLabel: 'Released revision',
+      isReleased: true
+    } as APIRevision;
+    component.apiRevisions = [initialRevision];
+    component.mappedApiRevisions = component.mapRevisionToMenu([initialRevision]);
+    component.activeApiRevisionsMenu = [...component.mappedApiRevisions];
+    const response = new Subject<PaginatedResult<APIRevision[]>>();
+    vi.spyOn(TestBed.inject(APIRevisionsService), 'getAPIRevisions').mockReturnValue(response);
+
+    component.activeApiRevisionFilterFunction({ value: 'released' });
+
+    expect(component.activeApiRevisionsMenu.map(revision => revision.id)).toEqual(['initial']);
+
+    response.next({ result: [releasedRevision] });
+    response.complete();
+
+    expect(component.activeApiRevisionsMenu.map(revision => revision.id)).toEqual(['released']);
   });
 
   describe('Tag APIRevision appropriately based on date and/or status', () => {

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/revision-options/revision-options.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/revision-options/revision-options.component.ts
@@ -56,8 +56,6 @@ export class RevisionOptionsComponent implements OnChanges {
 
   activeApiRevisionsFilterValue: string | undefined = '';
   diffApiRevisionsFilterValue: string | undefined = '';
-  private queriedRevisionFilters = new Set<string>();
-  private queriedReviewId: string | undefined;
 
   filterOptions: any[] = [
     { label: 'Approved', value: 'approved' },
@@ -72,10 +70,9 @@ export class RevisionOptionsComponent implements OnChanges {
   ngOnChanges(changes: SimpleChanges) {
     if (changes['apiRevisions'] || changes['activeApiRevisionId'] || changes['diffApiRevisionId']) {
       if (this.apiRevisions.length > 0) {
-        const mappedApiRevisions = this.mapRevisionToMenu(this.apiRevisions);
-        this.mappedApiRevisions = Array.from(new Map(
-          [...this.mappedApiRevisions, ...mappedApiRevisions].map(apiRevision => [apiRevision.id, apiRevision])
-        ).values());
+        const reviewId = this.apiRevisions[0].reviewId;
+        this.apiRevisionsService.cacheAPIRevisionOptions(reviewId, this.apiRevisions);
+        this.mappedApiRevisions = this.mapRevisionToMenu(this.apiRevisionsService.getCachedAPIRevisionOptions(reviewId));
         this.tagSpecialRevisions(this.mappedApiRevisions);
 
         this.activeApiRevisionsMenu = this.mappedApiRevisions.filter((apiRevision: any) => apiRevision.id !== this.diffApiRevisionId);
@@ -154,6 +151,7 @@ export class RevisionOptionsComponent implements OnChanges {
     if ((searchValue || filterValue) &&
         (dropDownMenu === this.ACTIVE_API_REVISION_SELECT || dropDownMenu === this.DIFF_API_REVISION_SELECT)) {
       this.queryFilteredAPIRevisions(searchValue, filterValue);
+      return;
     }
 
     this.applyDropdownFilter(searchValue, filterValue, dropDownMenu);
@@ -173,26 +171,13 @@ export class RevisionOptionsComponent implements OnChanges {
       return;
     }
 
-    if (this.queriedReviewId !== reviewId) {
-      this.queriedRevisionFilters.clear();
-      this.queriedReviewId = reviewId;
-    }
     const normalizedSearchValue = searchValue.trim();
     const queryKey = `${normalizedSearchValue}\u0000${filterValue || ''}`;
-    if (this.queriedRevisionFilters.has(queryKey)) {
-      return;
-    }
-    this.queriedRevisionFilters.add(queryKey);
-
-    this.apiRevisionsService.getAPIRevisions(
-      0, 100, reviewId, normalizedSearchValue || undefined, undefined, details, 'createdOn', 1, false, false, true
+    this.apiRevisionsService.getFilteredAPIRevisionOptions(
+      reviewId, normalizedSearchValue || undefined, details
     ).subscribe({
-      next: (response) => {
-        const results = Array.isArray(response.result) ? response.result : [];
-        const mappedResults = this.mapRevisionToMenu(results);
-        this.mappedApiRevisions = Array.from(new Map(
-          [...this.mappedApiRevisions, ...mappedResults].map(apiRevision => [apiRevision.id, apiRevision])
-        ).values());
+      next: () => {
+        this.mappedApiRevisions = this.mapRevisionToMenu(this.apiRevisionsService.getCachedAPIRevisionOptions(reviewId));
         this.tagSpecialRevisions(this.mappedApiRevisions);
         const dropdownStates = [
           [this.activeApiRevisionsSearchValue, this.activeApiRevisionsFilterValue, this.ACTIVE_API_REVISION_SELECT],
@@ -204,8 +189,7 @@ export class RevisionOptionsComponent implements OnChanges {
             this.applyDropdownFilter(currentSearchValue, currentFilterValue, currentDropDownMenu);
           }
         }
-      },
-      error: () => this.queriedRevisionFilters.delete(queryKey)
+      }
     });
   }
 

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/revision-options/revision-options.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/revision-options/revision-options.component.ts
@@ -174,7 +174,7 @@ export class RevisionOptionsComponent implements OnChanges {
     const normalizedSearchValue = searchValue.trim();
     const queryKey = `${normalizedSearchValue}\u0000${filterValue || ''}`;
     this.apiRevisionsService.getFilteredAPIRevisionOptions(
-      reviewId, normalizedSearchValue || undefined, details
+      reviewId, details
     ).subscribe({
       next: () => {
         this.mappedApiRevisions = this.mapRevisionToMenu(this.apiRevisionsService.getCachedAPIRevisionOptions(reviewId));

--- a/src/dotnet/APIView/ClientSPA/src/app/_services/revisions/revisions.service.spec.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_services/revisions/revisions.service.spec.ts
@@ -6,6 +6,8 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { APIRevisionsService } from './revisions.service';
 import { ConfigService } from '../config/config.service';
 import { of } from 'rxjs';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { APIRevision } from 'src/app/_models/revision';
 
 describe('RevisionsService', () => {
   let service: APIRevisionsService;
@@ -33,5 +35,18 @@ describe('RevisionsService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should share filtered revision queries and cache their results', () => {
+    const releasedRevision = { id: 'released', reviewId: 'review-id' } as APIRevision;
+    const getAPIRevisionsSpy = vi.spyOn(service, 'getAPIRevisions').mockReturnValue(of({
+      result: [releasedRevision]
+    }));
+
+    service.getFilteredAPIRevisionOptions('review-id', undefined, ['Released']).subscribe();
+    service.getFilteredAPIRevisionOptions('review-id', undefined, ['Released']).subscribe();
+
+    expect(getAPIRevisionsSpy).toHaveBeenCalledOnce();
+    expect(service.getCachedAPIRevisionOptions('review-id')).toEqual([releasedRevision]);
   });
 });

--- a/src/dotnet/APIView/ClientSPA/src/app/_services/revisions/revisions.service.spec.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_services/revisions/revisions.service.spec.ts
@@ -37,16 +37,19 @@ describe('RevisionsService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should share filtered revision queries and cache their results', () => {
+  it('should share fixed-filter revision queries and cache their results', () => {
     const releasedRevision = { id: 'released', reviewId: 'review-id' } as APIRevision;
     const getAPIRevisionsSpy = vi.spyOn(service, 'getAPIRevisions').mockReturnValue(of({
       result: [releasedRevision]
     }));
 
-    service.getFilteredAPIRevisionOptions('review-id', undefined, ['Released']).subscribe();
-    service.getFilteredAPIRevisionOptions('review-id', undefined, ['Released']).subscribe();
+    service.getFilteredAPIRevisionOptions('review-id', ['Released']).subscribe();
+    service.getFilteredAPIRevisionOptions('review-id', ['Released']).subscribe();
 
     expect(getAPIRevisionsSpy).toHaveBeenCalledOnce();
+    expect(getAPIRevisionsSpy).toHaveBeenCalledWith(
+      0, 100, 'review-id', undefined, undefined, ['Released'], 'createdOn', 1, false, false, true
+    );
     expect(service.getCachedAPIRevisionOptions('review-id')).toEqual([releasedRevision]);
   });
 });

--- a/src/dotnet/APIView/ClientSPA/src/app/_services/revisions/revisions.service.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_services/revisions/revisions.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, map, take } from 'rxjs';
+import { Observable, catchError, map, shareReplay, take, tap, throwError } from 'rxjs';
 
 import { PaginatedResult } from 'src/app/_models/pagination';
 import { APIRevision, APIRevisionGroupedByLanguage } from 'src/app/_models/revision';
@@ -15,6 +15,8 @@ import { INDEX_PAGE_NAME } from 'src/app/_helpers/router-helpers';
 export class APIRevisionsService {
   baseUrl : string = this.configService.apiUrl + "APIRevisions";
   paginatedResult: PaginatedResult<APIRevision[]> = new PaginatedResult<APIRevision[]>
+  private revisionOptionsCache = new Map<string, Map<string, APIRevision>>();
+  private revisionOptionsQueryCache = new Map<string, Observable<APIRevision[]>>();
 
   constructor(private http: HttpClient, private configService: ConfigService) { }
 
@@ -71,6 +73,40 @@ export class APIRevisionsService {
           }
         )
     );
+  }
+
+  cacheAPIRevisionOptions(reviewId: string, apiRevisions: APIRevision[]): void {
+    const cachedRevisions = this.revisionOptionsCache.get(reviewId) ?? new Map<string, APIRevision>();
+    for (const apiRevision of apiRevisions) {
+      cachedRevisions.set(apiRevision.id, apiRevision);
+    }
+    this.revisionOptionsCache.set(reviewId, cachedRevisions);
+  }
+
+  getCachedAPIRevisionOptions(reviewId: string): APIRevision[] {
+    return Array.from(this.revisionOptionsCache.get(reviewId)?.values() ?? []);
+  }
+
+  getFilteredAPIRevisionOptions(reviewId: string, label: string | undefined, details: string[]): Observable<APIRevision[]> {
+    const queryKey = JSON.stringify([reviewId, label ?? '', details]);
+    const cachedQuery = this.revisionOptionsQueryCache.get(queryKey);
+    if (cachedQuery) {
+      return cachedQuery;
+    }
+
+    const query = this.getAPIRevisions(
+      0, 100, reviewId, label, undefined, details, 'createdOn', 1, false, false, true
+    ).pipe(
+      map(response => Array.isArray(response.result) ? response.result : []),
+      tap(apiRevisions => this.cacheAPIRevisionOptions(reviewId, apiRevisions)),
+      catchError(error => {
+        this.revisionOptionsQueryCache.delete(queryKey);
+        return throwError(() => error);
+      }),
+      shareReplay({ bufferSize: 1, refCount: false })
+    );
+    this.revisionOptionsQueryCache.set(queryKey, query);
+    return query;
   }
 
   deleteAPIRevisions(reviewId: string, revisionIds: string[]): Observable<any> {

--- a/src/dotnet/APIView/ClientSPA/src/app/_services/revisions/revisions.service.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_services/revisions/revisions.service.ts
@@ -87,15 +87,15 @@ export class APIRevisionsService {
     return Array.from(this.revisionOptionsCache.get(reviewId)?.values() ?? []);
   }
 
-  getFilteredAPIRevisionOptions(reviewId: string, label: string | undefined, details: string[]): Observable<APIRevision[]> {
-    const queryKey = JSON.stringify([reviewId, label ?? '', details]);
+  getFilteredAPIRevisionOptions(reviewId: string, details: string[]): Observable<APIRevision[]> {
+    const queryKey = JSON.stringify([reviewId, details]);
     const cachedQuery = this.revisionOptionsQueryCache.get(queryKey);
     if (cachedQuery) {
       return cachedQuery;
     }
 
     const query = this.getAPIRevisions(
-      0, 100, reviewId, label, undefined, details, 'createdOn', 1, false, false, true
+      0, 100, reviewId, undefined, undefined, details, 'createdOn', 1, false, false, true
     ).pipe(
       map(response => Array.isArray(response.result) ? response.result : []),
       tap(apiRevisions => this.cacheAPIRevisionOptions(reviewId, apiRevisions)),


### PR DESCRIPTION
Follow-up to ensure filters use a shared cache.