### PR TITLE
Pilot automatic Copilot reviews for azsdk-cli

### DIFF
--- a/.github/skills/code-review/PILOT.md
+++ b/.github/skills/code-review/PILOT.md
@@ -1,0 +1,54 @@
+# azsdk-cli Copilot Code Review Pilot
+
+This pilot automatically requests a non-blocking GitHub Copilot review when a
+pull request changes `tools/azsdk-cli/**`. Copilot submits a comment review; it
+does not approve the pull request, request changes, satisfy required approvals,
+or block merging.
+
+The workflow requests one review when an eligible pull request is opened,
+reopened, or moved out of draft. It does not request another review for every
+push during the pilot.
+
+## Classify Review Results
+
+Maintainers classify each Copilot finding using its review comment:
+
+1. React with `:+1:` when the finding is correct, useful, and supported by the
+   changed code.
+2. React with `:-1:` when the finding is incorrect or unsupported.
+3. Reply with `duplicate: <check>` when an analyzer, compiler, linter, or CI
+   check already owns the finding.
+4. Record a missed defect in the pilot tracking issue with the pull request,
+   changed line, triggering scenario, and expected finding.
+5. Record a routing failure when the `code-review` skill is attributed to an
+   unrelated change or is not attributed to an azsdk-cli review where its rules
+   were relevant.
+
+Comments and replies are evidence for maintainers; Copilot does not process
+replies to its review comments.
+
+## Weekly Triage
+
+After each group of reviewed pull requests:
+
+1. Count confirmed findings, false positives, duplicates, missed defects, and
+   routing failures.
+2. Sanitize confirmed misses and false positives into Vally fixtures without
+   source code, credentials, customer data, or private repository context.
+3. Run each new fixture at least three times to detect unstable behavior.
+4. Update the skill only when the collected evidence demonstrates a recurring
+   review problem.
+
+Use these pilot measurements:
+
+| Measurement | Calculation |
+| --- | --- |
+| Review precision | Confirmed findings / all non-duplicate findings |
+| Duplicate rate | Duplicate findings / all findings |
+| Missed-defect count | Confirmed defects absent from the Copilot review |
+| Routing accuracy | Correct skill-routing decisions / reviewed pull requests |
+| Stability | Runs producing the expected result / repeated fixture runs |
+
+Pilot findings must not become merge-blocking checks. Reconsider enforcement
+only after the skill demonstrates high precision, stable repeated results, and
+low duplication across representative azsdk-cli pull requests.

--- a/.github/skills/code-review/PILOT.md
+++ b/.github/skills/code-review/PILOT.md
@@ -26,29 +26,3 @@ Maintainers classify each Copilot finding using its review comment:
 
 Comments and replies are evidence for maintainers; Copilot does not process
 replies to its review comments.
-
-## Weekly Triage
-
-After each group of reviewed pull requests:
-
-1. Count confirmed findings, false positives, duplicates, missed defects, and
-   routing failures.
-2. Sanitize confirmed misses and false positives into Vally fixtures without
-   source code, credentials, customer data, or private repository context.
-3. Run each new fixture at least three times to detect unstable behavior.
-4. Update the skill only when the collected evidence demonstrates a recurring
-   review problem.
-
-Use these pilot measurements:
-
-| Measurement | Calculation |
-| --- | --- |
-| Review precision | Confirmed findings / all non-duplicate findings |
-| Duplicate rate | Duplicate findings / all findings |
-| Missed-defect count | Confirmed defects absent from the Copilot review |
-| Routing accuracy | Correct skill-routing decisions / reviewed pull requests |
-| Stability | Runs producing the expected result / repeated fixture runs |
-
-Pilot findings must not become merge-blocking checks. Reconsider enforcement
-only after the skill demonstrates high precision, stable repeated results, and
-low duplication across representative azsdk-cli pull requests.

--- a/.github/workflows/azsdk-cli-copilot-review.yml
+++ b/.github/workflows/azsdk-cli-copilot-review.yml
@@ -1,0 +1,28 @@
+name: azsdk-cli Copilot review pilot
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+    paths:
+      - tools/azsdk-cli/**
+
+permissions: {}
+
+jobs:
+  request-copilot-review:
+    name: Request non-blocking Copilot review
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Request Copilot review
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh api \
+            --method POST \
+            "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/requested_reviewers" \
+            --field 'reviewers[]=copilot-pull-request-reviewer[bot]'


### PR DESCRIPTION
## Summary

- automatically request a non-blocking Copilot review when a pull request changes `tools/azsdk-cli/**`
- limit the pilot to PR open, reopen, and ready-for-review events rather than every push
- document how maintainers classify findings and convert evidence into repeated Vally fixtures

## Pilot safety

- uses `pull_request_target` only to call the review-request API
- does not checkout or execute pull request code
- grants only `pull-requests: write` to the review-request job
- does not create a required or merge-blocking check

## Validation

- `actionlint .github/workflows/azsdk-cli-copilot-review.yml`