### PR TITLE
azsdk-cli: move SDK-generation-blocking bugfix entry to 0.6.40 changelog

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- `azsdk_run_generate_sdk` now blocks SDK generation for a spec pull request until that pull request is merged, so SDK pull requests are no longer created — and surfaced to reviewers — while the release plan is still in the API Spec Review stage.
+
 ### Other Changes
 
 ## 0.6.39 (2026-08-31)
@@ -19,10 +21,6 @@
 ### Breaking Changes
 
 - Removed the option to force create a release plan to avoid duplicate release plan.
-
-### Bugs Fixed
-
-- `azsdk_run_generate_sdk` now blocks SDK generation for a spec pull request until that pull request is merged, so SDK pull requests are no longer created — and surfaced to reviewers — while the release plan is still in the API Spec Review stage.
 
 ## 0.6.38 (2026-08-26)
 


### PR DESCRIPTION
Moves the SDK-generation-blocking bugfix entry from the 0.6.39 changelog section to 0.6.40.

`azsdk_run_generate_sdk` blocking SDK generation until the spec pull request is merged (#16853) was merged after 0.6.39 was already cut/dated in the changelog by the automated version-bump PR (#16854). This moves that entry into the already-scaffolded `## 0.6.40 (Unreleased)` section instead of leaving it misattributed to 0.6.39.

No functional/code change - changelog content only.
