### PR TITLE
[verify-links.yml] Only trigger on pull_request

### DIFF
--- a/.github/workflows/verify-links.yml
+++ b/.github/workflows/verify-links.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   verify-links:
     name: Verify Links
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0

--- a/.github/workflows/verify-links.yml
+++ b/.github/workflows/verify-links.yml
@@ -6,10 +6,6 @@ on:
       - main
       - release/*
       - hotfix/*
-  check_run:
-    types:
-      - completed
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -17,37 +13,19 @@ permissions:
 jobs:
   verify-links:
     name: Verify Links
-    if: >-
-      github.event_name == 'pull_request' ||
-      (
-        github.event_name == 'check_run' &&
-        github.event.check_run.check_suite.app.name == 'Azure Pipelines' &&
-        (
-          (github.repository == 'Azure/azure-sdk-for-net' && contains(github.event.check_run.name, 'Compliance')) ||
-          (github.repository == 'Azure/azure-sdk-for-python' && contains(github.event.check_run.name, 'Analyze')) ||
-          (github.repository == 'Azure/azure-sdk-for-java' && contains(github.event.check_run.name, 'Analyze')) ||
-          (github.repository == 'Azure/azure-sdk-for-js' && contains(github.event.check_run.name, 'Analyze')) ||
-          (github.repository == 'Azure/azure-sdk-for-cpp' && contains(github.event.check_run.name, 'GenerateReleaseArtifacts')) ||
-          (github.repository == 'Azure/azure-sdk-for-go' && contains(github.event.check_run.name, 'Analyze')) ||
-          (github.repository == 'Azure/azure-sdk-for-ios' && contains(github.event.check_run.name, 'Analyze')) ||
-          (github.repository == 'Azure/azure-sdk-for-rust' && contains(github.event.check_run.name, 'Analyze'))
-        )
-      )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.event.check_run.head_sha || github.sha }}
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Link verification check
         shell: pwsh
-        env:
-          SYSTEM_PULLREQUEST_TARGETBRANCH: ${{ github.base_ref }}
-          SYSTEM_PULLREQUEST_SOURCECOMMITID: ${{ github.event.pull_request.head.sha }}
         run: |
-          $urls = & ./eng/common/scripts/get-markdown-files-from-changed-files.ps1
+          . ./eng/common/scripts/Helpers/git-helpers.ps1
+          $urls = Get-ChangedFiles -SourceCommittish HEAD -TargetCommittish HEAD^ -DiffPath '*.md'
+          
           if (-not $urls -or $urls.Count -eq 0) {
             Write-Host "No changed markdown files; nothing to verify."
             exit 0


### PR DESCRIPTION
- Only trigger on pull_request, which should be sufficient to verify links
- Run on ubuntu-slim for similar perf at lower cost
- Checkout default ref for simplicity and security
- Reduce checkout depth to 2, which is sufficient to diff the PR changes
- Directly call Get-ChangedFiles helper which allows passing commitish instead of branch

verification run: https://github.com/Azure/azure-sdk-tools/actions/runs/33593273538/job/100131474411#step:3:28