### PR TITLE
Filter unready SDK PRs from release plan dashboard

### DIFF
--- a/tools/release-plan-dashboard/CHANGELOG.md
+++ b/tools/release-plan-dashboard/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - **Sticky filters** — Filter and month selections now persist across page reloads and navigation, so the dashboard restores your previous filter state automatically
+- **Review-ready SDK pull requests** — The review-required view now excludes draft SDK pull requests and release plans whose API specification pull request has not been merged
 
 ## 1.0.0-dev.1
 

--- a/tools/release-plan-dashboard/public/app.js
+++ b/tools/release-plan-dashboard/public/app.js
@@ -3017,6 +3017,15 @@
     return "";
   }
 
+  function hasMergedSpecPr(plan) {
+    const specStatus = (plan.apiReadiness || "").toLowerCase();
+    return specStatus === "completed" || specStatus === "merged";
+  }
+
+  function isReviewRequiredSdkPrStatus(status) {
+    return (status || "").toLowerCase() === "open";
+  }
+
   // Extract candidate PRs without filtering by GitHub status (status fetched progressively).
   function extractCandidatePRs(plans) {
     const seen = new Set();
@@ -3025,6 +3034,7 @@
       if (!p.languages) continue;
       if (p.state === "Finished") continue;
       if (isPrivatePreviewPlan(p)) continue;
+      if (!hasMergedSpecPr(p)) continue;
       for (const [lang, l] of Object.entries(p.languages)) {
         if (isLangExcluded(l.exclusionStatus)) continue;
         if (!l.sdkPrUrl) continue;
@@ -3087,8 +3097,7 @@
   // (server-side enrichment), without making any GitHub requests.
   function buildPRListFromEmbeddedStatuses(candidates) {
     for (const c of candidates) {
-      const stLower = (c.prStatus || "").toLowerCase();
-      if (stLower === "open" || stLower === "draft") {
+      if (isReviewRequiredSdkPrStatus(c.prStatus)) {
         c._statusLoaded = true;
         getPrs().push(c);
       }
@@ -3163,8 +3172,7 @@
         if (!st) continue;
         c._statusLoaded = true;
         c.prStatus = st;
-        const stLower = st.toLowerCase();
-        if (stLower === "open" || stLower === "draft") {
+        if (isReviewRequiredSdkPrStatus(st)) {
           getPrs().push(c);
           needsRender = true;
         }
@@ -3181,8 +3189,7 @@
     // Final pass: add any candidates whose URL wasn't fetched (network error) if they look open
     for (const c of candidates) {
       if (!c._statusLoaded) {
-        const stLower = (c.prStatus || "").toLowerCase();
-        if (stLower === "open" || stLower === "draft") {
+        if (isReviewRequiredSdkPrStatus(c.prStatus)) {
           getPrs().push(c);
         }
       }

--- a/tools/release-plan-dashboard/public/app.js
+++ b/tools/release-plan-dashboard/public/app.js
@@ -72,7 +72,6 @@
         plane: "",
         month: "",
         prLang: "",
-        prStatus: "",
         tag: "",
         language: "",
       },
@@ -780,7 +779,6 @@
     month: { key: "month", default: "" },
     sort: { key: "sort", default: "month" },
     prLang: { key: "prLang", default: "" },
-    prStatus: { key: "prStatus", default: "" },
     tag: { key: "tag", default: "" },
     language: { key: "language", default: "" },
   };
@@ -2591,7 +2589,6 @@
         store().filters.month,
         store().filters.sort,
         store().filters.prLang,
-        store().filters.prStatus,
         store().filters.tag,
         store().filters.language,
         store().activeTab,
@@ -3202,17 +3199,12 @@
 
   function filterPRs(prs) {
     const langFilter = store().filters.prLang || "";
-    const statusFilter = store().filters.prStatus || "";
     const textFilter = store().filters.search.toLowerCase();
     const planeFilter = getGlobalPlaneFilter();
 
     return prs.filter((pr) => {
       if (planeFilter && pr.plane !== planeFilter) return false;
       if (langFilter && pr.language !== langFilter) return false;
-      if (statusFilter) {
-        const st = (pr.prStatus || "").toLowerCase();
-        if (st !== statusFilter) return false;
-      }
       if (textFilter) {
         const searchable =
           `${pr.language} ${pr.repo} ${pr.prNumber} ${pr.packageName} ${pr.planTitle} ${pr.releasePlanId} ${pr.prStatus}`.toLowerCase();

--- a/tools/release-plan-dashboard/public/index.html
+++ b/tools/release-plan-dashboard/public/index.html
@@ -183,7 +183,6 @@
         <select id="pr-filter-status" x-model="$store.app.filters.prStatus">
           <option value="">All Statuses</option>
           <option value="open">Open</option>
-          <option value="draft">Draft</option>
         </select>
         <span
           id="pr-count"

--- a/tools/release-plan-dashboard/public/index.html
+++ b/tools/release-plan-dashboard/public/index.html
@@ -40,7 +40,6 @@
             month: "",
             sort: "month",
             prLang: "",
-            prStatus: "",
             tag: "",
             language: "",
           },
@@ -179,10 +178,6 @@
           <option value="JavaScript">JavaScript</option>
           <option value="Python">Python</option>
           <option value="Go">Go</option>
-        </select>
-        <select id="pr-filter-status" x-model="$store.app.filters.prStatus">
-          <option value="">All Statuses</option>
-          <option value="open">Open</option>
         </select>
         <span
           id="pr-count"

--- a/tools/release-plan-dashboard/tests/package-feed.test.js
+++ b/tools/release-plan-dashboard/tests/package-feed.test.js
@@ -953,6 +953,55 @@ describe("PM view: ready to complete private preview", () => {
   });
 });
 
+describe("Review required SDK pull requests", () => {
+  function shouldIncludeReviewRequiredPr(plan, language) {
+    const specStatus = (plan.apiReadiness || "").toLowerCase();
+    const specPrMerged = specStatus === "completed" || specStatus === "merged";
+    const sdkPrStatus = (
+      language.sdkPrGitHubStatus ||
+      language.prStatus ||
+      ""
+    ).toLowerCase();
+    return specPrMerged && sdkPrStatus === "open";
+  }
+
+  test("includes an open SDK PR after the spec PR is merged", () => {
+    expect(
+      shouldIncludeReviewRequiredPr(
+        { apiReadiness: "completed" },
+        { sdkPrGitHubStatus: "open" },
+      ),
+    ).toBe(true);
+  });
+
+  test("excludes a draft SDK PR", () => {
+    expect(
+      shouldIncludeReviewRequiredPr(
+        { apiReadiness: "completed" },
+        { sdkPrGitHubStatus: "draft" },
+      ),
+    ).toBe(false);
+  });
+
+  test("excludes an SDK PR while the spec PR is still open", () => {
+    expect(
+      shouldIncludeReviewRequiredPr(
+        { apiReadiness: "pending" },
+        { sdkPrGitHubStatus: "open" },
+      ),
+    ).toBe(false);
+  });
+
+  test("excludes an SDK PR when the spec PR status is unavailable", () => {
+    expect(
+      shouldIncludeReviewRequiredPr(
+        { apiReadiness: "unknown" },
+        { sdkPrGitHubStatus: "open" },
+      ),
+    ).toBe(false);
+  });
+});
+
 describe("PM view: missing namespace approval", () => {
   function classifyPlane(p) {
     if (p.mgmtScope === "Yes") return "mgmt";


### PR DESCRIPTION
## Summary

- show SDK pull requests in the review-required view only after the linked spec PR is merged
- exclude draft SDK pull requests from embedded, progressively fetched, and fallback status paths
- remove the draft status filter and add focused regression coverage

## Testing

- `npm run check` (440 tests, lint, coverage, and formatting)

Fixes #16750



## Screenshots
test with https://azsdk-releaseplan-dashboard-hveph5aqhhcfhtgu.westus-01.azurewebsites.net/?releaseplan=35236&tab=tab-sdk-prs

### Release plan with spec review in progress

<img width="1200" alt="Release plan 35236 showing API Spec In Progress" src="https://github.com/user-attachments/assets/d3e64a44-5224-467b-8708-92d1959aff0b" />

### Review-required SDK pull requests after filtering

<img width="1200" alt="Review Required SDK Pull Requests showing no eligible PRs for release plan 35236" src="https://github.com/user-attachments/assets/cca25f12-e8d6-47bb-8abb-81e186ea0884" />

# BEFORE


<img width="3550" height="1889" alt="image" src="https://github.com/user-attachments/assets/c13ee425-e602-4b29-ba3f-f641117da6ce" />
<img width="3385" height="736" alt="image" src="https://github.com/user-attachments/assets/178fe126-9329-483f-b03d-b437cd151549" />


