### PR TITLE
Make QA bot evaluations traceable

### DIFF
--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/services/chat_service.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/services/chat_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timezone
+import hashlib
 import json
 import logging
 import re
@@ -50,12 +51,13 @@ from openai.types.responses import Response as OpenAIResponse
 from utils.azure_ai_foundry_agent import HostedAgentClient, ConversationBrokenError
 from openai.types.responses import (
     ResponseFunctionToolCall,
+    ResponseFunctionToolCallOutputItem,
     ResponseOutputItem,
     ResponseOutputMessage,
 )
 from openai.types.responses.response_input_item_param import ResponseInputItemParam
 from config.tenant_config import TenantID
-from typing import cast
+from typing import Any, cast
 from utils.background_tasks import BackgroundTaskTracker
 
 logger = logging.getLogger(__name__)
@@ -68,6 +70,48 @@ BOT_SENDER_ID = "azure-sdk-qa-bot"
 BOT_SENDER_NAME = "Azure SDK Q&A Bot"
 
 _CITATION_RE = re.compile(r"[^\w\s]*cite[^\w\s]*turn\d+\S*")
+_TRACE_SENSITIVE_KEY_RE = re.compile(
+    r"(?:authorization|connection.?string|credential|password|secret|token)",
+    re.IGNORECASE,
+)
+_TRACE_MAX_CALLS = 32
+_TRACE_MAX_ARGUMENT_CHARS = 2_000
+_TRACE_MAX_OUTPUT_CHARS = 8_000
+_TRACE_MAX_TOTAL_CHARS = 32_000
+_TRACE_OUTPUT_TOOLS = frozenset(
+    {
+        "file_access_grep",
+        "file_access_ls",
+        "file_access_read",
+        "web_fetch",
+        "web_search",
+    }
+)
+
+
+def _redact_trace_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            str(key): (
+                "[REDACTED]"
+                if _TRACE_SENSITIVE_KEY_RE.search(str(key))
+                else _redact_trace_value(item)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_trace_value(item) for item in value]
+    return value
+
+
+def _truncate_trace_text(text: str, limit: int) -> tuple[str, bool]:
+    if len(text) <= limit:
+        return text, False
+    marker = "\n... [trace truncated] ...\n"
+    remaining = max(limit - len(marker), 0)
+    head = remaining * 2 // 3
+    tail = remaining - head
+    return f"{text[:head]}{marker}{text[-tail:] if tail else ''}", True
 
 
 class ChatService:
@@ -515,11 +559,8 @@ class ChatService:
         agent_conversation_id: str | None,
     ) -> ChatResponse:
         """Map hosted-agent response to `ChatResponse`."""
-        tool_results = self._extract_tool_results(response.output)
-        search = tool_results.get("search_knowledge_base")
-        tool_references = (
-            search.results if isinstance(search, SearchKnowledgeBaseResult) else []
-        )
+        tool_result_entries = self._extract_tool_result_entries(response.output)
+        tool_references = self._collect_tool_references(tool_result_entries)
         tenant = self._extract_routed_tenant(response.output)
 
         output_text = response.output_text or ""
@@ -533,15 +574,19 @@ class ChatService:
             output_text, tool_references
         )
 
-        # Build full_context from search tool results when requested.
-        # Keys use "document_" prefix for compatibility with the eval pipeline.
         full_context = None
