### PR TITLE
Recover Foundry responses after malformed SSE

### DIFF
--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/azure_ai_foundry_agent_test.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/azure_ai_foundry_agent_test.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+from json import JSONDecodeError
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -48,6 +49,13 @@ async def _make_stream(events, item_delay: float = 0.0):
         if item_delay:
             await asyncio.sleep(item_delay)
         yield event
+
+
+async def _malformed_stream(events):
+    """Yield events, then fail as the OpenAI SSE JSON decoder does."""
+    for event in events:
+        yield event
+    raise JSONDecodeError("Extra data", "{}\n{}", 3)
 
 
 def _completed_stream(response: _FakeResponse):
@@ -203,6 +211,45 @@ async def test_consume_stream_raises_without_completed_event() -> None:
         await HostedAgentClient(AsyncMock())._consume_stream(stream, "conv")
 
 
+@pytest.mark.asyncio
+async def test_invoke_recovers_stored_response_after_malformed_sse() -> None:
+    """Malformed SSE after response creation retrieves the stored result."""
+    created = _FakeResponse(output_text="", status="in_progress", id="r1")
+    stored = _FakeResponse(output_text="answer", status="completed", id="r1")
+    client = _mock_client(
+        [_malformed_stream([_FakeEvent("response.created", created)])]
+    )
+    client.responses.retrieve = AsyncMock(return_value=stored)
+
+    with patch(
+        "utils.azure_ai_foundry_agent.asyncio.sleep", new_callable=AsyncMock
+    ):
+        _, out = await HostedAgentClient(client, retry_delay=0).invoke(
+            conversation_items=[],
+            agent_ref={},
+        )
+
+    assert out is stored
+    assert client.responses.create.await_count == 1
+    client.responses.retrieve.assert_awaited_once_with("r1")
+
+
+@pytest.mark.asyncio
+async def test_invoke_retries_when_malformed_sse_has_no_response_id() -> None:
+    """Malformed SSE before response creation retries with a new stream."""
+    good = _FakeResponse(output_text="answer", status="completed", id="r2")
+    client = _mock_client([_malformed_stream([]), _completed_stream(good)])
+
+    _, out = await HostedAgentClient(client, retry_delay=0).invoke(
+        conversation_items=[],
+        agent_ref={},
+    )
+
+    assert out is good
+    assert client.responses.create.await_count == 2
+    client.responses.retrieve.assert_not_awaited()
+
+
 def _api_error(error_cls, status_code: int):
     """Build a real OpenAI ``APIStatusError`` subclass instance for tests."""
     request = httpx.Request("POST", "https://example.test/v1/responses")
@@ -278,5 +325,3 @@ async def test_invoke_returns_content_safety_response_without_retry() -> None:
     assert out.output_text == CONTENT_SAFETY_MESSAGE
     # No retry: the deterministic content-safety block fails fast.
     assert client.responses.create.await_count == 1
-
-

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/utils/azure_ai_foundry_agent.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/utils/azure_ai_foundry_agent.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from json import JSONDecodeError
 from typing import Any
 
 from openai import (
@@ -269,29 +270,52 @@ class HostedAgentClient:
         stream,
         agent_conversation_id: str | None,
     ) -> OpenAIResponse:
-        """Consume a responses stream until the ``response.completed`` event."""
+        """Consume a responses stream until the ``response.completed`` event.
+
+        If Foundry returns malformed SSE after exposing a response ID, recover
+        the completed result from storage instead of rerunning the agent.
+        """
         response: OpenAIResponse | None = None
+        latest_response: OpenAIResponse | None = None
         last_event_type: str | None = None
-        async for event in stream:
-            logger.debug("Stream event: type=%s, content=%s", event.type, event)
-            last_event_type = event.type
-            if event.type == STREAM_EVENT_RESPONSE_COMPLETED:
-                response = event.response
-                break
-            if event.type in (
-                STREAM_EVENT_RESPONSE_FAILED,
-                STREAM_EVENT_RESPONSE_INCOMPLETE,
-            ):
-                failed = getattr(event, "response", None)
-                logger.error(
-                    "Agent stream %s: error=%s, incomplete_details=%s, status=%s, "
-                    "conversation=%s",
-                    event.type,
-                    getattr(failed, "error", None),
-                    getattr(failed, "incomplete_details", None),
-                    getattr(failed, "status", None),
-                    agent_conversation_id,
-                )
+        try:
+            async for event in stream:
+                logger.debug("Stream event: type=%s, content=%s", event.type, event)
+                last_event_type = event.type
+                event_response = getattr(event, "response", None)
+                if event_response is not None:
+                    latest_response = event_response
+                if event.type == STREAM_EVENT_RESPONSE_COMPLETED:
+                    response = event.response
+                    break
+                if event.type in (
+                    STREAM_EVENT_RESPONSE_FAILED,
+                    STREAM_EVENT_RESPONSE_INCOMPLETE,
+                ):
+                    failed = getattr(event, "response", None)
+                    logger.error(
+                        "Agent stream %s: error=%s, incomplete_details=%s, status=%s, "
+                        "conversation=%s",
+                        event.type,
+                        getattr(failed, "error", None),
+                        getattr(failed, "incomplete_details", None),
+                        getattr(failed, "status", None),
+                        agent_conversation_id,
+                    )
+        except JSONDecodeError as ex:
+            if latest_response is None:
+                raise RuntimeError(
+                    "Agent stream contained malformed SSE before a response ID "
+                    "was observed"
+                ) from ex
+            logger.warning(
+                "Agent stream contained malformed SSE; retrieving stored response: "
+                "response=%s, conversation=%s, error=%s",
+                latest_response.id,
+                agent_conversation_id,
+                ex,
+            )
+            return await self._poll_response(latest_response)
 
         if response is None:
             raise RuntimeError(


### PR DESCRIPTION
## Summary

- recover a completed Foundry response from storage when malformed SSE causes the OpenAI stream decoder to raise `JSONDecodeError` after a response ID has been observed
- retain the existing stream retry behavior when corruption occurs before any response ID is available
- add regression coverage for both recovery paths without changing normal streaming behavior

## Validation

- `python -m pytest tests/azure_ai_foundry_agent_test.py -q` — 12 passed
- `pyright --pythonversion 3.12 utils/azure_ai_foundry_agent.py tests/azure_ai_foundry_agent_test.py` — 0 errors
- reproduced the malformed SSE against the dev hosted agent and verified the same stored response was retrieved successfully on the first poll