### PR TITLE
Fix Service Tree lookup link

### DIFF
--- a/.github/skills/azsdk-common-prepare-release-plan/SKILL.md
+++ b/.github/skills/azsdk-common-prepare-release-plan/SKILL.md
@@ -23,6 +23,7 @@ DO NOT USE FOR: SDK code generation, pipeline troubleshooting, API review feedba
 - Do not display Azure DevOps work item URLs; only provide the Release Plan Link and ID.
 - Require an API spec PR link or a TypeSpec project path before creating or updating a plan.
 - Validate that the spec PR repository matches the requested API release type before creation.
+- If Service Tree IDs cannot be resolved automatically, direct the user to https://aka.ms/servicetree to look them up.
 - Release plan tools accept **either** a Release Plan ID or an Azure DevOps work item ID — pass whichever the user provides. Each tool resolves the value automatically (trying it as a Release Plan ID first, then as a work item ID), so you do not need to call `azure-sdk-mcp:azsdk_get_release_plan` first just to translate one ID into the other.
 
 ## MCP Tools

--- a/plugins/azure-sdk-tools/skills/prepare-release-plan/SKILL.md
+++ b/plugins/azure-sdk-tools/skills/prepare-release-plan/SKILL.md
@@ -23,6 +23,7 @@ DO NOT USE FOR: SDK code generation, pipeline troubleshooting, API review feedba
 - Do not display Azure DevOps work item URLs; only provide the Release Plan Link and ID.
 - Require an API spec PR link or a TypeSpec project path before creating or updating a plan.
 - Validate that the spec PR repository matches the requested API release type before creation.
+- If Service Tree IDs cannot be resolved automatically, direct the user to https://aka.ms/servicetree to look them up.
 - Release plan tools accept **either** a Release Plan ID or an Azure DevOps work item ID — pass whichever the user provides. Each tool resolves the value automatically (trying it as a Release Plan ID first, then as a work item ID), so you do not need to call `azure-sdk-mcp:azsdk_get_release_plan` first just to translate one ID into the other.
 
 ## MCP Tools

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/ReleasePlanToolTests.cs
@@ -1443,6 +1443,27 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         }
 
         [Test]
+        public async Task Test_FindProduct_with_valid_typespec_path_and_no_product()
+        {
+            // Arrange
+            var mockDevOps = new Mock<IDevOpsService>();
+            mockDevOps
+                .Setup(x => x.GetProductInfoByTypeSpecProjectPathAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ProductInfo?)null);
+            var tool = new ReleasePlanTool(mockDevOps.Object, gitHelper, typeSpecHelper, logger, userHelper, gitHubService, environmentHelper, inputSanitizer, httpClient, Mock.Of<INpxHelper>(), Mock.Of<IRawOutputHelper>(), Mock.Of<INotificationService>());
+            var typeSpecProjectPath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
+
+            // Act
+            var result = await tool.GetProductByTypeSpecPath(typeSpecProjectPath);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsNull(result.ProductInfo);
+            Assert.That(result.Message, Does.Contain("https://aka.ms/servicetree"));
+            Assert.That(result.Message, Does.Not.Contain("servicetree.msftcloudes.com"));
+        }
+
+        [Test]
         public async Task Test_FindProduct_with_nonexistent_typespec_path()
         {
             // Arrange

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs Fixed
 
 - `azsdk_run_generate_sdk` now blocks stable SDK generation for preview API versions.
+- Direct users to `https://aka.ms/servicetree` when automatic Service Tree ID lookup fails.
 
 ### Other Changes
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -2098,7 +2098,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 {
                     return new ProductInfoResponse
                     {
-                        Message = $"No release plan found for TypeSpec project path: {specRelativePath}",
+                        Message = $"No release plan found for TypeSpec project path: {specRelativePath}. Visit https://aka.ms/servicetree to look up the Service Tree ID and Product Service Tree ID.",
                         TypeSpecProject = specRelativePath
                     };
                 }


### PR DESCRIPTION
## Summary

- direct users to `https://aka.ms/servicetree` when automatic Service Tree ID lookup finds no product
- update both shared and plugin release-plan skill guidance to use the canonical link
- add regression coverage and a changelog entry

## Validation

- `dotnet test tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Azure.Sdk.Tools.Cli.Tests.csproj -p:CopilotSkipCliDownload=true --no-restore --filter FullyQualifiedName~ReleasePlanToolTests.Test_FindProduct` (4 passed)
- strict Vally lint for `.github/skills/azsdk-common-prepare-release-plan` (2/2 checks passed)
- Prettier check for both release-plan skill files

Fixes #15433