### PR TITLE
Regenerate C# SDKs after customized-code patches

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/CustomizedCodeUpdateToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/TypeSpec/CustomizedCodeUpdateToolTests.cs
@@ -1000,29 +1000,48 @@ public class CustomizedCodeUpdateToolAutoTests
     }
 
     // ========================================================================
-    // Java-specific: regen after patches
+    // Regeneration after patches
     // ========================================================================
 
-    [Test]
-    public async Task Java_RegenAfterPatches_Fails_ReturnsRegenerateAfterPatchesFailed()
+    [TestCase(SdkLanguage.Java, "azure-sdk-for-java", EditScope.All)]
+    [TestCase(SdkLanguage.Java, "azure-sdk-for-java", EditScope.CustomCode)]
+    [TestCase(SdkLanguage.DotNet, "azure-sdk-for-net", EditScope.All)]
+    [TestCase(SdkLanguage.DotNet, "azure-sdk-for-net", EditScope.CustomCode)]
+    public async Task RegenAfterPatches_Fails_ReturnsRegenerateAfterPatchesFailed(
+        SdkLanguage language, string repoName, EditScope editScope)
     {
+        var buildCalls = 0;
         var svc = new ConfigurableLanguageService(
-            buildFunc: () => (false, "error in build", null),
+            buildFunc: () =>
+            {
+                buildCalls++;
+                return (false, "error in build", null);
+            },
             hasCustomizations: true,
-            patchesFunc: () => [new AppliedPatch("test.java", "patch", 1)],
-            language: SdkLanguage.Java);
+            patchesFunc: () => [new AppliedPatch("customization", "patch", 1)],
+            language: language);
 
-        // Pass 1 regen call succeeds (1st call), Java regen-after-patches (2nd) fails
-        var failingTspForJavaRegen = new CallCountMockTspHelper(failAfterCall: 1, failError: "regen failed: tsp-client error");
-        var (tool, _) = CreateTool(languageService: svc, tspHelper: failingTspForJavaRegen);
+        var failingTsp = new CallCountMockTspHelper(
+            failAfterCall: editScope == EditScope.All ? 1 : 0,
+            failError: "regen failed: tsp-client error");
+        var (tool, _) = CreateTool(
+            languageService: svc,
+            tspHelper: failingTsp,
+            configureClassifier: editScope == EditScope.CustomCode ? CodeCustomizationClassifier("Fix customization") : null,
+            configureGit: g => g.Setup(x => x.GetRepoNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(repoName));
         var pkg = CreateTempDir();
-        var tspDir = CreateTempDir();
+        var tspDir = editScope == EditScope.All ? CreateTempDir() : null;
 
-        var result = await tool.UpdateAsync(packagePath: pkg, tspProjectPath: tspDir, customizationRequest: "test customization", ct: CancellationToken.None);
+        var result = await tool.UpdateAsync(
+            packagePath: pkg, tspProjectPath: tspDir, customizationRequest: "test customization",
+            editScope: editScope, ct: CancellationToken.None);
 
         Assert.That(result.Success, Is.False);
         Assert.That(result.ErrorCode, Is.EqualTo(CustomizedCodeUpdateResponse.KnownErrorCodes.RegenerateAfterPatchesFailed));
+        Assert.That(result.BuildResult, Is.EqualTo("regen failed: tsp-client error"));
         Assert.That(result.AppliedPatches, Is.Not.Null.And.Count.EqualTo(1));
+        Assert.That(result.TypeSpecChangesSummary, Has.Count.EqualTo(editScope == EditScope.All ? 1 : 0));
+        Assert.That(buildCalls, Is.EqualTo(1), "A failed regeneration must prevent the final build.");
     }
 
     // ========================================================================
@@ -1855,11 +1874,12 @@ public class CustomizedCodeUpdateToolAutoTests
     // Optional tspProjectPath (auto-resolve regen from pinned tsp-location.yaml)
     // ========================================================================
 
