### PR TITLE
Add Azure DevOps access guidance to agent responses

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Models/CommandResponseTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Models/CommandResponseTests.cs
@@ -23,8 +23,9 @@ public class CommandResponseTests
         Assert.Multiple(() =>
         {
             Assert.That(
-                document.RootElement.GetProperty("next_steps")[0].GetString(),
+                document.RootElement.GetProperty("permission_guidance").GetString(),
                 Is.EqualTo(CommandResponse.AzureDevOpsAccessRequiredMessage));
+            Assert.That(document.RootElement.TryGetProperty("next_steps", out _), Is.False);
             Assert.That(response.ToString(), Does.Contain(CommandResponse.AzureDevOpsAccessRequiredMessage));
         });
     }
@@ -37,6 +38,13 @@ public class CommandResponseTests
             ResponseError = "Access denied to a local file"
         };
 
-        Assert.That(response.NextSteps, Is.Null);
+        var output = new OutputHelper(OutputHelper.OutputModes.Mcp).Format(response);
+        using var document = JsonDocument.Parse(output);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(response.PermissionGuidance, Is.Null);
+            Assert.That(document.RootElement.TryGetProperty("permission_guidance", out _), Is.False);
+        });
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Models/CommandResponseTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Models/CommandResponseTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Text.Json;
+using Azure.Sdk.Tools.Cli.Helpers;
+using Azure.Sdk.Tools.Cli.Models;
+
+namespace Azure.Sdk.Tools.Cli.Tests.Models;
+
+[TestFixture]
+public class CommandResponseTests
+{
+    [Test]
+    public void AzureDevOpsAccessDeniedErrorIncludesAccessInstructions()
+    {
+        var response = new DefaultCommandResponse
+        {
+            ResponseError = "TF215106: Access denied"
+        };
+
+        var output = new OutputHelper(OutputHelper.OutputModes.Mcp).Format(response);
+        using var document = JsonDocument.Parse(output);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                document.RootElement.GetProperty("next_steps")[0].GetString(),
+                Is.EqualTo(CommandResponse.AzureDevOpsAccessRequiredMessage));
+            Assert.That(response.ToString(), Does.Contain(CommandResponse.AzureDevOpsAccessRequiredMessage));
+        });
+    }
+
+    [Test]
+    public void UnrelatedAccessDeniedErrorDoesNotIncludeAccessInstructions()
+    {
+        var response = new DefaultCommandResponse
+        {
+            ResponseError = "Access denied to a local file"
+        };
+
+        Assert.That(response.NextSteps, Is.Null);
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Models/CommandResponseTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Models/CommandResponseTests.cs
@@ -3,6 +3,8 @@
 using System.Text.Json;
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
+using Azure.Sdk.Tools.Cli.Models.Responses.Codeowners;
+using Azure.Sdk.Tools.Cli.Models.Responses.Package;
 
 namespace Azure.Sdk.Tools.Cli.Tests.Models;
 
@@ -46,5 +48,27 @@ public class CommandResponseTests
             Assert.That(response.PermissionGuidance, Is.Null);
             Assert.That(document.RootElement.TryGetProperty("permission_guidance", out _), Is.False);
         });
+    }
+
+    [Test]
+    public void CheckPackageResponseIncludesAccessInstructionsInCliOutput()
+    {
+        var response = new CheckPackageResponse
+        {
+            ResponseError = "TF215106: Access denied"
+        };
+
+        Assert.That(response.ToString(), Does.Contain(CommandResponse.AzureDevOpsAccessRequiredMessage));
+    }
+
+    [Test]
+    public void PackageMarkReleasedResponseIncludesAccessInstructionsInCliOutput()
+    {
+        var response = new PackageMarkReleasedResponse
+        {
+            ResponseErrors = ["TF215106: Access denied"]
+        };
+
+        Assert.That(response.ToString(), Does.Contain(CommandResponse.AzureDevOpsAccessRequiredMessage));
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Azure.Sdk.Tools.Cli.csproj
@@ -13,7 +13,7 @@
     <WarningsAsErrors>CA2254</WarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AssemblyName>azsdk</AssemblyName>
-    <VersionPrefix>0.6.45</VersionPrefix>
+    <VersionPrefix>0.6.46</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <!-- Package metadata -->

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## 0.6.46 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+- Agent responses now provide Azure SDK Partners access guidance when Azure DevOps returns `TF215106: Access denied`.
+
+### Other Changes
+
 ## 0.6.45 (2026-09-08)
 
 ### Bugs Fixed

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Codeowners/CheckPackageResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Codeowners/CheckPackageResponse.cs
@@ -133,6 +133,11 @@ public class CheckPackageResponse : CommandResponse
             messages.Add("[ERROR] " + error);
         }
 
