### PR TITLE
Update internal PR trigger settings

### DIFF
--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Azure.Sdk.Tools.PipelineGenerator.csproj
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Azure.Sdk.Tools.PipelineGenerator.csproj
@@ -14,11 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <!-- Aliased: the ADO 20.278 InteractiveClient pulls Azure.Core 1.53.0, which also defines the
-         Azure.Identity credential types, so alias Azure.Identity to avoid a CS0433 type collision. -->
-    <PackageReference Include="Azure.Identity" Version="1.14.2">
-      <Aliases>AzureIdentity</Aliases>
-    </PackageReference>
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="Microsoft.TeamFoundation.DistributedTask.WebApi" Version="20.278.0-preview" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="20.278.0-preview" />

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Azure.Sdk.Tools.PipelineGenerator.csproj
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Azure.Sdk.Tools.PipelineGenerator.csproj
@@ -14,13 +14,17 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Azure.Identity" Version="1.14.1" />
+    <!-- Aliased: the ADO 20.278 InteractiveClient pulls Azure.Core 1.53.0, which also defines the
+         Azure.Identity credential types, so alias Azure.Identity to avoid a CS0433 type collision. -->
+    <PackageReference Include="Azure.Identity" Version="1.14.2">
+      <Aliases>AzureIdentity</Aliases>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
-    <PackageReference Include="Microsoft.TeamFoundation.DistributedTask.WebApi" Version="20.257.0-preview" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="20.257.0-preview" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="20.257.0-preview" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.ServiceEndpoints.WebApi" Version="20.257.0-preview" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+    <PackageReference Include="Microsoft.TeamFoundation.DistributedTask.WebApi" Version="20.278.0-preview" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="20.278.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="20.278.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.ServiceEndpoints.WebApi" Version="20.278.0-preview" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.4" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.3" />
   </ItemGroup>
 </Project>

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
@@ -399,6 +399,10 @@ namespace PipelineGenerator.Conventions
                 newTrigger.IsCommentRequiredForPullRequest = securePipeline;
                 // Repository-internal PRs require a comment only for secure pipelines (off for CI).
                 newTrigger.IsCommentRequiredForInternalRepoPRs = securePipeline;
+                if (securePipeline)
+                {
+                    newTrigger.CommentOptionInternalRepos = CommentTriggerOption.All;
+                }
 
                 definition.Triggers.Add(newTrigger);
                 hasChanges = true;
@@ -436,17 +440,21 @@ namespace PipelineGenerator.Conventions
                         hasChanges = true;
                     }
                     if (trigger.RequireCommentsForNonTeamMembersOnly != false ||
-                       trigger.Forks.AllowSecrets != securePipeline ||
-                       trigger.Forks.Enabled != true ||
-                       trigger.IsCommentRequiredForPullRequest != securePipeline ||
-                       trigger.IsCommentRequiredForInternalRepoPRs != securePipeline
-                       )
+                        trigger.Forks.AllowSecrets != securePipeline ||
+                        trigger.Forks.Enabled != true ||
+                        trigger.IsCommentRequiredForPullRequest != securePipeline ||
+                        trigger.IsCommentRequiredForInternalRepoPRs != securePipeline ||
+                        (securePipeline && trigger.CommentOptionInternalRepos != CommentTriggerOption.All))
                     {
                         trigger.Forks.AllowSecrets = securePipeline;
                         trigger.Forks.Enabled = true;
                         trigger.RequireCommentsForNonTeamMembersOnly = false;
                         trigger.IsCommentRequiredForPullRequest = securePipeline;
                         trigger.IsCommentRequiredForInternalRepoPRs = securePipeline;
+                        if (securePipeline)
+                        {
+                            trigger.CommentOptionInternalRepos = CommentTriggerOption.All;
+                        }
 
                         hasChanges = true;
                     }

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
@@ -397,6 +397,8 @@ namespace PipelineGenerator.Conventions
 
                 newTrigger.RequireCommentsForNonTeamMembersOnly = false;
                 newTrigger.IsCommentRequiredForPullRequest = securePipeline;
+                // Repository-internal PRs require a comment only for secure pipelines (off for CI).
+                newTrigger.IsCommentRequiredForInternalRepoPRs = securePipeline;
 
                 definition.Triggers.Add(newTrigger);
                 hasChanges = true;
@@ -436,13 +438,15 @@ namespace PipelineGenerator.Conventions
                     if (trigger.RequireCommentsForNonTeamMembersOnly != false ||
                        trigger.Forks.AllowSecrets != securePipeline ||
                        trigger.Forks.Enabled != true ||
-                       trigger.IsCommentRequiredForPullRequest != securePipeline
+                       trigger.IsCommentRequiredForPullRequest != securePipeline ||
+                       trigger.IsCommentRequiredForInternalRepoPRs != securePipeline
                        )
                     {
                         trigger.Forks.AllowSecrets = securePipeline;
                         trigger.Forks.Enabled = true;
                         trigger.RequireCommentsForNonTeamMembersOnly = false;
                         trigger.IsCommentRequiredForPullRequest = securePipeline;
+                        trigger.IsCommentRequiredForInternalRepoPRs = securePipeline;
 
                         hasChanges = true;
                     }

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
@@ -371,7 +371,11 @@ namespace PipelineGenerator.Conventions
             return Task.FromResult(hasChanges);
         }
 
