### PR TITLE
Block sdk gen for multiple release plans for same package

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Mocks/Services/MockDevOpsService.cs
@@ -19,6 +19,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
         public ReleasePlanWorkItem? ConfiguredReleasePlanForSpecPrUrl { get; set; }
         public ReleasePlanWorkItem? ConfiguredReleasePlanForTypeSpecPath { get; set; }
         public string? ConfiguredReleasePlanForTypeSpecPathKey { get; set; }
+        public List<ReleasePlanWorkItem> ConfiguredActiveReleasePlansForTypeSpecPath { get; set; } = [];
         public ReleasePlanWorkItem? ConfiguredReleasePlanForTypeSpecPathAndApiVersion { get; set; }
         public string? ConfiguredReleasePlanForTypeSpecPathAndApiVersionKey { get; set; }
         public string? ConfiguredApiVersionForTypeSpecPathAndApiVersion { get; set; }
@@ -368,6 +369,11 @@ namespace Azure.Sdk.Tools.Cli.Tests.Mocks.Services
             }
 
             return Task.FromResult<ReleasePlanWorkItem?>(null);
+        }
+
+        Task<List<ReleasePlanWorkItem>> IDevOpsService.GetActiveReleasePlansByTypeSpecProjectPathAsync(string typeSpecProjectPath, ApiReleaseType apiReleaseType, CancellationToken ct)
+        {
+            return Task.FromResult(ConfiguredActiveReleasePlansForTypeSpecPath);
         }
 
         Task<ReleasePlanWorkItem?> IDevOpsService.GetReleasePlanByTypeSpecProjectPathAndApiVersionAsync(string typeSpecProjectPath, string apiVersion, CancellationToken ct)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/SpecWorkFlowToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/SpecWorkFlowToolTests.cs
@@ -410,6 +410,70 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         }
 
         [Test]
+        public async Task GenerateSDK_WhenCurrentReleasePlanHasSdkPullRequestForSameLanguage_AllowsRegeneration()
+        {
+            mockTypeSpecHelper.Setup(x => x.GetTypeSpecProjectRelativePath(It.IsAny<string>()))
+                .Returns("specification/testcontoso/Contoso.Management");
+            mockTypeSpecHelper.Setup(x => x.IsValidTypeSpecProjectPath(It.IsAny<string>()))
+                .Returns(true);
+
+            mockDevOpsService.ConfiguredRunSDKGenerationPipeline = new Build()
+            {
+                Id = 100,
+                Status = BuildStatus.InProgress,
+            };
+
+            // Current release plan already has an SDK pull request for the requested language (regeneration scenario).
+            var releasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 456,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo
+                    {
+                        Language = "Java",
+                        PackageName = "azure-test",
+                        SdkPullRequestUrl = "https://github.com/Azure/azure-sdk-for-java/pull/456"
+                    }
+                }
+            };
+            mockDevOpsService.ConfiguredReleasePlanForWorkItem = releasePlan;
+
+            // Another active release plan with an unreleased SDK pull request also exists, but regeneration of the
+            // current release plan should still be allowed because it already has its own SDK pull request.
+            mockDevOpsService.ConfiguredActiveReleasePlansForTypeSpecPath = new List<ReleasePlanWorkItem>
+            {
+                releasePlan,
+                new ReleasePlanWorkItem
+                {
+                    WorkItemId = 999,
+                    ReleasePlanId = 999,
+                    SDKInfo = new List<SDKInfo>
+                    {
+                        new SDKInfo
+                        {
+                            Language = "Java",
+                            PackageName = "azure-test",
+                            SdkPullRequestUrl = "https://github.com/Azure/azure-sdk-for-java/pull/123",
+                            ReleaseStatus = "In progress"
+                        }
+                    }
+                }
+            };
+
+            var result = await specWorkflowTool.RunGenerateSdkAsync(
+                typespecProjectRoot: "TypeSpecTestData/specification/testcontoso/Contoso.Management",
+                apiVersion: "2023-01-01",
+                sdkReleaseType: "beta",
+                language: "Java",
+                workItemId: 456
+            );
+
+            Assert.That(result.Status, Is.EqualTo("Success"));
+            Assert.That(result.ToString(), Does.Contain("has been initiated to generate the SDK"));
+        }
+
+        [Test]
         public async Task GenerateSdk_Without_pr_and_workitem()
         {
             mockTypeSpecHelper.Setup(x => x.GetTypeSpecProjectRelativePath(It.IsAny<string>()))

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/SpecWorkFlowToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/SpecWorkFlowToolTests.cs
@@ -327,7 +327,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
                         {
                             Language = "Java",
                             PackageName = "azure-test",
-                            SdkPullRequestUrl = "https://github.com/Azure/azure-sdk-for-java/pull/123"
+                            SdkPullRequestUrl = "https://github.com/Azure/azure-sdk-for-java/pull/123",
+                            ReleaseStatus = "In progress"
                         }
                     }
                 }
