### PR TITLE
Revert malformed SSE response recovery

### DIFF
--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/azure_ai_foundry_agent_test.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/azure_ai_foundry_agent_test.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from json import JSONDecodeError
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -53,13 +52,6 @@ async def _make_stream(events, item_delay: float = 0.0):
         if item_delay:
             await asyncio.sleep(item_delay)
         yield event
-
-
-async def _malformed_stream(events):
-    """Yield events, then fail as the OpenAI SSE JSON decoder does."""
-    for event in events:
-        yield event
-    raise JSONDecodeError("Extra data", "{}\n{}", 3)
 
 
 def _completed_stream(response: _FakeResponse):
@@ -233,45 +225,6 @@ async def test_consume_stream_raises_without_completed_event() -> None:
     )
     with pytest.raises(RuntimeError):
         await HostedAgentClient(AsyncMock())._consume_stream(stream, "conv")
-
-
-@pytest.mark.asyncio
-async def test_invoke_recovers_stored_response_after_malformed_sse() -> None:
-    """Malformed SSE after response creation retrieves the stored result."""
-    created = _FakeResponse(output_text="", status="in_progress", id="r1")
-    stored = _FakeResponse(output_text="answer", status="completed", id="r1")
-    client = _mock_client(
-        [_malformed_stream([_FakeEvent("response.created", created)])]
-    )
-    client.responses.retrieve = AsyncMock(return_value=stored)
-
-    with patch(
-        "utils.azure_ai_foundry_agent.asyncio.sleep", new_callable=AsyncMock
-    ):
-        _, out = await HostedAgentClient(client, retry_delay=0).invoke(
-            conversation_items=[],
-            agent_ref={},
-        )
-
-    assert out is stored
-    assert client.responses.create.await_count == 1
-    client.responses.retrieve.assert_awaited_once_with("r1")
-
-
-@pytest.mark.asyncio
-async def test_invoke_retries_when_malformed_sse_has_no_response_id() -> None:
-    """Malformed SSE before response creation retries with a new stream."""
-    good = _FakeResponse(output_text="answer", status="completed", id="r2")
-    client = _mock_client([_malformed_stream([]), _completed_stream(good)])
-
-    _, out = await HostedAgentClient(client, retry_delay=0).invoke(
-        conversation_items=[],
-        agent_ref={},
-    )
-
-    assert out is good
-    assert client.responses.create.await_count == 2
-    client.responses.retrieve.assert_not_awaited()
 
 
 def _api_error(

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/utils/azure_ai_foundry_agent.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/utils/azure_ai_foundry_agent.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from json import JSONDecodeError
 from typing import Any
 
 from openai import (
@@ -285,52 +284,29 @@ class HostedAgentClient:
         stream,
         agent_conversation_id: str | None,
     ) -> OpenAIResponse:
-        """Consume a responses stream until the ``response.completed`` event.
-
-        If Foundry returns malformed SSE after exposing a response ID, recover
-        the completed result from storage instead of rerunning the agent.
-        """
+        """Consume a responses stream until the ``response.completed`` event."""
         response: OpenAIResponse | None = None
-        latest_response: OpenAIResponse | None = None
         last_event_type: str | None = None
-        try:
-            async for event in stream:
-                logger.debug("Stream event: type=%s, content=%s", event.type, event)
-                last_event_type = event.type
-                event_response = getattr(event, "response", None)
-                if event_response is not None:
-                    latest_response = event_response
-                if event.type == STREAM_EVENT_RESPONSE_COMPLETED:
-                    response = event.response
-                    break
-                if event.type in (
-                    STREAM_EVENT_RESPONSE_FAILED,
-                    STREAM_EVENT_RESPONSE_INCOMPLETE,
-                ):
-                    failed = getattr(event, "response", None)
-                    logger.error(
-                        "Agent stream %s: error=%s, incomplete_details=%s, status=%s, "
-                        "conversation=%s",
-                        event.type,
-                        getattr(failed, "error", None),
-                        getattr(failed, "incomplete_details", None),
-                        getattr(failed, "status", None),
-                        agent_conversation_id,
-                    )
-        except JSONDecodeError as ex:
-            if latest_response is None:
-                raise RuntimeError(
-                    "Agent stream contained malformed SSE before a response ID "
-                    "was observed"
-                ) from ex
-            logger.warning(
-                "Agent stream contained malformed SSE; retrieving stored response: "
-                "response=%s, conversation=%s, error=%s",
-                latest_response.id,
-                agent_conversation_id,
-                ex,
-            )
-            return await self._poll_response(latest_response)
+        async for event in stream:
+            logger.debug("Stream event: type=%s, content=%s", event.type, event)
+            last_event_type = event.type
+            if event.type == STREAM_EVENT_RESPONSE_COMPLETED:
+                response = event.response
+                break
+            if event.type in (
+                STREAM_EVENT_RESPONSE_FAILED,
+                STREAM_EVENT_RESPONSE_INCOMPLETE,
+            ):
+                failed = getattr(event, "response", None)
+                logger.error(
+                    "Agent stream %s: error=%s, incomplete_details=%s, status=%s, "
+                    "conversation=%s",
+                    event.type,
+                    getattr(failed, "error", None),
+                    getattr(failed, "incomplete_details", None),
+                    getattr(failed, "status", None),
+                    agent_conversation_id,
+                )
 
         if response is None:
             raise RuntimeError(


### PR DESCRIPTION
## Summary

- revert the temporary malformed-SSE stored-response recovery added by #16836
- restore the original stream-consumption behavior now that the service-side issue is resolved
- preserve the newer conversation-history recovery behavior

## Incident

Resolved IcM: [857859907](https://portal.microsofticm.com/imp/v5/incidents/details/857859907/summary)

The issue is fixed and deployed. From the log search, the warning does not happen after 9/4.

│ Resource                         │ Count │ First seen (UTC)    │ Last seen (UTC)     │

│ azuresdkqabot-server             │   568 │ 2026-08-27 06:00:11 │ 2026-09-04 13:00:23 │

│ azuresdkqabot-server/slots/agent │     3 │ 2026-08-31 08:22:37 │ 2026-09-03 16:23:46 │


## Testing

- `.\.venv\Scripts\python.exe -m pytest tests\azure_ai_foundry_agent_test.py -q` — 11 passed
- `.\.venv\Scripts\pyright.exe --pythonpath .\.venv\Scripts\python.exe --pythonversion 3.12 utils\azure_ai_foundry_agent.py tests\azure_ai_foundry_agent_test.py` — 0 errors