### PR TITLE
Fix missing aiohttp dependency in Wiki index pipeline

### DIFF
--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-wiki-index/requirements.txt
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-wiki-index/requirements.txt
@@ -1,5 +1,6 @@
 azure-storage-blob==12.29.0
 azure-identity==1.26.0b2
 azure-appconfiguration==1.7.1
+aiohttp>=3.9.0
 openai>=1.40.0
 requests>=2.31.0


### PR DESCRIPTION
## Summary
- restore the iohttp runtime dependency used by asynchronous Azure Identity and Blob clients
- fix dev build 6746100 and prod build 6746357 failing during AsyncDefaultAzureCredential initialization

## Validation
- dependency matches the previously successful Wiki pipeline configuration
- repository PR checks will validate the package