@@ -345,6 +346,67 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             Assert.That(result.ToString(), Does.Contain("Another active release plan"));
             Assert.That(result.ToString(), Does.Contain("999"));
             Assert.That(result.ToString(), Does.Not.Contain("has been initiated to generate the SDK"));
+        }
+
+        [Test]
+        public async Task GenerateSDK_WhenAnotherReleasePlanSdkPullRequestIsReleased_AllowsGeneration()
+        {
+            mockTypeSpecHelper.Setup(x => x.GetTypeSpecProjectRelativePath(It.IsAny<string>()))
+                .Returns("specification/testcontoso/Contoso.Management");
+            mockTypeSpecHelper.Setup(x => x.IsValidTypeSpecProjectPath(It.IsAny<string>()))
+                .Returns(true);
+
+            mockDevOpsService.ConfiguredRunSDKGenerationPipeline = new Build()
+            {
+                Id = 100,
+                Status = BuildStatus.InProgress,
+            };
+
+            var releasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 456,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo
+                    {
+                        Language = "Java",
+                        PackageName = "azure-test"
+                    }
+                }
+            };
+            mockDevOpsService.ConfiguredReleasePlanForWorkItem = releasePlan;
+
+            // Another active release plan whose SDK pull request has already been released should not block generation.
+            mockDevOpsService.ConfiguredActiveReleasePlansForTypeSpecPath = new List<ReleasePlanWorkItem>
+            {
+                releasePlan,
+                new ReleasePlanWorkItem
+                {
+                    WorkItemId = 999,
+                    ReleasePlanId = 999,
+                    SDKInfo = new List<SDKInfo>
+                    {
+                        new SDKInfo
+                        {
+                            Language = "Java",
+                            PackageName = "azure-test",
+                            SdkPullRequestUrl = "https://github.com/Azure/azure-sdk-for-java/pull/123",
+                            ReleaseStatus = "Released"
+                        }
+                    }
+                }
+            };
+
+            var result = await specWorkflowTool.RunGenerateSdkAsync(
+                typespecProjectRoot: "TypeSpecTestData/specification/testcontoso/Contoso.Management",
+                apiVersion: "2023-01-01",
+                sdkReleaseType: "beta",
+                language: "Java",
+                workItemId: 456
+            );
+
+            Assert.That(result.Status, Is.EqualTo("Success"));
+            Assert.That(result.ToString(), Does.Contain("has been initiated to generate the SDK"));
         }
 
         [Test]

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/SpecWorkFlowToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/SpecWorkFlowToolTests.cs
@@ -239,6 +239,114 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
             Assert.That(result.ToString(), Does.Contain("Azure DevOps pipeline https://dev.azure.com/azure-sdk/internal/_build/results?buildId=100 has been initiated to generate the SDK. Build ID is 100"));
         }
 
