### PR TITLE
[Teams Chatbot] Recover from corrupted agent tool history

### DIFF
--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/services/chat_service.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/services/chat_service.py
@@ -22,7 +22,7 @@ from models.chat import (
     ConversationItem,
     Role,
 )
-from models.conversation import ConversationMessage
+from models.conversation import ConversationMessage, ConversationType
 from models.knowledge import DocumentContext, Reference, SearchKnowledgeBaseResult
 from services.conversation_service import ConversationService
 from tools import TOOL_REGISTRY
@@ -37,7 +37,6 @@ from utils.azure_ai_foundry import (
     get_stateless_session_id,
     set_stateless_session_id,
 )
-from utils.azure_ai_foundry_agent import HostedAgentClient
 from utils.teams_image import get_image_data_uri
 from utils.text_util import preprocess_message
 from utils.azure_memory_store import sanitize_scope
@@ -48,6 +47,7 @@ from openai import (
     NotFoundError,
 )
 from openai.types.responses import Response as OpenAIResponse
+from utils.azure_ai_foundry_agent import HostedAgentClient, ToolOutputError
 from openai.types.responses import (
     ResponseFunctionToolCall,
     ResponseOutputItem,
@@ -122,18 +122,17 @@ class ChatService:
                 openai_client, req
             )
             agent_session_id = None
+        tenant_system_msg = self._build_tenant_system_message(req.tenant_id)
+        tenant_system_item = cast(
+            ResponseInputItemParam,
+            ConversationItem(
+                role=Role.System,
+                content=tenant_system_msg,
+            ).model_dump(mode="json", exclude_none=True),
+        )
         conversation_items: list[ResponseInputItemParam] = []
         if is_new:
-            tenant_system_msg = self._build_tenant_system_message(req.tenant_id)
-            conversation_items.append(
-                cast(
-                    ResponseInputItemParam,
-                    ConversationItem(
-                        role=Role.System,
-                        content=tenant_system_msg,
-                    ).model_dump(mode="json", exclude_none=True),
-                )
-            )
+            conversation_items.append(tenant_system_item)
 
         memory_scope = self._resolve_memory_scope(req)
         if memory_scope:
@@ -183,12 +182,37 @@ class ChatService:
         }
 
         agent_client = HostedAgentClient(openai_client)
-        trace_id, response = await agent_client.invoke(
-            conversation_items=conversation_items,
-            agent_conversation_id=agent_conversation_id,
-            agent_session_id=agent_session_id,
-            agent_ref=agent_ref,
-        )
+        try:
+            trace_id, response = await agent_client.invoke(
+                conversation_items=conversation_items,
+                agent_conversation_id=agent_conversation_id,
+                agent_session_id=agent_session_id,
+                agent_ref=agent_ref,
+            )
+        except ToolOutputError:
+            if not agent_conversation_id:
+                raise
+            agent_conversation_id, conversation_items = (
+                await self._rebuild_conversation_after_failure(
+                    req.conversation_id,
+                    req.conversation_type,
+                )
+            )
+            # The replacement conversation has no tenant context of its own.
+            conversation_items.insert(0, tenant_system_item)
+            # Additional infos are not persisted in Cosmos; reuse the items already built.
+            conversation_items.extend(additional_items)
+            # Replace the poisoned mapping before the single recovery attempt.
+            await self._conversation_service.save_agent_conversation_mapping(
+                req.conversation_id,
+                req.conversation_type,
+                agent_conversation_id=agent_conversation_id,
+            )
+            trace_id, response = await agent_client.invoke(
+                conversation_items=conversation_items,
+                agent_conversation_id=agent_conversation_id,
+                agent_ref=agent_ref,
+            )
         # Cache the warm sandbox id so later stateless calls reuse it.
         if stateless and not self._get_stateless_session_id():
             extra = getattr(response, "model_extra", None) or {}
@@ -326,6 +350,72 @@ class ChatService:
 
         logger.info("Created new AI Foundry conversation: %s", new_id)
         return new_id, True