-    [Test]
-    public async Task CustomCodeScope_NoTspProjectPath_Java_RegeneratesFromPinnedCommit()
+    [TestCase(SdkLanguage.Java, "azure-sdk-for-java")]
+    [TestCase(SdkLanguage.DotNet, "azure-sdk-for-net")]
+    public async Task CustomCodeScope_NoTspProjectPath_RegeneratesFromPinnedCommit(SdkLanguage language, string repoName)
     {
         // CustomCode scope does not edit spec inputs, so a local TypeSpec checkout is optional. When
-        // tspProjectPath is omitted, the Java post-patch regeneration must pass localSpecRepoPath == null,
+        // tspProjectPath is omitted, post-patch regeneration must pass localSpecRepoPath == null,
         // causing tsp-client to regenerate from the commit pinned in the package's tsp-location.yaml.
         string? capturedLocalSpecRepo = "SENTINEL";
         var callCount = 0;
@@ -1875,7 +1895,7 @@ public class CustomizedCodeUpdateToolAutoTests
                 (_, _, _, localSpec, _) =>
                 {
                     callCount++;
-                    // CODE_CUSTOMIZATION only (no TSP_APPLICABLE), so the Java post-patch regen is the
+                    // CODE_CUSTOMIZATION only (no TSP_APPLICABLE), so post-patch regen is the
                     // first and only UpdateGenerationAsync call.
                     if (callCount == 1)
                         capturedLocalSpecRepo = localSpec;
@@ -1890,13 +1910,14 @@ public class CustomizedCodeUpdateToolAutoTests
                 return buildCalls <= 1 ? (false, "error: cannot find symbol foo", null) : (true, null, null);
             },
             hasCustomizations: true,
-            patchesFunc: () => [new AppliedPatch("Customization.java", "Fixed reference", 1)],
-            language: SdkLanguage.Java);
+            patchesFunc: () => [new AppliedPatch("customization", "Fixed reference", 1)],
+            language: language);
 
         var (tool, _) = CreateTool(
             languageService: svc,
             tspHelper: tsp.Object,
-            configureClassifier: CodeCustomizationClassifier("Fix customization reference"));
+            configureClassifier: CodeCustomizationClassifier("Fix customization reference"),
+            configureGit: g => g.Setup(x => x.GetRepoNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(repoName));
 
         var pkg = CreateTempDir();
 
@@ -1908,16 +1929,17 @@ public class CustomizedCodeUpdateToolAutoTests
 
         Assert.That(result.Success, Is.True);
         Assert.That(result.ErrorCode, Is.Null);
-        Assert.That(callCount, Is.GreaterThanOrEqualTo(1), "Java regen should run even without a local spec path.");
+        Assert.That(callCount, Is.EqualTo(1), "Regeneration should run once after patching, even without a local spec path.");
         Assert.That(capturedLocalSpecRepo, Is.Null,
-            "With tspProjectPath omitted, Java regen must pass localSpecRepoPath == null so tsp-client uses the pinned tsp-location.yaml commit.");
+            "With tspProjectPath omitted, regeneration must use the pinned tsp-location.yaml commit.");
+        tsp.Verify(t => t.UpdateGenerationAsync(pkg, null, false, null, CancellationToken.None), Times.Once);
     }
 
-    [Test]
-    public async Task CustomCodeScope_NoTspProjectPath_NonJava_SucceedsWithoutValidatingSpecPath()
+    [TestCase(SdkLanguage.JavaScript, "azure-sdk-for-js")]
+    [TestCase(SdkLanguage.Python, "azure-sdk-for-python")]
+    public async Task CustomCodeScope_NoTspProjectPath_OtherLanguages_DoNotRegenerate(SdkLanguage language, string repoName)
     {
-        // For a non-Java language the custom-code flow never regenerates, so tspProjectPath is unnecessary.
-        // When omitted, the tool must not attempt to validate a (non-existent) spec path and must succeed.
+        var tsp = new Mock<ITspClientHelper>(MockBehavior.Strict);
         var buildCalls = 0;
         var svc = new ConfigurableLanguageService(
             buildFunc: () =>
@@ -1926,13 +1948,14 @@ public class CustomizedCodeUpdateToolAutoTests
                 return buildCalls <= 1 ? (false, "error CS0103: name does not exist", null) : (true, null, null);
             },
             hasCustomizations: true,
-            patchesFunc: () => [new AppliedPatch("Customization.cs", "Fixed reference", 1)],
-            language: SdkLanguage.DotNet);
+            patchesFunc: () => [new AppliedPatch("customization", "Fixed reference", 1)],
+            language: language);
 
         var (tool, mocks) = CreateTool(
             languageService: svc,
+            tspHelper: tsp.Object,
             configureClassifier: CodeCustomizationClassifier("Fix customization reference"),
-            configureGit: g => g.Setup(x => x.GetRepoNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync("azure-sdk-for-net"));
+            configureGit: g => g.Setup(x => x.GetRepoNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(repoName));
 
         var pkg = CreateTempDir();
 
@@ -1946,12 +1969,17 @@ public class CustomizedCodeUpdateToolAutoTests
         Assert.That(result.ErrorCode, Is.Null);
         mocks.TypeSpecHelper.Verify(t => t.IsValidTypeSpecProjectPath(It.IsAny<string>()), Times.Never,
             "When tspProjectPath is omitted in CustomCode scope, the tool must not validate a spec path.");
+        tsp.VerifyNoOtherCalls();
     }
 
