### PR TITLE
[azsdk-cli] Enable Copilot token inheritance from MCP host environment

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/ServiceRegistrationsTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Services/ServiceRegistrationsTests.cs
@@ -7,29 +7,106 @@ namespace Azure.Sdk.Tools.Cli.Tests.Services;
 [NonParallelizable]
 internal class ServiceRegistrationsTests
 {
+    private readonly Dictionary<string, string?> _savedEnvVars = new();
+
+    [SetUp]
+    public void SaveEnvironmentVariables()
+    {
+        foreach (var envVar in ServiceRegistrations.GitHubTokenEnvironmentVariables)
+        {
+            _savedEnvVars[envVar] = Environment.GetEnvironmentVariable(envVar);
+            Environment.SetEnvironmentVariable(envVar, null);
+        }
+        _savedEnvVars["AZSDK_COPILOT_CLI_PATH"] = Environment.GetEnvironmentVariable("AZSDK_COPILOT_CLI_PATH");
+    }
+
+    [TearDown]
+    public void RestoreEnvironmentVariables()
+    {
+        foreach (var (key, value) in _savedEnvVars)
+        {
+            Environment.SetEnvironmentVariable(key, value);
+        }
+    }
+
     [Test]
     public void CreateCopilotClientOptions_ReadsEnvironmentOverrides()
     {
-        var originalPath = Environment.GetEnvironmentVariable("AZSDK_COPILOT_CLI_PATH");
-        var originalToken = Environment.GetEnvironmentVariable("AZSDK_COPILOT_GITHUB_TOKEN");
-        try
-        {
-            Environment.SetEnvironmentVariable("AZSDK_COPILOT_CLI_PATH", "  test-copilot  ");
-            Environment.SetEnvironmentVariable("AZSDK_COPILOT_GITHUB_TOKEN", "  test-token  ");
+        Environment.SetEnvironmentVariable("AZSDK_COPILOT_CLI_PATH", "  test-copilot  ");
+        Environment.SetEnvironmentVariable("AZSDK_COPILOT_GITHUB_TOKEN", "  test-token  ");
 
-            var options = ServiceRegistrations.CreateCopilotClientOptions(logger: null);
+        var options = ServiceRegistrations.CreateCopilotClientOptions(logger: null);
 
-            Assert.Multiple(() =>
-            {
-                Assert.That(options.GitHubToken, Is.EqualTo("test-token"));
-                Assert.That(options.Connection, Is.TypeOf<StdioRuntimeConnection>());
-                Assert.That(((StdioRuntimeConnection)options.Connection!).Path, Is.EqualTo("test-copilot"));
-            });
-        }
-        finally
+        Assert.Multiple(() =>
         {
-            Environment.SetEnvironmentVariable("AZSDK_COPILOT_CLI_PATH", originalPath);
-            Environment.SetEnvironmentVariable("AZSDK_COPILOT_GITHUB_TOKEN", originalToken);
-        }
+            Assert.That(options.GitHubToken, Is.EqualTo("test-token"));
+            Assert.That(options.Connection, Is.TypeOf<StdioRuntimeConnection>());
+            Assert.That(((StdioRuntimeConnection)options.Connection!).Path, Is.EqualTo("test-copilot"));
+        });
+    }
+
+    [Test]
+    public void ResolveGitHubToken_PrefersAzsdkToken()
+    {
+        Environment.SetEnvironmentVariable("AZSDK_COPILOT_GITHUB_TOKEN", "azsdk-token");
+        Environment.SetEnvironmentVariable("COPILOT_GITHUB_TOKEN", "copilot-token");
+        Environment.SetEnvironmentVariable("GH_TOKEN", "gh-token");
+        Environment.SetEnvironmentVariable("GITHUB_TOKEN", "github-token");
+
+        var token = ServiceRegistrations.ResolveGitHubToken();
+
+        Assert.That(token, Is.EqualTo("azsdk-token"));
+    }
+
+    [Test]
+    public void ResolveGitHubToken_FallsThroughToCopilotGithubToken()
+    {
+        Environment.SetEnvironmentVariable("COPILOT_GITHUB_TOKEN", "copilot-token");
+        Environment.SetEnvironmentVariable("GH_TOKEN", "gh-token");
+
+        var token = ServiceRegistrations.ResolveGitHubToken();
+
+        Assert.That(token, Is.EqualTo("copilot-token"));
+    }
+
+    [Test]
+    public void ResolveGitHubToken_FallsThroughToGhToken()
+    {
+        Environment.SetEnvironmentVariable("GH_TOKEN", "gh-token");
+        Environment.SetEnvironmentVariable("GITHUB_TOKEN", "github-token");
+
+        var token = ServiceRegistrations.ResolveGitHubToken();
+
+        Assert.That(token, Is.EqualTo("gh-token"));
+    }
+
+    [Test]
+    public void ResolveGitHubToken_FallsThroughToGithubToken()
+    {
+        Environment.SetEnvironmentVariable("GITHUB_TOKEN", "github-token");
+
+        var token = ServiceRegistrations.ResolveGitHubToken();
+
+        Assert.That(token, Is.EqualTo("github-token"));
+    }
+
+    [Test]
+    public void ResolveGitHubToken_ReturnsNullWhenNoTokensSet()
+    {
+        var token = ServiceRegistrations.ResolveGitHubToken();
+
+        Assert.That(token, Is.Null);
+    }
+
+    [Test]
+    public void ResolveGitHubToken_SkipsWhitespaceOnlyTokens()
+    {
+        Environment.SetEnvironmentVariable("AZSDK_COPILOT_GITHUB_TOKEN", "   ");
+        Environment.SetEnvironmentVariable("COPILOT_GITHUB_TOKEN", "");
+        Environment.SetEnvironmentVariable("GH_TOKEN", "  valid-token  ");
+
+        var token = ServiceRegistrations.ResolveGitHubToken();
+
+        Assert.That(token, Is.EqualTo("valid-token"));
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CopilotAgents/CopilotAgentRunner.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CopilotAgents/CopilotAgentRunner.cs
@@ -15,6 +15,9 @@ public class CopilotAgentRunner(
     /// <summary>
     /// Ensures the GitHub Copilot CLI is installed and authenticated.
     /// Throws a descriptive exception if not available or not authenticated.
+    /// In MCP mode, the host's Copilot token is typically inherited via environment
+    /// variables (COPILOT_GITHUB_TOKEN, GH_TOKEN, GITHUB_TOKEN) so this check
+    /// should pass without requiring a separate copilot login.
     /// </summary>
     private async Task EnsureAuthenticatedAsync(CancellationToken ct)
     {
@@ -28,14 +31,20 @@ public class CopilotAgentRunner(
             throw new CopilotCliUnavailableException(
                 "The GitHub Copilot CLI could not be found or failed to start. This tool requires the Copilot CLI to be installed. " +
                 "For installation instructions, see: https://docs.github.com/en/copilot/how-tos/copilot-cli/install-copilot-cli. " +
-                "If you already have the Copilot CLI installed elsewhere, set the AZSDK_COPILOT_CLI_PATH environment variable to the path of the Copilot CLI executable (copilot/copilot.exe).",
+                "If you already have the Copilot CLI installed elsewhere, set the AZSDK_COPILOT_CLI_PATH environment variable to the path of the Copilot CLI executable (copilot/copilot.exe). " +
+                "Alternatively, set one of the following environment variables with a valid GitHub token: " +
+                "AZSDK_COPILOT_GITHUB_TOKEN, COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN.",
                 ex);
         }
 
         if (!authStatus.IsAuthenticated)
         {
             throw new CopilotCliUnavailableException(
-                "GitHub Copilot is not authenticated. Please authenticate using the GitHub Copilot CLI by running: copilot login");
+                "GitHub Copilot is not authenticated. Please authenticate by one of the following methods: " +
+                "(1) Run 'copilot login' to authenticate the Copilot CLI, or " +
+                "(2) Set one of the following environment variables with a valid GitHub token: " +
+                "AZSDK_COPILOT_GITHUB_TOKEN, COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN. " +
+                "When running in MCP mode (e.g., via VS Code Copilot), the host's token should be inherited automatically.");
         }
 
         logger.LogDebug("Copilot authentication verified");

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/ServiceRegistrations.cs
@@ -198,17 +198,54 @@ namespace Azure.Sdk.Tools.Cli.Services
             });
         }
 