+
+    async def _rebuild_conversation_after_failure(
+        self,
+        conversation_id: str | None,
+        conversation_type: ConversationType | None,
+    ) -> tuple[str, list[ResponseInputItemParam]]:
+        """Replace corrupted history and replay only safe message items."""
+        openai_client = self._get_openai_client()
+        replay_items = await self._list_message_items(
+            conversation_id,
+            conversation_type,
+        )
+
+        replacement = await openai_client.conversations.create()
+        replacement_id = replacement.id
+
+        logger.info(
+            "Created replacement Foundry conversation %s: replay_messages=%d",
+            replacement_id,
+            len(replay_items),
+        )
+        return replacement_id, replay_items
+
+    async def _list_message_items(
+        self,
+        conversation_id: str | None,
+        conversation_type: ConversationType | None,
+    ) -> list[ResponseInputItemParam]:
+        """Read replayable conversation messages from Cosmos in chronological order."""
+        replay: list[ResponseInputItemParam] = []
+        if not conversation_id or not conversation_type:
+            return replay
+        try:
+            messages = await self._conversation_service.get_messages_by_conversation_id(
+                conversation_id,
+                conversation_type,
+            )
+            for message in messages:
+                if message.sender_role == Role.User:
+                    role = Role.User
+                elif message.sender_role in (Role.System, Role.Assistant):
+                    role = Role.Assistant
+                else:
+                    continue
+
+                replay.append(
+                    cast(
+                        ResponseInputItemParam,
+                        ConversationItem(
+                            role=role,
+                            content=message.content,
+                            user_id=(message.sender_id if role == Role.User else None),
+                            user_name=(
+                                message.sender_name if role == Role.User else None
+                            ),
+                        ).model_dump(mode="json", exclude_none=True),
+                    )
+                )
+        except Exception:
+            logger.warning(
+                "Failed to read messages from Cosmos conversation %s; "
+                "continuing with fresh history",
+                conversation_id,
+                exc_info=True,
+            )
+        return replay
 
     async def _build_additional_info_items(
         self,

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/services/chat_service.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/services/chat_service.py
@@ -47,7 +47,7 @@ from openai import (
     NotFoundError,
 )
 from openai.types.responses import Response as OpenAIResponse
-from utils.azure_ai_foundry_agent import HostedAgentClient, ToolOutputError
+from utils.azure_ai_foundry_agent import HostedAgentClient, ConversationBrokenError
 from openai.types.responses import (
     ResponseFunctionToolCall,
     ResponseOutputItem,
@@ -189,7 +189,7 @@ class ChatService:
                 agent_session_id=agent_session_id,
                 agent_ref=agent_ref,
             )
-        except ToolOutputError:
+        except ConversationBrokenError:
             if not agent_conversation_id:
                 raise
             agent_conversation_id, conversation_items = (

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/azure_ai_foundry_agent_test.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/azure_ai_foundry_agent_test.py
@@ -24,7 +24,7 @@ from openai import BadRequestError, NotFoundError
 from utils.azure_ai_foundry_agent import (
     CONTENT_SAFETY_MESSAGE,
     HostedAgentClient,
-    ToolOutputError,
+    ConversationBrokenError,
 )
 
 
@@ -135,7 +135,7 @@ async def test_invoke_retries_on_empty_response_then_succeeds() -> None:
 
 @pytest.mark.asyncio
 async def test_invoke_raises_after_empty_responses_exhaust_retries() -> None:
-    """When every attempt is empty, retries exhaust and a RuntimeError is raised."""
+    """Stateless empty responses exhaust retries without history recovery."""
     client = _mock_client(
         lambda *a, **k: _completed_stream(_FakeResponse(output_text=""))
     )
@@ -150,6 +150,26 @@ async def test_invoke_raises_after_empty_responses_exhaust_retries() -> None:
             )
 
     assert client.responses.create.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_invoke_recovers_thread_after_empty_response_polling_exhausted() -> None:
+    """An empty threaded response triggers recovery after polling is exhausted."""
+    client = _mock_client(
+        lambda *a, **k: _completed_stream(_FakeResponse(output_text=""))
+    )
+
+    with patch.object(
+        HostedAgentClient, "_poll_response", AsyncMock(side_effect=lambda r: r)
+    ):
+        with pytest.raises(ConversationBrokenError):
+            await HostedAgentClient(client, max_retries=2, retry_delay=0).invoke(
+                conversation_items=[],
+                agent_ref={},
+                agent_conversation_id="conv-broken",
+            )
+
+    assert client.responses.create.await_count == 1
 
 
 @pytest.mark.asyncio
@@ -316,35 +336,6 @@ def _content_filter_error() -> BadRequestError:
         }
     }
     return BadRequestError("blocked", response=response, body=body)
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "message",
-    [
-        "No tool output found for function call call_123.",
-        "No tool call found for function call output call_123.",
-    ],
-)
-async def test_invoke_raises_tool_output_error_from_runtime_error(
-    message: str,
-) -> None:
-    """Known tool-pairing runtime errors trigger conversation recovery."""
-
-    async def _failed_stream():
-        raise RuntimeError(message)
-        yield
-
-    client = _mock_client([_failed_stream()])
-
-    with pytest.raises(ToolOutputError):
-        await HostedAgentClient(client, retry_delay=0).invoke(
-            conversation_items=[],
-            agent_ref={},
-            agent_conversation_id="conv-broken",
-        )
-
-    assert client.responses.create.await_count == 1
 
 
 @pytest.mark.asyncio

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/azure_ai_foundry_agent_test.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/azure_ai_foundry_agent_test.py
@@ -326,23 +326,16 @@ def _content_filter_error() -> BadRequestError:
         "No tool call found for function call output call_123.",
     ],
 )
