### PR TITLE
[TypeSpec Authoring] Add skill sync pipeline for specs repo

### DIFF
--- a/doc/engsys_workflows_and_skills.md
+++ b/doc/engsys_workflows_and_skills.md
@@ -8,7 +8,7 @@ The `.github/skills` directory contains common [copilot skills](https://docs.git
 
 Any updates to files in the `.github/workflows` directory should be made in the [azure-sdk-tools](https://github.com/azure/azure-sdk-tools) repo.
 
-Any updates to directories matching the pattern `.github/skills/azsdk-common-*` should be made in the [azure-sdk-tools](https://github.com/azure/azure-sdk-tools) repo.
+Any updates to directories matching the pattern `.github/skills/azsdk-common-*` or to `.github/skills/azure-typespec-author` should be made in the [azure-sdk-tools](https://github.com/azure/azure-sdk-tools) repo.
 
 All changes made through the sync pipelines will cause PRs to be created in subscribed azure-sdk language repos which will blindly replace the synced files or directories in those repos. For that reason do **NOT** make changes to these files in the azure-sdk or individual azure-sdk language repos as they will be overwritten the next time an update is taken from the corresponding directory in the azure-sdk-tools repository.
 
@@ -16,6 +16,7 @@ All changes made through the sync pipelines will cause PRs to be created in subs
 
 - [`tools - sync-.github`][workflow-yml] syncs selected files from `.github/workflows/`, including `post-apiview.yml` and `protected-files.yml`.
 - [`tools - sync-.github-skills`][skills-yml] syncs shared skills from `.github/skills/azsdk-common-*`.
+- [`tools - sync-skills-to-rest-repo`][rest-skills-yml] syncs `.github/skills/azure-typespec-author` to `Azure/azure-rest-api-specs`.
 
 ## Workflow
 
@@ -27,7 +28,8 @@ This process is set up in such a way to make it easier for changes to be tested 
 2. The matching sync pipeline is automatically triggered for the **Tools PR**:
    - [`tools - sync-.github`][workflow-yml] for the synced workflow targets in `.github/workflows`.
    - [`tools - sync-.github-skills`][skills-yml] for `.github/skills/azsdk-common-*` changes.
-   - If your PR changes both areas, both pipelines will run.
+   - [`tools - sync-skills-to-rest-repo`][rest-skills-yml] for `.github/skills/azure-typespec-author` changes.
+   - If your PR changes multiple areas, each matching pipeline will run.
 3. Each triggered pipeline creates branches mirroring your changes, one branch in azure-sdk and one per language repository receiving that sync. You can use these branches to run tests in those repos. The pipeline also queues test runs for template pipelines for each repo. These help you test the changes in the **Tools PR**. All of this is done in the `Create Sync` stage of the corresponding pipeline, specifically through `template: ./templates/steps/sync-directory.yml`.
 4. If you make additional changes to your **Tools PR** repeat steps 1 - 3 until you have completed the necessary testing of your changes. This includes full releases of the template package, if necessary.
 5. Once you reviewed all the test runs and did any of additional ad-hoc tests from the created branches in language repositories, you must manually approve in your pipeline execution instance the next stage - creation of PRs.
@@ -40,3 +42,4 @@ This process is set up in such a way to make it easier for changes to be tested 
 
 [workflow-yml]: https://github.com/Azure/azure-sdk-tools/blob/main/eng/pipelines/sync-.github.yml
 [skills-yml]: https://github.com/Azure/azure-sdk-tools/blob/main/eng/pipelines/sync-.github-skills.yml
+[rest-skills-yml]: https://github.com/Azure/azure-sdk-tools/blob/main/eng/pipelines/sync-skills-to-rest-repo.yml

--- a/eng/pipelines/sync-skills-to-rest-repo.yml
+++ b/eng/pipelines/sync-skills-to-rest-repo.yml
@@ -17,6 +17,11 @@ parameters:
   default:
     - RepoOwner: Azure
       RepoName: azure-rest-api-specs
+- name: PRValidationPipelines
+  type: object
+  default:
+    - Repository: azure-rest-api-specs
+      DefinitionId: 110
 
 trigger: none
 
@@ -53,3 +58,4 @@ extends:
         workingDirectory: .github
         displayName: Check TypeSpec authoring skill formatting with Prettier
     Repos: ${{ parameters.Repos }}
+    PRValidationPipelines: ${{ parameters.PRValidationPipelines }}

--- a/eng/pipelines/sync-skills-to-rest-repo.yml
+++ b/eng/pipelines/sync-skills-to-rest-repo.yml
@@ -1,0 +1,55 @@
+# Mirror the TypeSpec authoring skill to the REST API specifications repository.
+#
+# For more information on this file, please see:
+# doc/engsys_workflows_and_skills.md
+parameters:
+- name: DirectoryToSync
+  type: string
+  default: .github/skills
+- name: FilePatterns
+  type: object
+  default:
+    # Evaluation and refinement tooling remain in azure-sdk-tools.
+    - 'azure-typespec-author/SKILL.md'
+    - 'azure-typespec-author/references'
+- name: Repos
+  type: object
+  default:
+    - RepoOwner: Azure
+      RepoName: azure-rest-api-specs
+
+trigger: none
+
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - .github/skills/azure-typespec-author/**
+
+extends:
+  template: /eng/pipelines/templates/stages/archetype-sdk-tool-repo-sync.yml
+  parameters:
+    DirectoryToSync: ${{ parameters.DirectoryToSync }}
+    FilePatterns: ${{ parameters.FilePatterns }}
+    AdditionalCheckoutPaths:
+      - .github/package.json
+      - .github/package-lock.json
+    PreSyncValidationSteps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '22.x'
+        displayName: Use Node 22
+
+      - script: npm ci
+        workingDirectory: .github
+        displayName: Install Prettier
+
+      - script: >
+          npm exec -- prettier -- --check
+          "skills/azure-typespec-author/SKILL.md"
+          "skills/azure-typespec-author/references/**"
+        workingDirectory: .github
+        displayName: Check TypeSpec authoring skill formatting with Prettier
+    Repos: ${{ parameters.Repos }}


### PR DESCRIPTION
## Summary

- add the `tools - sync-skills-to-rest-repo` Azure DevOps pipeline
- sync only the `azure-typespec-author` runtime skill (`SKILL.md` and `references/`) to `Azure/azure-rest-api-specs`
- validate the runtime skill with Prettier before syncing
- queue `public.rest-api-specs` validation for generated sync PRs
- document the new ownership and sync workflow

## Pipeline

- [tools - sync-skills-to-rest-repo](https://dev.azure.com/azure-sdk/internal/_build?definitionId=8373&_a=summary)
- modeled on [tools - sync-skills](https://dev.azure.com/azure-sdk/internal/_build?definitionId=8201&_a=summary)

## Validation

- targeted runtime-skill Prettier check passes
- Azure DevOps preview compilation succeeds (303 lines of expanded YAML; no stages executed)
- all seven runtime files match the current spec-repo copy

Fixes #16882