### PR TITLE
Add JavaScript SDK release tools documentation to knowledge config

### DIFF
--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/config/knowledge-config.json
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-knowledge-sync/config/knowledge-config.json
@@ -617,6 +617,15 @@
           "metadata": {
             "scope": "branded"
           }
+        },
+        {
+          "description": "JavaScript SDK release tools documentation",
+          "path": "/eng/tools/js-sdk-release-tools/docs/automation-pipeline.md",
+          "folder": "azure_sdk_tools_docs",
+          "relativeByRepoPath": true,
+          "metadata": {
+            "scope": "branded"
+          }
         }
       ]
     },
@@ -684,24 +693,6 @@
           "description": "OpenAPI Diff (OAD) rules documentation",
           "path": "/docs",
           "folder": "azure_openapi_diff_docs",
-          "relativeByRepoPath": true,
-          "metadata": {
-            "scope": "branded"
-          }
-        }
-      ]
-    },
-    {
-      "repository": {
-        "url": "https://github.com/Azure/azure-sdk-for-js.git",
-        "branch": "main",
-        "authType": "public"
-      },
-      "paths": [
-        {
-          "description": "JavaScript SDK release tools documentation",
-          "path": "/eng/tools/js-sdk-release-tools/docs/automation-pipeline.md",
-          "folder": "azure_sdk_tools_docs",
           "relativeByRepoPath": true,
           "metadata": {
             "scope": "branded"


### PR DESCRIPTION
This pull request updates the `knowledge-config.json` file to reorganize how the JavaScript SDK release tools documentation is referenced. The main change is moving the configuration for the `automation-pipeline.md` documentation from a separate repository entry into an existing one, streamlining the configuration.

Configuration reorganization:

* Moved the entry for the JavaScript SDK release tools documentation (`automation-pipeline.md`) from a standalone repository block into an existing block, reducing redundancy and simplifying the config structure. [[1]](diffhunk://#diff-b5f4b0b83e15ddf4c768ebf42f74ac0ab3eb0f03d5fa14b80b73feca100542e7R620-R628) [[2]](diffhunk://#diff-b5f4b0b83e15ddf4c768ebf42f74ac0ab3eb0f03d5fa14b80b73feca100542e7L694-L711)