### PR TITLE
APIView: refuse archive members that escape the extraction directory

### DIFF
--- a/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
@@ -42,7 +42,125 @@ INIT_EXTENSION_SUBSTRING = ".extend_path(__path__, __name__)"
 # versions on slower CI agents.
 PACKAGE_INSTALL_TIMEOUT_SECONDS = 800
 
+# A member name starting with a drive letter is rejected on every platform, not
+# just Windows, so that the same archive is accepted or refused identically
+# wherever the parser runs.
+_DRIVE_LETTER_PREFIX = re.compile(r"^[A-Za-z]:")
+
 logging.getLogger().setLevel(logging.ERROR)
+
+
+def _resolve_archive_member(member_name: str, dest_dir: str) -> str:
+    """Resolve *member_name* under *dest_dir* and refuse anything that escapes it.
+
+    Both the wheel and the sdist formats mandate ``/`` as the member path
+    separator and neither has a use for upward traversal, absolute names or
+    drive-relative names, so every rejection below is unreachable for a
+    well-formed package.
+
+    :param str member_name: the member name as recorded in the archive.
+    :param str dest_dir: the already-resolved extraction directory.
+    :returns: the resolved absolute destination path for the member.
+    :rtype: str
+    :raises ValueError: if the member cannot be written inside *dest_dir*.
+    """
+    if "\x00" in member_name:
+        raise ValueError(
+            "Refusing to extract archive member with an embedded null byte."
+        )
+
+    # On Windows a backslash would be collapsed as a separator, while on POSIX
+    # it is an ordinary filename character. Rejecting it outright keeps the
+    # containment decision identical on both.
+    if "\\" in member_name:
+        raise ValueError(
+            "Refusing to extract archive member whose name contains a "
+            f"backslash: {member_name!r}"
+        )
+
+    if member_name.startswith("/") or _DRIVE_LETTER_PREFIX.match(member_name):
+        raise ValueError(
+            "Refusing to extract archive member with an absolute or "
+            f"drive-relative name: {member_name!r}"
+        )
+
+    if any(part == os.pardir for part in member_name.split("/")):
+        raise ValueError(
+            "Refusing to extract archive member that traverses outside the "
+            f"package: {member_name!r}"
+        )
+
+    target = os.path.realpath(os.path.join(dest_dir, member_name))
+    try:
+        contained = os.path.commonpath([dest_dir, target]) == dest_dir
+    except ValueError:
+        # Raised when the paths share no common prefix at all, for example when
+        # they sit on different Windows drives.
+        contained = False
+
+    if not contained:
+        raise ValueError(
+            "Refusing to extract archive member that resolves outside the "
+            f"extraction directory: {member_name!r}"
+        )
+
+    return target
+
+
+def _safe_extract_tar(archive_path: str, dest_dir: str) -> None:
+    """Extract the tar archive at *archive_path* into *dest_dir*.
+
+    Every member is checked before anything is written, and the first
+    unacceptable member aborts the whole extraction, so a rejected package can
+    never be parsed from a half-populated directory.
+
+    :param str archive_path: path to the ``.tar.gz`` to extract.
+    :param str dest_dir: directory to extract into.
+    :raises ValueError: if any member is not a plain file or directory, or
+        would be written outside *dest_dir*.
+    """
+    resolved_dest = os.path.realpath(dest_dir)
+    with tarfile.open(archive_path) as tar_ref:
+        for member in tar_ref.getmembers():
+            # Symlinks, hardlinks, devices and FIFOs are the other half of the
+            # containment problem: their name can sit inside the directory
+            # while their target does not. Source distributions only ever hold
+            # regular files and directories, so allowlist those two.
+            if not (member.isfile() or member.isdir()):
+                raise ValueError(
+                    "Refusing to extract archive member that is not a plain "
+                    f"file or directory: {member.name!r}"
+                )
+            _resolve_archive_member(member.name, resolved_dest)
+
+        # ``filter="data"`` is belt and braces on the interpreters that ship it
+        # (3.12+, and the 3.10/3.11 patch releases that backported it): the
+        # members above have already been vetted, so it has nothing left to
+        # reject. It keeps the extraction safe should a future member type slip
+        # past the checks above.
+        if hasattr(tarfile, "data_filter"):
+            tar_ref.extractall(resolved_dest, filter="data")
+        else:
+            tar_ref.extractall(resolved_dest)
+
+
+def _safe_extract_zip(archive_path: str, dest_dir: str) -> None:
+    """Extract the zip archive at *archive_path* into *dest_dir*.
+
+    ``ZipFile.extractall`` silently rewrites an unsafe member name rather than
+    refusing it. For a tool whose whole job is to report on a package, a
+    package that asks to be written outside its own directory is a finding, so
+    validate the names up front and abort instead.
+
+    :param str archive_path: path to the ``.whl`` or ``.zip`` to extract.
+    :param str dest_dir: directory to extract into.
+    :raises ValueError: if any member would be written outside *dest_dir*.
+    """
+    resolved_dest = os.path.realpath(dest_dir)
+    with zipfile.ZipFile(archive_path) as zip_ref:
+        for member_name in zip_ref.namelist():
+            _resolve_archive_member(member_name, resolved_dest)
+        zip_ref.extractall(resolved_dest)
 
 
 class StubGenerator:
