### PR TITLE
Add azsdk-cli Copilot code review skill

### DIFF
--- a/.github/skills/.vally.yaml
+++ b/.github/skills/.vally.yaml
@@ -11,6 +11,7 @@ paths:
     - eval-authoring-skill/evals/
     - eval-authoring-tool/evals/
     - eval-authoring-workflow/evals/
+    - code-review/evals/
   results: results/
   evalFilenames: ["eval.yaml", "*.eval.yaml"]
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: code-review
+description: "Guide GitHub Copilot code review (CCR) for PRs and diffs that change tools/azsdk-cli, focusing on high-confidence behavioral and integration defects beyond analyzers. WHEN: 'GitHub Copilot code review for azsdk-cli', 'CCR review of an azsdk-cli PR', 'Copilot review of tools/azsdk-cli changes'."
+license: MIT
+metadata:
+  author: Microsoft
+  version: "1.0.0"
+compatibility: "GitHub Copilot code review, copilot-chat, @microsoft/vally-cli 0.7.0"
+---
+
+# azsdk-cli Code Review
+
+Apply this skill to GitHub Copilot code review when changed behavior is under
+`tools/azsdk-cli/**`. For other changes, do not apply azsdk-cli-specific
+guidance.
+
+## Process
+
+1. Read the pull request intent, changed files, and
+   `tools/azsdk-cli/AGENTS.md`.
+2. Identify the affected subsystem and trace changed behavior through its
+   callers, registrations, response models, tests, mocks, and applicable
+   design spec.
+3. Load and apply only the relevant [review rules](references/review-rules.md).
+4. Before reporting anything, enforce the
+   [finding contract](references/finding-contract.md).
+
+Prefer no finding over a speculative or analyzer-owned comment.

--- a/.github/skills/code-review/evals/eval.yaml
+++ b/.github/skills/code-review/evals/eval.yaml
@@ -1,0 +1,83 @@
+name: code-review-eval
+description: Routing and boundary tests for the azsdk-cli code-review skill
+type: capability
+
+environment: azsdk-mcp-mock
+
+tags:
+  area: code-review
+  type: ci-gate
+
+defaults:
+  runs: 1
+  timeout: "120s"
+  model: claude-opus-4.6
+  executor: copilot-sdk
+
+scoring:
+  threshold: 0.8
+
+stimuli:
+  - name: trigger-ccr-review-azsdk-cli-pr
+    prompt: |
+      Run a CCR review of this azsdk-cli PR. Review only this excerpt and do not modify files.
+
+      diff --git a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/WidgetService.cs b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/WidgetService.cs
+      - await client.WaitForCompletionAsync(ct).WaitAsync(TimeSpan.FromMinutes(5), ct);
+      + await client.WaitForCompletionAsync(ct);
+    graders:
+      - type: skill-invocation
+        config:
+          required: [code-review]
+
+  - name: trigger-copilot-review-azsdk-cli-diff
+    prompt: |
+      Use GitHub Copilot code review on this tools/azsdk-cli diff. Review only this excerpt and do not modify files.
+
+      diff --git a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/WidgetService.cs b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/WidgetService.cs
+      - await client.WaitForCompletionAsync(ct).WaitAsync(TimeSpan.FromMinutes(5), ct);
+      + await client.WaitForCompletionAsync(ct);
+    graders:
+      - type: skill-invocation
+        config:
+          required: [code-review]
+
+  - name: trigger-copilot-review-azsdk-cli
+    prompt: |
+      Run GitHub Copilot code review for this azsdk-cli change. Review only this excerpt and do not modify files.
+
+      diff --git a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/WidgetService.cs b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/WidgetService.cs
+      - await client.WaitForCompletionAsync(ct).WaitAsync(TimeSpan.FromMinutes(5), ct);
+      + await client.WaitForCompletionAsync(ct);
+    graders:
+      - type: skill-invocation
+        config:
+          required: [code-review]
+
+  - name: anti-trigger-implement-azsdk-cli-tool
+    prompt: "I need to implement a new azsdk-cli command for package validation. Identify the repository workflow that applies; do not inspect or modify files."
+    graders:
+      - type: skill-invocation
+        config:
+          disallowed: [code-review]
+
+  - name: anti-trigger-fix-azsdk-cli-pipeline
+    prompt: "I need to fix a failing build for tools/azsdk-cli. Identify the repository workflow that applies; do not inspect or modify files."
+    graders:
+      - type: skill-invocation
+        config:
+          disallowed: [code-review]
+
+  - name: anti-trigger-run-azsdk-cli-analyzers
+    prompt: "I need to run the MCP001-MCP007 analyzers and fix their errors. Identify the repository workflow that applies; do not inspect or modify files."
+    graders:
+      - type: skill-invocation
+        config:
+          disallowed: [code-review]
+
+  - name: anti-trigger-review-unrelated-tool
+    prompt: "I need a regression review of tools/release-plan-dashboard. Identify the repository workflow that applies; do not inspect or modify files."
+    graders:
+      - type: skill-invocation
+        config:
+          disallowed: [code-review]