-async def test_invoke_raises_tool_output_error_without_retry(message: str) -> None:
-    """Known tool-pairing bad requests are surfaced for conversation recovery."""
-    body = {
-        "error": {
-            "message": message,
-            "type": "invalid_request_error",
-            "param": "input",
-            "code": None,
-        }
-    }
-    error = _api_error(
-        BadRequestError,
-        400,
-        f"Error code: 400 - {body}",
-        body,
-    )
-    client = _mock_client([error])
+async def test_invoke_raises_tool_output_error_from_runtime_error(
+    message: str,
+) -> None:
+    """Known tool-pairing runtime errors trigger conversation recovery."""
+
+    async def _failed_stream():
+        raise RuntimeError(message)
+        yield
+
+    client = _mock_client([_failed_stream()])
 
     with pytest.raises(ToolOutputError):
         await HostedAgentClient(client, retry_delay=0).invoke(

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/azure_ai_foundry_agent_test.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/azure_ai_foundry_agent_test.py
@@ -21,7 +21,11 @@ if _PROJECT_ROOT not in sys.path:
 
 from openai import BadRequestError, NotFoundError
 
-from utils.azure_ai_foundry_agent import CONTENT_SAFETY_MESSAGE, HostedAgentClient
+from utils.azure_ai_foundry_agent import (
+    CONTENT_SAFETY_MESSAGE,
+    HostedAgentClient,
+    ToolOutputError,
+)
 
 
 class _FakeResponse:
@@ -250,11 +254,16 @@ async def test_invoke_retries_when_malformed_sse_has_no_response_id() -> None:
     client.responses.retrieve.assert_not_awaited()
 
 
-def _api_error(error_cls, status_code: int):
+def _api_error(
+    error_cls,
+    status_code: int,
+    message: str = "rejected",
+    body=None,
+):
     """Build a real OpenAI ``APIStatusError`` subclass instance for tests."""
     request = httpx.Request("POST", "https://example.test/v1/responses")
     response = httpx.Response(status_code, request=request)
-    return error_cls("rejected", response=response, body=None)
+    return error_cls(message, response=response, body=body)
 
 
 @pytest.mark.parametrize(
@@ -307,6 +316,42 @@ def _content_filter_error() -> BadRequestError:
         }
     }
     return BadRequestError("blocked", response=response, body=body)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message",
