### PR TITLE
test-proxy: keep the recording file inside the assets directory

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingPathContainmentTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingPathContainmentTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Azure.Sdk.tools.TestProxy.Common;
+using Azure.Sdk.Tools.TestProxy.Common.Exceptions;
+using Azure.Sdk.Tools.TestProxy.Store;
+using Xunit;
+
+namespace Azure.Sdk.Tools.TestProxy.Tests
+{
+    /// <summary>
+    /// An assets store that reports a directory of the test's choosing, so that
+    /// <see cref="RecordingHandler.GetRecordingPath"/> can be exercised on the
+    /// assets.json branch without a git backed store.
+    /// </summary>
+    public class FixedPathAssetsStore : IAssetsStore
+    {
+        private readonly string _contextDirectory;
+
+        public FixedPathAssetsStore(string contextDirectory) => _contextDirectory = contextDirectory;
+
+        public Task<int> Push(string pathToAssetsJson, bool ignoreSecretProtection = false) => Task.FromResult(0);
+
+        public Task<string> Restore(string pathToAssetsJson) => Task.FromResult(_contextDirectory);
+
+        public Task Reset(string pathToAssetsJson) => Task.CompletedTask;
+
+        public AssetsConfiguration ParseConfigurationFile(string pathToAssetsJson) => new AssetsConfiguration();
+
+        public Task<NormalizedString> GetPath(string pathToAssetsJson) => Task.FromResult(new NormalizedString(_contextDirectory));
+
+        public void SetStoreExceptionMode(bool throwOnException) { }
+    }
+
+    public class RecordingPathContainmentTests : IDisposable
+    {
+        private readonly string _root;
+        private readonly string _assetsContext;
+        private readonly RecordingHandler _handler;
+
+        public RecordingPathContainmentTests()
+        {
+            _root = Path.Join(Path.GetTempPath(), "test-proxy-containment-" + Guid.NewGuid().ToString("N"));
+            _assetsContext = Path.Join(_root, "context");
+            Directory.CreateDirectory(_assetsContext);
+
+            _handler = new RecordingHandler(_root, store: new FixedPathAssetsStore(_assetsContext));
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+
+        // Rejecting a fully qualified value already says the recording belongs
+        // under the assets context. These are the values that say the same thing
+        // without being fully qualified.
+        [Theory]
+        [InlineData("../escape.json")]
+        [InlineData("../../escape.json")]
+        [InlineData("nested/../../escape.json")]
+        [InlineData("./../escape.json")]
+        [InlineData("../context-sibling/escape.json")]
+        public async Task GetRecordingPathRejectsValuesThatLeaveTheAssetsDirectory(string file)
+        {
+            var exception = await Assert.ThrowsAsync<HttpException>(
+                async () => await _handler.GetRecordingPath(file, "assets.json"));
+
+            Assert.Contains("resolves outside the assets directory", exception.Message);
+        }
+
+        [Fact]
+        public async Task GetRecordingPathStillRejectsAFullyQualifiedValue()
+        {
+            var fullyQualified = Path.Join(_root, "escape.json");
+
+            var exception = await Assert.ThrowsAsync<HttpException>(
+                async () => await _handler.GetRecordingPath(fullyQualified, "assets.json"));
+
+            Assert.Contains("fully qualified", exception.Message);
+        }
+
+        [Theory]
+        [InlineData("recording.json")]
+        [InlineData("recordings/recording.json")]
+        [InlineData("recordings/nested/deep/recording.json")]
+        [InlineData("./recordings/recording.json")]
+        [InlineData("recordings/inner/../recording.json")]
+        public async Task GetRecordingPathAcceptsValuesInsideTheAssetsDirectory(string file)
+        {
+            var resolved = await _handler.GetRecordingPath(file, "assets.json");
+
+            Assert.StartsWith(
+                Path.TrimEndingDirectorySeparator(Path.GetFullPath(_assetsContext)) + Path.DirectorySeparatorChar,
+                Path.GetFullPath(resolved),
+                StringComparison.Ordinal);
+            Assert.EndsWith(".json", resolved, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public async Task GetRecordingPathAppendsJsonInsideTheAssetsDirectory()
+        {
+            var resolved = await _handler.GetRecordingPath("recordings/recording", "assets.json");
+
+            Assert.EndsWith(".json", resolved, StringComparison.Ordinal);
+        }
+
+        // A directory whose name merely begins with the context directory's name
+        // is not inside it, so a plain prefix comparison would be wrong.
+        [Fact]
+        public async Task GetRecordingPathRejectsASiblingSharingANamePrefix()
+        {
+            var exception = await Assert.ThrowsAsync<HttpException>(
+                async () => await _handler.GetRecordingPath("../context-extra/escape.json", "assets.json"));
+
+            Assert.Contains("resolves outside the assets directory", exception.Message);
+        }
+
+        // Without an assets.json the tool is documented as writing wherever the
+        // caller points it, so that behaviour is deliberately left alone.
+        [Fact]
+        public async Task GetRecordingPathWithoutAssetsJsonIsUnchanged()
+        {
+            var relative = await _handler.GetRecordingPath("recordings/recording.json");
+            Assert.Equal(Path.Join(_root, "recordings/recording.json"), relative);
+
+            var fullyQualified = Path.Join(_root, "elsewhere", "recording.json");
+            Assert.Equal(fullyQualified, await _handler.GetRecordingPath(fullyQualified));
+        }
+
+        [Fact]
+        public async Task GetRecordingPathStillRejectsAnEmptyValue()
+        {
+            await Assert.ThrowsAsync<HttpException>(async () => await _handler.GetRecordingPath("", "assets.json"));
+            await Assert.ThrowsAsync<HttpException>(async () => await _handler.GetRecordingPath("   "));
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -1199,10 +1199,26 @@ namespace Azure.Sdk.Tools.TestProxy
             }
         }
 
+        /// <summary>
+        /// Whether <paramref name="candidate"/> resolves to <paramref name="directory"/> or somewhere beneath it.
+        /// </summary>
+        /// <remarks>
+        /// The comparison is on resolved paths, so a value that walks upwards is
+        /// caught, and it is case sensitive so that a mismatch fails closed. The
+        /// candidate is always built by joining onto the directory, so the shared
+        /// prefix has the same casing either way.
+        /// </remarks>
+        private static bool IsContainedWithin(string directory, string candidate)
+        {
+            var resolvedDirectory = Path.TrimEndingDirectorySeparator(Path.GetFullPath(directory));
+            var resolvedCandidate = Path.TrimEndingDirectorySeparator(Path.GetFullPath(candidate));
+
+            return resolvedCandidate.Equals(resolvedDirectory, StringComparison.Ordinal)
+                || resolvedCandidate.StartsWith(resolvedDirectory + Path.DirectorySeparatorChar, StringComparison.Ordinal);
+        }
+
         public async Task<string> GetRecordingPath(string file, string assetsPath = null)
         {
-            var normalizedFileName = file.Replace('\\', '/');
-
             if (String.IsNullOrWhiteSpace(file))
             {
                 throw new HttpException(HttpStatusCode.BadRequest, $"Recording file value of {file} is invalid. Try again with a populated filename.");
@@ -1222,6 +1238,19 @@ namespace Azure.Sdk.Tools.TestProxy
                     );
                 }
                 path = Path.Join(contextDirectory, file);
+
+                // Rejecting a fully qualified value says the recording belongs under
+                // the assets context. Path.Join does not resolve `..`, so a relative
+                // value can still land outside it once the filesystem reads the path;
+                // compare the resolved locations to hold the boundary the check above
+                // is there to draw.
+                if (!IsContainedWithin(contextDirectory, path))
+                {
+                    throw new HttpException(
+                        HttpStatusCode.BadRequest,
+                        $"The path provided in the recording file value {file} resolves outside the assets directory. This is not allowed when an assets.json is provided."
+                    );
+                }
             }
             // otherwise, it's a basic restore like we're used to
             else


### PR DESCRIPTION
`RecordingHandler.GetRecordingPath` refuses a fully qualified recording file when an assets.json is in play:

```csharp
if (Path.IsPathFullyQualified(file)) {
    throw new HttpException(
        HttpStatusCode.BadRequest,
        $"The path provided in the recording file value {file} is fully qualified. This is not allowed when an assets.json is provided."
    );
}
path = Path.Join(contextDirectory, file);
```

That check says the recording belongs under the assets context directory. `Path.Join` does not resolve `..`, though, so a relative value could still land outside that directory once the filesystem read the path, and `StopRecording` would then create the directories and write the recording there.

This compares the resolved locations so the boundary the existing check draws is actually held. The comparison is case sensitive and appends a separator before testing the prefix, so a mismatch fails closed and a sibling directory that merely shares a name prefix cannot pass.

The behaviour without an assets.json is deliberately untouched. A fully qualified path is accepted there by design, so constraining relative values would gain nothing and would break callers keeping recordings beside the context directory.

The change also drops a `normalizedFileName` local that was computed and never read. It looks like the remains of this check, which is why it is going out with it rather than separately.

## Testing

`RecordingPathContainmentTests.cs` adds 15 cases. The refusal side covers `..` in several shapes, including through a nested segment and against a sibling directory sharing a name prefix. The retained side covers ordinary relative recordings, nested paths, `.` and interior `..` segments that stay inside, the `.json` suffix behaviour, the existing fully-qualified rejection, the empty-value rejection, and the no-assets.json path in both its relative and fully qualified forms.

Six of the fifteen fail without the change while the other nine keep passing.

The suite is at 434 passed and 30 failed on my machine, against 417 passed and 32 failed on an unmodified checkout. Every failure in both runs is a `GitStoreIntegration` test that needs a real assets repository and credentials; the count moves between runs because those are network dependent.