-        if req.with_full_context and tool_references:
+        if req.with_full_context:
+            contexts = self._build_tool_trace_contexts(response.output, response.id)
+            contexts.extend(
+                DocumentContext.from_reference(reference)
+                for reference in tool_references
+            )
+        else:
+            contexts = []
+        if contexts:
             full_context = json.dumps(
-                [
-                    DocumentContext.from_reference(r).model_dump(mode="json")
-                    for r in tool_references
-                ]
+                [context.model_dump(mode="json") for context in contexts],
+                ensure_ascii=False,
             )
 
         resp = ChatResponse(
@@ -654,33 +699,36 @@ class ChatService:
             return json.dumps(value)
         return None
 
-    def _extract_tool_results(
-        self, items: list[ResponseOutputItem]
+    @staticmethod
+    def _tool_outputs_by_call_id(
+        items: list[ResponseOutputItem],
     ) -> dict[str, object]:
-        """Decode tool outputs using TOOL_REGISTRY models.
+        outputs: dict[str, object] = {}
+        for item in items:
+            if isinstance(item, ResponseFunctionToolCallOutputItem):
+                outputs[item.call_id] = item.output
+            elif isinstance(item, ResponseOutputMessage):
+                extras = item.model_extra or {}
+                call_id = extras.get("call_id") or ""
+                if call_id and extras.get("output") is not None:
+                    outputs[call_id] = extras["output"]
+        return outputs
 
-        Returns a dict mapping tool name to its decoded Pydantic model instance.
-        """
-        results: dict[str, object] = {}
+    def _extract_tool_result_entries(
+        self, items: list[ResponseOutputItem]
+    ) -> list[tuple[str, object]]:
+        """Decode registered tool outputs while preserving call order."""
+        results: list[tuple[str, object]] = []
 
         if not items:
             return results
 
-        # Build mapping from call_id to tool name
-        call_id_to_name: dict[str, str] = {}
+        outputs = self._tool_outputs_by_call_id(items)
         for item in items:
-            if isinstance(item, ResponseFunctionToolCall):
-                if item.call_id and item.name:
-                    call_id_to_name[item.call_id] = item.name
-
-        # Decode each tool output using its registered response model
-        for item in items:
-            if not isinstance(item, ResponseOutputMessage):
+            if not isinstance(item, ResponseFunctionToolCall):
                 continue
-            extras = item.model_extra or {}
-            call_id = extras.get("call_id") or ""
-            output = extras.get("output", None)
-            tool_name = call_id_to_name.get(call_id, "") if call_id else ""
+            tool_name = item.name
+            output = outputs.get(item.call_id)
             if not tool_name or not output:
                 continue
 
@@ -691,11 +739,143 @@ class ChatService:
             try:
                 json_str = self._unwrap_json(output)
                 if json_str:
-                    results[tool_name] = response_model.model_validate_json(json_str)
+                    results.append(
+                        (tool_name, response_model.model_validate_json(json_str))
+                    )
             except Exception as e:
                 logger.warning("Failed to decode tool output for %s: %s", tool_name, e)
 
         return results
+
+    def _extract_tool_results(
+        self, items: list[ResponseOutputItem]
+    ) -> dict[str, object]:
+        """Decode registered tool outputs, retaining the last result per tool."""
+        return dict(self._extract_tool_result_entries(items))
+
+    @staticmethod
+    def _collect_tool_references(
+        entries: list[tuple[str, object]],
+    ) -> list[Reference]:
+        references: list[Reference] = []
+        seen: set[tuple[str, str, str, str, str]] = set()
+        for _, result in entries:
+            if not isinstance(result, SearchKnowledgeBaseResult):
+                continue
+            for reference in result.results:
+                key = (
+                    reference.source,
+                    reference.blob_path,
+                    reference.link,
+                    reference.title,
+                    reference.content,
+                )
+                if key in seen:
+                    continue
+                seen.add(key)
+                references.append(reference)
+        return references
+
+    @staticmethod
+    def _serialize_trace_value(value: object) -> str:
+        if isinstance(value, str):
+            return value
+        model_dump = getattr(value, "model_dump", None)
+        if callable(model_dump):
+            value = model_dump(mode="json")
+        try:
+            return json.dumps(value, ensure_ascii=False, default=str)
+        except (TypeError, ValueError):
+            return str(value)
+
+    @staticmethod
+    def _parse_trace_arguments(arguments: str) -> object:
+        try:
+            value = json.loads(arguments)
+        except (json.JSONDecodeError, TypeError):
+            value = arguments
+        redacted = _redact_trace_value(value)
+        serialized = ChatService._serialize_trace_value(redacted)
+        truncated, was_truncated = _truncate_trace_text(
+            serialized, _TRACE_MAX_ARGUMENT_CHARS
+        )
+        if not was_truncated:
+            return redacted
+        return {"text": truncated, "truncated": True}
+
+    def _build_tool_trace_contexts(
+        self,
+        items: list[ResponseOutputItem],
+        response_id: str,
+    ) -> list[DocumentContext]:
+        outputs = self._tool_outputs_by_call_id(items)
+        contexts: list[DocumentContext] = []
+        remaining_trace_chars = _TRACE_MAX_TOTAL_CHARS
+        sequence = 0
+        for item in items:
+            if not isinstance(item, ResponseFunctionToolCall):
+                continue
+            sequence += 1
+            if sequence > _TRACE_MAX_CALLS:
+                break
+
+            raw_output = outputs.get(item.call_id)
+            output_text = (
+                self._serialize_trace_value(raw_output)
+                if raw_output is not None
+                else ""
+            )
+            output_hash = (
+                hashlib.sha256(output_text.encode("utf-8")).hexdigest()
+                if output_text
+                else ""
+            )
+            trace = {
+                "sequence": sequence,
+                "tool_name": item.name,
+                "call_id": item.call_id,
+                "arguments": self._parse_trace_arguments(item.arguments),
+                "output": "",
+                "output_chars": len(output_text),
+                "output_sha256": output_hash,
+                "output_captured": False,
+                "output_truncated": (
+                    item.name in _TRACE_OUTPUT_TOOLS and bool(output_text)
+                ),
+            }
+            trace_content = json.dumps(trace, ensure_ascii=False)
+            if len(trace_content) >= remaining_trace_chars:
+                break
+
+            if item.name in _TRACE_OUTPUT_TOOLS and output_text:
+                available_output_chars = min(
+                    _TRACE_MAX_OUTPUT_CHARS,
+                    max((remaining_trace_chars - len(trace_content)) // 2, 0),
+                )
+                if available_output_chars:
+                    captured_output, output_truncated = _truncate_trace_text(
+                        output_text, available_output_chars
+                    )
+                    trace["output"] = captured_output
+                    trace["output_captured"] = True
+                    trace["output_truncated"] = output_truncated
+                    trace_content = json.dumps(trace, ensure_ascii=False)
+                    if len(trace_content) > remaining_trace_chars:
+                        trace["output"] = ""
+                        trace["output_captured"] = False
+                        trace["output_truncated"] = bool(output_text)
+                        trace_content = json.dumps(trace, ensure_ascii=False)
+
+            contexts.append(
+                DocumentContext(
+                    document_title=f"Tool call {sequence}: {item.name}",
+                    document_link=f"agent-trace://{response_id}/{item.call_id}",
+                    document_source="agent_tool_trace",
+                    document_content=trace_content,
+                )
+            )
+            remaining_trace_chars -= len(trace_content)
+        return contexts
 
     @staticmethod
     def _extract_routed_tenant(items: list[ResponseOutputItem]) -> TenantID | None:

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/services/chat_service.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/services/chat_service.py
@@ -70,10 +70,36 @@ BOT_SENDER_ID = "azure-sdk-qa-bot"
 BOT_SENDER_NAME = "Azure SDK Q&A Bot"
 
 _CITATION_RE = re.compile(r"[^\w\s]*cite[^\w\s]*turn\d+\S*")
+_TRACE_SENSITIVE_KEY_PATTERN = (
+    r"(?:access[-_ ]?key|access[-_ ]?token|account[-_ ]?key|api[-_ ]?key|"
+    r"authorization|client[-_ ]?secret|connection[-_ ]?string|credential|"
+    r"id[-_ ]?token|password|refresh[-_ ]?token|secret|shared[-_ ]?access[-_ ]?key|"
+    r"sig|signature|subscription[-_ ]?key|token)"
+)
 _TRACE_SENSITIVE_KEY_RE = re.compile(
-    r"(?:authorization|connection.?string|credential|password|secret|token)",
+    _TRACE_SENSITIVE_KEY_PATTERN,
     re.IGNORECASE,
 )
+_TRACE_SENSITIVE_QUERY_RE = re.compile(
+    rf"(?P<prefix>[?&](?:{_TRACE_SENSITIVE_KEY_PATTERN}|code|key)=)"
+    r"[^&#\s\"'<>]*",
+    re.IGNORECASE,
+)
+_TRACE_AUTHORIZATION_VALUE_RE = re.compile(
+    r"(?P<prefix>\bauthorization\b\s*[:=]\s*)"
+    r"(?:\"[^\"\r\n]*\"|'[^'\r\n]*'|[^\r\n,;}]+)",
+    re.IGNORECASE,
+)
+_TRACE_AUTH_SCHEME_RE = re.compile(
+    r"(?P<prefix>\b(?:basic|bearer)\s+)[A-Za-z0-9._~+/=-]+",
+    re.IGNORECASE,
+)
+_TRACE_SENSITIVE_ASSIGNMENT_RE = re.compile(
+    rf"(?P<prefix>\b{_TRACE_SENSITIVE_KEY_PATTERN}\b\s*[:=]\s*)"
+    r"(?:\"[^\"\r\n]*\"|'[^'\r\n]*'|[^\s,;&}]+)",
+    re.IGNORECASE,
+)
+_TRACE_REDACTED_VALUE = "[REDACTED]"
 _TRACE_MAX_CALLS = 32
 _TRACE_MAX_ARGUMENT_CHARS = 2_000
 _TRACE_MAX_OUTPUT_CHARS = 8_000
@@ -89,11 +115,26 @@ _TRACE_OUTPUT_TOOLS = frozenset(
 )
 
 
+def _redact_trace_string(value: str) -> str:
+    value = _TRACE_AUTHORIZATION_VALUE_RE.sub(
+        rf"\g<prefix>{_TRACE_REDACTED_VALUE}", value
+    )
+    value = _TRACE_AUTH_SCHEME_RE.sub(
+        rf"\g<prefix>{_TRACE_REDACTED_VALUE}", value
+    )
+    value = _TRACE_SENSITIVE_QUERY_RE.sub(
+        rf"\g<prefix>{_TRACE_REDACTED_VALUE}", value
+    )
+    return _TRACE_SENSITIVE_ASSIGNMENT_RE.sub(
+        rf"\g<prefix>{_TRACE_REDACTED_VALUE}", value
+    )
+
+
 def _redact_trace_value(value: Any) -> Any:
     if isinstance(value, dict):
         return {
             str(key): (
-                "[REDACTED]"
+                _TRACE_REDACTED_VALUE
                 if _TRACE_SENSITIVE_KEY_RE.search(str(key))
                 else _redact_trace_value(item)
             )
@@ -101,6 +142,8 @@ def _redact_trace_value(value: Any) -> Any:
         }
     if isinstance(value, list):
         return [_redact_trace_value(item) for item in value]
+    if isinstance(value, str):
+        return _redact_trace_string(value)
     return value
 
 

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/chat_service_test.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/chat_service_test.py
@@ -2,18 +2,25 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from openai.types.responses import (
+    ResponseFunctionToolCall,
+    ResponseFunctionToolCallOutputItem,
+    ResponseOutputMessage,
+)
 
 _PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
 if _PROJECT_ROOT not in sys.path:
     sys.path.insert(0, _PROJECT_ROOT)
 
 from models.chat import ChatRequest, Message as ChatMessage
+from models.knowledge import Reference, SearchKnowledgeBaseResult
 from services.chat_service import ChatService
 
 
@@ -76,6 +83,142 @@ def test_chat_service_returns_none_when_user_id_empty() -> None:
         message=ChatMessage(role="user", content="hello", user_id="  "),
     )
     assert service._resolve_memory_scope(whitespace_id) is None
+
+
+def test_postprocess_captures_ordered_tool_trace_and_all_knowledge() -> None:
+    service = ChatService(settings=lambda _key, default="": default)
+    search_result = SearchKnowledgeBaseResult(
+        results=[
+            Reference(
+                title="TypeSpec guide",
+                source="typespec",
+                blob_path="docs/guide.md",
+                link="https://example.test/guide",
+                content="Authoritative guidance.",
+            ),
+            Reference(
+                title="TypeSpec guide",
+                source="typespec",
+                blob_path="docs/guide.md",
+                link="https://example.test/guide",
+                content="A second relevant chunk.",
+            ),
+        ]
+    )
+    items = [
+        ResponseFunctionToolCall(
+            arguments='{"queries":["operation id"],"access_token":"secret"}',
+            call_id="call-search",
+            name="search_knowledge_base",
+            type="function_call",
+        ),
+        ResponseOutputMessage.model_construct(
+            id="output-search",
+            call_id="call-search",
+            output=search_result.model_dump_json(),
+            content=[],
+            role="assistant",
+            status="completed",
+            type="message",
+        ),
+        ResponseFunctionToolCall(
+            arguments='{"directory":"Azure/typespec-azure","regex_pattern":"clientLocation"}',
+            call_id="call-grep",
+            name="file_access_grep",
+            type="function_call",
+        ),
+        ResponseFunctionToolCallOutputItem(
+            id="output-grep",
+            call_id="call-grep",
+            output="packages/compiler/src/checker.ts:42: clientLocation",
+            status="completed",
+            type="function_call_output",
+        ),
+    ]
+    req = ChatRequest(
+        tenant_id="azure_sdk_qa_bot",
+        message=ChatMessage(role="user", content="How is this implemented?"),
+        with_full_context=True,
+    )
+    response = SimpleNamespace(
+        id="response-1",
+        output=items,
+        output_text="Use the documented API.",
+    )
+
+    result = service._postprocess(req, response, agent_conversation_id=None)
+
+    contexts = json.loads(result.full_context or "[]")
+    traces = [
+        json.loads(context["document_content"])
+        for context in contexts
+        if context["document_source"] == "agent_tool_trace"
+    ]
+    evidence = [
+        context
+        for context in contexts
+        if context["document_source"] != "agent_tool_trace"
+    ]
+
+    assert [trace["tool_name"] for trace in traces] == [
+        "search_knowledge_base",
+        "file_access_grep",
+    ]
+    assert traces[0]["arguments"]["access_token"] == "[REDACTED]"
+    assert traces[0]["output_captured"] is False
+    assert traces[0]["output_chars"] > 0
+    assert traces[1]["output_captured"] is True
+    assert "clientLocation" in traces[1]["output"]
+    assert traces[1]["output_sha256"]
+    assert evidence == [
+        {
+            "document_title": "TypeSpec guide",
+            "document_link": "https://example.test/guide",
+            "document_source": "typespec",
+            "document_content": "Authoritative guidance.",
+            "score": 0.0,
+        },
+        {
+            "document_title": "TypeSpec guide",
+            "document_link": "https://example.test/guide",
+            "document_source": "typespec",
+            "document_content": "A second relevant chunk.",
+            "score": 0.0,
+        }
+    ]
+
+
+def test_tool_trace_content_has_a_total_budget() -> None:
+    service = ChatService(settings=lambda _key, default="": default)
+    items = []
+    for index in range(10):
+        call_id = f"call-{index}"
+        items.extend(
+            [
+                ResponseFunctionToolCall(
+                    arguments='{"url":"https://example.test"}',
+                    call_id=call_id,
+                    name="web_fetch",
+                    type="function_call",
+                ),
+                ResponseFunctionToolCallOutputItem(
+                    id=f"output-{index}",
+                    call_id=call_id,
+                    output="x" * 10_000,
+                    status="completed",
+                    type="function_call_output",
+                ),
+            ]
+        )
+
+    contexts = service._build_tool_trace_contexts(items, "response-1")
+
+    assert contexts
+    assert sum(len(context.document_content) for context in contexts) <= 32_000
+    assert all(
+        json.loads(context.document_content)["output_sha256"]
+        for context in contexts
+    )
 
 
 @pytest.mark.asyncio

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/chat_service_test.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-agent/tests/chat_service_test.py
@@ -107,7 +107,11 @@ def test_postprocess_captures_ordered_tool_trace_and_all_knowledge() -> None:
     )
     items = [
         ResponseFunctionToolCall(
-            arguments='{"queries":["operation id"],"access_token":"secret"}',
+            arguments=(
+                '{"queries":["operation id"],"access_token":"secret",'
+                '"url":"https://storage.test/blob?sv=1&sig=sas-secret&se=tomorrow",'
+                '"nested":{"api-key":"api-secret"}}'
+            ),
             call_id="call-search",
             name="search_knowledge_base",
             type="function_call",
@@ -165,6 +169,10 @@ def test_postprocess_captures_ordered_tool_trace_and_all_knowledge() -> None:
         "file_access_grep",
     ]
     assert traces[0]["arguments"]["access_token"] == "[REDACTED]"
+    assert traces[0]["arguments"]["nested"]["api-key"] == "[REDACTED]"
+    assert "sas-secret" not in traces[0]["arguments"]["url"]
+    assert "sig=[REDACTED]" in traces[0]["arguments"]["url"]
+    assert "se=tomorrow" in traces[0]["arguments"]["url"]
     assert traces[0]["output_captured"] is False
     assert traces[0]["output_chars"] > 0
     assert traces[1]["output_captured"] is True
@@ -186,6 +194,21 @@ def test_postprocess_captures_ordered_tool_trace_and_all_knowledge() -> None:
             "score": 0.0,
         }
     ]
