### PR TITLE
Skip API version metadata in unknown language

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/TypeSpecHelperTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Helpers/TypeSpecHelperTests.cs
@@ -173,6 +173,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Helpers
                 packageName: "@azure/arm-contoso"
               Go:
                 packageName: sdk/resourcemanager/contoso/armcontoso
+              UnknownEmitter:
+                packageName: unknown-package
             """;
 
             // Set up the metadata output directory and file as the emitter would
@@ -199,6 +201,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Helpers
                 Assert.That(result.Packages.Any(p => p.Language == SdkLanguage.Python && p.PackageName == "azure-mgmt-contoso"));
                 Assert.That(result.Packages.Any(p => p.Language == SdkLanguage.JavaScript && p.PackageName == "@azure/arm-contoso"));
                 Assert.That(result.Packages.Any(p => p.Language == SdkLanguage.Go && p.PackageName == "sdk/resourcemanager/contoso/armcontoso"));
+                Assert.That(result.Packages, Has.None.Matches<PackageInfo>(p => p.Language == SdkLanguage.Unknown));
             }
             finally
             {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
@@ -2005,6 +2005,83 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             mockDevOps.Verify(x => x.UpdateReleasePlanSDKDetailsAsync(It.IsAny<int>(), It.IsAny<List<SDKInfo>>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Test_UpdateReleasePlan_filters_unsupported_emitter_languages(bool isManagementPlane)
+        {
+            var typeSpecPath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
+            var releasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 700,
+                ReleasePlanId = 70,
+                IsManagementPlane = isManagementPlane,
+                IsDataPlane = !isManagementPlane
+            };
+            var project = TypeSpecProject.ParseTypeSpecConfig(typeSpecPath);
+            project.Packages =
+            [
+                new PackageInfo { Language = SdkLanguage.Python, PackageName = "azure-contoso" },
+                new PackageInfo { Language = SdkLanguage.Go, PackageName = "sdk/contoso" },
+                new PackageInfo { Language = SdkLanguage.Rust, PackageName = "azure_contoso" },
+                new PackageInfo { Language = SdkLanguage.Cpp, PackageName = "azure-contoso-cpp" }
+            ];
+
+            var mockDevOps = new Mock<IDevOpsService>();
+            mockDevOps.Setup(x => x.ResolveReleasePlanByIdAsync(700, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(releasePlan);
+            mockDevOps.Setup(x => x.GetReleasePlanForWorkItemAsync(700, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(releasePlan);
+            mockDevOps.Setup(x => x.UpdateWorkItemAsync(700, It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem { Id = 700 });
+            mockDevOps.Setup(x => x.UpdateReleasePlanSDKDetailsAsync(
+                    700,
+                    It.Is<List<SDKInfo>>(sdkInfos =>
+                        sdkInfos.Count == 2 &&
+                        sdkInfos.Any(sdk => sdk.Language == "Python" && sdk.PackageName == "azure-contoso") &&
+                        sdkInfos.Any(sdk => sdk.Language == "Go" && sdk.PackageName == "sdk/contoso") &&
+                        sdkInfos.All(sdk => sdk.Language != "Rust" && sdk.Language != "C++")),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            var mockTypeSpecHelper = new Mock<ITypeSpecHelper>();
+            mockTypeSpecHelper.Setup(x => x.IsUrl(typeSpecPath)).Returns(false);
+            mockTypeSpecHelper.Setup(x => x.GetTypeSpecProjectRelativePath(typeSpecPath))
+                .Returns("specification/testcontoso/Contoso.Management");
+            mockTypeSpecHelper.Setup(x => x.IsTypeSpecProjectForMgmtPlane(typeSpecPath))
+                .Returns(isManagementPlane);
+            mockTypeSpecHelper.Setup(x => x.ParseTypeSpecProjectAsync(
+                    typeSpecPath,
+                    It.IsAny<INpxHelper>(),
+                    It.IsAny<ILogger>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(project);
+
+            var tool = new ReleasePlanTool(
+                mockDevOps.Object,
+                gitHelper,
+                mockTypeSpecHelper.Object,
+                logger,
+                userHelper,
+                gitHubService,
+                environmentHelper,
+                inputSanitizer,
+                httpClient,
+                Mock.Of<INpxHelper>(),
+                Mock.Of<IRawOutputHelper>(),
+                Mock.Of<INotificationService>());
+
+            var result = await tool.UpdateReleasePlan(
+                typeSpecProjectPath: typeSpecPath,
+                sdkReleaseType: "beta",
+                workItemId: 700);
+
+            Assert.That(result.ResponseError, Is.Null);
+            mockDevOps.Verify(x => x.UpdateReleasePlanSDKDetailsAsync(
+                700,
+                It.IsAny<List<SDKInfo>>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
         // ==================== KPI Attestation Tests ====================
 
         [Test]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 0.6.40 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 0.6.40 (2026-08-31)
 
 ### Bugs Fixed
 
-### Other Changes
+- Ignore API version associated with unknown language emitter configuration in metadata ouput.
+- Ignore unsupported languages when updating the languages in release plan.
 
 ## 0.6.39 (2026-08-31)
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugs Fixed
 
-- Ignore API version associated with unknown language emitter configuration in metadata ouput.
+- Ignore API version associated with unknown language emitter configuration in metadata output.
 - Ignore unsupported languages when updating the languages in release plan.
 
 ## 0.6.39 (2026-08-31)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TypeSpecHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/TypeSpecHelper.cs
@@ -271,6 +271,10 @@ namespace Azure.Sdk.Tools.Cli.Helpers
 
                         languageName = languageName.Contains("csharp") ? ".NET" : languageName;
                         var language = SdkLanguageHelpers.GetSdkLanguage(languageName);
+                        if (language == SdkLanguage.Unknown)
+                        {
+                            continue;
+                        }
                         if (!string.IsNullOrEmpty(packageName))
                         {
                             if (language == SdkLanguage.Java && packageName.Contains(':'))

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -759,6 +759,9 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                         Language = p.Language.ToWorkItemString(),
                         PackageName = p.PackageName ?? string.Empty
                     }).ToList();
+
+                    var supportedLanguages = releasePlan.IsManagementPlane ? languagesforMgmtplane : supportedLanguagesforDataplane;
+                    sdkInfos = [.. sdkInfos.Where(sdk => supportedLanguages.Contains(sdk.Language))];
                     var updated = await devOpsService.UpdateReleasePlanSDKDetailsAsync(releasePlan.WorkItemId, sdkInfos, ct);
                     if (!updated)
                     {


### PR DESCRIPTION
Bug fix to identify the API version in known language emitter config.