+        if (PermissionGuidance is { } permissionGuidance)
+        {
+            messages.Add(permissionGuidance);
+        }
+
         if (SupportChannel != null)
         {
             messages.Add(SupportChannel);

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/CommandResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/CommandResponse.cs
@@ -94,15 +94,9 @@ public abstract class CommandResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public virtual string? SupportChannel => OperationStatus == Status.Failed ? SupportChannelMessage : null;
 
-    private bool HasAzureDevOpsAccessDeniedError()
-    {
-        if (ResponseError?.Contains(AzureDevOpsAccessDeniedCode, StringComparison.OrdinalIgnoreCase) == true)
-        {
-            return true;
-        }
-
-        return ResponseErrors?.Any(error => error.Contains(AzureDevOpsAccessDeniedCode, StringComparison.OrdinalIgnoreCase)) == true;
-    }
+    private bool HasAzureDevOpsAccessDeniedError() =>
+        ResponseError?.Contains(AzureDevOpsAccessDeniedCode, StringComparison.OrdinalIgnoreCase) == true ||
+        ResponseErrors?.Any(error => error.Contains(AzureDevOpsAccessDeniedCode, StringComparison.OrdinalIgnoreCase)) == true;
 
     protected abstract string Format();
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/CommandResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/CommandResponse.cs
@@ -13,7 +13,13 @@ public enum Status
 
 public abstract class CommandResponse
 {
+    private const string AzureDevOpsAccessDeniedCode = "TF215106";
     private int? exitCode = null;
+    private List<string>? nextSteps;
+
+    public static readonly string AzureDevOpsAccessRequiredMessage =
+        "Azure DevOps permission is required for this operation. Join Azure SDK Partners to request access: https://aka.ms/azsdk/access";
+
     [JsonIgnore]
     public virtual int ExitCode
     {
@@ -48,7 +54,23 @@ public abstract class CommandResponse
     /// </summary>
     [JsonPropertyName("next_steps")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<string>? NextSteps { get; set; }
+    public List<string>? NextSteps
+    {
+        get
+        {
+            if (HasAzureDevOpsAccessDeniedError())
+            {
+                nextSteps ??= [];
+                if (!nextSteps.Contains(AzureDevOpsAccessRequiredMessage))
+                {
+                    nextSteps.Add(AzureDevOpsAccessRequiredMessage);
+                }
+            }
+
+            return nextSteps;
+        }
+        set => nextSteps = value;
+    }
 
     /// <summary>
     /// Status shows whether the command operation was successful.
@@ -71,7 +93,16 @@ public abstract class CommandResponse
     [JsonPropertyName("support_channel")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public virtual string? SupportChannel => OperationStatus == Status.Failed ? SupportChannelMessage : null;
-    
+
+    private bool HasAzureDevOpsAccessDeniedError()
+    {
+        if (ResponseError?.Contains(AzureDevOpsAccessDeniedCode, StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return true;
+        }
+
+        return ResponseErrors?.Any(error => error.Contains(AzureDevOpsAccessDeniedCode, StringComparison.OrdinalIgnoreCase)) == true;
+    }
 
     protected abstract string Format();
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/CommandResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/CommandResponse.cs
@@ -15,7 +15,6 @@ public abstract class CommandResponse
 {
     private const string AzureDevOpsAccessDeniedCode = "TF215106";
     private int? exitCode = null;
-    private List<string>? nextSteps;
 
     public static readonly string AzureDevOpsAccessRequiredMessage =
         "Azure DevOps permission is required for this operation. Join Azure SDK Partners to request access: https://aka.ms/azsdk/access";
@@ -54,23 +53,7 @@ public abstract class CommandResponse
     /// </summary>
     [JsonPropertyName("next_steps")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<string>? NextSteps
-    {
-        get
-        {
-            if (HasAzureDevOpsAccessDeniedError())
-            {
-                nextSteps ??= [];
-                if (!nextSteps.Contains(AzureDevOpsAccessRequiredMessage))
-                {
-                    nextSteps.Add(AzureDevOpsAccessRequiredMessage);
-                }
-            }
-
-            return nextSteps;
-        }
-        set => nextSteps = value;
-    }
+    public List<string>? NextSteps { get; set; }
 
     /// <summary>
     /// Status shows whether the command operation was successful.
@@ -93,6 +76,14 @@ public abstract class CommandResponse
     [JsonPropertyName("support_channel")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public virtual string? SupportChannel => OperationStatus == Status.Failed ? SupportChannelMessage : null;
+
+    /// <summary>
+    /// Permission guidance for Azure DevOps access failures.
+    /// </summary>
+    [JsonPropertyName("permission_guidance")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public virtual string? PermissionGuidance =>
+        HasAzureDevOpsAccessDeniedError() ? AzureDevOpsAccessRequiredMessage : null;
 
     private bool HasAzureDevOpsAccessDeniedError() =>
         ResponseError?.Contains(AzureDevOpsAccessDeniedCode, StringComparison.OrdinalIgnoreCase) == true ||
@@ -117,6 +108,11 @@ public abstract class CommandResponse
         foreach (var error in ResponseErrors ?? [])
         {
             messages.Add("[ERROR] " + error);
+        }
+
+        if (PermissionGuidance is { } permissionGuidance)
+        {
+            messages.Add(permissionGuidance);
         }
 
         if (NextSteps?.Count > 0)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageMarkReleasedResponse.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/Responses/Package/PackageMarkReleasedResponse.cs
@@ -45,9 +45,15 @@ public class PackageMarkReleasedResponse : CommandResponse
 
     public override string ToString()
     {
-        string output = Format().TrimEnd();
-        return SupportChannel == null
-            ? output
-            : $"{output}{Environment.NewLine}{SupportChannel}";
+        List<string> messages = [Format().TrimEnd()];
+        if (PermissionGuidance is { } permissionGuidance)
+        {
+            messages.Add(permissionGuidance);
+        }
+        if (SupportChannel is { } supportChannel)
+        {
+            messages.Add(supportChannel);
+        }
+        return string.Join(Environment.NewLine, messages);
     }
 }


### PR DESCRIPTION
## Summary
- add Azure DevOps permission guidance when an agent response contains `TF215106`
- direct users to join Azure SDK Partners through https://aka.ms/azsdk/access
- include guidance in both the base and custom CLI response formatters
- document the fix under `0.6.46 (Unreleased)`
- leave unrelated access-denied errors unchanged

## Existing flow

1. A tool catches the Azure DevOps failure and sets:

```csharp
ResponseError = "TF215106: Access denied";
```

2. `CommandResponse` marks the operation as failed.
3. `ToString()` formats the raw error, followed by the existing support channel:

```text
[ERROR] TF215106: Access denied
If you need any assistance, please reach out to the AzSDK Agent team...
```

For MCP, the response contains the raw error without actionable permission guidance:

```json
{
  "response_error": "TF215106: Access denied",
  "operation_status": "Failed",
  "support_channel": "If you need any assistance..."
}
```

## Flow with this change

1. The tool continues to set the original error unchanged:

```csharp
ResponseError = "TF215106: Access denied";
```

2. The computed `PermissionGuidance` property detects `TF215106` in `ResponseError` or `ResponseErrors` and returns the Azure SDK Partners access guidance.
3. The base and custom CLI response formatters append the guidance to their text output:

```text
[ERROR] TF215106: Access denied
Azure DevOps permission is required for this operation. Join Azure SDK Partners to request access: https://aka.ms/azsdk/access
If you need any assistance, please reach out to the AzSDK Agent team...
```

For MCP, the error and guidance remain separate JSON properties:

```json
{
  "response_error": "TF215106: Access denied",
  "operation_status": "Failed",
  "permission_guidance": "Azure DevOps permission is required for this operation. Join Azure SDK Partners to request access: https://aka.ms/azsdk/access",
  "support_channel": "If you need any assistance..."
}
```

The original error is preserved. For unrelated failures, `permission_guidance` remains `null` and is omitted from the MCP response.

## Build validation

The previous CI run failed while restoring `Microsoft.NETCore.App.Runtime` version `8.0.31` from the internal feed for Linux and macOS. All 5,661 executed tests passed, and the same publish jobs subsequently passed on the version-bump PR. Local self-contained publishes for `linux-x64` and `osx-x64` pass, and fresh Azure Pipelines build [6805832](https://dev.azure.com/azure-sdk/29ec6040-b234-4e31-b139-33dc4287b756/_build/results?buildId=6805832) completed successfully, confirming the feed issue has cleared.

The `0.6.46` version scaffold matches the pending automation PR #16960. Once that PR merges, only this PR's bug-fix changelog entry remains unique.

## Testing
- `Verify-ChangeLog.ps1 -VersionString 0.6.46` (passed)
- self-contained `dotnet publish` for `linux-x64` and `osx-x64` (passed)
- `dotnet test tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Azure.Sdk.Tools.Cli.Tests.csproj --filter "FullyQualifiedName~CommandResponseTests" -p:CopilotSkipCliDownload=true` (4 passed)
- `dotnet test tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Azure.Sdk.Tools.Cli.Tests.csproj --filter "FullyQualifiedName~CommandResponseTests|FullyQualifiedName~CodeownersToolsTests|FullyQualifiedName~PackageMarkReleasedToolTests" -p:CopilotSkipCliDownload=true` (45 passed)

Fixes #16955