+
+
+def test_tool_trace_redacts_non_json_credentials() -> None:
+    service = ChatService(settings=lambda _key, default="": default)
+
+    arguments = service._parse_trace_arguments(
+        "url=https://storage.test/blob?sv=1&sig=sas-secret "
+        "Authorization: Bearer bearer-secret, api_key=api-secret"
+    )
+
+    assert isinstance(arguments, str)
+    assert "sas-secret" not in arguments
+    assert "bearer-secret" not in arguments
+    assert "api-secret" not in arguments
+    assert arguments.count("[REDACTED]") == 3
 
 
 def test_tool_trace_content_has_a_total_budget() -> None:

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-evaluation/README.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-evaluation/README.md
@@ -84,9 +84,7 @@ contributors don't re-curate the same cases); `evaluation_datasets/basic/`, `eva
 
 ## Part 2 — Running evaluations
 
-We call the bot `/completion` endpoint **concurrently** (`--max_concurrency`, default
-8), collect each answer + context, then grade them inline. Reads cases from the local
-`evaluation_datasets/<target>/<scenario>.jsonl`.
+We call the bot `/completion` endpoint **concurrently** (`--max_concurrency`, default 8), collect each answer + context, then grade the collected responses inline in payload-bounded batches of at most 20 cases and merge the results. Batching keeps large perf datasets under Foundry's inline run-history payload limit. Reads cases from the local `evaluation_datasets/<target>/<scenario>.jsonl`.
 
 ```bash
 # Concurrent /completion collection + inline grading:
@@ -105,9 +103,9 @@ or `BOT_AGENT_ACCESS_TOKEN`) for the deployed bot, or run the agent `server.py` 
 (defaults to `http://localhost:8089`). Tenant routing is resolved from
 `BOT_CONFIG_CONTAINER` / `BOT_CONFIG_CHANNEL_BLOB`.
 
