### PR TITLE
APIView: escape the artifact file path into the download query

### DIFF
--- a/src/dotnet/APIView/APIViewUnitTests/DevopsArtifactUrlTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/DevopsArtifactUrlTests.cs
@@ -1,0 +1,71 @@
+using APIViewWeb.Repositories;
+using Xunit;
+
+namespace APIViewUnitTests
+{
+    public class DevopsArtifactUrlTests
+    {
+        private const string DownloadUrl = "https://artprodcus3.artifacts.visualstudio.com/_apis/artifact/abc/content?format=zip";
+
+        [Fact]
+        public void BuildArtifactDownloadUrlKeepsAnOrdinaryPathIntact()
+        {
+            var url = DevopsArtifactRepository.BuildArtifactDownloadUrl(DownloadUrl, "file", "/artifacts/package.json");
+
+            Assert.Equal(
+                "https://artprodcus3.artifacts.visualstudio.com/_apis/artifact/abc/content?format=file&subPath=%2Fartifacts%2Fpackage.json",
+                url);
+        }
+
+        [Fact]
+        public void BuildArtifactDownloadUrlAddsTheLeadingSeparator()
+        {
+            var url = DevopsArtifactRepository.BuildArtifactDownloadUrl(DownloadUrl, "file", "artifacts/package.json");
+
+            Assert.EndsWith("&subPath=%2Fartifacts%2Fpackage.json", url);
+        }
+
+        [Fact]
+        public void BuildArtifactDownloadUrlDropsAnyExistingQuery()
+        {
+            var url = DevopsArtifactRepository.BuildArtifactDownloadUrl(DownloadUrl, "zip", "/a.json");
+
+            Assert.StartsWith("https://artprodcus3.artifacts.visualstudio.com/_apis/artifact/abc/content?format=zip&subPath=", url);
+            Assert.Single(url.Split('?'), part => part.Contains("format="));
+        }
+
+        // A file path reaches this from the request. Without escaping, these values
+        // would add or truncate parameters on a request that carries the service's
+        // Azure DevOps credentials.
+        [Theory]
+        [InlineData("/a&format=zip/package.json")]
+        [InlineData("/a&subPath=/etc/package.json")]
+        [InlineData("/a#fragment/package.json")]
+        [InlineData("/a?other=1/package.json")]
+        [InlineData("/a=b/package.json")]
+        [InlineData("/a b/package.json")]
+        public void BuildArtifactDownloadUrlDoesNotLetAPathAddOrTruncateParameters(string filePath)
+        {
+            var url = DevopsArtifactRepository.BuildArtifactDownloadUrl(DownloadUrl, "file", filePath);
+
+            var query = url.Substring(url.IndexOf('?') + 1);
+            var parameters = query.Split('&');
+
+            Assert.Equal(2, parameters.Length);
+            Assert.Equal("format=file", parameters[0]);
+            Assert.StartsWith("subPath=", parameters[1]);
+            Assert.DoesNotContain("#", url);
+        }
+
+        [Fact]
+        public void BuildArtifactDownloadUrlRoundTripsThePathThroughTheQuery()
+        {
+            const string filePath = "/a&b/package.json";
+
+            var url = DevopsArtifactRepository.BuildArtifactDownloadUrl(DownloadUrl, "file", filePath);
+
+            var subPath = url.Substring(url.IndexOf("&subPath=") + "&subPath=".Length);
+            Assert.Equal(filePath, System.Uri.UnescapeDataString(subPath));
+        }
+    }
+}

--- a/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
@@ -46,6 +46,29 @@ namespace APIViewWeb.Repositories
             _connectionLock.Dispose();
         }
 
+        /// <summary>
+        /// Builds the artifact download URL for a single file within an artifact.
+        /// </summary>
+        /// <remarks>
+        /// <paramref name="filePath"/> reaches here from the request, so it is escaped
+        /// rather than concatenated: an unescaped <c>&amp;</c> or <c>#</c> would add or
+        /// truncate parameters on a request that carries this service's Azure DevOps
+        /// credentials. Escaping turns <c>/</c> into <c>%2F</c>, which is correct for a
+        /// query value and is decoded back by the server before use; the
+        /// path-segment reading of <c>%2F</c> does not apply to a query parameter.
+        /// </remarks>
+        public static string BuildArtifactDownloadUrl(string downloadUrl, string format, string filePath)
+        {
+            if (!filePath.StartsWith("/"))
+            {
+                filePath = "/" + filePath;
+            }
+
+            return downloadUrl.Split("?")[0]
+                + "?format=" + Uri.EscapeDataString(format)
+                + "&subPath=" + Uri.EscapeDataString(filePath);
+        }
+
         public async Task<Stream> DownloadPackageArtifact(string repoName, string buildId, string artifactName, string filePath, string project, string format= "file")
         {
             var downloadUrl = await getDownloadArtifactUrl(buildId, artifactName, project);
@@ -56,11 +79,7 @@ namespace APIViewWeb.Repositories
             
             if(!string.IsNullOrEmpty(filePath))
             {
-                if (!filePath.StartsWith("/"))
-                {
-                    filePath = "/" + filePath;
-                }
-                downloadUrl = downloadUrl.Split("?")[0] + "?format=" + format + "&subPath=" + filePath;
+                downloadUrl = BuildArtifactDownloadUrl(downloadUrl, format, filePath);
             }
 
             HttpResponseMessage downloadResp = await GetFromDevopsAsync(downloadUrl);


### PR DESCRIPTION
`DevopsArtifactRepository.DownloadPackageArtifact` built the single-file download URL by concatenation:

```csharp
downloadUrl = downloadUrl.Split("?")[0] + "?format=" + format + "&subPath=" + filePath;
```

`filePath` reaches this from the request. `CodeFileManager` passes the caller's `originalFileName` through as `filePath`, and `packageName` the same way on the zip path. A value containing `&` adds parameters to a request that carries this service's Azure DevOps credentials, and one containing `#` truncates it. The existing `ValidateInputParams` only requires the value to end in a known extension, which such a value can — `/a&format=zip/package.json` passes it.

This escapes the value. `Uri.EscapeDataString` is the same helper `ManagerHelpers` already uses for the query and fragment values it builds.

Escaping turns `/` into `%2F`. That is correct for a query value and the server decodes it before use — the path-segment reading of `%2F`, where it is not interchangeable with a separator, does not apply to a query parameter. I have called this out because it is the part most worth a second opinion from someone who can exercise the real artifact endpoint, and I would rather flag it than have it noticed after merge.

The URL building moves into a static method so it can be covered without standing up a repository and reaching Azure DevOps.

## Testing

`APIViewUnitTests/DevopsArtifactUrlTests.cs` adds 10 cases: an ordinary path, the leading separator being added, an existing query on the download URL being dropped, six values that would otherwise add or truncate parameters, and a round trip asserting the path survives unescaping intact.

Five of the ten fail against the previous concatenation, so they pin the behaviour rather than restate it.

The full `APIViewUnitTests` suite is at 810 passed, 0 failed, 2 skipped.
