### PR TITLE
[AzSdkCli] Update for latest version of ARH

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/ApiReviewHubServiceTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/ApiReviewHubServiceTests.cs
@@ -64,7 +64,7 @@ public class ApiReviewHubServiceTests
             {
                 Content = new StringContent(
                     """
-                    {"packageId":"11111111-1111-1111-1111-111111111111","packageVersionId":"22222222-2222-2222-2222-222222222222","packageName":"azure-test","language":"python","version":"1.0.0","releasedApiHash":"api-hash","approvalStatus":"Approved","isReleased":false,"releasedOn":null}
+                    {"packageId":"11111111-1111-1111-1111-111111111111","packageVersionId":"22222222-2222-2222-2222-222222222222","packageName":"azure-test","language":"python","version":"1.0.0","releasedApiHash":"api-hash","approvalStatus":"Approved","approvalRecordId":"approval-record-id","appliedInheritanceRule":"prereleaseToPrerelease","isReleased":false,"releasedOn":null}
                     """,
                     Encoding.UTF8,
                     "application/json")
@@ -89,6 +89,8 @@ public class ApiReviewHubServiceTests
         Assert.That(result.PackageName, Is.EqualTo("azure-test"));
         Assert.That(result.PackageVersionId, Is.EqualTo(Guid.Parse("22222222-2222-2222-2222-222222222222")));
         Assert.That(result.ApprovalStatus, Is.EqualTo("Approved"));
+        Assert.That(result.ApprovalRecordId, Is.EqualTo("approval-record-id"));
+        Assert.That(result.AppliedInheritanceRule, Is.EqualTo("prereleaseToPrerelease"));
         Assert.That(result.IsReleased, Is.False);
     }
 
@@ -158,6 +160,7 @@ public class ApiReviewHubServiceTests
                       "details": [],
                       "approvals": [
                         {
+                                                    "id": "approval-record-id",
                           "apiHash": "hash-1",
                           "version": "4.12.0b3",
                           "status": "approved",
@@ -181,6 +184,7 @@ public class ApiReviewHubServiceTests
         Assert.That(result.AppliedInheritanceRule, Is.EqualTo("prereleaseToStable"));
         Assert.That(result.Approvals, Is.Not.Null);
         Assert.That(result.Approvals!.Count, Is.EqualTo(1));
+        Assert.That(result.Approvals[0].Id, Is.EqualTo("approval-record-id"));
         Assert.That(result.Approvals[0].Version, Is.EqualTo("4.12.0b3"));
     }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackageApprovalStatusToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackageApprovalStatusToolTests.cs
@@ -1,3 +1,4 @@
+using Azure.Sdk.Tools.Cli.Models.ApiReviewHub;
 using Azure.Sdk.Tools.Cli.Services.ApiReviewHub;
 using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 using Azure.Sdk.Tools.Cli.Tools.Package;
@@ -16,5 +17,41 @@ public class PackageApprovalStatusToolTests
 
         Assert.That(packageTool.CommandHierarchy.Single().Verb, Is.EqualTo("pkg"));
         Assert.That(packageTool.GetCommandInstances().Single().Name, Is.EqualTo("get-approval-status"));
+    }
+
+    [Test]
+    public async Task GetApprovalStatus_SurfacesApprovalRecordId()
+    {
+        var releaseStatusService = new Mock<IPackageReleaseStatusService>();
+        releaseStatusService
+            .Setup(x => x.GetApprovalStatusAsync(It.IsAny<string>(), "python", "azure-test", "1.0.0", "hash", "", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PackageReleaseStatusResult
+            {
+                IsApproved = true,
+                FinalSource = "reviewHub",
+                Reason = "approved",
+                ReviewHub = new ApiReviewHubReleaseGateResult
+                {
+                    StatusCode = 200,
+                    IsApproved = true,
+                    Reason = "approved",
+                    Approvals =
+                    [
+                        new ApiReviewHubApprovalRecord
+                        {
+                            Id = "approval-record-id",
+                            ApiHash = "hash",
+                            Version = "1.0.0",
+                            Status = "approved"
+                        }
+                    ]
+                }
+            });
+        var packageTool = new PackageApprovalStatusTool(releaseStatusService.Object, new TestLogger<PackageApprovalStatusTool>());
+
+        var response = await packageTool.GetApprovalStatus("python", "azure-test", "1.0.0", "hash");
+
+        Assert.That(response.ToString(), Does.Contain("Approval record ID: approval-record-id"));
+        Assert.That(response.Result!.ReviewHub.Approvals![0].Id, Is.EqualTo("approval-record-id"));
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackageMarkReleasedToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackageMarkReleasedToolTests.cs
@@ -34,6 +34,8 @@ public class PackageMarkReleasedToolTests
                 Version = "1.0.0",
                 ReleasedApiHash = "hash",
                 ApprovalStatus = "Approved",
+                ApprovalRecordId = "approval-record-id",
+                AppliedInheritanceRule = "prereleaseToPrerelease",
                 IsReleased = false
             });
         apiViewService = new Mock<IAPIViewService>();
