### PR TITLE
Add direct Markdown output to Java APIView processor

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
+++ b/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>APIViewWeb</AssemblyName>
     <UserSecretsId>79cceff6-d533-4370-a0ee-f3321a343907</UserSecretsId>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <JavaProcessor>..\..\..\java\apiview-java-processor\target\apiview-java-processor-1.33.0.jar</JavaProcessor>
+    <JavaProcessor>..\..\..\java\apiview-java-processor\target\apiview-java-processor-1.34.0.jar</JavaProcessor>
     <GoProcessor>..\..\..\go\apiviewgo.exe</GoProcessor>
     <TypeScriptToolsVersion>latest</TypeScriptToolsVersion>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>

--- a/src/dotnet/APIView/APIViewWeb/Languages/JavaLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/JavaLanguageService.cs
@@ -11,7 +11,7 @@ namespace APIViewWeb
         public override string Name { get; } = "Java";
         public override string[] Extensions { get; } = { ".jar" };
         public override string ProcessName { get; } = "java";
-        public override string VersionString { get; } = "apiview-java-processor-1.33.0.jar";
+        public override string VersionString { get; } = "apiview-java-processor-1.34.0.jar";
 
         public JavaLanguageService(TelemetryClient telemetryClient) : base(telemetryClient)
         {

--- a/src/java/apiview-java-processor/pom.xml
+++ b/src/java/apiview-java-processor/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.azure</groupId>
   <artifactId>apiview-java-processor</artifactId>
-  <version>1.33.0</version>
+  <version>1.34.0</version>
 
   <properties>
     <maven.compiler.target>8</maven.compiler.target>

--- a/src/java/apiview-java-processor/readme.md
+++ b/src/java/apiview-java-processor/readme.md
@@ -13,13 +13,13 @@ the built jar files, one of which will take the form `<library-name>-sources.jar
 
 The application is run using the following structure:
 </br>
-`java -jar apiview-java-processor-<version>.jar [--markdown] <comma-separated list of jar files> <outputDirectory>`
+`java -jar apiview-java-processor-<version>.jar [--renderer=json|markdown] <comma-separated list of jar files> <outputDirectory>`
 
 For example:</br>
 
 * **One Jar File:** `java -jar apiview-java-processor-<version>.jar application-sources.jar temp`
 * **Multiple Jar Files:** `java -jar apiview-java-processor-<version>.jar application-sources.jar,test-library-sources.jar,other-library-sources.jar temp`
-* **Markdown without JavaDoc:** `java -jar apiview-java-processor-<version>.jar --markdown application-sources.jar temp`
+* **Markdown without JavaDoc:** `java -jar apiview-java-processor-<version>.jar --renderer=markdown application-sources.jar temp`
 
-The default output is APIView token JSON. The `--markdown` flag writes a fenced Java API snapshot directly and
-omits JavaDoc so that the result contains only the public API surface.
+The default renderer is `json`. The `markdown` renderer writes a fenced Java API snapshot directly and omits
+JavaDoc so that the result contains only the public API surface.

--- a/src/java/apiview-java-processor/readme.md
+++ b/src/java/apiview-java-processor/readme.md
@@ -13,9 +13,13 @@ the built jar files, one of which will take the form `<library-name>-sources.jar
 
 The application is run using the following structure:
 </br>
-`java -jar apiview-java-processor-1.0.0.jar <comma-separated list of jar files> <outputDirectory>` 
+`java -jar apiview-java-processor-<version>.jar [--markdown] <comma-separated list of jar files> <outputDirectory>`
 
 For example:</br>
 
-* **One Jar File:** `java -jar apiview-java-processor-1.0.0.jar application-sources.jar temp`
-* **Multiple Jar Files:** `java -jar apiview-java-processor-1.0.0.jar application-sources.jar,test-library-sources.jar,other-library-sources.jar temp`
+* **One Jar File:** `java -jar apiview-java-processor-<version>.jar application-sources.jar temp`
+* **Multiple Jar Files:** `java -jar apiview-java-processor-<version>.jar application-sources.jar,test-library-sources.jar,other-library-sources.jar temp`
+* **Markdown without JavaDoc:** `java -jar apiview-java-processor-<version>.jar --markdown application-sources.jar temp`
+
+The default output is APIView token JSON. The `--markdown` flag writes a fenced Java API snapshot directly and
+omits JavaDoc so that the result contains only the public API surface.

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/CommandLineOptions.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/CommandLineOptions.java
@@ -1,0 +1,53 @@
+package com.azure.tools.apiview.processor;
+
+import java.io.File;
+
+final class CommandLineOptions {
+    private static final String RENDERER_OPTION_PREFIX = "--renderer=";
+
+    private final OutputRenderer renderer;
+    private final String[] jarFiles;
+    private final File outputDirectory;
+
+    private CommandLineOptions(OutputRenderer renderer, String[] jarFiles, File outputDirectory) {
+        this.renderer = renderer;
+        this.jarFiles = jarFiles;
+        this.outputDirectory = outputDirectory;
+    }
+
+    static CommandLineOptions parse(String[] args) {
+        if (args.length != 2 && args.length != 3) {
+            throw new IllegalArgumentException("Expected two positional arguments and an optional renderer.");
+        }
+
+        boolean hasRendererOption = args[0].startsWith(RENDERER_OPTION_PREFIX);
+        if (args.length == 3 && !hasRendererOption) {
+            throw new IllegalArgumentException("Unsupported option '" + args[0] + "'.");
+        }
+        if (args.length == 2 && hasRendererOption) {
+            throw new IllegalArgumentException("The renderer option requires input JARs and an output directory.");
+        }
+
+        int positionalArgumentOffset = hasRendererOption ? 1 : 0;
+        OutputRenderer renderer = hasRendererOption
+            ? OutputRenderer.fromValue(args[0].substring(RENDERER_OPTION_PREFIX.length()))
+            : OutputRenderer.JSON;
+
+        return new CommandLineOptions(
+            renderer,
+            args[positionalArgumentOffset].split(","),
+            new File(args[positionalArgumentOffset + 1]));
+    }
+
+    OutputRenderer getRenderer() {
+        return renderer;
+    }
+
+    String[] getJarFiles() {
+        return jarFiles;
+    }
+
+    File getOutputDirectory() {
+        return outputDirectory;
+    }
+}

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/CommandLineOptions.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/CommandLineOptions.java
@@ -21,7 +21,7 @@ final class CommandLineOptions {
         }
 
         boolean hasRendererOption = args[0].startsWith(RENDERER_OPTION_PREFIX);
-        if (args.length == 3 && !hasRendererOption) {
+        if (!hasRendererOption && (args.length == 3 || args[0].startsWith("--"))) {
             throw new IllegalArgumentException("Unsupported option '" + args[0] + "'.");
         }
         if (args.length == 2 && hasRendererOption) {

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/Main.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/Main.java
@@ -33,45 +33,27 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 public class Main {
-    private static final String RENDERER_OPTION_PREFIX = "--renderer=";
-
     // expected argument order:
     // [--renderer=json|markdown] [inputFiles] <outputDirectory>
     public static void main(String[] args) {
-        if (args.length != 2 && args.length != 3) {
+        final CommandLineOptions options;
+        try {
+            options = CommandLineOptions.parse(args);
+        } catch (IllegalArgumentException e) {
+            System.out.println(e.getMessage());
             printUsage();
             System.exit(-1);
-        }
-
-        final boolean hasRendererOption = args.length == 3 && args[0].startsWith(RENDERER_OPTION_PREFIX);
-        if (args.length == 3 && !hasRendererOption) {
-            printUsage();
-            System.exit(-1);
+            return;
         }
 
         long startMillis = System.currentTimeMillis();
-        Renderer selectedRenderer = Renderer.JSON;
-        if (hasRendererOption) {
-            try {
-                selectedRenderer = Renderer.fromValue(args[0].substring(RENDERER_OPTION_PREFIX.length()));
-            } catch (IllegalArgumentException e) {
-                System.out.println(e.getMessage());
-                printUsage();
-                System.exit(-1);
-            }
-        }
-        final Renderer renderer = selectedRenderer;
-        final int positionalArgumentOffset = hasRendererOption ? 1 : 0;
-        final String jarFiles = args[positionalArgumentOffset];
-        final String[] jarFilesArray = jarFiles.split(",");
-
-        final File outputDir = new File(args[positionalArgumentOffset + 1]);
 
         System.out.println("Running with following configuration:");
-        System.out.printf("  Output directory: '%s'%n", outputDir);
-        System.out.printf("  Renderer: %s%n", renderer.value);
+        System.out.printf("  Output directory: '%s'%n", options.getOutputDirectory());
+        System.out.printf("  Renderer: %s%n", options.getRenderer().getValue());
 
-        Arrays.stream(jarFilesArray).forEach(jarFile -> run(new File(jarFile), outputDir, renderer));
+        Arrays.stream(options.getJarFiles())
+            .forEach(jarFile -> run(new File(jarFile), options.getOutputDirectory(), options.getRenderer()));
         System.out.println("Finished processing in " + (System.currentTimeMillis() - startMillis) + "ms");
     }
 
@@ -86,10 +68,10 @@ public class Main {
      * gzipped file.
      */
     public static File[] run(File jarFile, File outputDir) {
-        return run(jarFile, outputDir, Renderer.JSON);
+        return run(jarFile, outputDir, OutputRenderer.JSON);
     }
 
-    private static File[] run(File jarFile, File outputDir, Renderer renderer) {
+    private static File[] run(File jarFile, File outputDir, OutputRenderer renderer) {
         System.out.printf("  Processing input .jar file: '%s'%n", jarFile);
 
         if (!jarFile.exists()) {
@@ -104,15 +86,15 @@ public class Main {
             }
         }
 
-        final String outputFileName = jarFile.getName().substring(0, jarFile.getName().length() - 4);
+        final String outputFileNameBase = jarFile.getName().substring(0, jarFile.getName().length() - 4);
         final Optional<APIListing> apiListing = processFile(jarFile);
 
         if (apiListing.isPresent()) {
             switch (renderer) {
                 case JSON:
-                    return renderJson(apiListing.get(), outputDir, outputFileName);
+                    return renderJson(apiListing.get(), outputDir, outputFileNameBase);
                 case MARKDOWN:
-                    return renderMarkdown(apiListing.get(), outputDir, outputFileName);
+                    return renderMarkdown(apiListing.get(), outputDir, outputFileNameBase);
                 default:
                     throw new IllegalStateException("Unsupported renderer: " + renderer);
             }
@@ -121,9 +103,9 @@ public class Main {
         return new File[] { };
     }
 
-    private static File[] renderJson(APIListing apiListing, File outputDir, String outputFileName) {
+    private static File[] renderJson(APIListing apiListing, File outputDir, String outputFileNameBase) {
         File[] files = new File[Constants.GZIP_OUTPUT ? 2 : 1];
-        files[0] = new File(outputDir, outputFileName + ".json");
+        files[0] = new File(outputDir, outputFileNameBase + ".json");
         apiListing.toFile(files[0], false);
         System.out.println("  Output written to file: " + files[0]);
 
@@ -165,7 +147,7 @@ public class Main {
         }
 
         if (Constants.GZIP_OUTPUT) {
-            files[1] = new File(outputDir, outputFileName + ".json.tgz");
+            files[1] = new File(outputDir, outputFileNameBase + ".json.tgz");
             apiListing.toFile(files[1], true);
             System.out.println("  Output written to file: " + files[1]);
         }
@@ -173,33 +155,11 @@ public class Main {
         return files;
     }
 
-    private static File[] renderMarkdown(APIListing apiListing, File outputDir, String outputFileName) {
-        File outputFile = new File(outputDir, outputFileName + ".md");
+    private static File[] renderMarkdown(APIListing apiListing, File outputDir, String outputFileNameBase) {
+        File outputFile = new File(outputDir, outputFileNameBase + ".md");
         MarkdownRenderer.write(apiListing, outputFile);
         System.out.println("  Output written to file: " + outputFile);
         return new File[] { outputFile };
-    }
-
-    private enum Renderer {
-        JSON("json"),
-        MARKDOWN("markdown");
-
-        private final String value;
-
-        Renderer(String value) {
-            this.value = value;
-        }
-
-        private static Renderer fromValue(String value) {
-            switch (value) {
-                case "json":
-                    return JSON;
-                case "markdown":
-                    return MARKDOWN;
-                default:
-                    throw new IllegalArgumentException("Unsupported renderer '" + value + "'. Expected json or markdown.");
-            }
-        }
     }
 
     private static Optional<APIListing> processFile(final File inputFile) {

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/Main.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/Main.java
@@ -39,15 +39,13 @@ public class Main {
     // [--renderer=json|markdown] [inputFiles] <outputDirectory>
     public static void main(String[] args) {
         if (args.length != 2 && args.length != 3) {
-            System.out.println("Expected argument order: [--renderer=json|markdown] "
-                + "[comma-separated sources jarFiles] <outputDirectory>, e.g. /path/to/jarfile.jar ./temp/");
+            printUsage();
             System.exit(-1);
         }
 
         final boolean hasRendererOption = args.length == 3 && args[0].startsWith(RENDERER_OPTION_PREFIX);
         if (args.length == 3 && !hasRendererOption) {
-            System.out.println("Expected argument order: [--renderer=json|markdown] [comma-separated sources jarFiles] "
-                + "<outputDirectory>, e.g. /path/to/jarfile.jar ./temp/");
+            printUsage();
             System.exit(-1);
         }
 
@@ -74,6 +72,11 @@ public class Main {
 
         Arrays.stream(jarFilesArray).forEach(jarFile -> run(new File(jarFile), outputDir, renderer));
         System.out.println("Finished processing in " + (System.currentTimeMillis() - startMillis) + "ms");
+    }
+
+    private static void printUsage() {
+        System.out.println("Expected argument order: [--renderer=json|markdown] "
+            + "[comma-separated sources jarFiles] <outputDirectory>, e.g. /path/to/jarfile.jar ./temp/");
     }
 
     /**

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/Main.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/Main.java
@@ -7,6 +7,7 @@ import com.azure.tools.apiview.processor.model.APIListing;
 import com.azure.tools.apiview.processor.model.ApiViewProperties;
 import com.azure.tools.apiview.processor.model.Language;
 import com.azure.tools.apiview.processor.model.LanguageVariant;
+import com.azure.tools.apiview.processor.model.MarkdownRenderer;
 import com.azure.tools.apiview.processor.model.maven.Pom;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -32,25 +33,30 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 public class Main {
+    private static final String MARKDOWN_FLAG = "--markdown";
 
     // expected argument order:
-    // [inputFiles] <outputDirectory>
+    // [--markdown] [inputFiles] <outputDirectory>
     public static void main(String[] args) {
-        if (args.length != 2) {
-            System.out.println("Expected argument order: [comma-separated sources jarFiles] <outputFile>, e.g. /path/to/jarfile.jar ./temp/");
+        final boolean markdownOutput = args.length == 3 && MARKDOWN_FLAG.equals(args[0]);
+        if ((!markdownOutput && args.length != 2) || (args.length == 3 && !MARKDOWN_FLAG.equals(args[0]))) {
+            System.out.println("Expected argument order: [--markdown] [comma-separated sources jarFiles] "
+                + "<outputDirectory>, e.g. /path/to/jarfile.jar ./temp/");
             System.exit(-1);
         }
 
         long startMillis = System.currentTimeMillis();
-        final String jarFiles = args[0];
+        final int positionalArgumentOffset = markdownOutput ? 1 : 0;
+        final String jarFiles = args[positionalArgumentOffset];
         final String[] jarFilesArray = jarFiles.split(",");
 
-        final File outputDir = new File(args[1]);
+        final File outputDir = new File(args[positionalArgumentOffset + 1]);
 
         System.out.println("Running with following configuration:");
         System.out.printf("  Output directory: '%s'%n", outputDir);
+        System.out.printf("  Output format: %s%n", markdownOutput ? "Markdown without JavaDoc" : "APIView JSON");
 
-        Arrays.stream(jarFilesArray).forEach(jarFile -> run(new File(jarFile), outputDir));
+        Arrays.stream(jarFilesArray).forEach(jarFile -> run(new File(jarFile), outputDir, markdownOutput));
         System.out.println("Finished processing in " + (System.currentTimeMillis() - startMillis) + "ms");
     }
 
@@ -60,6 +66,18 @@ public class Main {
      * gzipped file.
      */
     public static File[] run(File jarFile, File outputDir) {
+        return run(jarFile, outputDir, false);
+    }
+
+    /**
+     * Runs the APIView parser.
+     *
+     * @param jarFile The sources JAR to process.
+     * @param outputDir The output directory.
+     * @param markdownOutput Whether to write Markdown without JavaDoc instead of APIView JSON.
+     * @return The generated output files.
+     */
+    public static File[] run(File jarFile, File outputDir, boolean markdownOutput) {
         System.out.printf("  Processing input .jar file: '%s'%n", jarFile);
 
         if (!jarFile.exists()) {
@@ -74,10 +92,18 @@ public class Main {
             }
         }
 
-        final String outputFileName = jarFile.getName().substring(0, jarFile.getName().length() - 4) + ".json";
+        final String outputFileName = jarFile.getName().substring(0, jarFile.getName().length() - 4)
+            + (markdownOutput ? ".md" : ".json");
         final Optional<APIListing> apiListing = processFile(jarFile);
 
         if (apiListing.isPresent()) {
+            if (markdownOutput) {
+                File outputFile = new File(outputDir, outputFileName);
+                MarkdownRenderer.write(apiListing.get(), outputFile);
+                System.out.println("  Output written to file: " + outputFile);
+                return new File[] { outputFile };
+            }
+
             File[] files = new File[Constants.GZIP_OUTPUT ? 2 : 1];
             files[0] = new File(outputDir, outputFileName);
             apiListing.get().toFile(files[0], false);

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/Main.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/Main.java
@@ -33,20 +33,36 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 public class Main {
-    private static final String MARKDOWN_FLAG = "--markdown";
+    private static final String RENDERER_OPTION_PREFIX = "--renderer=";
 
     // expected argument order:
-    // [--markdown] [inputFiles] <outputDirectory>
+    // [--renderer=json|markdown] [inputFiles] <outputDirectory>
     public static void main(String[] args) {
-        final boolean markdownOutput = args.length == 3 && MARKDOWN_FLAG.equals(args[0]);
-        if ((!markdownOutput && args.length != 2) || (args.length == 3 && !MARKDOWN_FLAG.equals(args[0]))) {
-            System.out.println("Expected argument order: [--markdown] [comma-separated sources jarFiles] "
+        if (args.length != 2 && args.length != 3) {
+            System.out.println("Expected argument order: [--renderer=json|markdown] "
+                + "[comma-separated sources jarFiles] <outputDirectory>, e.g. /path/to/jarfile.jar ./temp/");
+            System.exit(-1);
+        }
+
+        final boolean hasRendererOption = args.length == 3 && args[0].startsWith(RENDERER_OPTION_PREFIX);
+        if (args.length == 3 && !hasRendererOption) {
+            System.out.println("Expected argument order: [--renderer=json|markdown] [comma-separated sources jarFiles] "
                 + "<outputDirectory>, e.g. /path/to/jarfile.jar ./temp/");
             System.exit(-1);
         }
 
         long startMillis = System.currentTimeMillis();
-        final int positionalArgumentOffset = markdownOutput ? 1 : 0;
+        Renderer selectedRenderer = Renderer.JSON;
+        if (hasRendererOption) {
+            try {
+                selectedRenderer = Renderer.fromValue(args[0].substring(RENDERER_OPTION_PREFIX.length()));
+            } catch (IllegalArgumentException e) {
+                System.out.println(e.getMessage());
+                System.exit(-1);
+            }
+        }
+        final Renderer renderer = selectedRenderer;
+        final int positionalArgumentOffset = hasRendererOption ? 1 : 0;
         final String jarFiles = args[positionalArgumentOffset];
         final String[] jarFilesArray = jarFiles.split(",");
 
@@ -54,9 +70,9 @@ public class Main {
 
         System.out.println("Running with following configuration:");
         System.out.printf("  Output directory: '%s'%n", outputDir);
-        System.out.printf("  Output format: %s%n", markdownOutput ? "Markdown without JavaDoc" : "APIView JSON");
+        System.out.printf("  Renderer: %s%n", renderer.value);
 
-        Arrays.stream(jarFilesArray).forEach(jarFile -> run(new File(jarFile), outputDir, markdownOutput));
+        Arrays.stream(jarFilesArray).forEach(jarFile -> run(new File(jarFile), outputDir, renderer));
         System.out.println("Finished processing in " + (System.currentTimeMillis() - startMillis) + "ms");
     }
 
@@ -66,18 +82,10 @@ public class Main {
      * gzipped file.
      */
     public static File[] run(File jarFile, File outputDir) {
-        return run(jarFile, outputDir, false);
+        return run(jarFile, outputDir, Renderer.JSON);
     }
 
-    /**
-     * Runs the APIView parser.
-     *
-     * @param jarFile The sources JAR to process.
-     * @param outputDir The output directory.
-     * @param markdownOutput Whether to write Markdown without JavaDoc instead of APIView JSON.
-     * @return The generated output files.
-     */
-    public static File[] run(File jarFile, File outputDir, boolean markdownOutput) {
+    private static File[] run(File jarFile, File outputDir, Renderer renderer) {
         System.out.printf("  Processing input .jar file: '%s'%n", jarFile);
 
         if (!jarFile.exists()) {
@@ -92,70 +100,102 @@ public class Main {
             }
         }
 
-        final String outputFileName = jarFile.getName().substring(0, jarFile.getName().length() - 4)
-            + (markdownOutput ? ".md" : ".json");
+        final String outputFileName = jarFile.getName().substring(0, jarFile.getName().length() - 4);
         final Optional<APIListing> apiListing = processFile(jarFile);
 
         if (apiListing.isPresent()) {
-            if (markdownOutput) {
-                File outputFile = new File(outputDir, outputFileName);
-                MarkdownRenderer.write(apiListing.get(), outputFile);
-                System.out.println("  Output written to file: " + outputFile);
-                return new File[] { outputFile };
+            switch (renderer) {
+                case JSON:
+                    return renderJson(apiListing.get(), outputDir, outputFileName);
+                case MARKDOWN:
+                    return renderMarkdown(apiListing.get(), outputDir, outputFileName);
+                default:
+                    throw new IllegalStateException("Unsupported renderer: " + renderer);
             }
-
-            File[] files = new File[Constants.GZIP_OUTPUT ? 2 : 1];
-            files[0] = new File(outputDir, outputFileName);
-            apiListing.get().toFile(files[0], false);
-            System.out.println("  Output written to file: " + files[0]);
-
-            if (Constants.PRETTY_PRINT_JSON) {
-                try {
-                    String json = new String(Files.readAllBytes(files[0].toPath()));
-                    ObjectMapper mapper = new ObjectMapper();
-                    Object jsonObject = mapper.readValue(json, Object.class);
-                    mapper.writerWithDefaultPrettyPrinter().writeValue(files[0], jsonObject);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-
-            if (Constants.VALIDATE_JSON_SCHEMA) {
-                System.out.println("  Validating the generated JSON file against the schema...");
-                try {
-                    JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
-                    // Load the schema from the classpath resource
-                    URL resource = Main.class.getResource(Constants.APIVIEW_JSON_SCHEMA_RESOURCE);
-                    if (resource == null) {
-                        throw new IllegalStateException("Resource not found: " + Constants.APIVIEW_JSON_SCHEMA_RESOURCE);
-                    }
-                    URI localResourceUri = resource.toURI();
-                    JsonSchema schema = factory.getSchema(localResourceUri);
-
-                    JsonNode jsonNode = new ObjectMapper().readTree(files[0]);
-                    schema.initializeValidators();
-                    Set<ValidationMessage> validationMessages = schema.validate(jsonNode);
-                    if (validationMessages.isEmpty()) {
-                        System.out.println("    Validation passed.");
-                    } else {
-                        System.out.println("    Validation failed. Errors:");
-                        validationMessages.forEach(msg -> System.out.println("      " + msg.getMessage()));
-                    }
-                } catch (IOException | URISyntaxException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-
-            if (Constants.GZIP_OUTPUT) {
-                files[1] = new File(outputDir, outputFileName + ".tgz");
-                apiListing.get().toFile(files[1], true);
-                System.out.println("  Output written to file: " + files[1]);
-            }
-
-            return files;
         }
 
         return new File[] { };
+    }
+
+    private static File[] renderJson(APIListing apiListing, File outputDir, String outputFileName) {
+        File[] files = new File[Constants.GZIP_OUTPUT ? 2 : 1];
+        files[0] = new File(outputDir, outputFileName + ".json");
+        apiListing.toFile(files[0], false);
+        System.out.println("  Output written to file: " + files[0]);
+
+        if (Constants.PRETTY_PRINT_JSON) {
+            try {
+                String json = new String(Files.readAllBytes(files[0].toPath()));
+                ObjectMapper mapper = new ObjectMapper();
+                Object jsonObject = mapper.readValue(json, Object.class);
+                mapper.writerWithDefaultPrettyPrinter().writeValue(files[0], jsonObject);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        if (Constants.VALIDATE_JSON_SCHEMA) {
+            System.out.println("  Validating the generated JSON file against the schema...");
+            try {
+                JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
+                // Load the schema from the classpath resource
+                URL resource = Main.class.getResource(Constants.APIVIEW_JSON_SCHEMA_RESOURCE);
+                if (resource == null) {
+                    throw new IllegalStateException("Resource not found: " + Constants.APIVIEW_JSON_SCHEMA_RESOURCE);
+                }
+                URI localResourceUri = resource.toURI();
+                JsonSchema schema = factory.getSchema(localResourceUri);
+
+                JsonNode jsonNode = new ObjectMapper().readTree(files[0]);
+                schema.initializeValidators();
+                Set<ValidationMessage> validationMessages = schema.validate(jsonNode);
+                if (validationMessages.isEmpty()) {
+                    System.out.println("    Validation passed.");
+                } else {
+                    System.out.println("    Validation failed. Errors:");
+                    validationMessages.forEach(msg -> System.out.println("      " + msg.getMessage()));
+                }
+            } catch (IOException | URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        if (Constants.GZIP_OUTPUT) {
+            files[1] = new File(outputDir, outputFileName + ".json.tgz");
+            apiListing.toFile(files[1], true);
+            System.out.println("  Output written to file: " + files[1]);
+        }
+
+        return files;
+    }
+
+    private static File[] renderMarkdown(APIListing apiListing, File outputDir, String outputFileName) {
+        File outputFile = new File(outputDir, outputFileName + ".md");
+        MarkdownRenderer.write(apiListing, outputFile);
+        System.out.println("  Output written to file: " + outputFile);
+        return new File[] { outputFile };
+    }
+
+    private enum Renderer {
+        JSON("json"),
+        MARKDOWN("markdown");
+
+        private final String value;
+
+        Renderer(String value) {
+            this.value = value;
+        }
+
+        private static Renderer fromValue(String value) {
+            switch (value) {
+                case "json":
+                    return JSON;
+                case "markdown":
+                    return MARKDOWN;
+                default:
+                    throw new IllegalArgumentException("Unsupported renderer '" + value + "'. Expected json or markdown.");
+            }
+        }
     }
 
     private static Optional<APIListing> processFile(final File inputFile) {

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/Main.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/Main.java
@@ -56,6 +56,7 @@ public class Main {
                 selectedRenderer = Renderer.fromValue(args[0].substring(RENDERER_OPTION_PREFIX.length()));
             } catch (IllegalArgumentException e) {
                 System.out.println(e.getMessage());
+                printUsage();
                 System.exit(-1);
             }
         }

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/OutputRenderer.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/OutputRenderer.java
@@ -1,0 +1,27 @@
+package com.azure.tools.apiview.processor;
+
+enum OutputRenderer {
+    JSON("json"),
+    MARKDOWN("markdown");
+
+    private final String value;
+
+    OutputRenderer(String value) {
+        this.value = value;
+    }
+
+    String getValue() {
+        return value;
+    }
+
+    static OutputRenderer fromValue(String value) {
+        switch (value) {
+            case "json":
+                return JSON;
+            case "markdown":
+                return MARKDOWN;
+            default:
+                throw new IllegalArgumentException("Unsupported renderer '" + value + "'. Expected json or markdown.");
+        }
+    }
+}

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
@@ -1419,6 +1419,9 @@ public class JavaASTAnalyser implements Analyser {
             }
         }
 
+        // close declaration
+        definitionLine.addToken(PUNCTUATION, ")");
+
         // FIXME this is a bit hacky - it would be nice to have 'MethodRule' like we do for Annotations.
         // we want to special-case here for methods called `getLatest()` which are within a class that implements the
         // `ServiceVersion` interface. We want to add a comment to the method to indicate that it is a special method
@@ -1438,9 +1441,6 @@ public class JavaASTAnalyser implements Analyser {
                 }
             }
         }
-
-        // close declaration
-        definitionLine.addToken(PUNCTUATION, ")");
     }
 
     private boolean visitTypeParameters(NodeList<TypeParameter> typeParameters, ReviewLine reviewLine) {

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/MarkdownRenderer.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/MarkdownRenderer.java
@@ -76,11 +76,13 @@ public final class MarkdownRenderer {
                 continue;
             }
             if (token.getTokenKind() != TokenKind.COMMENT) {
+                // Inline comments can carry API information, such as an elided initializer or a service-version value.
                 return false;
             }
             hasComment = true;
         }
 
+        // Comment-only lines are APIView presentation metadata, such as grouping labels or empty-type explanations.
         return hasComment;
     }
 

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/MarkdownRenderer.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/MarkdownRenderer.java
@@ -50,6 +50,10 @@ public final class MarkdownRenderer {
 
         for (ReviewLine line : reviewLines) {
             List<ReviewToken> tokens = line.getTokens();
+            if (isStandaloneCommentLine(tokens)) {
+                continue;
+            }
+
             String renderedLine = renderTokens(tokens);
 
             if (tokens.isEmpty()) {
@@ -62,6 +66,22 @@ public final class MarkdownRenderer {
                 renderLines(line.getChildren(), indentLevel + 1, output);
             }
         }
+    }
+
+    private static boolean isStandaloneCommentLine(List<ReviewToken> tokens) {
+        boolean hasComment = false;
+
+        for (ReviewToken token : tokens) {
+            if (token.isDocumentation()) {
+                continue;
+            }
+            if (token.getTokenKind() != TokenKind.COMMENT) {
+                return false;
+            }
+            hasComment = true;
+        }
+
+        return hasComment;
     }
 
     private static String renderTokens(List<ReviewToken> tokens) {

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/MarkdownRenderer.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/MarkdownRenderer.java
@@ -1,0 +1,98 @@
+package com.azure.tools.apiview.processor.model;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Renders an API listing as concise Java Markdown without documentation tokens.
+ */
+public final class MarkdownRenderer {
+    private static final String INDENT = "    ";
+
+    private MarkdownRenderer() {
+    }
+
+    /**
+     * Writes an API listing as fenced Java Markdown without documentation tokens.
+     *
+     * @param apiListing The API listing to render.
+     * @param outputFile The destination Markdown file.
+     */
+    public static void write(APIListing apiListing, File outputFile) {
+        try {
+            Files.write(outputFile.toPath(), render(apiListing).getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Renders an API listing as fenced Java Markdown without documentation tokens.
+     *
+     * @param apiListing The API listing to render.
+     * @return The rendered Markdown.
+     */
+    public static String render(APIListing apiListing) {
+        List<String> lines = new ArrayList<>();
+        lines.add("```java");
+        renderLines(apiListing.getChildren(), 0, lines);
+        lines.add("```");
+        return String.join(System.lineSeparator(), lines);
+    }
+
+    private static void renderLines(List<ReviewLine> reviewLines, int indentLevel, List<String> output) {
+        String indent = repeatIndent(indentLevel);
+
+        for (ReviewLine line : reviewLines) {
+            List<ReviewToken> tokens = line.getTokens();
+            String renderedLine = renderTokens(tokens);
+
+            if (tokens.isEmpty()) {
+                output.add("");
+            } else if (!renderedLine.isEmpty()) {
+                output.add(indent + renderedLine);
+            }
+
+            if (!line.getChildren().isEmpty()) {
+                renderLines(line.getChildren(), indentLevel + 1, output);
+            }
+        }
+    }
+
+    private static String renderTokens(List<ReviewToken> tokens) {
+        StringBuilder line = new StringBuilder();
+
+        for (ReviewToken token : tokens) {
+            if (token.isDocumentation()) {
+                continue;
+            }
+
+            if (token.hasPrefixSpace()) {
+                line.append(' ');
+            }
+            line.append(token.getValue());
+            if (token.hasSuffixSpace()) {
+                line.append(' ');
+            }
+        }
+
+        int length = line.length();
+        while (length > 0 && Character.isWhitespace(line.charAt(length - 1))) {
+            length--;
+        }
+        return line.substring(0, length);
+    }
+
+    private static String repeatIndent(int indentLevel) {
+        StringBuilder indent = new StringBuilder(indentLevel * INDENT.length());
+        for (int i = 0; i < indentLevel; i++) {
+            indent.append(INDENT);
+        }
+        return indent.toString();
+    }
+}

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/MarkdownRenderer.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/MarkdownRenderer.java
@@ -50,12 +50,13 @@ public final class MarkdownRenderer {
 
         for (ReviewLine line : reviewLines) {
             List<ReviewToken> tokens = line.getTokens();
-            String renderedLine = renderTokens(tokens);
-
             if (tokens.isEmpty()) {
                 output.add("");
-            } else if (!renderedLine.isEmpty()) {
-                output.add(indent + renderedLine);
+            } else {
+                String renderedLine = renderTokens(tokens);
+                if (!renderedLine.isEmpty()) {
+                    output.add(indent + renderedLine);
+                }
             }
 
             if (!line.getChildren().isEmpty()) {
@@ -73,11 +74,25 @@ public final class MarkdownRenderer {
             }
 
             // Comments are review context, including method groupings, API shape hints, and inline values.
-            if (token.hasPrefixSpace()) {
+            String value = token.getValue();
+            int start = 0;
+            int end = value.length();
+            while (start < end && Character.isWhitespace(value.charAt(start))) {
+                start++;
+            }
+            while (end > start && Character.isWhitespace(value.charAt(end - 1))) {
+                end--;
+            }
+
+            boolean prefixSpace = token.hasPrefixSpace() || start > 0;
+            boolean suffixSpace = token.hasSuffixSpace() || end < value.length();
+            if (prefixSpace && line.length() > 0 && !Character.isWhitespace(line.charAt(line.length() - 1))) {
                 line.append(' ');
             }
-            line.append(token.getValue());
-            if (token.hasSuffixSpace()) {
+
+            line.append(value, start, end);
+
+            if (suffixSpace && line.length() > 0 && !Character.isWhitespace(line.charAt(line.length() - 1))) {
                 line.append(' ');
             }
         }

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/MarkdownRenderer.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/MarkdownRenderer.java
@@ -50,10 +50,6 @@ public final class MarkdownRenderer {
 
         for (ReviewLine line : reviewLines) {
             List<ReviewToken> tokens = line.getTokens();
-            if (isStandaloneCommentLine(tokens)) {
-                continue;
-            }
-
             String renderedLine = renderTokens(tokens);
 
             if (tokens.isEmpty()) {
@@ -68,24 +64,6 @@ public final class MarkdownRenderer {
         }
     }
 
-    private static boolean isStandaloneCommentLine(List<ReviewToken> tokens) {
-        boolean hasComment = false;
-
-        for (ReviewToken token : tokens) {
-            if (token.isDocumentation()) {
-                continue;
-            }
-            if (token.getTokenKind() != TokenKind.COMMENT) {
-                // Inline comments can carry API information, such as an elided initializer or a service-version value.
-                return false;
-            }
-            hasComment = true;
-        }
-
-        // Comment-only lines are APIView presentation metadata, such as grouping labels or empty-type explanations.
-        return hasComment;
-    }
-
     private static String renderTokens(List<ReviewToken> tokens) {
         StringBuilder line = new StringBuilder();
 
@@ -94,6 +72,7 @@ public final class MarkdownRenderer {
                 continue;
             }
 
+            // Comments are review context, including method groupings, API shape hints, and inline values.
             if (token.hasPrefixSpace()) {
                 line.append(' ');
             }

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/ReviewToken.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/ReviewToken.java
@@ -127,6 +127,22 @@ public class ReviewToken implements JsonSerializable<ReviewToken> {
         return tokenKind;
     }
 
+    public String getValue() {
+        return value;
+    }
+
+    public boolean hasPrefixSpace() {
+        return hasPrefixSpace;
+    }
+
+    public boolean hasSuffixSpace() {
+        return hasSuffixSpace;
+    }
+
+    public boolean isDocumentation() {
+        return isDocumentation;
+    }
+
     //    public ReviewToken addProperty(String key, String value) {
 //        properties.put(Objects.requireNonNull(key), Objects.requireNonNull(value));
 //        return this;

--- a/src/java/apiview-java-processor/src/test/java/com/azure/tools/apiview/processor/CommandLineOptionsTests.java
+++ b/src/java/apiview-java-processor/src/test/java/com/azure/tools/apiview/processor/CommandLineOptionsTests.java
@@ -1,0 +1,68 @@
+package com.azure.tools.apiview.processor;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class CommandLineOptionsTests {
+    @Test
+    public void defaultsToJsonRenderer() {
+        CommandLineOptions options = CommandLineOptions.parse(new String[] { "library-sources.jar", "output" });
+
+        assertEquals(OutputRenderer.JSON, options.getRenderer());
+        assertArrayEquals(new String[] { "library-sources.jar" }, options.getJarFiles());
+        assertEquals(new File("output"), options.getOutputDirectory());
+    }
+
+    @Test
+    public void parsesMarkdownRendererAndMultipleJars() {
+        CommandLineOptions options = CommandLineOptions.parse(new String[] {
+            "--renderer=markdown",
+            "first-sources.jar,second-sources.jar",
+            "output"
+        });
+
+        assertEquals(OutputRenderer.MARKDOWN, options.getRenderer());
+        assertArrayEquals(new String[] { "first-sources.jar", "second-sources.jar" }, options.getJarFiles());
+        assertEquals(new File("output"), options.getOutputDirectory());
+    }
+
+    @Test
+    public void parsesExplicitJsonRenderer() {
+        CommandLineOptions options = CommandLineOptions.parse(
+            new String[] { "--renderer=json", "library-sources.jar", "output" });
+
+        assertEquals(OutputRenderer.JSON, options.getRenderer());
+    }
+
+    @Test
+    public void rejectsInvalidArgumentCount() {
+        assertThrows(IllegalArgumentException.class, () -> CommandLineOptions.parse(new String[] { "input.jar" }));
+        assertThrows(IllegalArgumentException.class,
+            () -> CommandLineOptions.parse(new String[] { "one.jar", "output", "unexpected", "extra" }));
+    }
+
+    @Test
+    public void rejectsUnsupportedOption() {
+        assertThrows(IllegalArgumentException.class,
+            () -> CommandLineOptions.parse(new String[] { "--format=markdown", "input.jar", "output" }));
+    }
+
+    @Test
+    public void rejectsRendererWithoutPositionalArguments() {
+        assertThrows(IllegalArgumentException.class,
+            () -> CommandLineOptions.parse(new String[] { "--renderer=markdown", "output" }));
+    }
+
+    @Test
+    public void rejectsUnsupportedRenderer() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> CommandLineOptions.parse(new String[] { "--renderer=xml", "input.jar", "output" }));
+
+        assertEquals("Unsupported renderer 'xml'. Expected json or markdown.", exception.getMessage());
+    }
+}

--- a/src/java/apiview-java-processor/src/test/java/com/azure/tools/apiview/processor/CommandLineOptionsTests.java
+++ b/src/java/apiview-java-processor/src/test/java/com/azure/tools/apiview/processor/CommandLineOptionsTests.java
@@ -50,6 +50,8 @@ public class CommandLineOptionsTests {
     public void rejectsUnsupportedOption() {
         assertThrows(IllegalArgumentException.class,
             () -> CommandLineOptions.parse(new String[] { "--format=markdown", "input.jar", "output" }));
+        assertThrows(IllegalArgumentException.class,
+            () -> CommandLineOptions.parse(new String[] { "--format=markdown", "output" }));
     }
 
     @Test

--- a/src/java/apiview-java-processor/src/test/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyserTests.java
+++ b/src/java/apiview-java-processor/src/test/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyserTests.java
@@ -1,0 +1,38 @@
+package com.azure.tools.apiview.processor.analysers;
+
+import com.azure.tools.apiview.processor.model.APIListing;
+import com.azure.tools.apiview.processor.model.MarkdownRenderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JavaASTAnalyserTests {
+    @Test
+    public void rendersServiceVersionReturnHintAfterMethodSignature(@TempDir Path tempDir) throws IOException {
+        Path sourceFile = tempDir.resolve("TestServiceVersion.java");
+        Files.write(sourceFile, String.join(System.lineSeparator(),
+            "package com.azure.test;",
+            "public enum TestServiceVersion implements ServiceVersion {",
+            "    V1;",
+            "    public static TestServiceVersion getLatest() {",
+            "        return V1;",
+            "    }",
+            "}").getBytes(StandardCharsets.UTF_8));
+
+        APIListing listing = new APIListing();
+        listing.setPackageName("io.clientcore:test");
+        new JavaASTAnalyser(listing).analyse(Collections.singletonList(sourceFile));
+        String markdown = MarkdownRenderer.render(listing);
+
+        assertTrue(markdown.contains("public static TestServiceVersion getLatest() // returns V1"));
+        assertFalse(markdown.contains("getLatest(// returns V1"));
+    }
+}

--- a/src/java/apiview-java-processor/src/test/java/com/azure/tools/apiview/processor/model/MarkdownRendererTests.java
+++ b/src/java/apiview-java-processor/src/test/java/com/azure/tools/apiview/processor/model/MarkdownRendererTests.java
@@ -73,4 +73,24 @@ public class MarkdownRendererTests {
             "public Widget = new Widget(/* Elided */)",
             "```"), MarkdownRenderer.render(listing));
     }
+
+    @Test
+    public void normalizesWhitespaceAtTokenBoundaries() {
+        APIListing listing = new APIListing();
+        listing.addChildLine()
+            .addToken(TokenKind.ANNOTATION_NAME, "@Example", Spacing.NO_SPACE)
+            .addToken(TokenKind.PUNCTUATION, "(", Spacing.NO_SPACE)
+            .addToken(TokenKind.ANNOTATION_PARAMETER_NAME, "value", Spacing.NO_SPACE)
+            .addToken(TokenKind.PUNCTUATION, " = ")
+            .addToken(TokenKind.ANNOTATION_PARAMETER_VALUE, "left")
+            .addToken(TokenKind.PUNCTUATION, " + ")
+            .addToken(TokenKind.ANNOTATION_PARAMETER_VALUE, "right", Spacing.NO_SPACE)
+            .addToken(TokenKind.PUNCTUATION, ",")
+            .addToken(TokenKind.PUNCTUATION, "}", Spacing.SPACE_BEFORE);
+
+        assertEquals(String.join(System.lineSeparator(),
+            "```java",
+            "@Example(value = left + right, }",
+            "```"), MarkdownRenderer.render(listing));
+    }
 }

--- a/src/java/apiview-java-processor/src/test/java/com/azure/tools/apiview/processor/model/MarkdownRendererTests.java
+++ b/src/java/apiview-java-processor/src/test/java/com/azure/tools/apiview/processor/model/MarkdownRendererTests.java
@@ -51,4 +51,25 @@ public class MarkdownRendererTests {
             "public Widget",
             "```"), MarkdownRenderer.render(listing));
     }
+
+    @Test
+    public void removesStandaloneCommentsButPreservesInlineComments() {
+        APIListing listing = new APIListing();
+        listing.addChildLine()
+            .addToken(TokenKind.COMMENT, "// This interface does not declare any API.");
+        listing.addChildLine()
+            .addToken(TokenKind.KEYWORD, "public")
+            .addToken(TokenKind.TYPE_NAME, "Widget", Spacing.NO_SPACE)
+            .addToken(TokenKind.PUNCTUATION, "=", Spacing.SPACE_BEFORE_AND_AFTER)
+            .addToken(TokenKind.KEYWORD, "new")
+            .addToken(TokenKind.TYPE_NAME, "Widget", Spacing.NO_SPACE)
+            .addToken(TokenKind.PUNCTUATION, "(", Spacing.NO_SPACE)
+            .addToken(TokenKind.COMMENT, "/* Elided */", Spacing.NO_SPACE)
+            .addToken(TokenKind.PUNCTUATION, ")", Spacing.NO_SPACE);
+
+        assertEquals(String.join(System.lineSeparator(),
+            "```java",
+            "public Widget = new Widget(/* Elided */)",
+            "```"), MarkdownRenderer.render(listing));
+    }
 }

--- a/src/java/apiview-java-processor/src/test/java/com/azure/tools/apiview/processor/model/MarkdownRendererTests.java
+++ b/src/java/apiview-java-processor/src/test/java/com/azure/tools/apiview/processor/model/MarkdownRendererTests.java
@@ -1,0 +1,54 @@
+package com.azure.tools.apiview.processor.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class MarkdownRendererTests {
+    @Test
+    public void rendersNestedApiWithoutDocumentation() {
+        APIListing listing = new APIListing();
+        ReviewLine module = listing.addChildLine()
+            .addToken(TokenKind.KEYWORD, "module")
+            .addToken(TokenKind.MODULE_NAME, "com.azure.widgets")
+            .addContextStartTokens();
+
+        module.addChildLine()
+            .addToken(new ReviewToken(TokenKind.JAVADOC, "/** Widget client. */").setDocumentation());
+
+        module.addChildLine()
+            .addToken(TokenKind.KEYWORD, "public")
+            .addToken(TokenKind.RETURN_TYPE, "Widget")
+            .addToken(TokenKind.METHOD_NAME, "getWidget", Spacing.NO_SPACE)
+            .addToken(TokenKind.PUNCTUATION, "(", Spacing.NO_SPACE)
+            .addToken(TokenKind.PARAMETER_TYPE, "String")
+            .addToken(TokenKind.PARAMETER_NAME, "name", Spacing.NO_SPACE)
+            .addToken(TokenKind.PUNCTUATION, ")", Spacing.NO_SPACE);
+
+        String expected = String.join(System.lineSeparator(),
+            "```java",
+            "module com.azure.widgets {",
+            "    public Widget getWidget(String name)",
+            "```");
+
+        String markdown = MarkdownRenderer.render(listing);
+
+        assertEquals(expected, markdown);
+        assertFalse(markdown.contains("Widget client"));
+    }
+
+    @Test
+    public void removesDocumentationTokensFromMixedLines() {
+        APIListing listing = new APIListing();
+        listing.addChildLine()
+            .addToken(new ReviewToken(TokenKind.JAVADOC, "documentation").setDocumentation())
+            .addToken(TokenKind.KEYWORD, "public")
+            .addToken(TokenKind.TYPE_NAME, "Widget", Spacing.NO_SPACE);
+
+        assertEquals(String.join(System.lineSeparator(),
+            "```java",
+            "public Widget",
+            "```"), MarkdownRenderer.render(listing));
+    }
+}

--- a/src/java/apiview-java-processor/src/test/java/com/azure/tools/apiview/processor/model/MarkdownRendererTests.java
+++ b/src/java/apiview-java-processor/src/test/java/com/azure/tools/apiview/processor/model/MarkdownRendererTests.java
@@ -53,10 +53,10 @@ public class MarkdownRendererTests {
     }
 
     @Test
-    public void removesStandaloneCommentsButPreservesInlineComments() {
+    public void preservesStandaloneAndInlineComments() {
         APIListing listing = new APIListing();
         listing.addChildLine()
-            .addToken(TokenKind.COMMENT, "// This interface does not declare any API.");
+            .addToken(TokenKind.COMMENT, "// Service Methods:");
         listing.addChildLine()
             .addToken(TokenKind.KEYWORD, "public")
             .addToken(TokenKind.TYPE_NAME, "Widget", Spacing.NO_SPACE)
@@ -69,6 +69,7 @@ public class MarkdownRendererTests {
 
         assertEquals(String.join(System.lineSeparator(),
             "```java",
+            "// Service Methods:",
             "public Widget = new Widget(/* Elided */)",
             "```"), MarkdownRenderer.render(listing));
     }


### PR DESCRIPTION
## Summary

- add `--renderer=markdown` to the Java APIView processor
- keep `json` as the default renderer
- dispatch rendering through a simple renderer switch
- isolate JSON and Markdown output in separate methods
- omit Javadoc while preserving standalone and inline APIView comments
- document the new mode and add focused renderer and CLI parser tests

## Motivation

Automated API review benefits from a compact public API snapshot instead of full generated source. The Markdown renderer retains complete signatures and useful review context while removing Javadoc.

See generated examples in Azure/azure-sdk-for-java#50226.

## Usage

```text
java -jar apiview-java-processor-<version>.jar --renderer=markdown <sources.jar> <output-directory>
```

Omitting `--renderer` retains the existing JSON behavior and filename pattern.

## Validation

- `mvn --batch-mode --no-transfer-progress test`
- generated snapshots for `azure-core`, `azure-storage-blob`, and `azure-analytics-planetarycomputer`
- confirmed that method groupings, API shape hints, elided initializers, and service-version value mappings remain
- the default invocation still produces schema-valid APIView JSON