-Results appear on the Evaluation tab of the Azure AI Foundry portal (each run prints
-its `report_url`). `--cache_result full` writes per-case JSON + failed-cases JSON
-under `cache/`.
+Results appear on the Evaluation tab of the Azure AI Foundry portal (each run prints its `report_url`). `--cache_result full` writes per-case JSON + failed-cases JSON under `cache/`.
+
+Each cached case preserves an `execution` block with the hosted-agent response ID, Foundry trace ID, agent conversation ID, latency, response length, and ordered tool calls. Tool calls record redacted arguments, output size/hash, and bounded output for evidence-bearing file/web tools; trace content is capped at 32K characters per response, with at most 32 calls and 8K characters from one output. The raw `actual.context` used by the groundedness evaluator is also retained, so a score can be audited against the exact bounded evidence supplied to the grader. The final summary reports `traced_cases`, `tool_call_count`, `file_access_cases`, and per-tool call/case counts.
 
 ### Evaluators
 
@@ -121,7 +119,7 @@ All evaluators are builtin LLM evaluators that read the collected bot answer via
 | `relevance` | builtin LLM (model) | answer vs `query` |
 | `coherence` | builtin LLM (model) | answer vs `query` |
 | `fluency` | builtin LLM (model) | answer vs `query` |
-| `groundedness` | builtin LLM (model) | answer vs retrieved context (`{{item.context}}`) |
+| `groundedness` | builtin LLM (model) | answer vs retrieved documentation plus bounded execution evidence (`{{item.context}}`) |
 | `bot_evals` | local composite | weighted `similarity` + `response_completeness` |
 
 LLM-graded evaluators use the 1-5 `EVALUATE_THRESHOLD`.

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-evaluation/README.md
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-evaluation/README.md
@@ -84,7 +84,7 @@ contributors don't re-curate the same cases); `evaluation_datasets/basic/`, `eva
 
 ## Part 2 — Running evaluations
 