@@ -85,6 +87,8 @@ public class PackageMarkReleasedToolTests
         var apiView = document.RootElement.GetProperty("api_view");
 
         Assert.That(reviewHub.GetProperty("packageVersionId").GetString(), Is.EqualTo("22222222-2222-2222-2222-222222222222"));
+        Assert.That(reviewHub.GetProperty("approvalRecordId").GetString(), Is.EqualTo("approval-record-id"));
+        Assert.That(reviewHub.GetProperty("appliedInheritanceRule").GetString(), Is.EqualTo("prereleaseToPrerelease"));
         Assert.That(reviewHub.TryGetProperty("succeeded", out _), Is.False);
         Assert.That(apiView.GetProperty("revisionId").GetString(), Is.EqualTo("revision456"));
         Assert.That(apiView.TryGetProperty("message", out _), Is.False);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackageMarkReleasedToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Package/PackageMarkReleasedToolTests.cs
@@ -100,6 +100,30 @@ public class PackageMarkReleasedToolTests
     }
 
     [Test]
+    public async Task MarkReleasedAsync_JsonOmitsUnavailableReviewHubFields()
+    {
+        apiReviewHubService
+            .Setup(x => x.MarkPackageReleasedAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+            .ReturnsAsync(new ApiReviewHubMarkReleasedResult
+            {
+                PackageId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+                PackageVersionId = Guid.Parse("22222222-2222-2222-2222-222222222222"),
+                PackageName = "azure-test",
+                Language = "python",
+                Version = "1.0.0",
+                ReleasedApiHash = "hash",
+                ApprovalStatus = "Approved",
+                IsReleased = false
+            });
+
+        var response = await MarkReleasedAsync();
+
+        Assert.That(response.ApiReviewHub!.Value.TryGetProperty("approvalRecordId", out _), Is.False);
+        Assert.That(response.ApiReviewHub.Value.TryGetProperty("appliedInheritanceRule", out _), Is.False);
+    }
+
+    [Test]
     public async Task MarkReleasedAsync_WhenReviewHubFails_StillCallsAPIView()
     {
         apiReviewHubService

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 0.6.38 (Unreleased)
+## 0.6.38 (2026-08-26)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- `package mark-released` output now includes the API Review Hub approval record ID and applied inheritance rule.
+- `package get-approval-status` output now includes IDs for API Review Hub approval records.
 
 ## 0.6.37 (2026-08-21)
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ApiReviewHub/ApiReviewHubModels.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ApiReviewHub/ApiReviewHubModels.cs
@@ -52,6 +52,8 @@ public class ApiReviewHubMarkReleasedResult
     public required string Version { get; set; }
     public required string ReleasedApiHash { get; set; }
     public required string ApprovalStatus { get; set; }
+    public string? ApprovalRecordId { get; set; }
+    public string? AppliedInheritanceRule { get; set; }
     public bool IsReleased { get; set; }
     public DateTimeOffset? ReleasedOn { get; set; }
 }
@@ -104,6 +106,10 @@ public class OperationStatus
 
 public class ApiReviewHubApprovalRecord
 {
+    [JsonPropertyName("id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Id { get; set; }
+
     [JsonPropertyName("apiHash")]
     public string ApiHash { get; set; } = string.Empty;
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ApiReviewHub/ApiReviewHubModels.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ApiReviewHub/ApiReviewHubModels.cs
@@ -52,7 +52,9 @@ public class ApiReviewHubMarkReleasedResult
     public required string Version { get; set; }
     public required string ReleasedApiHash { get; set; }
     public required string ApprovalStatus { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ApprovalRecordId { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? AppliedInheritanceRule { get; set; }
     public bool IsReleased { get; set; }
     public DateTimeOffset? ReleasedOn { get; set; }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/PackageApprovalStatusTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/PackageApprovalStatusTool.cs
@@ -217,6 +217,11 @@ public class PackageApprovalStatusTool(
             var versionText = string.IsNullOrWhiteSpace(approval.Version) ? string.Empty : $" (version {approval.Version})";
             details.Add($"- {approval.Status}: {approval.ApiHash}{matchText}{versionText}");
 
+            if (!string.IsNullOrWhiteSpace(approval.Id))
+            {
+                details.Add($"  Approval record ID: {approval.Id}");
+            }
+
             if (!string.IsNullOrWhiteSpace(approval.LastUpdatedBy) || !string.IsNullOrWhiteSpace(approval.LastUpdatedOn))
             {
                 details.Add($"  Updated by: {approval.LastUpdatedBy ?? "unknown"}{FormatOnSuffix(approval.LastUpdatedOn)}");


### PR DESCRIPTION
Adds `releasedPackageApprovalId` and `releasedApprovalInheritanceRule` to the output of `azsdk package mark-released` for the ARH path. 