+        [TestCase("In progress")]
+        [TestCase("Pending")]
+        [TestCase("PENDING")]
+        public async Task GenerateSDK_WhenGenerationAlreadyInProgress_SkipsNewRun(string generationStatus)
+        {
+            mockTypeSpecHelper.Setup(x => x.GetTypeSpecProjectRelativePath(It.IsAny<string>()))
+                .Returns("specification/testcontoso/Contoso.Management");
+            mockTypeSpecHelper.Setup(x => x.IsValidTypeSpecProjectPath(It.IsAny<string>()))
+                .Returns(true);
+
+            mockDevOpsService.ConfiguredRunSDKGenerationPipeline = new Build()
+            {
+                Id = 100,
+                Status = BuildStatus.InProgress,
+            };
+
+            var releasePlan = new ReleasePlanWorkItem
+            {
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo
+                    {
+                        Language = "Java",
+                        PackageName = "azure-test",
+                        GenerationStatus = generationStatus,
+                        GenerationPipelineUrl = "https://dev.azure.com/azure-sdk/internal/_build/results?buildId=99"
+                    }
+                }
+            };
+            mockDevOpsService.ConfiguredReleasePlanForWorkItem = releasePlan;
+
+            var result = await specWorkflowTool.RunGenerateSdkAsync(
+                typespecProjectRoot: "TypeSpecTestData/specification/testcontoso/Contoso.Management",
+                apiVersion: "2023-01-01",
+                sdkReleaseType: "beta",
+                language: "Java",
+                workItemId: 456
+            );
+
+            Assert.That(result.Status, Is.EqualTo("Success"));
+            Assert.That(result.ToString(), Does.Contain("was not triggered to avoid duplicate generation"));
+            Assert.That(result.ToString(), Does.Contain("https://dev.azure.com/azure-sdk/internal/_build/results?buildId=99"));
+            // A new generation run should not have been triggered.
+            Assert.That(result.ToString(), Does.Not.Contain("has been initiated to generate the SDK"));
+        }
+
+        [Test]
+        public async Task GenerateSDK_WhenAnotherActiveReleasePlanHasSdkPullRequest_BlocksGeneration()
+        {
+            mockTypeSpecHelper.Setup(x => x.GetTypeSpecProjectRelativePath(It.IsAny<string>()))
+                .Returns("specification/testcontoso/Contoso.Management");
+            mockTypeSpecHelper.Setup(x => x.IsValidTypeSpecProjectPath(It.IsAny<string>()))
+                .Returns(true);
+
+            mockDevOpsService.ConfiguredRunSDKGenerationPipeline = new Build()
+            {
+                Id = 100,
+                Status = BuildStatus.InProgress,
+            };
+
+            var releasePlan = new ReleasePlanWorkItem
+            {
+                WorkItemId = 456,
+                SDKInfo = new List<SDKInfo>
+                {
+                    new SDKInfo
+                    {
+                        Language = "Java",
+                        PackageName = "azure-test"
+                    }
+                }
+            };
+            mockDevOpsService.ConfiguredReleasePlanForWorkItem = releasePlan;
+
+            // Another active release plan for the same TypeSpec project that already has an SDK pull request.
+            mockDevOpsService.ConfiguredActiveReleasePlansForTypeSpecPath = new List<ReleasePlanWorkItem>
+            {
+                releasePlan,
+                new ReleasePlanWorkItem
+                {
+                    WorkItemId = 999,
+                    ReleasePlanId = 999,
+                    SDKInfo = new List<SDKInfo>
+                    {
+                        new SDKInfo
+                        {
+                            Language = "Java",
+                            PackageName = "azure-test",
+                            SdkPullRequestUrl = "https://github.com/Azure/azure-sdk-for-java/pull/123"
+                        }
+                    }
+                }
+            };
+
+            var result = await specWorkflowTool.RunGenerateSdkAsync(
+                typespecProjectRoot: "TypeSpecTestData/specification/testcontoso/Contoso.Management",
+                apiVersion: "2023-01-01",
+                sdkReleaseType: "beta",
+                language: "Java",
+                workItemId: 456
+            );
+
+            Assert.That(result.Status, Is.EqualTo("Failed"));
+            Assert.That(result.ToString(), Does.Contain("Another active release plan"));
+            Assert.That(result.ToString(), Does.Contain("999"));
+            Assert.That(result.ToString(), Does.Not.Contain("has been initiated to generate the SDK"));
+        }
+
         [Test]
         public async Task GenerateSdk_Without_pr_and_workitem()
         {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 0.6.42 (Unreleased)
+## 0.6.42 (2026-09-01)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Skip SDK generation is SDK generation pipeline is already in progress for the release plan
+- Do not run SDK generation if another release plan is in progress for same package.
 
 ## 0.6.41 (2026-08-31)
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Features Added
 
-- Skip SDK generation is SDK generation pipeline is already in progress for the release plan
-- Do not run SDK generation if another release plan is in progress for same package.
+- Skip SDK generation if an SDK generation pipeline is already in progress for the release plan.
+- Do not run SDK generation if another release plan is in progress for the same package.
 
 ## 0.6.41 (2026-08-31)
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -172,6 +172,7 @@ namespace Azure.Sdk.Tools.Cli.Services
         public Task<ProductInfo?> GetProductInfoByTypeSpecProjectPathAsync(string typeSpecProjectPath, CancellationToken ct);
         public Task<ProductInfo?> GetProductInfoFromTriageWorkItemAsync(string productServiceTreeId, CancellationToken ct);
         public Task<ReleasePlanWorkItem?> GetReleasePlanByTypeSpecProjectPathAsync(string typeSpecProjectPath, bool includeFinishedPlans = false, ApiReleaseType apiReleaseType = ApiReleaseType.Unknown, CancellationToken ct = default);
+        public Task<List<ReleasePlanWorkItem>> GetActiveReleasePlansByTypeSpecProjectPathAsync(string typeSpecProjectPath, ApiReleaseType apiReleaseType = ApiReleaseType.Unknown, CancellationToken ct = default);
         public Task<ReleasePlanWorkItem?> GetReleasePlanByTypeSpecProjectPathAndApiVersionAsync(string typeSpecProjectPath, string apiVersion, CancellationToken ct = default);
         Task<List<WorkItem>> FetchWorkItemsPagedAsync(string query, int top = 100000, int batchSize = 200, WorkItemExpand expand = WorkItemExpand.All, CancellationToken ct = default);
         Task<List<WorkItem>> QueryWorkItemsByTypeAndFieldAsync(string workItemType, string fieldName, string fieldValue, WorkItemExpand expand = WorkItemExpand.Relations, CancellationToken ct = default);
@@ -2052,6 +2053,46 @@ namespace Azure.Sdk.Tools.Cli.Services
             {
                 logger.LogError(ex, "Failed to get release plan for TypeSpec project path: {typeSpecProjectPath}", typeSpecProjectPath);
                 throw new Exception($"Failed to get release plan for TypeSpec project path '{typeSpecProjectPath}'. Error: {ex.Message}", ex);
+            }
+        }
+
+        public async Task<List<ReleasePlanWorkItem>> GetActiveReleasePlansByTypeSpecProjectPathAsync(string typeSpecProjectPath, ApiReleaseType apiReleaseType = ApiReleaseType.Unknown, CancellationToken ct = default)
+        {
+            if (string.IsNullOrEmpty(typeSpecProjectPath))
+            {
+                throw new ArgumentException("TypeSpec project path cannot be null or empty.", nameof(typeSpecProjectPath));
+            }
+
+            try
+            {
+                logger.LogInformation("Searching for active release plans with TypeSpec project path: {typeSpecProjectPath}", typeSpecProjectPath);
+
+                var escapedPath = typeSpecProjectPath.Replace("'", "''");
+                var query = $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{Constants.AZURE_SDK_DEVOPS_RELEASE_PROJECT}'";
+                query += $" AND [Custom.ApiSpecProjectPath] = '{escapedPath}'";
+                query += " AND [System.WorkItemType] = 'Release Plan'";
+                query += " AND [System.State] NOT IN ('Closed','Duplicate','Abandoned','Finished')";
+                query += $" AND [System.Tags] {(IsAgentTesting ? "CONTAINS" : "NOT CONTAINS")} '{RELEASE_PLANNER_APP_TEST}'";
+                if (apiReleaseType != ApiReleaseType.Unknown)
+                {
+                    query += $" AND [Custom.ReleasePlanType] = '{apiReleaseType.ToAdoFieldValue()}'";
+                }
+                query += "  ORDER BY [System.Id] DESC";
+
+                var releasePlanWorkItems = await FetchWorkItemsAsync(query, ct);
+                if (releasePlanWorkItems.Count == 0)
+                {
+                    logger.LogInformation("No active release plan found for TypeSpec project path: {typeSpecProjectPath}", typeSpecProjectPath);
+                    return [];
+                }
+
+                var releasePlans = await Task.WhenAll(releasePlanWorkItems.Select(workItem => MapWorkItemToReleasePlanAsync(workItem, ct)));
+                return releasePlans.ToList();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to get active release plans for TypeSpec project path: {typeSpecProjectPath}", typeSpecProjectPath);
+                throw new Exception($"Failed to get active release plans for TypeSpec project path '{typeSpecProjectPath}'. Error: {ex.Message}", ex);
             }
         }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/SpecWorkFlowTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/SpecWorkFlowTool.cs
