### PR TITLE
Add Java APIView dev feed release pipeline

### DIFF
--- a/src/java/apiview-java-processor/ci.yml
+++ b/src/java/apiview-java-processor/ci.yml
@@ -1,0 +1,160 @@
+trigger:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - /src/java/apiview-java-processor/
+
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - /src/java/apiview-java-processor/
+
+parameters:
+  - name: publishDevFeed
+    displayName: Publish to the Java dev feed
+    type: boolean
+    default: false
+
+extends:
+  template: /eng/pipelines/templates/stages/1es-redirect.yml
+  parameters:
+    stages:
+      - stage: Build
+        displayName: Build and test
+        variables:
+          - template: /eng/pipelines/templates/variables/globals.yml
+          - template: /eng/pipelines/templates/variables/image.yml
+
+        jobs:
+          - job: Build
+            pool:
+              name: $(WINDOWSPOOL)
+              image: $(WINDOWSVMIMAGE)
+              os: windows
+
+            steps:
+              - template: /eng/common/pipelines/templates/steps/maven-authenticate.yml
+
+              - task: Maven@3
+                displayName: Build and test
+                inputs:
+                  mavenPomFile: src/java/apiview-java-processor/pom.xml
+                  goals: clean verify
+                  options: --batch-mode --no-transfer-progress
+                  javaHomeOption: JDKVersion
+                  jdkVersionOption: '1.8'
+                  jdkArchitectureOption: x64
+                  publishJUnitResults: true
+                  testResultsFiles: src/java/apiview-java-processor/target/surefire-reports/TEST-*.xml
+
+              - pwsh: |
+                  $projectDirectory = "$(Build.SourcesDirectory)\src\java\apiview-java-processor"
+                  [xml]$pom = Get-Content -Path "$projectDirectory\pom.xml"
+                  $version = $pom.project.version
+                  $jarPath = "$projectDirectory\target\apiview-java-processor-$version.jar"
+                  $stagingDirectory = "$(Build.ArtifactStagingDirectory)\apiview-java-processor"
+
+                  if (-not (Test-Path -Path $jarPath)) {
+                    throw "Expected package was not produced: $jarPath"
+                  }
+
+                  New-Item -ItemType Directory -Force -Path $stagingDirectory | Out-Null
+                  Copy-Item -Path $jarPath -Destination $stagingDirectory
+                  Copy-Item -Path "$projectDirectory\pom.xml" `
+                    -Destination "$stagingDirectory\apiview-java-processor-$version.pom"
+                displayName: Stage Maven package
+
+              - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+                parameters:
+                  ArtifactName: apiview-java-processor
+                  ArtifactPath: $(Build.ArtifactStagingDirectory)/apiview-java-processor
+
+      - stage: PublishDevFeed
+        displayName: Publish to Java dev feed
+        dependsOn: Build
+        condition: |
+          and(
+            succeeded(),
+            eq(${{ parameters.publishDevFeed }}, true),
+            eq(variables['Build.Reason'], 'Manual'),
+            eq(variables['Build.SourceBranch'], 'refs/heads/main'),
+            eq(variables['System.TeamProject'], 'internal')
+          )
+        variables:
+          - template: /eng/pipelines/templates/variables/globals.yml
+          - template: /eng/pipelines/templates/variables/image.yml
+
+        jobs:
+          - job: PublishDevFeed
+            displayName: Publish Maven package
+            pool:
+              name: $(WINDOWSPOOL)
+              image: $(WINDOWSVMIMAGE)
+              os: windows
+
+            steps:
+              - download: current
+                displayName: Download Maven package
+                artifact: apiview-java-processor
+
+              - template: /eng/common/pipelines/templates/steps/maven-authenticate.yml
+
+              - pwsh: |
+                  $packageDirectory = "$(Pipeline.Workspace)\apiview-java-processor"
+                  $pomFiles = @(Get-ChildItem -Path $packageDirectory -Filter *.pom -File -ErrorAction Stop)
+                  if ($pomFiles.Count -ne 1) {
+                    throw "Expected one POM file in $packageDirectory, found $($pomFiles.Count)."
+                  }
+                  $pomFile = $pomFiles[0]
+                  [xml]$pom = Get-Content -Path $pomFile.FullName
+                  $version = $pom.project.version
+                  $jarPath = "$packageDirectory\apiview-java-processor-$version.jar"
+
+                  if (-not (Test-Path -Path $jarPath)) {
+                    throw "Expected package artifact was not downloaded: $jarPath"
+                  }
+
+                  $packageUrl = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-java/maven/v1/com/azure/apiview-java-processor/$version/apiview-java-processor-$version.pom"
+                  $headers = @{ Authorization = "BEARER $env:SYSTEM_ACCESSTOKEN" }
+                  $response = Invoke-WebRequest -Method Get -Uri $packageUrl -Headers $headers -SkipHttpErrorCheck
+
+                  if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
+                    throw "com.azure:apiview-java-processor:$version already exists in the Java dev feed."
+                  }
+                  if ($response.StatusCode -ne 404) {
+                    throw "Unable to check the Java dev feed. HTTP status: $($response.StatusCode)"
+                  }
+
+                  Write-Host "##vso[task.setvariable variable=PackageVersion]$version"
+                  Write-Host "##vso[task.setvariable variable=PackageJarPath]$jarPath"
+                  Write-Host "##vso[task.setvariable variable=PackagePomPath]$($pomFile.FullName)"
+                displayName: Validate package version
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+              - task: Maven@3
+                displayName: Publish package
+                inputs:
+                  mavenPomFile: src/java/apiview-java-processor/pom.xml
+                  goals: org.apache.maven.plugins:maven-deploy-plugin:3.1.4:deploy-file
+                  options: >-
+                    --batch-mode
+                    --no-transfer-progress
+                    -DrepositoryId=azure-sdk-for-java
+                    -Durl=https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-java/maven/v1
+                    -DgroupId=com.azure
+                    -DartifactId=apiview-java-processor
+                    -Dversion=$(PackageVersion)
+                    -Dpackaging=jar
+                    -Dfile="$(PackageJarPath)"
+                    -DpomFile="$(PackagePomPath)"
+                    -DgeneratePom=false
+                  javaHomeOption: JDKVersion
+                  jdkVersionOption: '1.8'
+                  jdkArchitectureOption: x64
+                  publishJUnitResults: false

--- a/src/java/apiview-java-processor/readme.md
+++ b/src/java/apiview-java-processor/readme.md
@@ -8,8 +8,8 @@ Compile to a fatjar using the following command: </br>`mvn clean package`
 
 ## Releasing
 
-The Azure DevOps pipeline in `ci.yml` validates pull requests and builds on `main`. To publish
-`com.azure:apiview-java-processor` to the Java dev feed, manually run the pipeline from `main`
+The existing APIView CI pipeline validates changes to this project. To publish
+`com.azure:apiview-java-processor` to the Java dev feed, manually run `release.yml` from `main`
 with **Publish to the Java dev feed** enabled.
 
 Publishing a version is immutable. Update the version in `pom.xml` before releasing a new package.

--- a/src/java/apiview-java-processor/readme.md
+++ b/src/java/apiview-java-processor/readme.md
@@ -12,7 +12,7 @@ The existing APIView CI pipeline validates changes to this project. To publish
 `com.azure:apiview-java-processor` to the Java dev feed, manually run `release.yml` from `main`
 with **Publish to the Java dev feed** enabled.
 
-Publishing a version is immutable. Update the version in `pom.xml` before releasing a new package.
+Publishing a version is immutable. Before releasing a new package, update the version in `pom.xml`, the `JavaProcessor` path in `../../dotnet/APIView/APIViewWeb/APIViewWeb.csproj`, and `VersionString` in `../../dotnet/APIView/APIViewWeb/Languages/JavaLanguageService.cs`.
 The pipeline publishes only to the Azure Artifacts Java dev feed, not Maven Central.
 
 ## How To Use

--- a/src/java/apiview-java-processor/readme.md
+++ b/src/java/apiview-java-processor/readme.md
@@ -6,6 +6,15 @@ This application tokenises a Java project into a format useful for Java API revi
 
 Compile to a fatjar using the following command: </br>`mvn clean package`
 
+## Releasing
+
+The Azure DevOps pipeline in `ci.yml` validates pull requests and builds on `main`. To publish
+`com.azure:apiview-java-processor` to the Java dev feed, manually run the pipeline from `main`
+with **Publish to the Java dev feed** enabled.
+
+Publishing a version is immutable. Update the version in `pom.xml` before releasing a new package.
+The pipeline publishes only to the Azure Artifacts Java dev feed, not Maven Central.
+
 ## How To Use
 
 Compile your source code using Maven `mvn clean package`. This will create a `target` directory containing

--- a/src/java/apiview-java-processor/release.yml
+++ b/src/java/apiview-java-processor/release.yml
@@ -1,18 +1,5 @@
-trigger:
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - /src/java/apiview-java-processor/
-
-pr:
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - /src/java/apiview-java-processor/
+trigger: none
+pr: none
 
 parameters:
   - name: publishDevFeed


### PR DESCRIPTION
## Summary

- add a manual-only release pipeline for the Java APIView processor
- publish only to the Azure Artifacts Java dev feed
- restrict publishing to opted-in runs from `main` in the internal project
- reject duplicate package versions and document the release process

The existing APIView CI pipeline continues to validate Java processor changes.

## Validation

- built the processor and ran its tests
- tested the Maven `deploy-file` flow against a local repository
- reviewed the final change with a dedicated code-review agent
