### PR TITLE
Address eval review feedback from #16932

### DIFF
--- a/.github/skills/azsdk-common-pipeline-analysis/evals/trigger.eval.yaml
+++ b/.github/skills/azsdk-common-pipeline-analysis/evals/trigger.eval.yaml
@@ -72,11 +72,15 @@ stimuli:
           required: ["azsdk-common-pipeline-fixer"]
           disallowed: ["azsdk-common-pipeline-analysis"]
   - name: anti-trigger-write-a-typespec-definition
-    prompt: "write a TypeSpec definition"
-    environment: *targetSkill
+    prompt: "Add an optional color property to the WidgetSuite model in main.tsp."
+    environment:
+      skills:
+        - ..
+        - ../../azure-typespec-author
     graders:
       - type: skill-invocation
         config:
+          required: ["azure-typespec-author"]
           disallowed: ["azsdk-common-pipeline-analysis"]
   - name: anti-trigger-create-a-new-skill
     prompt: "create a new skill"

--- a/evals/tools/prompt-to-tool-typespec.eval.yaml
+++ b/evals/tools/prompt-to-tool-typespec.eval.yaml
@@ -24,19 +24,21 @@ scoring:
 stimuli:
   # ==== azsdk_convert_swagger_to_typespec triggers ====
   - name: invoke-azsdk-convert-swagger-to-typespec-1
-    prompt: "Convert the Azure Swagger described by specification/contosowidgetmanager/resource-manager/readme.md to TypeSpec in the existing empty output directory specification/contosowidgetmanager/Contoso.WidgetManager. This is a data-plane API and full compatibility is false. Invoke the appropriate Azure SDK MCP tool directly to do this — do not inspect or edit the workspace files yourself."
+    prompt: "Convert the Azure Swagger described by specification/contosowidgetmanager/resource-manager/readme.md to TypeSpec in the existing empty output directory specification/contosowidgetmanager/Contoso.WidgetManager. This is an ARM API and full compatibility is false. Invoke the appropriate Azure SDK MCP tool directly to do this — do not inspect or edit the workspace files yourself."
     graders:
       - type: tool-calls
         config:
           required:
             - name: "azsdk_convert_swagger_to_typespec"
+              pattern: '"isAzureResourceManagement":true'
   - name: invoke-azsdk-convert-swagger-to-typespec-2
-    prompt: "Migrate my data-plane API from Swagger to TypeSpec using specification/contosowidgetmanager/resource-manager/readme.md, writing to the existing empty directory specification/contosowidgetmanager/Contoso.WidgetManager with full compatibility disabled. Invoke the appropriate Azure SDK MCP tool directly to do this — do not inspect or edit the workspace files yourself."
+    prompt: "Migrate my ARM API from Swagger to TypeSpec using specification/contosowidgetmanager/resource-manager/readme.md, writing to the existing empty directory specification/contosowidgetmanager/Contoso.WidgetManager with full compatibility disabled. Invoke the appropriate Azure SDK MCP tool directly to do this — do not inspect or edit the workspace files yourself."
     graders:
       - type: tool-calls
         config:
           required:
             - name: "azsdk_convert_swagger_to_typespec"
+              pattern: '"isAzureResourceManagement":true'
 
   # ==== azsdk_customized_code_update triggers ====
   - name: invoke-azsdk-customized-code-update-1


### PR DESCRIPTION
Follow up on Copilot review feedback from #16932 after that PR was merged.

- Make both Swagger-to-TypeSpec prompts consistently describe ARM APIs.
- Require `isAzureResourceManagement: true` in both tool-call graders.
- Make the pipeline-analysis TypeSpec anti-trigger non-vacuous by mounting and requiring `azure-typespec-author`.

Validation:
- TypeSpec tool eval: 72/72 graders passed.
- Pipeline-analysis routing eval: the corrected TypeSpec boundary passed; suite passed its 80% threshold at 10/11, with one unrelated stochastic auto-fix boundary failure.
- Strict lint for `azsdk-common-pipeline-analysis`: 2/2 checks passed.

A post-rebase routing rerun was canceled by the Copilot executor before model execution for all stimuli (0 tokens/0 turns), rather than producing a behavior-scoped failure.