@@ -400,12 +518,10 @@ class StubGenerator:
             "Extracting {0} to directory {1}".format(self.pkg_path, temp_pkg_dir)
         )
         if self.pkg_path.endswith(".tar.gz"):
-            with tarfile.open(self.pkg_path) as tar_ref:
-                tar_ref.extractall(temp_pkg_dir)
-                self._remove_extra_internal_folder(temp_pkg_dir)
+            _safe_extract_tar(self.pkg_path, temp_pkg_dir)
+            self._remove_extra_internal_folder(temp_pkg_dir)
         else:
-            with zipfile.ZipFile(self.pkg_path) as zip_ref:
-                zip_ref.extractall(temp_pkg_dir)
+            _safe_extract_zip(self.pkg_path, temp_pkg_dir)
         logging.debug("Extracted package files into temp path")
 
         return temp_pkg_dir

--- a/packages/python-packages/apiview-stub-generator/tests/archive_extraction_test.py
+++ b/packages/python-packages/apiview-stub-generator/tests/archive_extraction_test.py
@@ -1,0 +1,262 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import io
+import os
+import tarfile
+import zipfile
+
+import pytest
+
+from apistub._stub_generator import (
+    _resolve_archive_member,
+    _safe_extract_tar,
+    _safe_extract_zip,
+)
+
+# Names that must never be written, whichever archive format carries them.
+ESCAPING_NAMES = [
+    "../escape.txt",
+    "../../escape.txt",
+    "pkg/../../escape.txt",
+    "..",
+    "/tmp/escape.txt",
+    "//host/share/escape.txt",
+    "C:/escape.txt",
+    "c:/escape.txt",
+    "C:\\escape.txt",
+    "\\\\host\\share\\escape.txt",
+    "..\\escape.txt",
+]
+
+# Tar member types that can point outside the extraction root even when their
+# own name sits inside it, plus the special files a package never needs.
+NON_REGULAR_TAR_TYPES = [
+    (tarfile.SYMTYPE, "/etc/passwd"),
+    (tarfile.LNKTYPE, "pkg/__init__.py"),
+    (tarfile.FIFOTYPE, ""),
+    (tarfile.CHRTYPE, ""),
+    (tarfile.BLKTYPE, ""),
+]
+
+
+def _add_tar_file(tar, name, data=b"payload"):
+    info = tarfile.TarInfo(name)
+    info.size = len(data)
+    tar.addfile(info, io.BytesIO(data))
+
+
+def _write_tar(path, names):
+    with tarfile.open(path, "w:gz") as tar:
+        for name in names:
+            _add_tar_file(tar, name)
+
+
+def _write_zip(path, names):
+    with zipfile.ZipFile(path, "w") as zf:
+        for name in names:
+            # Assigning ``filename`` after construction keeps the name exactly
+            # as written; ``ZipInfo`` rewrites ``os.sep`` to "/" otherwise, so a
+            # backslash case would only be meaningful on Windows.
+            info = zipfile.ZipInfo("placeholder")
+            info.filename = name
+            zf.writestr(info, b"payload")
+
+
+def _tree(root):
+    found = set()
+    for dirpath, _, filenames in os.walk(root):
+        for filename in filenames:
+            found.add(os.path.relpath(os.path.join(dirpath, filename), root))
+    return found
+
+
+class TestArchiveExtraction:
+    """Containment tests for sdist and wheel extraction.
+
+    Each case asserts both halves of the fix: the archive is refused, and
+    nothing is left behind either outside or inside the extraction directory.
+    """
+
+    def _dirs(self, tmp_path):
+        dest = tmp_path / "dest"
+        dest.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        return dest, outside
+
+    @pytest.mark.parametrize("name", ESCAPING_NAMES)
+    def test_tar_escaping_member_is_rejected(self, tmp_path, name):
+        dest, outside = self._dirs(tmp_path)
+        archive = tmp_path / "pkg.tar.gz"
+        _write_tar(archive, [name])
+
+        with pytest.raises(ValueError):
+            _safe_extract_tar(str(archive), str(dest))
+
+        assert _tree(dest) == set()
+        assert _tree(outside) == set()
+
+    @pytest.mark.parametrize("name", ESCAPING_NAMES)
+    def test_zip_escaping_member_is_rejected(self, tmp_path, name):
+        dest, outside = self._dirs(tmp_path)
+        archive = tmp_path / "pkg.whl"
+        _write_zip(archive, [name])
+
+        with pytest.raises(ValueError):
+            _safe_extract_zip(str(archive), str(dest))
+
+        assert _tree(dest) == set()
+        assert _tree(outside) == set()
+
+    @pytest.mark.parametrize("member_type,linkname", NON_REGULAR_TAR_TYPES)
+    def test_tar_non_regular_member_is_rejected(self, tmp_path, member_type, linkname):
+        dest, outside = self._dirs(tmp_path)
+        archive = tmp_path / "pkg.tar.gz"
+        with tarfile.open(archive, "w:gz") as tar:
+            _add_tar_file(tar, "pkg/__init__.py", b"")
+            info = tarfile.TarInfo("pkg/secrets")
+            info.type = member_type
+            info.linkname = linkname
+            tar.addfile(info)
+
+        with pytest.raises(ValueError):
+            _safe_extract_tar(str(archive), str(dest))
+
+        assert _tree(dest) == set()
+        assert _tree(outside) == set()
+
+    def test_tar_aborts_before_writing_any_member(self, tmp_path):
+        """A bad member anywhere in the archive must leave the directory empty.
+
+        Validating during extraction would leave the earlier members on disk,
+        and the parser would then install and import a partially unpacked
+        package.
+        """
+        dest, _ = self._dirs(tmp_path)
+        archive = tmp_path / "pkg.tar.gz"
+        _write_tar(
+            archive,
+            [
+                "pkg-1.0.0/pkg/__init__.py",
+                "pkg-1.0.0/pkg/client.py",
+                "../escape.txt",
+            ],
+        )
+
+        with pytest.raises(ValueError):
+            _safe_extract_tar(str(archive), str(dest))
+
+        assert _tree(dest) == set()
+
+    def test_zip_aborts_before_writing_any_member(self, tmp_path):
+        dest, _ = self._dirs(tmp_path)
+        archive = tmp_path / "pkg.whl"
+        _write_zip(
+            archive,
+            ["pkg/__init__.py", "pkg/client.py", "../escape.txt"],
+        )
+
+        with pytest.raises(ValueError):
+            _safe_extract_zip(str(archive), str(dest))
+
+        assert _tree(dest) == set()
+
+    def test_well_formed_sdist_still_extracts(self, tmp_path):
+        dest, _ = self._dirs(tmp_path)
+        archive = tmp_path / "pkg.tar.gz"
+        _write_tar(
+            archive,
+            [
+                "pkg-1.0.0/setup.py",
+                "pkg-1.0.0/pkg/__init__.py",
+                "pkg-1.0.0/pkg/nested/deep.py",
+                "./pkg-1.0.0/pkg/dotted.py",
+            ],
+        )
+
+        _safe_extract_tar(str(archive), str(dest))
+
+        assert _tree(dest) == {
+            os.path.join("pkg-1.0.0", "setup.py"),
+            os.path.join("pkg-1.0.0", "pkg", "__init__.py"),
+            os.path.join("pkg-1.0.0", "pkg", "nested", "deep.py"),
+            os.path.join("pkg-1.0.0", "pkg", "dotted.py"),
+        }
+
+    def test_well_formed_wheel_still_extracts(self, tmp_path):
+        dest, _ = self._dirs(tmp_path)
+        archive = tmp_path / "pkg.whl"
+        _write_zip(
+            archive,
+            [
+                "pkg/__init__.py",
+                "pkg/nested/deep.py",
+                "pkg-1.0.0.dist-info/METADATA",
+                "pkg-1.0.0.dist-info/RECORD",
+            ],
+        )
+
+        _safe_extract_zip(str(archive), str(dest))
+
+        assert _tree(dest) == {
+            os.path.join("pkg", "__init__.py"),
+            os.path.join("pkg", "nested", "deep.py"),
+            os.path.join("pkg-1.0.0.dist-info", "METADATA"),
+            os.path.join("pkg-1.0.0.dist-info", "RECORD"),
+        }
+
+    def test_directory_members_are_allowed(self, tmp_path):
+        dest, _ = self._dirs(tmp_path)
+        archive = tmp_path / "pkg.tar.gz"
+        with tarfile.open(archive, "w:gz") as tar:
+            for directory_name in (".", "pkg-1.0.0", "pkg-1.0.0/pkg"):
+                directory = tarfile.TarInfo(directory_name)
+                directory.type = tarfile.DIRTYPE
+                tar.addfile(directory)
+            _add_tar_file(tar, "pkg-1.0.0/pkg/__init__.py", b"")
+
+        _safe_extract_tar(str(archive), str(dest))
+
+        assert (dest / "pkg-1.0.0" / "pkg" / "__init__.py").is_file()
+
+    def test_resolve_archive_member_returns_contained_path(self, tmp_path):
+        dest, _ = self._dirs(tmp_path)
+        resolved_dest = os.path.realpath(str(dest))
+
+        resolved = _resolve_archive_member("pkg-1.0.0/pkg/__init__.py", resolved_dest)
+
+        assert resolved == os.path.join(
+            resolved_dest, "pkg-1.0.0", "pkg", "__init__.py"
+        )
+
+    def test_resolve_archive_member_rejects_null_byte(self, tmp_path):
+        dest, _ = self._dirs(tmp_path)
+
+        with pytest.raises(ValueError):
+            _resolve_archive_member("pkg/\x00.py", os.path.realpath(str(dest)))
+
+    def test_extraction_directory_reached_through_a_symlink(self, tmp_path):
+        """Containment is decided on resolved paths, not on the caller's spelling.
+
+        The parser is handed a temp directory it did not create, so that path
+        may itself run through a symlink. Comparing unresolved paths would then
+        reject every member of a perfectly good package.
+        """
+        real_dest = tmp_path / "real_dest"
+        real_dest.mkdir()
+        link = tmp_path / "linked_dest"
+        try:
+            link.symlink_to(real_dest, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("creating a directory symlink is not permitted here")
+
+        archive = tmp_path / "pkg.tar.gz"
+        _write_tar(archive, ["pkg-1.0.0/pkg/__init__.py"])
+
+        _safe_extract_tar(str(archive), str(link))
+
+        assert (real_dest / "pkg-1.0.0" / "pkg" / "__init__.py").is_file()


### PR DESCRIPTION
`StubGenerator._extract_wheel` unpacks the package it has been asked to review before installing and importing it. For a `.tar.gz` that was `tarfile.extractall` with no filter and no member validation, so a member named `../escape.txt` was written outside the temporary package directory, and a symlink member was created pointing wherever it named. A source distribution needs neither.

Every member is now checked before anything is written, and the first member that is not a plain file or directory, or whose name resolves outside the extraction directory, aborts the extraction. Aborting up front rather than skipping the offending member matters here: the parser installs and imports whatever it unpacked, so a partially populated directory must never be reachable.

Points worth a reviewer's attention:

- Containment is decided on `realpath` compared with `commonpath` rather than a string prefix, so a sibling directory sharing a name prefix cannot pass, and an extraction directory reached through a symlink still works.
- Absolute, drive-relative and UNC names, backslash separators and embedded null bytes are refused identically on every platform, since both archive formats mandate `/` and neither has a use for the rest.
- `filter="data"` is passed on the interpreters that ship the tar extraction filters, behind the explicit checks rather than instead of them. The plain call is kept as a fallback because `requires-python` is `>=3.10.0` and the filters only arrived in 3.10.12.

The zip path gets the same validation. It was not escaping — `ZipFile.extractall` strips the offending components itself — but it does so silently, and for a tool whose purpose is to report on a package, a package that asks to be written outside its own directory reads better as a hard failure than as a quietly rewritten path.

## Testing

`tests/archive_extraction_test.py` adds 35 cases: traversal, absolute, drive-relative and UNC names, backslash separators, symlink, hardlink and device members, aborting before any member is written, and positive cases for well-formed sdists and wheels including an extraction directory reached through a symlink.

Run against 3.10, 3.11, 3.12, 3.13 and 3.14, the versions listed in `ci.yml`. All pass on each.

I also ran the change against real published packages to check nothing legitimate is now refused: 12 archives (6 sdists and 6 wheels, among them `azure-storage-blob`, `azure-mgmt-compute`, `azure-core`, `azure-identity`, `pylint` and `setuptools`) extract to a byte-identical file set compared with the unmodified `extractall`.

`tox -e pytest` reports 16 passed and 8 failed on my Windows machine; all 8 failures are `[src]` cases where the temporary git clone cannot be removed (`PermissionError: [WinError 5]`), which is unrelated to archive extraction and reproduces on an unmodified checkout.