--- a/.github/skills/code-review/references/finding-contract.md
+++ b/.github/skills/code-review/references/finding-contract.md
@@ -1,0 +1,20 @@
+# Finding Contract
+
+Report a finding only when every condition holds:
+
+1. The pull request introduced or worsened the issue.
+2. The comment targets an exact changed line.
+3. A concrete input, state, or call sequence reaches the failure.
+4. The user or system impact is clear.
+5. Nearby guards, callers, tests, and intentional patterns do not invalidate
+   the concern.
+6. The issue is not merely an MCP001-MCP007, compiler, formatter, linter, or
+   CI result.
+
+Do not report style preferences, pre-existing problems, generic hardening,
+theoretical concerns, or missing tests without an uncovered behavioral risk.
+Consolidate repeated symptoms into one root-cause finding.
+
+Keep a finding concise: state the defect, the triggering scenario and impact,
+then a safe fix direction. If any required evidence is missing, continue
+investigating or omit the finding.

--- a/.github/skills/code-review/references/review-rules.md
+++ b/.github/skills/code-review/references/review-rules.md
@@ -1,0 +1,24 @@
+# azsdk-cli Review Rules
+
+`tools/azsdk-cli/AGENTS.md` is the architectural source of truth and is owned
+by the azsdk-cli team. Use the changed surface to select additional context;
+do not apply every check mechanically.
+
+| Changed surface | Inspect for behavioral risk | Repository context |
+| --- | --- | --- |
+| Tool or command | CLI/MCP behavior parity, cancellation through the full call chain, and meaningful failure responses | `Commands/`, `Tools/Core/`, corresponding tool tests |
+| Response model | Consistent plain, JSON, and MCP behavior; accurate errors, status, exit code, and `NextSteps` | `Models/Responses/`, `Helpers/OutputHelper.cs`, response tests |
+| Service or helper | Correct DI lifetime, unsafe shared state, resource cleanup, and bounded external work | `Services/ServiceRegistrations.cs`, callers, helper/service tests |
+| Process, HTTP, polling, or retry code | Cancellation, timeout or termination bound, retry limit, and surfaced terminal failure | `docs/process-calling.md`, process helpers, failure-path tests |
+| MCP mock or tool contract | Mock signature and response behavior still match the live tool | live tool, `Azure.Sdk.Tools.Mock/`, tool evals |
+| Language-specific behavior | Supported-language coverage, explicit unsupported behavior, and consistent fallback | `Services/Languages/`, `docs/per-language.md`, language tests |
+| Feature governed by a spec | Implementation and failure behavior still satisfy the applicable design | `docs/specs/`, implementation, tests |
+
+Look for omissions across files when a changed contract requires registration,
+serialization, mock, documentation, or test updates. Require a concrete
+failure path before treating missing coverage as a finding.
+
+MCP001-MCP007, compiler errors, formatting, and exact CI failures are owned by
+deterministic checks. Do not restate them as skill findings. Investigate
+behavior beyond those checks, such as a cancellation token that is forwarded
+but ineffective or a registered service with an unsafe lifetime.


### PR DESCRIPTION
## What

Adds the first review-focused Agent Skill for GitHub Copilot code review of changes under `tools/azsdk-cli/**`.

- Keeps `SKILL.md` as a thin CCR router.
- Uses `tools/azsdk-cli/AGENTS.md` as the architectural source of truth.
- Loads behavioral review rules and the evidence contract progressively.
- Excludes MCP001-MCP007, compiler, formatter, and exact CI findings from the skill-owned review surface.
- Adds three CCR trigger cases and four boundary anti-trigger cases.

## Validation

- Vally lint: 2/2 checks passed.
- Focused routing suite: 7/7 cases passed.
- Mock MCP build succeeded.
- `git diff --check` passed.

Closes #16766
