### PR TITLE
[TypeSpec Authoring] Format skill for spec repo sync

### DIFF
--- a/.github/skills/azure-typespec-author/SKILL.md
+++ b/.github/skills/azure-typespec-author/SKILL.md
@@ -29,10 +29,10 @@ This includes but is not limited to:
 
 ## MCP Tools
 
-| Tool                                                   | Purpose                                                   |
-| ------------------------------------------------------ | --------------------------------------------------------- |
+| Tool                                                   | Purpose                                                                                                                                                                                                              |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `azure-sdk-mcp:azsdk_typespec_generate_authoring_plan` | Generate a grounded authoring plan for requests **not** covered by the eight cases in [reference-document-links.md](references/reference-document-links.md). Covered cases use agentic search (`web_fetch`) instead. |
-| `azure-sdk-mcp:azsdk_run_typespec_validation`          | Validate TypeSpec                                         |
+| `azure-sdk-mcp:azsdk_run_typespec_validation`          | Validate TypeSpec                                                                                                                                                                                                    |
 
 **Prerequisite:** `azure-sdk-mcp` server must be running.
 

--- a/.github/skills/azure-typespec-author/references/analyze-project.md
+++ b/.github/skills/azure-typespec-author/references/analyze-project.md
@@ -2,17 +2,17 @@
 
 Collect the inputs below from the TypeSpec project. Ask **up to 6 concise questions** for any that are missing.
 
-| #   | Input                       | Example                                                          |
-| --- | --------------------------- | ---------------------------------------------------------------- |
+| #   | Input                       | Example                                                                                                                                 |
+| --- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | 1   | TypeSpec project root       | ARM: `/specification/widget/resource-manager/Microsoft.Widget/Widget`<br>Data-plane: `/specification/widget/data-plane/WidgetAnalytics` |
-| 2   | Path to `tspconfig.yaml`    | `<spec-root>/tspconfig.yaml`                                     |
-| 3   | Service type                | ARM / data-plane                                                 |
-| 4   | Existing API versions       | `2024-01-01 (stable)`, `2024-06-01-preview`                      |
-| 5   | Latest API version          | Most recent entry in the `Versions` enum                         |
-| 6   | Current working API version | The version being added or modified this session                 |
-| 7   | Intent                      | add / modify / fix                                               |
-| 8   | Target resource/interface   | Resource or operation name (if known)                            |
-| 9   | Constraints                 | Breaking-change limits, naming rules, emitter targets, etc.      |
+| 2   | Path to `tspconfig.yaml`    | `<spec-root>/tspconfig.yaml`                                                                                                            |
+| 3   | Service type                | ARM / data-plane                                                                                                                        |
+| 4   | Existing API versions       | `2024-01-01 (stable)`, `2024-06-01-preview`                                                                                             |
+| 5   | Latest API version          | Most recent entry in the `Versions` enum                                                                                                |
+| 6   | Current working API version | The version being added or modified this session                                                                                        |
+| 7   | Intent                      | add / modify / fix                                                                                                                      |
+| 8   | Target resource/interface   | Resource or operation name (if known)                                                                                                   |
+| 9   | Constraints                 | Breaking-change limits, naming rules, emitter targets, etc.                                                                             |
 
 ## Output
 

--- a/.github/skills/azure-typespec-author/references/intake.md
+++ b/.github/skills/azure-typespec-author/references/intake.md
@@ -7,12 +7,12 @@
 1. Run [agentic search](agentic-search.md) using the Step 1 result and the user's request.
 2. Identify the case from the table below and gather more information if case matches. If no case matches, skip Step 2.2.
 
-| Case | Name                      | Description                                            | Service Type     |
-| ---- | ------------------------- | ------------------------------------------------------ | ---------------- |
-| 1    | Add ARM Resource Type     | Define a new ARM resource with operations              | ARM              |
+| Case | Name                       | Description                                            | Service Type     |
+| ---- | -------------------------- | ------------------------------------------------------ | ---------------- |
+| 1    | Add ARM Resource Type      | Define a new ARM resource with operations              | ARM              |
 | 2    | Add ARM Resource Operation | Add CRUD or custom actions on an existing resource     | ARM              |
-| 3    | API Versioning            | Add, bump, or promote an API version (preview/stable)  | ARM / Data-plane |
-| 4    | Add Data-Plane Operations | Add CRUD or custom operations on a data-plane resource | Data-plane       |
+| 3    | API Versioning             | Add, bump, or promote an API version (preview/stable)  | ARM / Data-plane |
+| 4    | Add Data-Plane Operations  | Add CRUD or custom operations on a data-plane resource | Data-plane       |
 
 ---
 


### PR DESCRIPTION
## Summary

- format the `azure-typespec-author` Markdown files with the spec repository's pinned Prettier version and `printWidth: 100`
- keep the source skill formatting compatible with automated syncs to `Azure/azure-rest-api-specs`

## Validation

- Prettier check passes for all three affected files
- formatted Git blob hashes match the corresponding files in Azure/azure-rest-api-specs#46033
- `git diff --check`

Fixes #16882