@@ -297,31 +297,37 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 // Check if another active (in progress) release plan exists for the same TypeSpec project that already
                 // has an SDK pull request that has not been released yet. If so, block SDK generation for the current
                 // release plan to avoid conflicting/duplicate SDK pull requests for the same service.
-                var activeReleasePlans = await devopsService.GetActiveReleasePlansByTypeSpecProjectPathAsync(typeSpecProjectPath, ct: ct);
-                var conflictingReleasePlan = activeReleasePlans?.FirstOrDefault(rp =>
-                    rp.WorkItemId != workItemId &&
-                    rp.SDKInfo.Any(s => s.Language == language &&
-                        !string.IsNullOrEmpty(s.SdkPullRequestUrl) &&
-                        !string.Equals(s.ReleaseStatus, "Released", StringComparison.OrdinalIgnoreCase)));
-                if (conflictingReleasePlan != null)
+                // Skip this check when the current release plan already has an SDK pull request for the same language,
+                // so that regenerating the SDK for the current release plan is allowed.
+                var currentSdkPullRequestUrl = sdkInfo?.SdkPullRequestUrl;
+                if (string.IsNullOrEmpty(currentSdkPullRequestUrl))
                 {
-                    var existingSdkPullRequests = conflictingReleasePlan.SDKInfo
-                        .Where(s => !string.IsNullOrEmpty(s.SdkPullRequestUrl) &&
-                            !string.Equals(s.ReleaseStatus, "Released", StringComparison.OrdinalIgnoreCase))
-                        .Select(s => $"{s.Language}: {s.SdkPullRequestUrl}");
-                    logger.LogInformation(
-                        "Another active release plan (work item {ConflictingWorkItemId}) with SDK pull request(s) already exists for TypeSpec project {TypeSpecProjectPath}. Blocking SDK generation for release plan {WorkItemId}.",
-                        conflictingReleasePlan.WorkItemId,
-                        typeSpecProjectPath,
-                        workItemId);
-                    response.Status = "Failed";
-                    var blockMessage = $"Another active release plan (work item {conflictingReleasePlan.WorkItemId}) with an SDK pull request already exists for this service. " +
-                        "SDK can be generated for the current release plan only after completing the previous release plan or after abandoning it.";
-                    response.ResponseErrors.Add(blockMessage);
-                    response.Details.Add($"Existing release plan: {conflictingReleasePlan.ReleasePlanLink}");
-                    response.Details.AddRange(existingSdkPullRequests.Select(pr => $"Existing SDK pull request: {pr}"));
-                    response.NextSteps = ["Complete or abandon the previous release plan before generating the SDK for the current release plan."];
-                    return response;
+                    var activeReleasePlans = await devopsService.GetActiveReleasePlansByTypeSpecProjectPathAsync(typeSpecProjectPath, ct: ct);
+                    var conflictingReleasePlan = activeReleasePlans?.FirstOrDefault(rp =>
+                        rp.WorkItemId != workItemId &&
+                        rp.SDKInfo.Any(s => s.Language == language &&
+                            !string.IsNullOrEmpty(s.SdkPullRequestUrl) &&
+                            !string.Equals(s.ReleaseStatus, "Released", StringComparison.OrdinalIgnoreCase)));
+                    if (conflictingReleasePlan != null)
+                    {
+                        var existingSdkPullRequests = conflictingReleasePlan.SDKInfo
+                            .Where(s => !string.IsNullOrEmpty(s.SdkPullRequestUrl) &&
+                                !string.Equals(s.ReleaseStatus, "Released", StringComparison.OrdinalIgnoreCase))
+                            .Select(s => $"{s.Language}: {s.SdkPullRequestUrl}");
+                        logger.LogInformation(
+                            "Another active release plan (work item {ConflictingWorkItemId}) with SDK pull request(s) already exists for TypeSpec project {TypeSpecProjectPath}. Blocking SDK generation for release plan {WorkItemId}.",
+                            conflictingReleasePlan.WorkItemId,
+                            typeSpecProjectPath,
+                            workItemId);
+                        response.Status = "Failed";
+                        var blockMessage = $"Another active release plan (work item {conflictingReleasePlan.WorkItemId}) with an SDK pull request already exists for this service. " +
+                            "SDK can be generated for the current release plan only after completing the previous release plan or after abandoning it.";
+                        response.ResponseErrors.Add(blockMessage);
+                        response.Details.Add($"Existing release plan: {conflictingReleasePlan.ReleasePlanLink}");
+                        response.Details.AddRange(existingSdkPullRequests.Select(pr => $"Existing SDK pull request: {pr}"));
+                        response.NextSteps = ["Complete or abandon the previous release plan before generating the SDK for the current release plan."];
+                        return response;
+                    }
                 }
 
                 string apiSpecBranchRef = "main";

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/SpecWorkFlowTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/SpecWorkFlowTool.cs
@@ -273,6 +273,54 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     return response;
                 }
 