-We call the bot `/completion` endpoint **concurrently** (`--max_concurrency`, default 8), collect each answer + context, then grade the collected responses inline in payload-bounded batches of at most 20 cases and merge the results. Batching keeps large perf datasets under Foundry's inline run-history payload limit. Reads cases from the local `evaluation_datasets/<target>/<scenario>.jsonl`.
+We call the bot `/completion` endpoint **concurrently** (`--max_concurrency`, default 8), collect each answer + context, then grade the collected responses inline in payload-bounded batches of at most 20 cases and merge the results. Batching keeps large perf datasets under Foundry's inline run-history payload limit; an individual case above the byte limit fails locally with its testcase name instead of submitting an oversized request. Reads cases from the local `evaluation_datasets/<target>/<scenario>.jsonl`.
 
 ```bash
 # Concurrent /completion collection + inline grading:
@@ -105,7 +105,7 @@ or `BOT_AGENT_ACCESS_TOKEN`) for the deployed bot, or run the agent `server.py` 
 
 Results appear on the Evaluation tab of the Azure AI Foundry portal (each run prints its `report_url`). `--cache_result full` writes per-case JSON + failed-cases JSON under `cache/`.
 
-Each cached case preserves an `execution` block with the hosted-agent response ID, Foundry trace ID, agent conversation ID, latency, response length, and ordered tool calls. Tool calls record redacted arguments, output size/hash, and bounded output for evidence-bearing file/web tools; trace content is capped at 32K characters per response, with at most 32 calls and 8K characters from one output. The raw `actual.context` used by the groundedness evaluator is also retained, so a score can be audited against the exact bounded evidence supplied to the grader. The final summary reports `traced_cases`, `tool_call_count`, `file_access_cases`, and per-tool call/case counts.
+Each cached case preserves an `execution` block with the hosted-agent response ID, Foundry trace ID, agent conversation ID, latency, response length, and ordered tool calls. Tool calls record redacted arguments, output size/hash, and bounded output for evidence-bearing file/web tools; trace content is capped at 32K characters per response, with at most 32 calls and 8K characters from one output. The raw `actual.context` used by the groundedness evaluator is also retained, so a score can be audited against the exact bounded evidence supplied to the grader. The final summary reports `traced_cases` from Foundry trace IDs, `response_id_cases`, `tool_call_count`, `file_access_cases`, and per-tool call/case counts.
 
 ### Evaluators
 

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-evaluation/_evals_result.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-evaluation/_evals_result.py
@@ -115,12 +115,15 @@ class EvalsResult:
 
         tool_usage: dict[str, dict[str, int]] = {}
         traced_cases = 0
+        response_id_cases = 0
         file_access_cases = 0
         tool_call_count = 0
         for row in result["rows"]:
             traces = row.get("inputs.tool_trace", []) or []
-            if row.get("inputs.trace_id") or row.get("inputs.response_id"):
+            if row.get("inputs.trace_id"):
                 traced_cases += 1
+            if row.get("inputs.response_id"):
+                response_id_cases += 1
             case_tools: set[str] = set()
             for trace in traces:
                 if not isinstance(trace, dict):
@@ -140,6 +143,7 @@ class EvalsResult:
         summary_result: dict[str, Any] = {
             "total_evals": len(result["rows"]),
             "traced_cases": traced_cases,
+            "response_id_cases": response_id_cases,
             "tool_call_count": tool_call_count,
             "file_access_cases": file_access_cases,
             "tool_usage": tool_usage,

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-evaluation/_evals_result.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-evaluation/_evals_result.py
@@ -57,6 +57,7 @@ class EvalsResult:
         for row in result["rows"]:
             row_result: dict[str, Any] = {}
             row_result["testcase"] = row["inputs.testcase"]
+            row_result["query"] = row.get("inputs.query", "")
             row_result["expected"] = {
                 "answer": row["inputs.ground_truth"],
                 "references": row["inputs.expected_references"],
@@ -66,6 +67,25 @@ class EvalsResult:
                 "answer": row["inputs.response"],
                 "references": row["inputs.references"],
                 "knowledges": row["inputs.knowledges"],
+                "context": row.get("inputs.context", ""),
+            }
+            tool_trace = row.get("inputs.tool_trace", []) or []
+            used_file_access = any(
+                isinstance(trace, dict)
+                and isinstance(trace.get("tool_name"), str)
+                and trace["tool_name"].startswith("file_access_")
+                for trace in tool_trace
+            )
+            row_result["execution"] = {
+                "response_id": row.get("inputs.response_id", ""),
+                "trace_id": row.get("inputs.trace_id", ""),
+                "agent_conversation_id": row.get(
+                    "inputs.agent_conversation_id", ""
+                ),
+                "latency_seconds": row.get("inputs.latency", 0.0),
+                "response_length": row.get("inputs.response_length", 0),
+                "used_file_access": used_file_access,
+                "tool_calls": tool_trace,
             }
             pattern = r"^outputs\.(\w+)\.(\w+)$"
             for index, (key, value) in enumerate(row.items()):
@@ -93,7 +113,37 @@ class EvalsResult:
                         row_result[metric_name] = value
             run_result.append(row_result)
 
-        summary_result: dict[str, Any] = {"total_evals": len(result["rows"])}
+        tool_usage: dict[str, dict[str, int]] = {}
+        traced_cases = 0
+        file_access_cases = 0
+        tool_call_count = 0
+        for row in result["rows"]:
+            traces = row.get("inputs.tool_trace", []) or []
+            if row.get("inputs.trace_id") or row.get("inputs.response_id"):
+                traced_cases += 1
+            case_tools: set[str] = set()
+            for trace in traces:
+                if not isinstance(trace, dict):
+                    continue
+                tool_name = trace.get("tool_name")
+                if not isinstance(tool_name, str) or not tool_name:
+                    continue
+                tool_call_count += 1
+                case_tools.add(tool_name)
+                usage = tool_usage.setdefault(tool_name, {"calls": 0, "cases": 0})
+                usage["calls"] += 1
+            for tool_name in case_tools:
+                tool_usage[tool_name]["cases"] += 1
+            if any(name.startswith("file_access_") for name in case_tools):
+                file_access_cases += 1
+
+        summary_result: dict[str, Any] = {
+            "total_evals": len(result["rows"]),
+            "traced_cases": traced_cases,
+            "tool_call_count": tool_call_count,
+            "file_access_cases": file_access_cases,
+            "tool_usage": tool_usage,
+        }
         for index, (key, value) in enumerate(pass_rates.items()):
             summary_result[f"{key}_pass_rate"] = value
         for index, (key, value) in enumerate(fail_rates.items()):

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-evaluation/_evals_runner.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-evaluation/_evals_runner.py
@@ -50,6 +50,8 @@ SCENARIO_TO_CHANNEL: dict[str, str] = {
 
 # Composite weights
 BOT_EVALS_WEIGHTS = {"similarity": 0.6, "response_completeness": 0.4}
+INLINE_EVAL_BATCH_SIZE = 20
+INLINE_EVAL_BATCH_MAX_BYTES = 400_000
 
 # Item schema for the inline eval data: the answer/context are collected from
 # /completion and carried in the item (read via {{item.response}} / {{item.context}}).
@@ -61,6 +63,11 @@ COMPLETION_ITEM_SCHEMA: dict[str, Any] = {
         "ground_truth": {"type": "string"},
         "response": {"type": "string"},
         "context": {"type": "string"},
+        "response_id": {"type": "string"},
+        "trace_id": {"type": "string"},
+        "agent_conversation_id": {"type": "string"},
+        "latency": {"type": "number"},
+        "response_length": {"type": "integer"},
         "expected_references": {"type": "array", "items": {"type": "object"}},
         "expected_knowledges": {"type": "array", "items": {"type": "object"}},
         "references": {"type": "array", "items": {"type": "object"}},
@@ -78,11 +85,87 @@ def _completion_item(it: dict[str, Any]) -> dict[str, Any]:
         "ground_truth": it.get("ground_truth", ""),
         "response": it.get("response", ""),
         "context": it.get("context", "") or "",
+        "response_id": it.get("response_id", "") or "",
+        "trace_id": it.get("trace_id", "") or "",
+        "agent_conversation_id": it.get("agent_conversation_id", "") or "",
+        "latency": float(it.get("latency", 0.0) or 0.0),
+        "response_length": int(it.get("response_length", 0) or 0),
         "expected_references": it.get("expected_references", []),
         "expected_knowledges": it.get("expected_knowledges", []),
         "references": it.get("references", []),
         "knowledges": it.get("knowledges", []),
     }
+
+
+def _combine_batch_results(
+    batch_results: list[list[dict[str, Any]]],
+    evaluators: list[str],
+) -> list[dict[str, Any]]:
+    combined: list[dict[str, Any]] = []
+    summary: dict[str, Any] = {"total_evals": 0}
+    for evaluator in evaluators:
+        summary[f"{evaluator}_pass_rate"] = 0
+        summary[f"{evaluator}_fail_rate"] = 0
+    summary["traced_cases"] = 0
+    summary["tool_call_count"] = 0
+    summary["file_access_cases"] = 0
+    summary["tool_usage"] = {}
+    for result in batch_results:
+        if not result:
+            raise ValueError("evaluation batch result must include a summary")
+        combined.extend(result[:-1])
+        batch_summary = result[-1]
+        summary["total_evals"] += batch_summary["total_evals"]
+        for evaluator in evaluators:
+            summary[f"{evaluator}_pass_rate"] += batch_summary[
+                f"{evaluator}_pass_rate"
+            ]
+            summary[f"{evaluator}_fail_rate"] += batch_summary[
+                f"{evaluator}_fail_rate"
+            ]
+        summary["traced_cases"] += batch_summary.get("traced_cases", 0)
+        summary["tool_call_count"] += batch_summary.get("tool_call_count", 0)
+        summary["file_access_cases"] += batch_summary.get("file_access_cases", 0)
+        for tool_name, usage in batch_summary.get("tool_usage", {}).items():
+            combined_usage = summary["tool_usage"].setdefault(
+                tool_name, {"calls": 0, "cases": 0}
+            )
+            combined_usage["calls"] += usage.get("calls", 0)
+            combined_usage["cases"] += usage.get("cases", 0)
+    combined.append(summary)
+    return combined
+
+
+def _batch_completion_items(
+    items: list[dict[str, Any]],
+    *,
+    max_items: int = INLINE_EVAL_BATCH_SIZE,
+    max_bytes: int = INLINE_EVAL_BATCH_MAX_BYTES,
+) -> list[list[dict[str, Any]]]:
+    if max_items <= 0:
+        raise ValueError("max_items must be positive")
+    if max_bytes <= 0:
+        raise ValueError("max_bytes must be positive")
+
+    batches: list[list[dict[str, Any]]] = []
+    current: list[dict[str, Any]] = []
+    current_bytes = 0
+    for item in items:
+        projected = _completion_item(item)
+        item_bytes = len(
+            json.dumps(projected, ensure_ascii=False).encode("utf-8")
+        )
+        if current and (
+            len(current) >= max_items or current_bytes + item_bytes > max_bytes
+        ):
+            batches.append(current)
+            current = []
+            current_bytes = 0
+        current.append(projected)
+        current_bytes += item_bytes
+    if current:
+        batches.append(current)
+    return batches
 
 
 def extract_title_and_link_from_references(references: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -111,12 +194,47 @@ def extract_title_and_link_from_context(context: str) -> list[dict[str, Any]]:
             title = ""
             link = ""
             if isinstance(doc, dict):
+                if doc.get("document_source") == "agent_tool_trace":
+                    continue
                 title = doc.get("document_title") or doc.get("title") or ""
                 link = doc.get("document_link") or doc.get("link") or ""
             docs.append({"title": title, "link": link})
     except (json.JSONDecodeError, TypeError) as exc:
         logger.warning("Failed to parse full_context JSON: %s", exc)
     return docs
+
+
+def extract_tool_trace_from_context(context: str) -> list[dict[str, Any]]:
+    """Extract structured hosted-agent tool calls from ``full_context``."""
+    if not context:
+        return []
+    traces: list[dict[str, Any]] = []
+    try:
+        docs_obj = json.loads(context)
+    except (json.JSONDecodeError, TypeError) as exc:
+        logger.warning("Failed to parse tool trace JSON: %s", exc)
+        return traces
+    if not isinstance(docs_obj, list):
+        return traces
+    for doc in docs_obj:
+        if not isinstance(doc, dict):
+            continue
+        if doc.get("document_source") != "agent_tool_trace":
+            continue
+        content = doc.get("document_content", "")
+        if not isinstance(content, str):
+            continue
+        try:
+            trace = json.loads(content)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning(
+                "Failed to parse tool trace entry: %s",
+                doc.get("document_title", "unknown"),
+            )
+            continue
+        if isinstance(trace, dict):
+            traces.append(trace)
+    return traces
 
 
 class CompletionCollector:
@@ -177,6 +295,10 @@ class CompletionCollector:
                     "ground_truth": record.get("ground_truth", ""),
                     "response": answer,
                     "response_id": api_response.get("id", ""),
+                    "trace_id": api_response.get("trace_id", ""),
+                    "agent_conversation_id": api_response.get(
+                        "agent_conversation_id", ""
+                    ),
                     "context": full_context,
                     "latency": time.time() - start,
                     "response_length": len(answer),
@@ -311,13 +433,25 @@ def output_items_to_rows(
     for oi in output_items:
         item = _get(oi, "datasource_item", {}) or {}
         results = _get(oi, "results", []) or []
+        context = item.get("context", "") or ""
 
         row: dict[str, Any] = {
             "inputs.testcase": item.get("testcase", item.get("query", "unknown")),
+            "inputs.query": item.get("query", ""),
             "inputs.ground_truth": item.get("ground_truth", ""),
             "inputs.expected_references": item.get("expected_references", []),
             "inputs.expected_knowledges": item.get("expected_knowledges", []),
             "inputs.response": item.get("response", ""),
+            "inputs.context": context,
+            "inputs.response_id": item.get("response_id", "") or "",
+            "inputs.trace_id": item.get("trace_id", "") or "",
+            "inputs.agent_conversation_id": item.get(
+                "agent_conversation_id", ""
+            )
+            or "",
+            "inputs.latency": float(item.get("latency", 0.0) or 0.0),
+            "inputs.response_length": int(item.get("response_length", 0) or 0),
+            "inputs.tool_trace": extract_tool_trace_from_context(context),
             "inputs.references": item.get("references", []) or [],
             "inputs.knowledges": item.get("knowledges", []) or [],
         }
@@ -419,10 +553,18 @@ class FoundryEvalsRunner:
         """A synthetic result row that fails every requested metric (uncollected case)."""
         row: dict[str, Any] = {
             "inputs.testcase": record.get("testcase", record.get("query", "unknown")),
+            "inputs.query": record.get("query", ""),
             "inputs.ground_truth": record.get("ground_truth", ""),
             "inputs.expected_references": record.get("expected_references", []),
             "inputs.expected_knowledges": record.get("expected_knowledges", []),
             "inputs.response": "",
+            "inputs.context": "",
+            "inputs.response_id": "",
+            "inputs.trace_id": "",
+            "inputs.agent_conversation_id": "",
+            "inputs.latency": 0.0,
+            "inputs.response_length": 0,
+            "inputs.tool_trace": [],
             "inputs.references": [],
             "inputs.knowledges": [],
         }
@@ -505,16 +647,52 @@ class FoundryEvalsRunner:
         )
         logger.info("Evaluation created (id=%s, name=%s)", eval_object.id, name)
 
-        # 3) Grade the pre-collected answers as inline data (no agent target).
-        content = [SourceFileContentContent(item=_completion_item(it)) for it in items]
-        data_source = CreateEvalJSONLRunDataSourceParam(
-            type="jsonl", source=SourceFileContent(type="file_content", content=content)
-        )
-        run = openai_client.evals.runs.create(
-            eval_id=eval_object.id, name=f"{name}-run", data_source=data_source  # type: ignore[arg-type]
-        )
-        logger.info("Evaluation run created (id=%s)", run.id)
-        return self._poll_and_adapt(openai_client, eval_object.id, run.id, scenario, failed_rows)
+        # 3) Grade the pre-collected answers as bounded inline batches. Foundry
+        # run-history rejects oversized inline documents before grading starts.
+        batch_results: list[list[dict[str, Any]]] = []
+        batches = _batch_completion_items(items)
+        batch_count = len(batches)
+        for batch_index, batch in enumerate(batches, start=1):
+            batch_bytes = sum(
+                len(json.dumps(item, ensure_ascii=False).encode("utf-8"))
+                for item in batch
+            )
+            content = [
+                SourceFileContentContent(item=item)
+                for item in batch
+            ]
+            data_source = CreateEvalJSONLRunDataSourceParam(
+                type="jsonl",
+                source=SourceFileContent(type="file_content", content=content),
+            )
+            run = openai_client.evals.runs.create(
+                eval_id=eval_object.id,
+                name=f"{name}-run-{batch_index:02d}",
+                data_source=data_source,  # type: ignore[arg-type]
+            )
+            logger.info(
+                "Evaluation batch %d/%d created (id=%s, cases=%d, bytes=%d)",
+                batch_index,
+                batch_count,
+                run.id,
+                len(batch),
+                batch_bytes,
+            )
+            adapted = self._poll_and_adapt(
+                openai_client,
+                eval_object.id,
+                run.id,
+                f"{scenario}-batch-{batch_index:02d}",
+                failed_rows if batch_index == batch_count else None,
+            )
+            batch_results.append(next(iter(adapted.values())))
+
+        return {
+            f"{scenario}_batched": _combine_batch_results(
+                batch_results,
+                self._evaluators,
+            )
+        }
 
 
 def resolve_records(dataset_spec: str, *, script_dir: Path) -> tuple[list[dict[str, Any]], str]:
@@ -563,5 +741,6 @@ __all__ = [
     "resolve_tenant_for_scenario",
     "extract_title_and_link_from_references",
     "extract_title_and_link_from_context",
+    "extract_tool_trace_from_context",
     "COMPLETION_ITEM_SCHEMA",
 ]

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-evaluation/_evals_runner.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-evaluation/_evals_runner.py
@@ -107,6 +107,7 @@ def _combine_batch_results(
         summary[f"{evaluator}_pass_rate"] = 0
         summary[f"{evaluator}_fail_rate"] = 0
     summary["traced_cases"] = 0
+    summary["response_id_cases"] = 0
     summary["tool_call_count"] = 0
     summary["file_access_cases"] = 0
     summary["tool_usage"] = {}
@@ -124,6 +125,9 @@ def _combine_batch_results(
                 f"{evaluator}_fail_rate"
             ]
         summary["traced_cases"] += batch_summary.get("traced_cases", 0)
+        summary["response_id_cases"] += batch_summary.get(
+            "response_id_cases", 0
+        )
         summary["tool_call_count"] += batch_summary.get("tool_call_count", 0)
         summary["file_access_cases"] += batch_summary.get("file_access_cases", 0)
         for tool_name, usage in batch_summary.get("tool_usage", {}).items():
@@ -149,20 +153,23 @@ def _batch_completion_items(
 
     batches: list[list[dict[str, Any]]] = []
     current: list[dict[str, Any]] = []
-    current_bytes = 0
     for item in items:
         projected = _completion_item(item)
         item_bytes = len(
-            json.dumps(projected, ensure_ascii=False).encode("utf-8")
+            json.dumps([projected], ensure_ascii=False).encode("utf-8")
         )
-        if current and (
-            len(current) >= max_items or current_bytes + item_bytes > max_bytes
-        ):
+        if item_bytes > max_bytes:
+            raise ValueError(
+                f"Evaluation item {projected['testcase']!r} is {item_bytes} bytes, "
+                f"which exceeds the {max_bytes}-byte inline batch limit"
+            )
+        candidate_bytes = len(
+            json.dumps([*current, projected], ensure_ascii=False).encode("utf-8")
+        )
+        if current and (len(current) >= max_items or candidate_bytes > max_bytes):
             batches.append(current)
             current = []
-            current_bytes = 0
         current.append(projected)
-        current_bytes += item_bytes
     if current:
         batches.append(current)
     return batches

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-evaluation/unit_tests/test_pure_logic.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-evaluation/unit_tests/test_pure_logic.py
@@ -29,9 +29,13 @@ from dataset.schema import (  # noqa: E402
 )
 from dataset.review import review  # noqa: E402
 from _evals_runner import (  # noqa: E402
+    _batch_completion_items,
+    _completion_item,
+    _combine_batch_results,
     output_items_to_rows,
     extract_title_and_link_from_references,
     extract_title_and_link_from_context,
+    extract_tool_trace_from_context,
     resolve_tenant_for_scenario,
 )
 from eval.criteria import build_testing_criteria, BUILTIN_EVALUATORS  # noqa: E402
@@ -254,6 +258,82 @@ def test_output_items_to_rows_groundedness_fail():
     assert rows[0]["outputs.groundedness.groundedness_result"] == "fail"
 
 
+def test_combine_batch_results_sums_summaries():
+    combined = _combine_batch_results(
+        [
+            [
+                {"testcase": "one"},
+                {
+                    "total_evals": 1,
+                    "similarity_pass_rate": 1,
+                    "similarity_fail_rate": 0,
+                    "traced_cases": 1,
+                    "tool_call_count": 2,
+                    "file_access_cases": 1,
+                    "tool_usage": {
+                        "search_knowledge_base": {"calls": 1, "cases": 1},
+                        "file_access_grep": {"calls": 1, "cases": 1},
+                    },
+                },
+            ],
+            [
+                {"testcase": "two"},
+                {
+                    "total_evals": 1,
+                    "similarity_pass_rate": 0,
+                    "similarity_fail_rate": 1,
+                    "traced_cases": 1,
+                    "tool_call_count": 1,
+                    "file_access_cases": 0,
+                    "tool_usage": {
+                        "search_knowledge_base": {"calls": 1, "cases": 1},
+                    },
+                },
+            ],
+        ],
+        ["similarity"],
+    )
+
+    assert combined[:-1] == [{"testcase": "one"}, {"testcase": "two"}]
+    assert combined[-1] == {
+        "total_evals": 2,
+        "similarity_pass_rate": 1,
+        "similarity_fail_rate": 1,
+        "traced_cases": 2,
+        "tool_call_count": 3,
+        "file_access_cases": 1,
+        "tool_usage": {
+            "search_knowledge_base": {"calls": 2, "cases": 2},
+            "file_access_grep": {"calls": 1, "cases": 1},
+        },
+    }
+
+
+def test_batch_completion_items_respects_count_and_payload_limits():
+    items = [
+        {"testcase": f"case-{index}", "query": "q", "response": "x" * 80}
+        for index in range(5)
+    ]
+
+    count_batches = _batch_completion_items(items, max_items=2, max_bytes=10_000)
+    assert [len(batch) for batch in count_batches] == [2, 2, 1]
+
+    payload_batches = _batch_completion_items(
+        items, max_items=20, max_bytes=350
+    )
+    assert len(payload_batches) > 1
+    assert [
+        item["testcase"] for batch in payload_batches for item in batch
+    ] == [item["testcase"] for item in items]
+
+    try:
+        _batch_completion_items(items, max_items=0)
+    except ValueError as exc:
+        assert "max_items" in str(exc)
+    else:
+        raise AssertionError("expected max_items validation")
+
+
 def test_build_testing_criteria_all_builtins():
     crit = build_testing_criteria(list(BUILTIN_EVALUATORS), model="gpt-4o")
     by_name = {c["evaluator_name"]: c for c in crit}
@@ -300,11 +380,50 @@ def test_extract_references():
 def test_extract_context_from_full_context_json():
     import json as _json
 
-    ctx = _json.dumps([{"document_title": "D", "document_link": "http://d"}, {"title": "E", "link": "http://e"}])
+    trace = {
+        "sequence": 1,
+        "tool_name": "file_access_grep",
+        "call_id": "call-1",
+    }
+    ctx = _json.dumps([
+        {"document_title": "D", "document_link": "http://d"},
+        {"title": "E", "link": "http://e"},
+        {
+            "document_title": "Tool call 1: file_access_grep",
+            "document_link": "agent-trace://response/call-1",
+            "document_source": "agent_tool_trace",
+            "document_content": _json.dumps(trace),
+        },
+    ])
     out = extract_title_and_link_from_context(ctx)
     assert out == [{"title": "D", "link": "http://d"}, {"title": "E", "link": "http://e"}]
+    assert extract_tool_trace_from_context(ctx) == [trace]
     assert extract_title_and_link_from_context("") == []
+    assert extract_tool_trace_from_context("") == []
     assert extract_title_and_link_from_context("not-json") == []
+    assert extract_tool_trace_from_context("not-json") == []
+
+
+def test_completion_item_preserves_execution_metadata():
+    item = _completion_item(
+        {
+            "testcase": "traceable",
+            "query": "q",
+            "response": "answer",
+            "response_id": "response-1",
+            "trace_id": "trace-1",
+            "agent_conversation_id": "conversation-1",
+            "latency": 1.25,
+            "response_length": 6,
+        }
+    )
+
+    assert item["response_id"] == "response-1"
+    assert item["trace_id"] == "trace-1"
+    assert item["agent_conversation_id"] == "conversation-1"
+    assert item["latency"] == 1.25
+    assert item["response_length"] == 6
+    assert "tool_trace" not in item
 
 
 def test_resolve_tenant_for_scenario():
@@ -321,10 +440,28 @@ def test_resolve_tenant_for_scenario():
 
 def test_output_items_to_rows_completion_item_response():
     # In completion mode the answer/references live in the datasource_item.
+    import json as _json
+
+    trace = {"tool_name": "file_access_read"}
+    context = _json.dumps(
+        [
+            {
+                "document_source": "agent_tool_trace",
+                "document_content": _json.dumps(trace),
+            }
+        ]
+    )
     output_items = [
         {
             "datasource_item": {
-                "testcase": "t", "ground_truth": "gt", "response": "collected answer",
+                "testcase": "t", "query": "question", "ground_truth": "gt",
+                "response": "collected answer",
+                "context": context,
+                "response_id": "response-1",
+                "trace_id": "trace-1",
+                "agent_conversation_id": "conversation-1",
+                "latency": 1.5,
+                "response_length": 16,
                 "references": [{"title": "R", "link": "http://r"}],
                 "knowledges": [{"title": "K", "link": "http://k"}],
             },
@@ -333,9 +470,76 @@ def test_output_items_to_rows_completion_item_response():
         }
     ]
     rows = output_items_to_rows(output_items, ["similarity"])["rows"]
+    assert rows[0]["inputs.query"] == "question"
     assert rows[0]["inputs.response"] == "collected answer"
+    assert rows[0]["inputs.context"] == context
+    assert rows[0]["inputs.response_id"] == "response-1"
+    assert rows[0]["inputs.trace_id"] == "trace-1"
+    assert rows[0]["inputs.agent_conversation_id"] == "conversation-1"
+    assert rows[0]["inputs.latency"] == 1.5
+    assert rows[0]["inputs.response_length"] == 16
+    assert rows[0]["inputs.tool_trace"] == [trace]
     assert rows[0]["inputs.references"] == [{"title": "R", "link": "http://r"}]
     assert rows[0]["inputs.knowledges"] == [{"title": "K", "link": "http://k"}]
+
+
+def test_record_run_result_preserves_trace_and_summarizes_tool_usage():
+    from _evals_result import EvalsResult
+
+    er = EvalsResult(metrics={"similarity": None}, suppressions=None)
+    recorded = er.record_run_result(
+        {
+            "rows": [
+                {
+                    "inputs.testcase": "traceable",
+                    "inputs.query": "question",
+                    "inputs.ground_truth": "gt",
+                    "inputs.expected_references": [],
+                    "inputs.expected_knowledges": [],
+                    "inputs.response": "answer",
+                    "inputs.context": "context",
+                    "inputs.response_id": "response-1",
+                    "inputs.trace_id": "trace-1",
+                    "inputs.agent_conversation_id": "conversation-1",
+                    "inputs.latency": 1.25,
+                    "inputs.response_length": 6,
+                    "inputs.tool_trace": [
+                        {"tool_name": "search_knowledge_base"},
+                        {"tool_name": "file_access_grep"},
+                        {"tool_name": "file_access_read"},
+                    ],
+                    "inputs.references": [],
+                    "inputs.knowledges": [],
+                    "outputs.similarity.similarity": 5.0,
+                    "outputs.similarity.similarity_result": "pass",
+                }
+            ]
+        }
+    )
+
+    assert recorded[0]["query"] == "question"
+    assert recorded[0]["actual"]["context"] == "context"
+    assert recorded[0]["execution"] == {
+        "response_id": "response-1",
+        "trace_id": "trace-1",
+        "agent_conversation_id": "conversation-1",
+        "latency_seconds": 1.25,
+        "response_length": 6,
+        "used_file_access": True,
+        "tool_calls": [
+            {"tool_name": "search_knowledge_base"},
+            {"tool_name": "file_access_grep"},
+            {"tool_name": "file_access_read"},
+        ],
+    }
+    assert recorded[-1]["traced_cases"] == 1
+    assert recorded[-1]["tool_call_count"] == 3
+    assert recorded[-1]["file_access_cases"] == 1
+    assert recorded[-1]["tool_usage"] == {
+        "search_knowledge_base": {"calls": 1, "cases": 1},
+        "file_access_grep": {"calls": 1, "cases": 1},
+        "file_access_read": {"calls": 1, "cases": 1},
+    }
 
 
 def test_failed_row_counts_as_failure_in_gate():

--- a/tools/sdk-ai-bots/azure-sdk-qa-bot-evaluation/unit_tests/test_pure_logic.py
+++ b/tools/sdk-ai-bots/azure-sdk-qa-bot-evaluation/unit_tests/test_pure_logic.py
@@ -11,6 +11,7 @@ Run:
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 
@@ -268,6 +269,7 @@ def test_combine_batch_results_sums_summaries():
                     "similarity_pass_rate": 1,
                     "similarity_fail_rate": 0,
                     "traced_cases": 1,
+                    "response_id_cases": 1,
                     "tool_call_count": 2,
                     "file_access_cases": 1,
                     "tool_usage": {
@@ -283,6 +285,7 @@ def test_combine_batch_results_sums_summaries():
                     "similarity_pass_rate": 0,
                     "similarity_fail_rate": 1,
                     "traced_cases": 1,
+                    "response_id_cases": 1,
                     "tool_call_count": 1,
                     "file_access_cases": 0,
                     "tool_usage": {
@@ -300,6 +303,7 @@ def test_combine_batch_results_sums_summaries():
         "similarity_pass_rate": 1,
         "similarity_fail_rate": 1,
         "traced_cases": 2,
+        "response_id_cases": 2,
         "tool_call_count": 3,
         "file_access_cases": 1,
         "tool_usage": {
@@ -319,12 +323,16 @@ def test_batch_completion_items_respects_count_and_payload_limits():
     assert [len(batch) for batch in count_batches] == [2, 2, 1]
 
     payload_batches = _batch_completion_items(
-        items, max_items=20, max_bytes=350
+        items, max_items=20, max_bytes=500
     )
     assert len(payload_batches) > 1
     assert [
         item["testcase"] for batch in payload_batches for item in batch
     ] == [item["testcase"] for item in items]
+    assert all(
+        len(json.dumps(batch, ensure_ascii=False).encode("utf-8")) <= 500
+        for batch in payload_batches
+    )
 
     try:
         _batch_completion_items(items, max_items=0)
@@ -332,6 +340,17 @@ def test_batch_completion_items_respects_count_and_payload_limits():
         assert "max_items" in str(exc)
     else:
         raise AssertionError("expected max_items validation")
+
+    try:
+        _batch_completion_items(
+            [{"testcase": "too-large", "response": "x" * 1_000}],
+            max_bytes=200,
+        )
+    except ValueError as exc:
+        assert "too-large" in str(exc)
+        assert "200-byte" in str(exc)
+    else:
+        raise AssertionError("expected oversized item validation")
 
 
 def test_build_testing_criteria_all_builtins():
@@ -533,6 +552,7 @@ def test_record_run_result_preserves_trace_and_summarizes_tool_usage():
         ],
     }
     assert recorded[-1]["traced_cases"] == 1
+    assert recorded[-1]["response_id_cases"] == 1
     assert recorded[-1]["tool_call_count"] == 3
     assert recorded[-1]["file_access_cases"] == 1
     assert recorded[-1]["tool_usage"] == {
@@ -540,6 +560,34 @@ def test_record_run_result_preserves_trace_and_summarizes_tool_usage():
         "file_access_grep": {"calls": 1, "cases": 1},
         "file_access_read": {"calls": 1, "cases": 1},
     }
+
+
+def test_record_run_result_distinguishes_response_and_trace_ids():
+    from _evals_result import EvalsResult
+
+    er = EvalsResult(metrics={"similarity": None}, suppressions=None)
+    recorded = er.record_run_result(
+        {
+            "rows": [
+                {
+                    "inputs.testcase": "response-only",
+                    "inputs.ground_truth": "gt",
+                    "inputs.expected_references": [],
+                    "inputs.expected_knowledges": [],
+                    "inputs.response": "answer",
+                    "inputs.response_id": "response-1",
+                    "inputs.trace_id": "",
+                    "inputs.references": [],
+                    "inputs.knowledges": [],
+                    "outputs.similarity.similarity": 5.0,
+                    "outputs.similarity.similarity_result": "pass",
+                }
+            ]
+        }
+    )
+
+    assert recorded[-1]["traced_cases"] == 0
+    assert recorded[-1]["response_id_cases"] == 1
 
 
 def test_failed_row_counts_as_failure_in_gate():


### PR DESCRIPTION
## Summary

- Keep `/completion`, `chat_service.py`, and documentation-only `full_context` behavior unchanged.
- Retrieve each stored Hosted Agent response from Foundry by the `/completion` response ID.
- Keep normalized tool calls and complete tool results only in local full-result caches; do not send them to Foundry evaluators or persist them in baselines.
- Preserve the pre-existing single inline evaluation run behavior.

## Implementation

- Use the generic project OpenAI client for the Foundry Evals API and a separate agent-scoped preview client for stored response retrieval.
- Send `response_id` with the Foundry item only for post-grading correlation, then attach local tool calls after grading.
- Store only `response_id` and ordered `tool_calls` under each cached case's `execution` block.
- Store each tool call as `tool_name`, `arguments`, and `output`; support the bot's function calls and hosted web search calls.
- Treat the synthetic content-filter response as having no persisted tool calls so a blocked case does not abort the remaining evaluation.
- Store `search_knowledge_base` and `wiki_search` JSON results as objects rather than escaped JSON strings.
- Keep raw stored response output out of caches and exclude `execution` plus duplicated `actual.context` from baseline and `.log` snapshots.

## Validation

- Evaluation pure-logic tests: 21 passed.
- Pyright: 0 errors for the changed evaluation modules and tests.
- `git diff --check` passed.
- A live 2-case `basic/sdkagent` run completed collection, stored-response retrieval, Foundry grading, and full-cache generation. Both groundedness grades passed; both answer-quality composite grades failed independently of trace capture.
- The net PR diff was reduced from 527 additions / 58 deletions to 267 additions / 33 deletions.
- `chat_service.py` and `chat_service_test.py` match `main` and do not appear in the final PR diff.