-        protected bool EnsureDefaultPullRequestTrigger(BuildDefinition definition, bool overrideYaml = true, bool securePipeline = true)
+        protected bool EnsureDefaultPullRequestTrigger(
+            BuildDefinition definition,
+            bool overrideYaml = true,
+            bool securePipeline = true,
+            CommentTriggerOption internalRepoCommentOption = CommentTriggerOption.All)
         {
             bool hasChanges = false;
             var prTriggers = definition.Triggers.OfType<PullRequestTrigger>();
@@ -401,7 +405,7 @@ namespace PipelineGenerator.Conventions
                 newTrigger.IsCommentRequiredForInternalRepoPRs = securePipeline;
                 if (securePipeline)
                 {
-                    newTrigger.CommentOptionInternalRepos = CommentTriggerOption.All;
+                    newTrigger.CommentOptionInternalRepos = internalRepoCommentOption;
                 }
 
                 definition.Triggers.Add(newTrigger);
@@ -444,7 +448,7 @@ namespace PipelineGenerator.Conventions
                         trigger.Forks.Enabled != true ||
                         trigger.IsCommentRequiredForPullRequest != securePipeline ||
                         trigger.IsCommentRequiredForInternalRepoPRs != securePipeline ||
-                        (securePipeline && trigger.CommentOptionInternalRepos != CommentTriggerOption.All))
+                        (securePipeline && trigger.CommentOptionInternalRepos != internalRepoCommentOption))
                     {
                         trigger.Forks.AllowSecrets = securePipeline;
                         trigger.Forks.Enabled = true;
@@ -453,7 +457,7 @@ namespace PipelineGenerator.Conventions
                         trigger.IsCommentRequiredForInternalRepoPRs = securePipeline;
                         if (securePipeline)
                         {
-                            trigger.CommentOptionInternalRepos = CommentTriggerOption.All;
+                            trigger.CommentOptionInternalRepos = internalRepoCommentOption;
                         }
 
                         hasChanges = true;

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
@@ -22,7 +22,11 @@ namespace PipelineGenerator.Conventions
         {
             var hasChanges = await base.ApplyConventionAsync(definition, component);
 
-            if (EnsureDefaultPullRequestTrigger(definition, overrideYaml: true, securePipeline: true))
+            if (EnsureDefaultPullRequestTrigger(
+                definition,
+                overrideYaml: true,
+                securePipeline: true,
+                internalRepoCommentOption: CommentTriggerOption.NonTeamMembersNonContributor))
             {
                 hasChanges = true;
             }

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/PipelineGenerationContext.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/PipelineGenerationContext.cs
@@ -1,5 +1,5 @@
-extern alias AzureIdentity;
 using Azure.Core;
+using Azure.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.TeamFoundation.Build.WebApi;
 using Microsoft.TeamFoundation.Core.WebApi;
@@ -75,9 +75,9 @@ namespace PipelineGenerator
 
         private TokenCredential GetAzureCredentials()
         {
-            return new AzureIdentity::Azure.Identity.ChainedTokenCredential(
-                new AzureIdentity::Azure.Identity.AzureCliCredential(),
-                new AzureIdentity::Azure.Identity.AzurePowerShellCredential()
+            return new ChainedTokenCredential(
+                new AzureCliCredential(),
+                new AzurePowerShellCredential()
             );
         }
 

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/PipelineGenerationContext.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/PipelineGenerationContext.cs
@@ -1,5 +1,5 @@
+extern alias AzureIdentity;
 using Azure.Core;
-using Azure.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.TeamFoundation.Build.WebApi;
 using Microsoft.TeamFoundation.Core.WebApi;
@@ -75,9 +75,9 @@ namespace PipelineGenerator
 
         private TokenCredential GetAzureCredentials()
         {
-            return new ChainedTokenCredential(
-                new AzureCliCredential(),
-                new AzurePowerShellCredential()
+            return new AzureIdentity::Azure.Identity.ChainedTokenCredential(
+                new AzureIdentity::Azure.Identity.AzureCliCredential(),
+                new AzureIdentity::Azure.Identity.AzurePowerShellCredential()
             );
         }
 


### PR DESCRIPTION
## Summary
- configure internal-repository PR comment requirements to match secure pipeline behavior
- require comments from all internal-repository users for secure pipelines while leaving CI pipelines unrestricted
- update Azure Identity and Azure DevOps client dependencies to versions that expose the required trigger settings

## Testing
- Not run (configuration-only change)