### PR TITLE
Add package root path to execution report

### DIFF
--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2026-09-04 - 0.9.8
+
+- Added 'packageRootPath' to each package in the execution report
+
 ## 2026-04-07 - 0.9.7
 
 - Made 'sdk-release-type' parameter optional, same as 'api-version'

--- a/tools/spec-gen-sdk/package-lock.json
+++ b/tools/spec-gen-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/spec-gen-sdk",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/spec-gen-sdk",
-      "version": "0.9.7",
+      "version": "0.9.8",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",
@@ -2332,9 +2332,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha1-jkT7FKJkPFlya7FXh7XxUSyz0/s=",
       "dev": true,
       "funding": [
         {

--- a/tools/spec-gen-sdk/package-lock.json
+++ b/tools/spec-gen-sdk/package-lock.json
@@ -2333,8 +2333,8 @@
     },
     "node_modules/js-yaml": {
       "version": "4.3.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.2.tgz",
-      "integrity": "sha1-jkT7FKJkPFlya7FXh7XxUSyz0/s=",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {

--- a/tools/spec-gen-sdk/package.json
+++ b/tools/spec-gen-sdk/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-tools"
   },
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "A TypeScript implementation of the API specification to SDK tool",
   "tags": [
     "spec-gen-sdk"

--- a/tools/spec-gen-sdk/src/automation/reportStatus.ts
+++ b/tools/spec-gen-sdk/src/automation/reportStatus.ts
@@ -44,6 +44,7 @@ export const generateReport = (context: WorkflowContext) => {
     const packageReport: PackageReport = {
       serviceName: pkg.serviceName,
       packageName: pkg.name,
+      packageRootPath: pkg.relativeFolderPath,
       result: pkg.status,
       artifactPaths: pkg.artifactPaths,
       readmeMd: pkg.readmeMd,

--- a/tools/spec-gen-sdk/src/types/ExecutionReport.ts
+++ b/tools/spec-gen-sdk/src/types/ExecutionReport.ts
@@ -20,6 +20,7 @@ export type ExecutionReport = {
 export type PackageReport = {
   serviceName?: string;
   packageName?: string;
+  packageRootPath: string;
   result: SDKAutomationState;
   artifactPaths?: string[];
   readmeMd?: string[];

--- a/tools/spec-gen-sdk/src/types/ExecutionReportSchema.json
+++ b/tools/spec-gen-sdk/src/types/ExecutionReportSchema.json
@@ -34,6 +34,10 @@
             // By default it's folder name of first entry in path.
             "type": "string"
           },
+          "packageRootPath": {
+            // Relative path from the root of the SDK repository to the root of the package source code.
+            "type": "string"
+          },
           "result": {
             // Status of package. By default it's succeeded.
             "type": "string",
@@ -97,7 +101,7 @@
             "$ref": "InstallInstructionScriptOutput"
           }          
         },
-        "required": ["executionResult", "artifactPaths", "language"]
+        "required": ["executionResult", "artifactPaths", "language", "packageRootPath"]
       }
     }
   }

--- a/tools/spec-gen-sdk/test/automation/__snapshots__/reportStatus.test.ts.snap
+++ b/tools/spec-gen-sdk/test/automation/__snapshots__/reportStatus.test.ts.snap
@@ -113,6 +113,7 @@ exports[`reportStatus > generateReport > should generate report successfully wit
       "installInstructions": "npm install test-package",
       "language": "JavaScript",
       "packageName": "test-package",
+      "packageRootPath": "packages/test-package",
       "presentBreakingChangeSuppressions": [],
       "readmeMd": [
         "README.md",


### PR DESCRIPTION
## Summary

- add `packageRootPath` to each package in the spec-gen-sdk execution report
- require the field in the execution report schema and update the TypeScript type and test snapshot
- bump spec-gen-sdk to version 0.9.8 and document the change

## Testing

- Not run (not requested)