### PR TITLE
Accept list of files to check from stdin

### DIFF
--- a/eng/common/spelling/Invoke-Cspell.ps1
+++ b/eng/common/spelling/Invoke-Cspell.ps1
@@ -39,8 +39,9 @@ param(
   [Parameter()]
   [string] $JobType = 'lint',
 
+  # Defaulting to $input accepts a list of files on stdin from both PowerShell and external shells e.g., bash.
   [Parameter(ValueFromPipeline)]
-  [array]$FileList,
+  [array]$FileList = $input,
 
   [Parameter()]
   [string] $CSpellConfigPath = (Resolve-Path "$PSScriptRoot/../../../.vscode/cspell.json"),


### PR DESCRIPTION
Invoke-Cspell.ps1 works fine when piping a list of file names to it from
within PowerShell, but not another shell like bash. This is the fix.