-    [Test]
-    public async Task CustomCodeScope_WithTspProjectPath_Java_UsesLocalSpecRepo()
+    [TestCase(SdkLanguage.Java, "azure-sdk-for-java", false)]
+    [TestCase(SdkLanguage.Java, "azure-sdk-for-java", true)]
+    [TestCase(SdkLanguage.DotNet, "azure-sdk-for-net", false)]
+    [TestCase(SdkLanguage.DotNet, "azure-sdk-for-net", true)]
+    public async Task CustomCodeScope_WithTspProjectPath_UsesLocalSpecRepo(
+        SdkLanguage language, string repoName, bool useRelativePath)
     {
-        // When a local TypeSpec project path IS provided in CustomCode scope, the Java post-patch regen
+        // When a local TypeSpec project path IS provided in CustomCode scope, post-patch regen
         // should use it as localSpecRepoPath (regenerate from the local checkout).
         string? capturedLocalSpecRepo = null;
         var callCount = 0;
@@ -1980,13 +2008,14 @@ public class CustomizedCodeUpdateToolAutoTests
                 return buildCalls <= 1 ? (false, "error: cannot find symbol foo", null) : (true, null, null);
             },
             hasCustomizations: true,
-            patchesFunc: () => [new AppliedPatch("Customization.java", "Fixed reference", 1)],
-            language: SdkLanguage.Java);
+            patchesFunc: () => [new AppliedPatch("customization", "Fixed reference", 1)],
+            language: language);
 
         var (tool, _) = CreateTool(
             languageService: svc,
             tspHelper: tsp.Object,
-            configureClassifier: CodeCustomizationClassifier("Fix customization reference"));
+            configureClassifier: CodeCustomizationClassifier("Fix customization reference"),
+            configureGit: g => g.Setup(x => x.GetRepoNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(repoName));
 
         var pkg = CreateTempDir();
         var tspDir = CreateTempDir();
@@ -1994,13 +2023,207 @@ public class CustomizedCodeUpdateToolAutoTests
         var result = await tool.UpdateAsync(
             packagePath: pkg,
             customizationRequest: "Fix customization reference",
-            tspProjectPath: tspDir,
+            tspProjectPath: useRelativePath ? Path.GetRelativePath(Environment.CurrentDirectory, tspDir) : tspDir,
             editScope: EditScope.CustomCode,
             ct: CancellationToken.None);
 
         Assert.That(result.Success, Is.True);
