### PR TITLE
Revert pipeline generator version bump

### DIFF
--- a/eng/common/pipelines/templates/steps/install-pipeline-generation.yml
+++ b/eng/common/pipelines/templates/steps/install-pipeline-generation.yml
@@ -9,7 +9,7 @@ steps:
   - script: >
       dotnet tool install
       Azure.Sdk.Tools.PipelineGenerator
-      --version 1.1.0-dev.20260909.1
+      --version 1.1.0-dev.20260901.1
       --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
       --tool-path ${{parameters.ToolPath}}
     workingDirectory: $(Pipeline.Workspace)/pipeline-generator


### PR DESCRIPTION
## Description

Reverts the pipeline generator update introduced by #16977.

Restores Azure.Sdk.Tools.PipelineGenerator from version 1.1.0-dev.20260909.1 to 1.1.0-dev.20260901.1.