### PR TITLE
Use package name instead of artifact name to update release status in…

### DIFF
--- a/eng/common/scripts/Resolve-AutoReleasePackages.ps1
+++ b/eng/common/scripts/Resolve-AutoReleasePackages.ps1
@@ -231,13 +231,10 @@ function Invoke-AutoReleaseResolution {
         try
         {
           $packageName = $name
-          $lookupKeys = @($name)
-          if ($groupId) { $lookupKeys += "$groupId/$name" }
-          foreach ($artifactKey in $lookupKeys) {
-            if ($artifactNameToPackageName.ContainsKey($artifactKey)) {
-              $packageName = $artifactNameToPackageName[$artifactKey]
-              break
-            }
+          $lookupKey = if ($groupId) { "$groupId/$name" } else { $name }
+
+          if ($artifactNameToPackageName.ContainsKey($lookupKey)) {
+            $packageName = $artifactNameToPackageName[$lookupKey]
           }
           if($AzsdkExePath)
           {

--- a/eng/common/scripts/Resolve-AutoReleasePackages.ps1
+++ b/eng/common/scripts/Resolve-AutoReleasePackages.ps1
@@ -175,13 +175,24 @@ function Invoke-AutoReleaseResolution {
       $artifactName = [string]$package.ArtifactName
     }
 
-    # Set package name as artifact name if artifact name is missing
-    # Set artifact name- package name map
-    if (-not $artifactName) { $artifactName = $packageName }
-    $artifactNameToPackageName[$artifactName] = $packageName
-
     $group = $null
     if ($package.PSObject.Properties['Group'] -and $package.Group) { $group = [string]$package.Group }
+
+    # Map all relevant name variants to the canonical package name so later lookups work for both
+    # ungrouped and group-qualified artifact keys. This keeps the release-plan update aligned with the
+    # releasable key matching used above.
+    $lookupNames = @()
+    if ($packageName) { $lookupNames += [string]$packageName }
+    if ($artifactName) { $lookupNames += [string]$artifactName }
+    if ($group) {
+      if ($packageName) { $lookupNames += "$group/$packageName" }
+      if ($artifactName) { $lookupNames += "$group/$artifactName" }
+    }
+
+    foreach ($lookupName in ($lookupNames | Sort-Object -Unique)) {
+      if (-not $lookupName) { continue }
+      $artifactNameToPackageName[$lookupName] = $packageName
+    }
 
     foreach ($name in ($names | Sort-Object -Unique)) {
       [void]$releasableKeys.Add($name)
@@ -220,8 +231,13 @@ function Invoke-AutoReleaseResolution {
         try
         {
           $packageName = $name
-          if ($artifactNameToPackageName.ContainsKey($name)) {
-            $packageName = $artifactNameToPackageName[$name]
+          $lookupKeys = @($name)
+          if ($groupId) { $lookupKeys += "$groupId/$name" }
+          foreach ($artifactKey in $lookupKeys) {
+            if ($artifactNameToPackageName.ContainsKey($artifactKey)) {
+              $packageName = $artifactNameToPackageName[$artifactKey]
+              break
+            }
           }
           if($AzsdkExePath)
           {
@@ -241,7 +257,7 @@ function Invoke-AutoReleaseResolution {
             if ($LASTEXITCODE -ne 0)
             {
                 ## Not all releases have a release plan. So we should not fail the script even if a release plan is missing.
-                Write-Host "Failed to update release pending status for package '$packageName' using azsdk. Exit code: $LASTEXITCODE"
+                Write-Host "Failed to update release in progress status for package '$packageName' using azsdk. Exit code: $LASTEXITCODE"
             }
           }
           else
@@ -251,7 +267,7 @@ function Invoke-AutoReleaseResolution {
         }
         catch
         {
-          Write-Host "Failed to update release pending status in release plan for package '$name'. $($_.Exception.Message)"
+          Write-Host "Failed to update release in progress status in release plan for package '$name'. $($_.Exception.Message)"
         }
       }
       else {

--- a/eng/common/scripts/Resolve-AutoReleasePackages.ps1
+++ b/eng/common/scripts/Resolve-AutoReleasePackages.ps1
@@ -157,7 +157,7 @@ function Invoke-AutoReleaseResolution {
   # the correct group and are not confused by name collisions across groups. Packages pulled in solely
   # for validation are not releasable.
   $releasableKeys = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
-  $artifactNameToPackageName = [System.Collections.Generic.Dictionary[string, string]]::new()
+  $artifactNameToPackageName = [System.Collections.Generic.Dictionary[string, string]]::new([System.StringComparer]::OrdinalIgnoreCase)
   foreach ($package in $changedPackages) {
     if ($package.IncludedForValidation) { continue }
 

--- a/eng/common/scripts/Resolve-AutoReleasePackages.ps1
+++ b/eng/common/scripts/Resolve-AutoReleasePackages.ps1
@@ -157,12 +157,28 @@ function Invoke-AutoReleaseResolution {
   # the correct group and are not confused by name collisions across groups. Packages pulled in solely
   # for validation are not releasable.
   $releasableKeys = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+  $artifactNameToPackageName = [System.Collections.Generic.Dictionary[string, string]]::new()
   foreach ($package in $changedPackages) {
     if ($package.IncludedForValidation) { continue }
 
     $names = @()
-    if ($package.Name) { $names += [string]$package.Name }
-    if ($package.PSObject.Properties['ArtifactName'] -and $package.ArtifactName) { $names += [string]$package.ArtifactName }
+    $packageName = $null
+    $artifactName = $null
+    if ($package.Name)
+    {
+      $names += [string]$package.Name
+      $packageName = [string]$package.Name
+    }
+    if ($package.PSObject.Properties['ArtifactName'] -and $package.ArtifactName)
+    {
+      $names += [string]$package.ArtifactName
+      $artifactName = [string]$package.ArtifactName
+    }
+
+    # Set package name as artifact name if artifact name is missing
+    # Set artifact name- package name map
+    if (-not $artifactName) { $artifactName = $packageName }
+    $artifactNameToPackageName[$artifactName] = $packageName
 
     $group = $null
     if ($package.PSObject.Properties['Group'] -and $package.Group) { $group = [string]$package.Group }
@@ -203,29 +219,34 @@ function Invoke-AutoReleaseResolution {
         # The release status is updated to "Released" after successful completion; until then, mark it as "Release In Progress" to indicate that the release is underway.
         try
         {
+          $packageName = $name
+          if ($artifactNameToPackageName.ContainsKey($name)) {
+            $packageName = $artifactNameToPackageName[$name]
+          }
           if($AzsdkExePath)
           {
             $sdkPullRequestUrl = $pr.html_url
-            $cliArgs = @("release-plan", "update-release-status", "--package-name", $name, "--language", $LanguageDisplayName, "--status", "Release In Progress", "--sdk-pull-request", $sdkPullRequestUrl)
+            Write-Host "Updating release plan for package '$packageName' (artifact name: '$name', package name: '$packageName')"
+            $cliArgs = @("release-plan", "update-release-status", "--package-name", $packageName, "--language", $LanguageDisplayName, "--status", "Release In Progress", "--sdk-pull-request", $sdkPullRequestUrl)
             if ($PipelineUrl)
             {
                 $cliArgs += @("--release-pipeline", $PipelineUrl)
             }
             else
             {
-              LogWarning "Pipeline URL is not set; Not setting release pipeline link for package '$name' in release plan."
+              LogWarning "Pipeline URL is not set; Not setting release pipeline link for package '$packageName' in release plan."
             }
 
             & $AzsdkExePath @cliArgs
             if ($LASTEXITCODE -ne 0)
             {
                 ## Not all releases have a release plan. So we should not fail the script even if a release plan is missing.
-                Write-Host "Failed to update release pending status for package '$name' using azsdk. Exit code: $LASTEXITCODE"
+                Write-Host "Failed to update release pending status for package '$packageName' using azsdk. Exit code: $LASTEXITCODE"
             }
           }
           else
           {
-            Write-Host "AzsdkExePath is not set; skipping release plan update for package '$name'."
+            Write-Host "AzsdkExePath is not set; skipping release plan update for package '$packageName'."
           }          
         }
         catch


### PR DESCRIPTION
Auto release pipeline is using artifact name to update the release plan to show that release is in progress. This won't work because release plan has package name and not artifact name. This PR stores artifact to package name map and uses the package name when running azsdk CLI command to update release in progress status. 