+        /// <summary>
+        /// Token resolution priority for Copilot SDK authentication:
+        /// 1. AZSDK_COPILOT_GITHUB_TOKEN (explicit tool-specific override)
+        /// 2. COPILOT_GITHUB_TOKEN (set by Copilot host in MCP mode)
+        /// 3. GH_TOKEN (set by GitHub CLI, GitHub Actions, or login-to-github)
+        /// 4. GITHUB_TOKEN (set by GitHub Actions or CI pipelines)
+        /// This enables token inheritance from the MCP host so users running
+        /// through VS Code Copilot or Copilot CLI agent don't need a separate copilot login.
+        /// </summary>
+        public static readonly string[] GitHubTokenEnvironmentVariables =
+        [
+            "AZSDK_COPILOT_GITHUB_TOKEN",
+            "COPILOT_GITHUB_TOKEN",
+            "GH_TOKEN",
+            "GITHUB_TOKEN"
+        ];
+
         public static CopilotClientOptions CreateCopilotClientOptions(ILogger<CopilotClient>? logger)
         {
             var cliPath = Environment.GetEnvironmentVariable("AZSDK_COPILOT_CLI_PATH");
-            var githubToken = Environment.GetEnvironmentVariable("AZSDK_COPILOT_GITHUB_TOKEN");
+            var githubToken = ResolveGitHubToken(logger);
             return new CopilotClientOptions
             {
                 Connection = RuntimeConnection.ForStdio(
                     string.IsNullOrWhiteSpace(cliPath) ? null : cliPath.Trim()),
-                GitHubToken = string.IsNullOrWhiteSpace(githubToken) ? null : githubToken.Trim(),
+                GitHubToken = githubToken,
                 Logger = logger
             };
+        }
+
+        /// <summary>
+        /// Resolves a GitHub token by checking environment variables in priority order.
+        /// Returns the first non-empty token found, or null if none are set.
+        /// </summary>
+        public static string? ResolveGitHubToken(ILogger? logger = null)
+        {
+            foreach (var envVar in GitHubTokenEnvironmentVariables)
+            {
+                var token = Environment.GetEnvironmentVariable(envVar);
+                if (!string.IsNullOrWhiteSpace(token))
+                {
+                    logger?.LogDebug("Resolved GitHub token from {EnvironmentVariable}", envVar);
+                    return token.Trim();
+                }
+            }
+
+            logger?.LogDebug("No GitHub token found in environment variables");
+            return null;
         }
 
         // Update checking and upgrade management in MCP server mode


### PR DESCRIPTION
## Problem

The customization tool requires \copilot login\ even when running in MCP mode where the host (VS Code Copilot, Copilot CLI agent) already has a valid token. This blocks users unnecessarily.

## Fix

Broaden token resolution to inherit from the MCP host environment. Priority order:
1. \AZSDK_COPILOT_GITHUB_TOKEN\ (explicit override)
2. \COPILOT_GITHUB_TOKEN\ (set by Copilot host in MCP mode)
3. \GH_TOKEN\ (GitHub CLI / Actions / \login-to-github\)
4. \GITHUB_TOKEN\ (GitHub Actions / CI)

Also updates auth error messages to mention env var alternatives and adds tests for token resolution.