### PR TITLE
allow relative links in internal docs

### DIFF
--- a/eng/common/scripts/allow-relative-links.txt
+++ b/eng/common/scripts/allow-relative-links.txt
@@ -11,3 +11,6 @@ AGENTS.md
 eng/**
 # Allow relative links for the top-level eval suite (evals is a cross-cutting asset at repo root).
 evals/**
+# Allow relative links in internal engineering documentation
+doc/**
+docs/**


### PR DESCRIPTION
We make frequent use of relative links between internal docs (which are particularly useful for work with agents) in the Cosmos DB SDK for Rust. The link checker makes this very difficult. We've tried to centralize all our docs into `sdk/cosmos/docs/` so this PR adds `docs/` directories (as well as `doc/` if anyone is using that) to the list that allow relative links. Critically, we continue to disallow them in READMEs, and other docs that end up in release documentation.