### PR TITLE
spec-gen-sdk: keep the SDK automation config path inside the SDK repository

### DIFF
--- a/tools/spec-gen-sdk/src/automation/entrypoint.ts
+++ b/tools/spec-gen-sdk/src/automation/entrypoint.ts
@@ -16,7 +16,7 @@ import { getSpecConfig, specConfigPath } from '../types/SpecConfig';
 import { getSwaggerToSdkConfig } from '../types/SwaggerToSdkConfig';
 import { extractPathFromSpecConfig } from '../utils/utils';
 import { FailureType, SdkAutoContext, SdkAutoOptions, WorkflowContext } from '../types/Workflow';
-import { getSdkRepoConfig, loadConfigContent, setFailureType } from '../utils/workflowUtils';
+import { getSdkRepoConfig, loadConfigContent, resolveRepoRelativePath, setFailureType } from '../utils/workflowUtils';
 
 export const getSdkAutoContext = async (options: SdkAutoOptions): Promise<SdkAutoContext> => {
   const logger = winston.createLogger({
@@ -60,7 +60,7 @@ export const getSdkAutoContext = async (options: SdkAutoOptions): Promise<SdkAut
   const specRepoConfig = getSpecConfig(specConfigContent, options.specRepo);
 
   const sdkRepoConfig = await getSdkRepoConfig(options, specRepoConfig);
-  const swaggerToSdkConfigPath = path.join(options.localSdkRepoPath, sdkRepoConfig.configFilePath);
+  const swaggerToSdkConfigPath = resolveRepoRelativePath(options.localSdkRepoPath, sdkRepoConfig.configFilePath, 'configFilePath');
   const swaggerToSdkConfigContent = loadConfigContent(swaggerToSdkConfigPath, logger);
   const swaggerToSdkConfig = getSwaggerToSdkConfig(swaggerToSdkConfigContent);
 

--- a/tools/spec-gen-sdk/src/utils/workflowUtils.ts
+++ b/tools/spec-gen-sdk/src/utils/workflowUtils.ts
@@ -3,7 +3,52 @@ import { SpecConfig, SdkRepoConfig } from '../types/SpecConfig';
 import { toolError } from '../utils/messageUtils';
 import { getRepoKey, RepoKey } from '../utils/repo';
 import { readFileSync } from 'fs';
+import * as path from 'path';
 import * as winston from 'winston';
+
+/**
+ * Resolves a repository-relative path that came from configuration, refusing any
+ * value that would read outside the repository it is declared against.
+ *
+ * `path.join` and `path.resolve` leak through different inputs -- `join` follows
+ * `..` out of the root while treating `/etc/passwd` as a relative segment, and
+ * `resolve` honours absolute, drive-relative and UNC values instead -- so the
+ * containment check below is what actually holds the boundary, rather than the
+ * choice of joining function.
+ *
+ * Absolute values are rejected with their own message, and both path flavours
+ * take part in every decision, so that a given configuration is accepted or
+ * refused identically on Linux and Windows agents. Without that, a value such
+ * as `..\..\config.json` would climb out of the root on a Windows agent while
+ * landing inside it as a literal filename on a Linux one.
+ */
+export const resolveRepoRelativePath = (repoRootPath: string, configuredPath: string, settingName: string): string => {
+  const normalizedPath = configuredPath.split('\\').join('/');
+
+  if (path.posix.isAbsolute(normalizedPath) || path.win32.isAbsolute(normalizedPath)) {
+    throw new Error(
+      toolError(
+        `The '${settingName}' value '${configuredPath}' must be a path relative to the repository root, but it is absolute. ` +
+        `Please correct the config at the 'specificationRepositoryConfiguration.json' file under the root folder of the azure-rest-api-specs(-pr) repository`
+      )
+    );
+  }
+
+  const repoRoot = path.resolve(repoRootPath);
+  const resolved = path.resolve(repoRoot, normalizedPath);
+  const repoRootPrefix = repoRoot.endsWith(path.sep) ? repoRoot : `${repoRoot}${path.sep}`;
+
+  if (resolved !== repoRoot && !resolved.startsWith(repoRootPrefix)) {
+    throw new Error(
+      toolError(
+        `The '${settingName}' value '${configuredPath}' resolves outside the repository at '${repoRoot}'. ` +
+        `Please correct the config at the 'specificationRepositoryConfiguration.json' file under the root folder of the azure-rest-api-specs(-pr) repository`
+      )
+    );
+  }
+
+  return resolved;
+};
 
 export const setFailureType = (context: WorkflowContext, failureType: FailureType) => {
   if (context.failureType !== FailureType.CodegenFailed) {

--- a/tools/spec-gen-sdk/test/automation/entrypoint.test.ts
+++ b/tools/spec-gen-sdk/test/automation/entrypoint.test.ts
@@ -56,7 +56,11 @@ vi.mock('../../src/utils/utils', () => ({
   extractPathFromSpecConfig: vi.fn(() => 'test-prefix')
 }));
 
-vi.mock('../../src/utils/workflowUtils', () => ({
+// Only the config *loading* is stubbed here. `resolveRepoRelativePath` keeps its
+// real implementation so these tests still exercise the containment check that
+// guards the automation config path.
+vi.mock('../../src/utils/workflowUtils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/utils/workflowUtils')>()),
   loadConfigContent: vi.fn(() => ({})),
   getSdkRepoConfig: vi.fn(() => ({
     configFilePath: 'swagger_to_sdk_config.json',

--- a/tools/spec-gen-sdk/test/utils/resolveRepoRelativePath.test.ts
+++ b/tools/spec-gen-sdk/test/utils/resolveRepoRelativePath.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import * as path from "path";
+import { resolveRepoRelativePath } from "../../src/utils/workflowUtils";
+
+// `specificationRepositoryConfiguration.json` lives in the spec repository, so
+// `configFilePath` is content that arrives with a specification change. It names
+// the automation config to load out of the SDK checkout, and that config in turn
+// chooses which scripts run and which environment variables they receive, so the
+// path must stay inside the repository it is declared against.
+const REPO_ROOT = path.resolve(path.sep === "\\" ? "C:\\work\\azure-sdk-for-js" : "/work/azure-sdk-for-js");
+
+// Values that climb out of the repository once the separators are normalized.
+const TRAVERSING_PATHS = [
+    "../spec/config.json",
+    "../../../../etc/passwd",
+    "nested/../../escape.json",
+    "..",
+    "../",
+    "..\\..\\escape.json",
+    "nested\\..\\..\\escape.json",
+];
+
+// Values that name a location directly rather than relative to the repository.
+const ABSOLUTE_PATHS = [
+    "/etc/passwd",
+    "//host/share/config.json",
+    "C:/Windows/win.ini",
+    "c:/Windows/win.ini",
+    "C:\\Windows\\win.ini",
+    "\\\\host\\share\\config.json",
+];
+
+describe("resolveRepoRelativePath", () => {
+    describe("accepts paths inside the repository", () => {
+        it.each([
+            ["swagger_to_sdk_config.json", ["swagger_to_sdk_config.json"]],
+            ["./swagger_to_sdk_config.json", ["swagger_to_sdk_config.json"]],
+            ["eng/swagger_to_sdk_config.json", ["eng", "swagger_to_sdk_config.json"]],
+            ["eng/nested/deep/config.json", ["eng", "nested", "deep", "config.json"]],
+            ["eng/./config.json", ["eng", "config.json"]],
+            ["eng/inner/../config.json", ["eng", "config.json"]],
+        ])("resolves %s", (configuredPath, expectedSegments) => {
+            expect(resolveRepoRelativePath(REPO_ROOT, configuredPath, "configFilePath")).toBe(
+                path.join(REPO_ROOT, ...(expectedSegments as string[]))
+            );
+        });
+
+        it("accepts a Windows-style separator on every platform", () => {
+            expect(resolveRepoRelativePath(REPO_ROOT, "eng\\config.json", "configFilePath")).toBe(
+                path.join(REPO_ROOT, "eng", "config.json")
+            );
+        });
+
+        it("resolves the repository root itself", () => {
+            expect(resolveRepoRelativePath(REPO_ROOT, ".", "configFilePath")).toBe(REPO_ROOT);
+        });
+    });
+
+    describe("rejects paths outside the repository", () => {
+        it.each(TRAVERSING_PATHS)("rejects %s", (configuredPath) => {
+            expect(() => resolveRepoRelativePath(REPO_ROOT, configuredPath, "configFilePath")).toThrow(
+                /resolves outside the repository/
+            );
+        });
+
+        it.each(ABSOLUTE_PATHS)("rejects %s", (configuredPath) => {
+            expect(() => resolveRepoRelativePath(REPO_ROOT, configuredPath, "configFilePath")).toThrow(
+                /must be a path relative to the repository root/
+            );
+        });
+
+        it("names the offending setting and value so the spec author can fix it", () => {
+            expect(() => resolveRepoRelativePath(REPO_ROOT, "../spec/config.json", "configFilePath")).toThrow(
+                /configFilePath/
+            );
+            expect(() => resolveRepoRelativePath(REPO_ROOT, "../spec/config.json", "configFilePath")).toThrow(
+                /\.\.\/spec\/config\.json/
+            );
+        });
+
+        it("does not accept a sibling directory that shares the repository name as a prefix", () => {
+            // A plain `startsWith` on the root without a trailing separator would
+            // let `azure-sdk-for-js-secrets` through.
+            expect(() => resolveRepoRelativePath(REPO_ROOT, "../azure-sdk-for-js-secrets/config.json", "configFilePath")).toThrow(
+                /resolves outside the repository/
+            );
+        });
+    });
+
+    it("normalizes the repository root before comparing", () => {
+        const unnormalizedRoot = path.join(REPO_ROOT, "sdk", "..");
+
+        expect(resolveRepoRelativePath(unnormalizedRoot, "swagger_to_sdk_config.json", "configFilePath")).toBe(
+            path.join(REPO_ROOT, "swagger_to_sdk_config.json")
+        );
+    });
+});


### PR DESCRIPTION
`sdkRepoConfig.configFilePath` comes from `specificationRepositoryConfiguration.json` in the specification repository, and `getSdkAutoContext` joined it onto the SDK checkout with a plain `path.join`. A value such as `../../config.json` therefore resolved outside that checkout, and whatever file it landed on was read and parsed as the SDK automation config — the file that decides which scripts a generation run executes and which environment variables they are handed.

The value now goes through a helper that refuses anything leaving the repository it is declared against.

The choice of joining function is not the fix, and swapping one for the other only moves the hole: `path.join` follows `..` out of the root while treating `/etc/passwd` as a relative segment, and `path.resolve` honours absolute, drive-relative and UNC values instead. The containment comparison after resolution is what holds the boundary. The root is normalized first and the prefix carries a trailing separator, so a sibling directory sharing a name prefix cannot pass.

Separators are normalized before the decision so that a given configuration is accepted or refused identically on Linux and Windows agents. Without that, `..\..\config.json` climbs out of the root on a Windows agent while landing inside it as a literal filename on a Linux one. As a side effect, a config written with Windows separators now also resolves on Linux.

This is the containment half only. Loading the automation config from a trusted branch rather than from pull request head content, and replacing the `RunOptions.envs` passthrough with an allow list, are worth doing as well, but they change what the tool is permitted to do rather than where it is permitted to read from, so they seemed better as a separate change.

## Testing

`test/utils/resolveRepoRelativePath.test.ts` adds 24 cases: traversal in both separator styles, absolute, drive-relative and UNC values, a sibling directory sharing a name prefix, an unnormalized repository root, and positive cases for the default `swagger_to_sdk_config.json`, nested paths, `.` and `..` segments that stay inside, and a Windows-style separator.

`test/automation/entrypoint.test.ts` now keeps the real implementation of the helper through `importOriginal` rather than stubbing the whole module, so those tests exercise the containment check on the happy path.

`npm run lint` and `tsc --noEmit` are clean. `vitest run` reports 329 passed and 1 failed; that one failure is `should create log directories if they don't exist`, which asserts `stringContaining('out/logs')` and so fails on Windows regardless of this change — it reproduces on an unmodified checkout.
