### PR TITLE
Update dashboard to avoid showing release sdk action when release is in progress

### DIFF
--- a/tools/release-plan-dashboard/public/app.js
+++ b/tools/release-plan-dashboard/public/app.js
@@ -412,6 +412,11 @@
     return rpt.includes("private");
   }
 
+  function isStatusInProgress(status) {
+    const normalized = (status || "").toLowerCase().replace(/[\s_-]+/g, "");
+    return normalized.includes("inprogress") || normalized.includes("running");
+  }
+
   /**
    * Computes the current workflow step and who action is required from.
    * Steps progress: API Spec → SDK Generation → SDK Review → Merge → Release.
@@ -484,6 +489,16 @@
 
     // Check if any SDK PRs exist
     const langsWithPr = activeLangs.filter((k) => langs[k].sdkPrUrl);
+    const langsAwaitingGeneration = activeLangs.filter(
+      (k) =>
+        !langs[k].sdkPrUrl && !isStatusInProgress(langs[k].generationStatus),
+    );
+    if (!langsWithPr.length && !langsAwaitingGeneration.length)
+      return {
+        status: "SDK Generation In Progress",
+        action: "",
+        statusClass: "step-inprogress",
+      };
     if (!langsWithPr.length)
       return {
         status: "SDK To Be Generated",
@@ -511,9 +526,22 @@
     const allReleased = releaseStatuses.every(
       (s) => s.includes("completed") || s.includes("released"),
     );
+    const allReleasedOrInProgress = releaseStatuses.every(
+      (s) =>
+        s.includes("completed") ||
+        s.includes("released") ||
+        isStatusInProgress(s),
+    );
+    const anyReleaseInProgress = releaseStatuses.some(isStatusInProgress);
 
     if (allMerged && allReleased)
       return { status: "Released", action: "", statusClass: "step-released" };
+    if (allMerged && allReleasedOrInProgress && anyReleaseInProgress)
+      return {
+        status: "SDK Release In Progress",
+        action: "",
+        statusClass: "step-inprogress",
+      };
     if (allMerged)
       return {
         status: "SDK Ready To Release",
@@ -593,7 +621,11 @@
       const isMergedOrCompleted = st === "merged" || st === "completed";
       const isReleasedOrCompleted = rel === "released" || rel === "completed";
 
-      return isMergedOrCompleted && !isReleasedOrCompleted;
+      return (
+        isMergedOrCompleted &&
+        !isReleasedOrCompleted &&
+        !isStatusInProgress(rel)
+      );
     });
   }
 
@@ -1386,7 +1418,8 @@
           (st.includes("merged") || st.includes("completed")) &&
           rel !== "completed" &&
           rel !== "released" &&
-          rel !== "approval pending"
+          rel !== "approval pending" &&
+          !isStatusInProgress(rel)
         );
       });
       const langList = toRelease.length
@@ -1986,8 +2019,12 @@
                 // Release is queued and waiting for the service team to approve
                 // the release stage in the release pipeline. Link directly to it.
                 actionCell = `<a class="lang-action-btn action-btn-approve" href="${esc(l.releasePipeline)}" target="_blank" rel="noopener" title="Approve the package release in the release pipeline">Approve Release</a>`;
+              } else if (isStatusInProgress(relSt)) {
+                actionCell = "";
               } else if (!hasPr) {
-                actionCell = langActionBtn(ACTION_TYPES.GENERATE, lang, p, l);
+                if (!isStatusInProgress(l.generationStatus)) {
+                  actionCell = langActionBtn(ACTION_TYPES.GENERATE, lang, p, l);
+                }
               } else if (isClosed && !isMerged) {
                 actionCell = langActionBtn(ACTION_TYPES.LINK_PR, lang, p, l);
               } else if (isDraft) {

--- a/tools/release-plan-dashboard/public/app.js
+++ b/tools/release-plan-dashboard/public/app.js
@@ -524,12 +524,12 @@
       (langs[k].releaseStatus || "").toLowerCase(),
     );
     const allReleased = releaseStatuses.every(
-      (s) => s.includes("completed") || s.includes("released"),
+      (s) => s === "completed" || s === "released",
     );
     const allReleasedOrInProgress = releaseStatuses.every(
       (s) =>
-        s.includes("completed") ||
-        s.includes("released") ||
+        s === "completed" ||
+        s === "released" ||
         isStatusInProgress(s),
     );
     const anyReleaseInProgress = releaseStatuses.some(isStatusInProgress);

--- a/tools/release-plan-dashboard/public/app.js
+++ b/tools/release-plan-dashboard/public/app.js
@@ -527,10 +527,7 @@
       (s) => s === "completed" || s === "released",
     );
     const allReleasedOrInProgress = releaseStatuses.every(
-      (s) =>
-        s === "completed" ||
-        s === "released" ||
-        isStatusInProgress(s),
+      (s) => s === "completed" || s === "released" || isStatusInProgress(s),
     );
     const anyReleaseInProgress = releaseStatuses.some(isStatusInProgress);
 

--- a/tools/release-plan-dashboard/tests/package-feed.test.js
+++ b/tools/release-plan-dashboard/tests/package-feed.test.js
@@ -519,6 +519,11 @@ describe("getPackageFeedInfo", () => {
 
 describe("closed PR action logic", () => {
   // Replicates the action determination logic from app.js SDK table rendering
+  function isStatusInProgress(status) {
+    const normalized = (status || "").toLowerCase().replace(/[\s_-]+/g, "");
+    return normalized.includes("inprogress") || normalized.includes("running");
+  }
+
   function determineAction(l) {
     const prSt = (l.sdkPrGitHubStatus || l.prStatus || "").toLowerCase();
     const relSt = (l.releaseStatus || "").toLowerCase();
@@ -539,7 +544,9 @@ describe("closed PR action logic", () => {
       l.prDetails.mergeableState === "clean";
 
     if (isReleased) return null;
-    if (!hasPr) return "generate";
+    if (isStatusInProgress(relSt)) return null;
+    if (!hasPr)
+      return isStatusInProgress(l.generationStatus) ? null : "generate";
     if (isClosed && !isMerged) return "link-pr";
     if (isDraft) return "mark-ready";
     if (isOpen && hasFailedChecks) return "fix-checks";
@@ -578,6 +585,16 @@ describe("closed PR action logic", () => {
     expect(action).toBe("release");
   });
 
+  test("returns null when release is in progress for a merged PR", () => {
+    const action = determineAction({
+      sdkPrUrl: "https://github.com/Azure/azure-sdk-for-go/pull/123",
+      sdkPrGitHubStatus: "merged",
+      prStatus: "",
+      releaseStatus: "Release In Progress",
+    });
+    expect(action).toBeNull();
+  });
+
   test("does not return link-pr when PR is merged", () => {
     const action = determineAction({
       sdkPrUrl: "https://github.com/Azure/azure-sdk-for-go/pull/123",
@@ -595,6 +612,16 @@ describe("closed PR action logic", () => {
       releaseStatus: "",
     });
     expect(action).toBe("generate");
+  });
+
+  test("returns null when SDK generation is in progress", () => {
+    const action = determineAction({
+      sdkPrUrl: "",
+      prStatus: "",
+      generationStatus: "In Progress",
+      releaseStatus: "",
+    });
+    expect(action).toBeNull();
   });
 
   test("returns null when release status is released and SDK PR is missing", () => {


### PR DESCRIPTION
Hide Release SDK action when release is in progress.
Hide Generate SDK action when SDK generation is in progress.