+                // Check the current SDK generation status for the language in the release plan.
+                // If a generation is already in progress or pending, skip triggering a new run to avoid duplicate SDK generation.
+                var sdkInfo = releasePlan?.SDKInfo.FirstOrDefault(s => s.Language == language);
+                var currentGenerationStatus = sdkInfo?.GenerationStatus ?? string.Empty;
+                if (currentGenerationStatus.Equals("In progress", StringComparison.OrdinalIgnoreCase) ||
+                    currentGenerationStatus.Equals("Pending", StringComparison.OrdinalIgnoreCase))
+                {
+                    logger.LogInformation(
+                        "SDK generation for {Language} is already in status '{GenerationStatus}'. Skipping new generation run to avoid a duplicate.",
+                        language,
+                        currentGenerationStatus);
+                    response.Status = "Success";
+                    var duplicateMessage = $"SDK generation for {language} is already '{currentGenerationStatus}' for release plan work item {workItemId}. A new SDK generation run was not triggered to avoid duplicate generation.";
+                    if (!string.IsNullOrEmpty(sdkInfo?.GenerationPipelineUrl))
+                    {
+                        duplicateMessage += $" Previous SDK generation pipeline: {sdkInfo.GenerationPipelineUrl}.";
+                    }
+                    response.Details.Add(duplicateMessage);
+                    return response;
+                }
+
+                // Check if another active (in progress) release plan exists for the same TypeSpec project that already
+                // has SDK pull request link(s). If so, block SDK generation for the current release plan to avoid
+                // conflicting/duplicate SDK pull requests for the same service.
+                var activeReleasePlans = await devopsService.GetActiveReleasePlansByTypeSpecProjectPathAsync(typeSpecProjectPath, ct: ct);
+                var conflictingReleasePlan = activeReleasePlans?.FirstOrDefault(rp =>
+                    rp.WorkItemId != workItemId &&
+                    rp.SDKInfo.Any(s => !string.IsNullOrEmpty(s.SdkPullRequestUrl)));
+                if (conflictingReleasePlan != null)
+                {
+                    var existingSdkPullRequests = conflictingReleasePlan.SDKInfo
+                        .Where(s => !string.IsNullOrEmpty(s.SdkPullRequestUrl))
+                        .Select(s => $"{s.Language}: {s.SdkPullRequestUrl}");
+                    logger.LogInformation(
+                        "Another active release plan (work item {ConflictingWorkItemId}) with SDK pull request(s) already exists for TypeSpec project {TypeSpecProjectPath}. Blocking SDK generation for release plan {WorkItemId}.",
+                        conflictingReleasePlan.WorkItemId,
+                        typeSpecProjectPath,
+                        workItemId);
+                    response.Status = "Failed";
+                    var blockMessage = $"Another active release plan (work item {conflictingReleasePlan.WorkItemId}) with an SDK pull request already exists for this service. " +
+                        "SDK can be generated for the current release plan only after completing the previous release plan or after abandoning it.";
+                    response.ResponseErrors.Add(blockMessage);
+                    response.Details.Add($"Existing release plan: {conflictingReleasePlan.ReleasePlanLink}");
+                    response.Details.AddRange(existingSdkPullRequests.Select(pr => $"Existing SDK pull request: {pr}"));
+                    response.NextSteps = ["Complete or abandon the previous release plan before generating the SDK for the current release plan."];
+                    return response;
+                }
+
                 string apiSpecBranchRef = "main";
                 if (pullRequestNumber > 0)
                 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/SpecWorkFlowTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/SpecWorkFlowTool.cs
