### PR TITLE
Add dataLocation to Azure US Government JSON

### DIFF
--- a/eng/common/TestResources/clouds/AzureUSGovernment.json
+++ b/eng/common/TestResources/clouds/AzureUSGovernment.json
@@ -4,6 +4,7 @@
     "cognitiveServicesEndpointSuffix": ".cognitiveservices.azure.us",
     "containerRegistryEndpointSuffix": ".azurecr.us",
     "cosmosEndpointSuffix": "cosmos.azure.us",
+    "dataLocation": "usgov",
     "enableStorageVersioning": false,
     "formRecognizerLocation": "usgovvirginia",
     "keyVaultDomainSuffix": ".vault.usgovcloudapi.net",


### PR DESCRIPTION
Add dataLocation field for Azure US Government to support enhancement of Azure Government test config for Azure MCP in this change https://github.com/microsoft/mcp/pull/3569