+    [
+        "No tool output found for function call call_123.",
+        "No tool call found for function call output call_123.",
+    ],
+)
+async def test_invoke_raises_tool_output_error_without_retry(message: str) -> None:
+    """Known tool-pairing bad requests are surfaced for conversation recovery."""
+    body = {
+        "error": {
+            "message": message,
+            "type": "invalid_request_error",
+            "param": "input",
+            "code": None,
+        }
+    }
+    error = _api_error(
+        BadRequestError,
+        400,
+        f"Error code: 400 - {body}",
+        body,
+    )
+    client = _mock_client([error])
+
+    with pytest.raises(ToolOutputError):
+        await HostedAgentClient(client, retry_delay=0).invoke(
+            conversation_items=[],
+            agent_ref={},
+            agent_conversation_id="conv-broken",
+        )
+
+    assert client.responses.create.await_count == 1
 
 
 @pytest.mark.asyncio

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/chat_service_test.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/chat_service_test.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 _PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
 if _PROJECT_ROOT not in sys.path:
@@ -17,7 +21,7 @@ from services.chat_service import ChatService
 
 
 def test_chat_service_resolves_memory_scope() -> None:
-    service = ChatService()
+    service = ChatService(settings=lambda _key, default="": default)
 
     # user_id present → user_{user_id}
     with_user_id = ChatRequest(
@@ -59,7 +63,7 @@ def test_chat_service_resolves_memory_scope() -> None:
 
 def test_chat_service_returns_none_when_user_id_empty() -> None:
     """Empty/whitespace user_id returns None."""
-    service = ChatService()
+    service = ChatService(settings=lambda _key, default="": default)
 
     empty_id = ChatRequest(
         tenant_id="azure_sdk_qa_bot",
@@ -72,3 +76,74 @@ def test_chat_service_returns_none_when_user_id_empty() -> None:
         message=ChatMessage(role="user", content="hello", user_id="  "),
     )
     assert service._resolve_memory_scope(whitespace_id) is None
+
+
+@pytest.mark.asyncio
+async def test_rebuild_replays_safe_messages_in_chronological_order() -> None:
+    """Recovery replays durable Cosmos messages into a fresh conversation."""
+    from datetime import datetime, timezone
+
+    from models.conversation import ConversationMessageItem, ConversationType, Role
+
+    openai_client = MagicMock()
+    openai_client.conversations.create = AsyncMock(
+        return_value=SimpleNamespace(id="conv-new")
+    )
+    service = ChatService(openai_client=openai_client)
+    service._conversation_service.get_messages_by_conversation_id = AsyncMock(
+        return_value=[
+            ConversationMessageItem(
+                id="user-old",
+                tenant_id="azure_sdk_qa_bot",
+                sender_role=Role.User,
+                sender_id="user-1",
+                sender_name="Ada",
+                content="previous question",
+                created_at=datetime.now(timezone.utc),
+                conversation_id="teams-thread",
+                conversation_type="teams_channel",
+                conversation_partition="teams_channel:teams-thread",
+            ),
+            ConversationMessageItem(
+                id="bot-old",
+                tenant_id="azure_sdk_qa_bot",
+                sender_role=Role.System,
+                sender_id="azure-sdk-qa-bot",
+                sender_name="Azure SDK Q&A Bot",
+                content="previous answer",
+                created_at=datetime.now(timezone.utc),
+                conversation_id="teams-thread",
+                conversation_type="teams_channel",
+                conversation_partition="teams_channel:teams-thread",
+            ),
+            ConversationMessageItem(
+                id="current-message",
+                tenant_id="azure_sdk_qa_bot",
+                sender_role=Role.User,
+                sender_id="user-1",
+                sender_name="Ada",
+                content="current question",
+                created_at=datetime.now(timezone.utc),
+                conversation_id="teams-thread",
+                conversation_type="teams_channel",
+                conversation_partition="teams_channel:teams-thread",
+            ),
+        ]
+    )
+    replacement_id, rebuilt = await service._rebuild_conversation_after_failure(
+        "teams-thread",
+        ConversationType.teams_channel,
+    )
+
+    assert replacement_id == "conv-new"
+    assert [item["role"] for item in rebuilt] == [
+        "user",
+        "assistant",
+        "user",
+    ]
+    assert [item["content"] for item in rebuilt] == [
+        "previous question",
+        "previous answer",
+        "current question",
+    ]
+    assert openai_client.conversations.items.list.call_count == 0

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/utils/azure_ai_foundry_agent.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/utils/azure_ai_foundry_agent.py
@@ -187,13 +187,6 @@ class HostedAgentClient:
                         exc_info=True,
                     )
                     return None, _build_content_safety_response()