@@ -295,16 +295,19 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 }
 
                 // Check if another active (in progress) release plan exists for the same TypeSpec project that already
-                // has SDK pull request link(s). If so, block SDK generation for the current release plan to avoid
-                // conflicting/duplicate SDK pull requests for the same service.
+                // has an SDK pull request that has not been released yet. If so, block SDK generation for the current
+                // release plan to avoid conflicting/duplicate SDK pull requests for the same service.
                 var activeReleasePlans = await devopsService.GetActiveReleasePlansByTypeSpecProjectPathAsync(typeSpecProjectPath, ct: ct);
                 var conflictingReleasePlan = activeReleasePlans?.FirstOrDefault(rp =>
                     rp.WorkItemId != workItemId &&
-                    rp.SDKInfo.Any(s => !string.IsNullOrEmpty(s.SdkPullRequestUrl)));
+                    rp.SDKInfo.Any(s => s.Language == language &&
+                        !string.IsNullOrEmpty(s.SdkPullRequestUrl) &&
+                        !string.Equals(s.ReleaseStatus, "Released", StringComparison.OrdinalIgnoreCase)));
                 if (conflictingReleasePlan != null)
                 {
                     var existingSdkPullRequests = conflictingReleasePlan.SDKInfo
-                        .Where(s => !string.IsNullOrEmpty(s.SdkPullRequestUrl))
+                        .Where(s => !string.IsNullOrEmpty(s.SdkPullRequestUrl) &&
+                            !string.Equals(s.ReleaseStatus, "Released", StringComparison.OrdinalIgnoreCase))
                         .Select(s => $"{s.Language}: {s.SdkPullRequestUrl}");
                     logger.LogInformation(
                         "Another active release plan (work item {ConflictingWorkItemId}) with SDK pull request(s) already exists for TypeSpec project {TypeSpecProjectPath}. Blocking SDK generation for release plan {WorkItemId}.",


### PR DESCRIPTION
- Skip SDK generation is SDK generation pipeline is already in progress for the release plan
- Do not run SDK generation if another release plan is in progress for same package.