+        Assert.That(callCount, Is.EqualTo(1));
         Assert.That(capturedLocalSpecRepo, Is.EqualTo(Path.GetFullPath(tspDir)),
-            "When provided, the local TypeSpec project path should be passed to the Java regen as localSpecRepoPath.");
+            "When provided, the local TypeSpec project path should be passed to regeneration as an absolute localSpecRepoPath.");
+        tsp.Verify(t => t.UpdateGenerationAsync(pkg, null, false, Path.GetFullPath(tspDir), CancellationToken.None), Times.Once);
+    }
+
+    [TestCase(EditScope.CustomCode, true)]
+    [TestCase(EditScope.CustomCode, false)]
+    [TestCase(EditScope.All, true)]
+    [TestCase(EditScope.All, false)]
+    public async Task DotNet_Patches_AreRegeneratedBeforeFinalBuild(EditScope editScope, bool finalBuildSucceeds)
+    {
+        using var cts = new CancellationTokenSource();
+        var pkg = CreateTempDir();
+        var tspDir = editScope == EditScope.All ? CreateTempDir() : null;
+        var repoRoot = CreateTempDir();
+        var operations = new List<string>();
+        var customTypeIsPublic = false;
+        var generatedTypeIsPublic = false;
+        var svc = new ConfigurableLanguageService(
+            buildFunc: () =>
+            {
+                operations.Add("build");
+                if (customTypeIsPublic != generatedTypeIsPublic)
+                {
+                    return (false, "CS0262: Partial declarations have conflicting accessibility", null);
+                }
+                if (!generatedTypeIsPublic)
+                {
+                    return (false, "CS0050: Inconsistent accessibility", null);
+                }
+                return finalBuildSucceeds ? (true, null, null) : (false, "Unresolved build error", null);
+            },
+            hasCustomizations: true,
+            patchesFunc: () =>
+            {
+                operations.Add("patch");
+                customTypeIsPublic = true;
+                return [new AppliedPatch("Models/Token.cs", "Make the token public", 1)];
+            },
+            language: SdkLanguage.DotNet,
+            preGenerateFunc: async (root, ct) =>
+            {
+                Assert.That(root, Is.EqualTo(repoRoot));
+                Assert.That(ct, Is.EqualTo(cts.Token));
+                await Task.Yield();
+                operations.Add("prepare");
+            });
+        var tsp = new Mock<ITspClientHelper>(MockBehavior.Strict);
+        tsp.Setup(t => t.UpdateGenerationAsync(pkg, null, false, tspDir, cts.Token))
+            .Callback(() =>
+            {
+                operations.Add("regenerate");
+                generatedTypeIsPublic = customTypeIsPublic;
+            })
+            .ReturnsAsync(new TspToolResponse { IsSuccessful = true, TypeSpecProject = pkg });
+        var (tool, mocks) = CreateTool(
+            languageService: svc,
+            tspHelper: tsp.Object,
+            configureClassifier: CodeCustomizationClassifier("Fix token accessibility"),
+            configureGit: g =>
+            {
+                g.Setup(x => x.GetRepoNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync("azure-sdk-for-net");
+                g.Setup(x => x.DiscoverRepoRootAsync(pkg, cts.Token)).ReturnsAsync(repoRoot);
+            });
+
+        var result = await tool.UpdateAsync(pkg, "Fix token accessibility", tspDir, editScope, cts.Token);
+
+        Assert.That(operations, Is.EqualTo(new[] { "build", "patch", "prepare", "regenerate", "build" }));
+        Assert.That(result.Success, Is.EqualTo(finalBuildSucceeds));
+        Assert.That(result.ErrorCode, Is.EqualTo(finalBuildSucceeds ? null : CustomizedCodeUpdateResponse.KnownErrorCodes.BuildAfterPatchesFailed));
+        Assert.That(result.BuildResult, Is.EqualTo(finalBuildSucceeds ? null : "Unresolved build error"));
+        Assert.That(result.AppliedPatches, Has.Count.EqualTo(1));
+        tsp.VerifyAll();
+        mocks.TypeSpecCustomization.Verify(t => t.ApplyCustomizationAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task DotNet_NoPatches_DoesNotRegenerate(bool hasCustomizations)
+    {
+        var buildCalls = 0;
+        var preparationCalls = 0;
+        var svc = new ConfigurableLanguageService(
+            buildFunc: () =>
+            {
+                buildCalls++;
+                return (false, "Build failed", null);
+            },
+            hasCustomizations: hasCustomizations,
+            language: SdkLanguage.DotNet,
+            preGenerateFunc: (_, _) =>
+            {
+                preparationCalls++;
+                return Task.CompletedTask;
+            });
+        var tsp = new Mock<ITspClientHelper>(MockBehavior.Strict);
+        var (tool, _) = CreateTool(
+            languageService: svc,
+            tspHelper: tsp.Object,
+            configureClassifier: CodeCustomizationClassifier("Fix customization"),
+            configureGit: g => g.Setup(x => x.GetRepoNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync("azure-sdk-for-net"));
+
+        var result = await tool.UpdateAsync(CreateTempDir(), "Fix customization", editScope: EditScope.CustomCode);
+
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.ErrorCode, Is.EqualTo(hasCustomizations
+            ? CustomizedCodeUpdateResponse.KnownErrorCodes.PatchesFailed
+            : CustomizedCodeUpdateResponse.KnownErrorCodes.BuildNoCustomizationsFailed));
+        Assert.That(buildCalls, Is.EqualTo(1));
+        Assert.That(preparationCalls, Is.Zero);
+        tsp.VerifyNoOtherCalls();
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task DotNet_PostPatchPreparationFailure_StopsRegeneration(bool cancel)
+    {
+        using var cts = new CancellationTokenSource();
+        var buildCalls = 0;
+        var svc = new ConfigurableLanguageService(
+            buildFunc: () =>
+            {
+                buildCalls++;
+                return (false, "Build failed", null);
+            },
+            hasCustomizations: true,
+            patchesFunc: () => [new AppliedPatch("Customization.cs", "Fixed reference", 1)],
+            language: SdkLanguage.DotNet,
+            preGenerateFunc: (_, ct) =>
+            {
+                if (cancel)
+                {
+                    cts.Cancel();
+                    throw new OperationCanceledException(ct);
+                }
+                throw new InvalidOperationException("Preparation failed");
+            });
+        var tsp = new Mock<ITspClientHelper>(MockBehavior.Strict);
+        var (tool, _) = CreateTool(
+            languageService: svc,
+            tspHelper: tsp.Object,
+            configureClassifier: CodeCustomizationClassifier("Fix customization"),
+            configureGit: g => g.Setup(x => x.GetRepoNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync("azure-sdk-for-net"));
+        var pkg = CreateTempDir();
+
+        if (cancel)
+        {
+            var exception = Assert.ThrowsAsync<OperationCanceledException>(
+                () => tool.UpdateAsync(pkg, "Fix customization", editScope: EditScope.CustomCode, ct: cts.Token));
+            Assert.That(exception!.CancellationToken, Is.EqualTo(cts.Token));
+        }
+        else
+        {
+            var result = await tool.UpdateAsync(pkg, "Fix customization", editScope: EditScope.CustomCode, ct: cts.Token);
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorCode, Is.EqualTo(CustomizedCodeUpdateResponse.KnownErrorCodes.UnexpectedError));
+            Assert.That(result.BuildResult, Is.EqualTo("Preparation failed"));
+        }
+
+        Assert.That(buildCalls, Is.EqualTo(1));
+        tsp.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public void DotNet_PostPatchRegenerationCancellation_Propagates()
+    {
+        using var cts = new CancellationTokenSource();
+        var pkg = CreateTempDir();
+        var buildCalls = 0;
+        var svc = new ConfigurableLanguageService(
+            buildFunc: () =>
+            {
+                buildCalls++;
+                return (false, "Build failed", null);
+            },
+            hasCustomizations: true,
+            patchesFunc: () => [new AppliedPatch("Customization.cs", "Fixed reference", 1)],
+            language: SdkLanguage.DotNet);
+        var tsp = new Mock<ITspClientHelper>(MockBehavior.Strict);
+        tsp.Setup(t => t.UpdateGenerationAsync(pkg, null, false, null, cts.Token))
+            .Callback(cts.Cancel)
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+        var (tool, _) = CreateTool(
+            languageService: svc,
+            tspHelper: tsp.Object,
+            configureClassifier: CodeCustomizationClassifier("Fix customization"),
+            configureGit: g => g.Setup(x => x.GetRepoNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync("azure-sdk-for-net"));
+
+        var exception = Assert.ThrowsAsync<OperationCanceledException>(
+            () => tool.UpdateAsync(pkg, "Fix customization", editScope: EditScope.CustomCode, ct: cts.Token));
+
+        Assert.That(exception!.CancellationToken, Is.EqualTo(cts.Token));
+        Assert.That(buildCalls, Is.EqualTo(1));
+        tsp.VerifyAll();
     }
 
     [Test]
@@ -2052,6 +2275,7 @@ public class CustomizedCodeUpdateToolAutoTests
         private readonly Func<List<AppliedPatch>>? _patchesFunc;
         private readonly bool _hasCustomizations;
         private readonly bool _isCustomizedCodeUpdateSupported;
+        private readonly Func<string, CancellationToken, Task>? _preGenerateFunc;
 
         public override SdkLanguage Language { get; }
         public override bool IsCustomizedCodeUpdateSupported => _isCustomizedCodeUpdateSupported;
@@ -2061,14 +2285,19 @@ public class CustomizedCodeUpdateToolAutoTests
             bool hasCustomizations = false,
             Func<List<AppliedPatch>>? patchesFunc = null,
             SdkLanguage language = SdkLanguage.Java,
-            bool isCustomizedCodeUpdateSupported = true)
+            bool isCustomizedCodeUpdateSupported = true,
+            Func<string, CancellationToken, Task>? preGenerateFunc = null)
         {
             _buildFunc = buildFunc ?? (() => (true, null, null));
             _hasCustomizations = hasCustomizations;
             _patchesFunc = patchesFunc;
             Language = language;
             _isCustomizedCodeUpdateSupported = isCustomizedCodeUpdateSupported;
+            _preGenerateFunc = preGenerateFunc;
         }
+
+        public override Task PreGenerateAsync(string repoRoot, CancellationToken ct)
+            => _preGenerateFunc?.Invoke(repoRoot, ct) ?? Task.CompletedTask;
 
         public override Task<List<ApiChange>> DiffAsync(string oldGenerationPath, string newGenerationPath, CancellationToken ct)
             => Task.FromResult(new List<ApiChange>());

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- C# customized-code updates now regenerate the SDK after patching customizations and before the final build.
+
 ### Other Changes
 
 ## 0.6.43 (2026-09-03)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 0.6.45 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 0.6.45 (2026-09-08)
 
 ### Bugs Fixed
 
 - C# customized-code updates now regenerate the SDK after patching customizations and before the final build.
-
-### Other Changes
 
 ## 0.6.44 (2026-09-08)
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,16 +1,16 @@
 # Release History
 
-## 0.6.44 (2026-09-08)
-
-### Breaking Changes
-
-- Product onboarding: removed the `--needs-sdk` option, renamed `N/A` to `I don't know` for `--data-plane` and `--management-plane` options.
+## 0.6.45 (2026-09-08)
 
 ### Bugs Fixed
 
 - C# customized-code updates now regenerate the SDK after patching customizations and before the final build.
 
-### Other Changes
+## 0.6.44 (2026-09-08)
+
+### Breaking Changes
+
+- Product onboarding: removed the `--needs-sdk` option, renamed `N/A` to `I don't know` for `--data-plane` and `--management-plane` options.
 
 ## 0.6.43 (2026-09-03)
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/CustomizedCodeUpdateTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/TypeSpec/CustomizedCodeUpdateTool.cs
@@ -146,7 +146,7 @@ public class CustomizedCodeUpdateTool : LanguageMcpTool
 
     /// <summary>
     /// MCP tool entry point — applies patches to customization files based on build errors,
-    /// regenerates code if needed (Java), builds, and returns success/failure with build result.
+    /// regenerates code if needed (C# and Java), builds, and returns success/failure with build result.
     /// </summary>
     /// <param name="packagePath">Absolute path to the SDK package directory.</param>
     /// <param name="customizationRequest">Description of the requested customization to apply to the TypeSpec, used for guiding the update process.</param>
@@ -154,7 +154,7 @@ public class CustomizedCodeUpdateTool : LanguageMcpTool
     /// <param name="editScope">Which source categories the tool may edit (custom code, spec inputs, or both).</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A <see cref="CustomizedCodeUpdateResponse"/> indicating the outcome.</returns>
-    [McpServerTool(Name = CustomizedCodeUpdateToolName), Description("Applies patches to customization files based on build errors, regenerates code if needed (Java), builds, and returns success/failure with build result.")]
+    [McpServerTool(Name = CustomizedCodeUpdateToolName), Description("Applies patches to customization files based on build errors, regenerates code if needed (C# and Java), builds, and returns success/failure with build result.")]
     public Task<CustomizedCodeUpdateResponse> UpdateAsync(
         [Description("Absolute path to the SDK package directory. REQUIRED. Example: 'path/to/azure-sdk-for-java/sdk/healthdataaiservices/azure-health-deidentification'.")]
         string packagePath,
@@ -715,19 +715,21 @@ public class CustomizedCodeUpdateTool : LanguageMcpTool
             });
         }
 
-        // Step 5: Regenerate if Java (only Java needs regen after patching customization files)
-        if (languageService.Language == SdkLanguage.Java)
+        // C# partial customizations affect generated declarations; Java customizations run during generation.
+        if (languageService.Language is SdkLanguage.Java or SdkLanguage.DotNet)
         {
-            logger.LogInformation("Regenerating code after patches (Java)...");
+            logger.LogInformation("Regenerating code after patches ({Language})...", languageService.Language);
 
             // tspProjectPath is optional in custom-code-only scope. When supplied, regenerate from the
             // local spec project; when omitted, pass no local spec repo so tsp-client regenerates from the
             // pinned commit recorded in the package's tsp-location.yaml (no local spec checkout required).
             string? localSpecProjectPath = string.IsNullOrWhiteSpace(tspProjectPath) ? null : Path.GetFullPath(tspProjectPath);
 
-            logger.LogDebug("Java regeneration local spec source: {localSpecProjectPath}",
+            logger.LogDebug("Regeneration local spec source: {localSpecProjectPath}",
                 localSpecProjectPath ?? "(pinned commit from tsp-location.yaml)");
 
+            var repoRoot = await gitHelper.DiscoverRepoRootAsync(packagePath, ct);
+            await languageService.PreGenerateAsync(repoRoot, ct);
             var regenResult = await tspClientHelper.UpdateGenerationAsync(packagePath, localSpecRepoPath: localSpecProjectPath, isCli: false, ct: ct);
             if (!regenResult.IsSuccessful)
             {

--- a/tools/azsdk-cli/docs/mcp-tools.md
+++ b/tools/azsdk-cli/docs/mcp-tools.md
@@ -20,7 +20,7 @@ This document provides a comprehensive list of all MCP (Model Context Protocol) 
 | azsdk_create_pull_request |  | Create pull request for repository changes. Provide title, description and path to repository root. Creates a pull request for committed changes in the current branch. |
 | azsdk_create_release_plan | `azsdk release-plan create` | Create Release Plan for a TypeSpec project and API release type. API release types support Private Preview, Public Preview, and GA. Service ID and product ID are optional and will be resolved from existing release plans when available. |
 | azsdk_create_service_label |  | Creates a pull request to add a new service label |
-| azsdk_customized_code_update | `azsdk tsp client customized-update` | Applies patches to customization files based on build errors, regenerates code if needed (Java), builds, and returns success/failure with build result. |
+| azsdk_customized_code_update | `azsdk tsp client customized-update` | Applies patches to customization files based on build errors, regenerates code if needed (C# and Java), builds, and returns success/failure with build result. |
 | azsdk_engsys_codeowner_add_label_owner |  | Add owner(s) to a label with an optional path in CODEOWNERS work items. Valid ownerType values: service-owner, azsdk-owner, pr-label. A 3-segment path (e.g. sdk/<service>/<package>) is rejected because it targets a package directory; add owners to the package by name instead, or set force=true to create the path anyway. |
 | azsdk_engsys_codeowner_add_package_label |  | Add PR label(s) to a package in CODEOWNERS work items. |
 | azsdk_engsys_codeowner_add_package_owner |  | Add source owner(s) to a package in CODEOWNERS work items. |
@@ -104,4 +104,3 @@ This document provides a comprehensive list of all MCP (Model Context Protocol) 
 |  | `azsdk mcp` | Starts the MCP server (stdio mode) |
 |  | `azsdk config codeowners audit` | Audit CODEOWNERS work items for violations and optionally fix them. You MUST update the CODEOWNERS cache before running this command. |
 |  | `azsdk list` |  |
-

--- a/tools/azsdk-cli/docs/specs/3-customizing-client-tsp.spec.md
+++ b/tools/azsdk-cli/docs/specs/3-customizing-client-tsp.spec.md
@@ -117,7 +117,7 @@ This lives in `eng/common/knowledge/customizing-client-tsp.md` so that all langu
 
 #### Usage
 
-This document will be referenced by [eng/common/instructions/azsdk-tools/typespec-docs.instructions.md](eng/common/instructions/azsdk-tools/typespec-docs.instructions.md). These instructions are already included in the azure-rest-api-specs repo when the user asks TypeSpec-related questions.
+This document will be referenced by [eng/common/instructions/azsdk-tools/typespec-docs.instructions.md](https://github.com/Azure/azure-sdk-tools/blob/main/eng/common/instructions/azsdk-tools/typespec-docs.instructions.md). These instructions are already included in the azure-rest-api-specs repo when the user asks TypeSpec-related questions.
 
 Additionally, it can be referenced by custom prompts or agents when knowledge of how to apply client.tsp customizations is needed.
 

--- a/tools/azsdk-cli/docs/specs/3-customizing-client-tsp.spec.md
+++ b/tools/azsdk-cli/docs/specs/3-customizing-client-tsp.spec.md
@@ -154,7 +154,7 @@ The existing CustomizedCodeUpdateTool will be enhanced to implement a two-phase 
      - ✅ **In**: Remove duplicates, update references, add imports, rename keywords, update type annotations
      - ❌ **Out**: Convenience methods, architecture changes, visibility (use `@access`), error handling, complex logic
 
-   - **Workflow**: Analyze errors → Assess feasibility → Apply patches (if deterministic) OR return manual guidance → Validate → Iterate (max 2 attempts)
+   - **Workflow**: Analyze errors → Assess feasibility → Apply patches (if deterministic) OR return manual guidance → Regenerate the SDK for C# and Java → Validate → Iterate (max 2 attempts). Other languages validate immediately after patching.
 
 1. **Summary Response:**
    - Present summary of changes made to local repository files (TypeSpec and SDK code)
@@ -281,7 +281,7 @@ The tool modifies files across two repositories but **does not commit changes** 
 
 **Modified Files by Phase**:
 - **Phase A**: Updates `client.tsp` in azure-rest-api-specs repo, regenerates SDK code in azure-sdk-for-* repo
-- **Phase B**: Updates customization files (e.g., `*Customization.java`, `*_patch.py`, partial classes) in azure-sdk-for-* repo
+- **Phase B**: Updates customization files (e.g., `*Customization.java`, `*_patch.py`, partial classes) in azure-sdk-for-* repo. C# and Java SDKs are regenerated after these patches because their customizations affect generation output.
 
 
 **User Workflow After Tool Completion**:


### PR DESCRIPTION
## Summary

Regenerate C# SDKs after applying customized-code patches and before the final build, matching the existing Java regeneration flow.

The auto-build-repair investigation for Azure/azure-sdk-for-net#62724 exposed this gap: changing a handwritten partial class's accessibility without regenerating left its generated partial declaration stale. The repair then rebuilt inconsistent declarations and reversed the accessibility change on its next attempt.

## Changes

- Include C# in post-patch regeneration, invoking the existing language preparation hook first so the .NET emitter plugin is prepared before generation.
- Keep the `tsp-location.yaml` pinned commit when no local TypeSpec project is supplied; continue supporting explicit local projects without editing spec inputs in custom-code-only scope.
- Preserve regeneration failure reporting, cancellation propagation, and the final build result. JavaScript and Python custom-code updates still skip regeneration.
- Update the tool description and CLI changelog.

## Regression coverage

The customized-code update fixture passes all 58 cases. Before the production fix, the expanded fixture failed the same 12 C# cases in two runs.

Coverage includes patch/prepare/regenerate/build ordering, pinned and local spec inputs, both custom-code-only and combined edit scopes, regeneration failures, cancellation, no-patch paths, and unaffected languages.

```powershell
dotnet test tools\azsdk-cli\Azure.Sdk.Tools.Cli.Tests\Azure.Sdk.Tools.Cli.Tests.csproj --no-restore -p:CopilotSkipCliDownload=true --filter "FullyQualifiedName~CustomizedCodeUpdateToolAutoTests" --verbosity quiet
```

`CopilotSkipCliDownload` uses the existing supported opt-out for the bundled Copilot CLI download; the repair dependencies in this fixture are mocked.

This fixes the missing C# regeneration step, not the broader TypeSpec migration and independent CI failures in Azure/azure-sdk-for-net#62724. It does not change the skill or redesign the repair orchestration.