-                if isinstance(ex, BadRequestError) and any(
-                    message in str(ex).lower() for message in _TOOL_OUTPUT_ERRORS
-                ):
-                    # Retrying the same corrupted tool history cannot succeed;
-                    # let the service rebuild the conversation instead.
-                    # This is a known bug for foundry agent: https://github.com/Azure/azure-sdk-for-python/issues/46092
-                    raise ToolOutputError(str(ex)) from ex
                 # Rejected cached session: drop it and retry without one.
                 if agent_session_id:
                     set_stateless_session_id(None)
@@ -231,11 +224,27 @@ class HostedAgentClient:
                     self._max_retries,
                     agent_conversation_id,
                 )
-            except (EmptyAgentResponseError, RuntimeError) as ex:
-                # ``RuntimeError`` = stream ended without a completed event;
-                # both are transient and retryable.
+            except EmptyAgentResponseError as ex:
                 last_error = ex
                 await self.close_stream(stream)
+                logger.warning(
+                    "Agent returned no usable response (attempt %d/%d): "
+                    "conversation=%s, error=%s",
+                    attempt,
+                    self._max_retries,
+                    agent_conversation_id,
+                    ex,
+                )
+            except RuntimeError as ex:
+                last_error = ex
+                await self.close_stream(stream)
+                if any(
+                    message in str(ex).lower() for message in _TOOL_OUTPUT_ERRORS
+                ):
+                    # Retrying the same corrupted tool history cannot succeed;
+                    # let the service rebuild the conversation instead.
+                    # This is a known bug for foundry agent: https://github.com/Azure/azure-sdk-for-python/issues/46092
+                    raise ToolOutputError(str(ex)) from ex
                 logger.warning(
                     "Agent returned no usable response (attempt %d/%d): "
                     "conversation=%s, error=%s",

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/utils/azure_ai_foundry_agent.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/utils/azure_ai_foundry_agent.py
@@ -51,18 +51,12 @@ CONTENT_SAFETY_MESSAGE = (
     "our content safety policy. Please rephrase your message and try again."
 )
 
-_TOOL_OUTPUT_ERRORS = (
-    "no tool output found for function call",
-    "no tool call found for function call output",
-)
-
-
 class EmptyAgentResponseError(Exception):
     """Raised when the agent completes with empty ``output_text`` (retryable)."""
 
 
-class ToolOutputError(Exception):
-    """Raised when stored conversation history contains invalid tool output."""
+class ConversationBrokenError(Exception):
+    """Raised when a threaded conversation can no longer produce a response."""
 
 
 def _is_content_filter_error(ex: BadRequestError) -> bool:
@@ -227,6 +221,8 @@ class HostedAgentClient:
             except EmptyAgentResponseError as ex:
                 last_error = ex
                 await self.close_stream(stream)
+                if agent_conversation_id:
+                    raise ConversationBrokenError(str(ex)) from ex
                 logger.warning(
                     "Agent returned no usable response (attempt %d/%d): "
                     "conversation=%s, error=%s",
@@ -238,15 +234,9 @@ class HostedAgentClient:
             except RuntimeError as ex:
                 last_error = ex
                 await self.close_stream(stream)
-                if any(
-                    message in str(ex).lower() for message in _TOOL_OUTPUT_ERRORS
-                ):
-                    # Retrying the same corrupted tool history cannot succeed;
-                    # let the service rebuild the conversation instead.
-                    # This is a known bug for foundry agent: https://github.com/Azure/azure-sdk-for-python/issues/46092
-                    raise ToolOutputError(str(ex)) from ex
                 logger.warning(
-                    "Agent returned no usable response (attempt %d/%d): "
+                    "Agent invocation failed with a retryable runtime error "
+                    "(attempt %d/%d): "
                     "conversation=%s, error=%s",
                     attempt,
                     self._max_retries,
@@ -259,7 +249,7 @@ class HostedAgentClient:
             await asyncio.sleep(self._retry_delay * attempt)
 
         raise RuntimeError(
-            f"Failed to obtain a non-empty agent response after "
+            f"Failed to obtain an agent response after "
             f"{self._max_retries} attempts (conversation={agent_conversation_id})"
         ) from last_error
 

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/utils/azure_ai_foundry_agent.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/utils/azure_ai_foundry_agent.py
@@ -51,9 +51,18 @@ CONTENT_SAFETY_MESSAGE = (
     "our content safety policy. Please rephrase your message and try again."
 )
 
+_TOOL_OUTPUT_ERRORS = (
+    "no tool output found for function call",
+    "no tool call found for function call output",
+)
+
 
 class EmptyAgentResponseError(Exception):
     """Raised when the agent completes with empty ``output_text`` (retryable)."""
+
+
+class ToolOutputError(Exception):
+    """Raised when stored conversation history contains invalid tool output."""
 
 
 def _is_content_filter_error(ex: BadRequestError) -> bool:
@@ -178,6 +187,13 @@ class HostedAgentClient:
                         exc_info=True,
                     )
                     return None, _build_content_safety_response()
+                if isinstance(ex, BadRequestError) and any(
+                    message in str(ex).lower() for message in _TOOL_OUTPUT_ERRORS
+                ):
+                    # Retrying the same corrupted tool history cannot succeed;
+                    # let the service rebuild the conversation instead.
+                    # This is a known bug for foundry agent: https://github.com/Azure/azure-sdk-for-python/issues/46092
+                    raise ToolOutputError(str(ex)) from ex
                 # Rejected cached session: drop it and retry without one.
                 if agent_session_id:
                     set_stateless_session_id(None)


### PR DESCRIPTION
## Context

When the conversation is too large, the foundry will automatically compress the conversation, but it missed some tool call output, which cause the conversation is broken, and the agent will return this kind of error: 

> , **Message**: ("<class 'agent_framework_foundry._chat_client.FoundryChatClient'> service failed to complete the prompt: Error code: 400 - {'error': {'message': 'No tool output found for function call call_xpPuZCn2Fd2drPJSM57qTkVO.', 'type': 'invalid_request_error', 'param': 'input', 'code': None, 'request_id': '3e6d68e94cdb6d6facbb4268898b53d8'}}", BadRequestError("Error code: 400 - {'error': {'message': 'No tool output found for function call call_xpPuZCn2Fd2drPJSM57qTkVO.', 'type': 'invalid_request_error', 'param': 'input', 'code': None, 'request_id': '3e6d68e94cdb6d6facbb4268898b53d8'}}"))

This is a known Foundry agent issue tracked by [Azure/azure-sdk-for-python#46092](https://github.com/Azure/azure-sdk-for-python/issues/46092).

This PR implemented a recover logic that when this deterministic error occurs, the chatbot will create a new Foundry conversation from the stored conversation history in Cosmos DB, to rebuild the conversation. This avoids repeatedly error with the broken Foundry history.

## Testing

- Added error-classification coverage for invalid tool history.
- Added replacement-conversation and Cosmos replay coverage.
- Ran the affected test files: **34 passed**.
- Real test: [case](https://teams.microsoft.com/l/message/19:rMhMrxg7UjfwZmVoSeVvWvNQIfT_G6ds8napsytWqzw1@thread.tacv2/1787911248574?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=39910aef-85da-4e30-b5e3-35f04ef38648&parentMessageId=1787617443714&teamName=Azure%20SDK%20Q%26A%20Bot%20Testing&channelName=Azure%20SDK%20QA%20bot%20for%20TypeSpec%20Testing&createdTime=1787911248574) <img width="1009" height="171" alt="image" src="https://github.com/user-attachments/assets/2c2ab5fe-be1d-4f02-ba6d-7b2179112701" />
