### PR TITLE
Require comment triggers for all internal pull requests

### DIFF
--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
@@ -371,11 +371,7 @@ namespace PipelineGenerator.Conventions
             return Task.FromResult(hasChanges);
         }
 
-        protected bool EnsureDefaultPullRequestTrigger(
-            BuildDefinition definition,
-            bool overrideYaml = true,
-            bool securePipeline = true,
-            CommentTriggerOption internalRepoCommentOption = CommentTriggerOption.All)
+        protected bool EnsureDefaultPullRequestTrigger(BuildDefinition definition, bool overrideYaml = true, bool securePipeline = true)
         {
             bool hasChanges = false;
             var prTriggers = definition.Triggers.OfType<PullRequestTrigger>();
@@ -405,7 +401,7 @@ namespace PipelineGenerator.Conventions
                 newTrigger.IsCommentRequiredForInternalRepoPRs = securePipeline;
                 if (securePipeline)
                 {
-                    newTrigger.CommentOptionInternalRepos = internalRepoCommentOption;
+                    newTrigger.CommentOptionInternalRepos = CommentTriggerOption.All;
                 }
 
                 definition.Triggers.Add(newTrigger);
@@ -448,7 +444,7 @@ namespace PipelineGenerator.Conventions
                         trigger.Forks.Enabled != true ||
                         trigger.IsCommentRequiredForPullRequest != securePipeline ||
                         trigger.IsCommentRequiredForInternalRepoPRs != securePipeline ||
-                        (securePipeline && trigger.CommentOptionInternalRepos != internalRepoCommentOption))
+                        (securePipeline && trigger.CommentOptionInternalRepos != CommentTriggerOption.All))
                     {
                         trigger.Forks.AllowSecrets = securePipeline;
                         trigger.Forks.Enabled = true;
@@ -457,7 +453,7 @@ namespace PipelineGenerator.Conventions
                         trigger.IsCommentRequiredForInternalRepoPRs = securePipeline;
                         if (securePipeline)
                         {
-                            trigger.CommentOptionInternalRepos = internalRepoCommentOption;
+                            trigger.CommentOptionInternalRepos = CommentTriggerOption.All;
                         }
 
                         hasChanges = true;

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
@@ -22,11 +22,7 @@ namespace PipelineGenerator.Conventions
         {
             var hasChanges = await base.ApplyConventionAsync(definition, component);
 
-            if (EnsureDefaultPullRequestTrigger(
-                definition,
-                overrideYaml: true,
-                securePipeline: true,
-                internalRepoCommentOption: CommentTriggerOption.NonTeamMembersNonContributor))
+            if (EnsureDefaultPullRequestTrigger(definition, overrideYaml: true, securePipeline: true))
             {
                 hasChanges = true;
             }


### PR DESCRIPTION
## Summary
- require comment triggers for all internal repository pull requests in generated secure pipelines
- remove the unified pipeline override that limited internal comment triggers to non-team members and non-contributors
- keep trigger creation and update behavior consistent

## Testing
- Not run (configuration-only behavior change)