### PR TITLE
Harden ExcludePaths matching semantics

### DIFF
--- a/doc/common/common_engsys.md
+++ b/doc/common/common_engsys.md
@@ -16,6 +16,13 @@ To help keep the content of the `eng/common` directory as small as possible we s
 - Assign the function name to a variable in the `eng/common/scripts/common.ps1` file.
 - Call the function using the variable name like so `&$VariableName`.
 
+### ExcludePaths
+
+`ExcludePaths` values are case-insensitive, literal repository-relative paths that use `/` as the directory separator.
+An entry ending in `/` matches that directory's descendants. An entry without a trailing `/` matches only that exact
+file or path. For example, `docs/` matches `docs/guide.md` but not `docs-tools/build.ps1`, and `README.md` does not match
+`README.md.template`. Glob syntax is not supported.
+
 ## Updating
 
 Any updates to files in the `eng/common` directory should be made in the [azure-sdk-tools](https://github.com/azure/azure-sdk-tools) repo.

--- a/eng/common-tests/helpers/Path-Helpers.Tests.ps1
+++ b/eng/common-tests/helpers/Path-Helpers.Tests.ps1
@@ -1,0 +1,59 @@
+Import-Module Pester
+
+Describe "ExcludePaths matching" -Tag "UnitTest", "Path-Helpers" {
+    BeforeAll {
+        . $PSScriptRoot/../../common/scripts/Package-Properties.ps1
+    }
+
+    It "matches an exact file" {
+        Test-PathExcluded -Path "README.md" -ExcludePaths @("README.md") | Should -BeTrue
+    }
+
+    It "does not match a longer file name" {
+        Test-PathExcluded -Path "README.md.template" -ExcludePaths @("README.md") | Should -BeFalse
+    }
+
+    It "matches a descendant of a trailing-slash directory" {
+        Test-PathExcluded -Path "docs/guide.md" -ExcludePaths @("docs/") | Should -BeTrue
+    }
+
+    It "does not match a sibling with the same leading characters" {
+        Test-PathExcluded -Path "docs-tools/build.ps1" -ExcludePaths @("docs/") | Should -BeFalse
+    }
+
+    It "matches exact files and directories case-insensitively" {
+        Test-PathExcluded -Path "eng/Versioning/Version_Client.txt" -ExcludePaths @("ENG/versioning/version_client.txt") | Should -BeTrue
+        Test-PathExcluded -Path "SDK/Cosmos/azure-cosmos/setup.py" -ExcludePaths @("sdk/cosmos/") | Should -BeTrue
+    }
+
+    It "does not interpret glob syntax" {
+        Test-PathExcluded -Path "docs/guide.md" -ExcludePaths @("docs/*.md") | Should -BeFalse
+    }
+
+    It "applies multiple exclusions" {
+        $result = Update-TargetedFilesForExclude `
+            -TargetedFiles @("README.md", "docs/guide.md", "src/main.ps1") `
+            -ExcludePaths @("README.md", "docs/")
+
+        $result | Should -Be @("src/main.ps1")
+    }
+
+    It "preserves all targeted files for empty exclusions" {
+        $targetedFiles = @("README.md", "docs/guide.md")
+
+        $result = Update-TargetedFilesForExclude -TargetedFiles $targetedFiles -ExcludePaths @()
+
+        $result | Should -Be $targetedFiles
+    }
+
+    It "applies exclusions after changed and deleted paths are combined" {
+        $targetedFiles = @(
+            "src/changed.ps1"
+            "docs/deleted.md"
+        )
+
+        $result = Update-TargetedFilesForExclude -TargetedFiles $targetedFiles -ExcludePaths @("docs/")
+
+        $result | Should -Be @("src/changed.ps1")
+    }
+}

--- a/eng/common/scripts/Generate-PR-Diff.ps1
+++ b/eng/common/scripts/Generate-PR-Diff.ps1
@@ -10,6 +10,10 @@ The folder in which the result will be written.
 
 .PARAMETER TargetPath
 The path under which changes will be detected.
+
+.PARAMETER ExcludePaths
+Case-insensitive, literal repository-relative paths to exclude during package detection. Entries ending in '/'
+match directory descendants; other entries match only the exact path. Glob syntax is not supported.
 #>
 [CmdletBinding()]
 Param (

--- a/eng/common/scripts/Helpers/Path-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Path-Helpers.ps1
@@ -1,0 +1,37 @@
+<#
+.SYNOPSIS
+Tests whether a repository-relative path is excluded by an ExcludePaths list.
+
+.DESCRIPTION
+ExcludePaths entries are matched case-insensitively and literally. An entry ending in '/'
+matches that directory and its descendants. Any other entry matches only the exact path.
+Glob syntax is not interpreted.
+
+.PARAMETER Path
+The repository-relative path to test, using '/' as the directory separator.
+
+.PARAMETER ExcludePaths
+The repository-relative file and directory exclusions.
+#>
+function Test-PathExcluded {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [AllowEmptyCollection()]
+        [string[]]$ExcludePaths = @()
+    )
+
+    foreach ($excludePath in $ExcludePaths) {
+        if ($excludePath.EndsWith('/')) {
+            if ($Path.StartsWith($excludePath, [System.StringComparison]::CurrentCultureIgnoreCase)) {
+                return $true
+            }
+        }
+        elseif ($Path.Equals($excludePath, [System.StringComparison]::CurrentCultureIgnoreCase)) {
+            return $true
+        }
+    }
+
+    return $false
+}

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -1,6 +1,7 @@
 # Helper functions for retrieving useful information from azure-sdk-for-* repo
 . "${PSScriptRoot}\logging.ps1"
 . "${PSScriptRoot}\Helpers\Package-Helpers.ps1"
+. "${PSScriptRoot}\Helpers\Path-Helpers.ps1"
 class PackageProps {
     [string]$Name
     [string]$Version
@@ -352,14 +353,7 @@ function Update-TargetedFilesForTriggerPaths([string[]]$TargetedFiles, [string[]
 function Update-TargetedFilesForExclude([string[]]$TargetedFiles, [string[]]$ExcludePaths) {
     $files = @()
     foreach ($file in $TargetedFiles) {
-        $shouldExclude = $false
-        foreach ($exclude in $ExcludePaths) {
-            if ($file.StartsWith($exclude,'CurrentCultureIgnoreCase')) {
-                $shouldExclude = $true
-                break
-            }
-        }
-        if (!$shouldExclude) {
+        if (-not (Test-PathExcluded -Path $file -ExcludePaths $ExcludePaths)) {
             $files += $file
         }
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/EngSys/PackageInfoTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/EngSys/PackageInfoTool.cs
@@ -401,7 +401,10 @@ public class PackageInfoTool(
         var results = new List<string>();
         foreach (var file in targetedFiles)
         {
-            var shouldExclude = excludePaths.Any(exclude => file.StartsWith(exclude, StringComparison.CurrentCultureIgnoreCase));
+            var shouldExclude = excludePaths.Any(exclude =>
+                exclude.EndsWith("/", StringComparison.Ordinal)
+                    ? file.StartsWith(exclude, StringComparison.CurrentCultureIgnoreCase)
+                    : file.Equals(exclude, StringComparison.CurrentCultureIgnoreCase));
             if (!shouldExclude)
             {
                 results.Add(file);


### PR DESCRIPTION
`ExcludePaths` currently uses case-insensitive prefix matching, so an exact entry like`README.md` would also exclude paths such as `README.md.template`.

This change defines and applies explicit matching semantics:

- Entries ending in `/` match directory descendants case-insensitively.
- Entries without a trailing `/` match only the exact repository-relative path.
- Glob syntax remains unsupported.
- The azsdk CLI package-info implementation uses the same behavior as the shared PowerShell implementation.

Validation:

- Shared helper tests: 18 passed.
- Auto-release diff and resolution tests: 32 passed.
- PowerShell parser checks passed.
- PSScriptAnalyzer reported no new warnings.
- Representative Java, Python, and .NET exclusion values behaved as expected.
- The azsdk CLI build completed with 0 warnings and 0 errors.
- The compiled CLI matcher was exercised against exact-file and directory-prefix collision cases.

Written with the help of vcolin7-copilot.