### PR TITLE
Commitsha in release plan

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/SpecWorkFlowToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlan/SpecWorkFlowToolTests.cs
@@ -17,6 +17,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
     {
         private MockDevOpsService mockDevOpsService;
         private Mock<IGitHubService> mockGitHubService;
+        private Mock<IGitHelper> mockGitHelper;
         private Mock<ITypeSpecHelper> mockTypeSpecHelper;
         private ILogger<SpecWorkflowTool> logger;
         private SpecWorkflowTool specWorkflowTool;
@@ -27,6 +28,9 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
         {
             mockDevOpsService = new MockDevOpsService();
             mockGitHubService = new Mock<IGitHubService>();
+            mockGitHelper = new Mock<IGitHelper>();
+            mockGitHelper.Setup(x => x.IsValidCommitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
             mockTypeSpecHelper = new Mock<ITypeSpecHelper>();
             logger = new TestLogger<SpecWorkflowTool>();
             inputSanitizer = new InputSanitizer();
@@ -38,6 +42,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools.ReleasePlan
 
             specWorkflowTool = new SpecWorkflowTool(
                 mockGitHubService.Object,
+                mockGitHelper.Object,
                 mockDevOpsService,
                 mockTypeSpecHelper.Object,
                 logger,

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Release plan CLI commands now support storing and updating the TypeSpec specification commit SHA. SDK generation uses the stored commit when it is valid in the local repository and otherwise falls back to `main`.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/GitHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/GitHelper.cs
@@ -16,6 +16,7 @@ namespace Azure.Sdk.Tools.Cli.Helpers
         public Task<string> GetMergeBaseCommitShaAsync(string pathInRepo, string targetBranch, CancellationToken ct);
         public Task<string> DiscoverRepoRootAsync(string pathInRepo, CancellationToken ct);
         public Task<string> GetRepoNameAsync(string pathInRepo, CancellationToken ct);
+        public Task<bool> IsValidCommitAsync(string pathInRepo, string commitSha, CancellationToken ct);
         public Task<List<string>> GetChangedFilesAsync(string repoRoot, string targetCommitish, string? sourceCommitish, string? diffPath, string diffFilterType, CancellationToken ct);
     }
 
@@ -245,6 +246,19 @@ namespace Azure.Sdk.Tools.Cli.Helpers
 
             string repoName = segments[^1].Replace(".git", "");
             return repoName;
+        }
+
+        public async Task<bool> IsValidCommitAsync(string pathInRepo, string commitSha, CancellationToken ct)
+        {
+            if (string.IsNullOrWhiteSpace(commitSha))
+            {
+                return false;
+            }
+
+            var repoRoot = await DiscoverRepoRootAsync(pathInRepo, ct);
+            var options = new GitOptions(["rev-parse", "--verify", $"{commitSha}^{{commit}}"], repoRoot, logOutputStream: false);
+            var result = await gitCommandHelper.Run(options, ct);
+            return result.ExitCode == 0;
         }
 
         /// <summary>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AzureDevOps/ReleasePlanWorkItem.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/AzureDevOps/ReleasePlanWorkItem.cs
@@ -79,6 +79,9 @@ namespace Azure.Sdk.Tools.Cli.Models.AzureDevOps
         [FieldName("Custom.ApiSpecProjectPath")]
         public string APISpecProjectPath { get; set; } = string.Empty;
 
+        [FieldName("Custom.SpecCommitSHA")]
+        public string SpecCommitSHA { get; set; } = string.Empty;
+
         [FieldName("Custom.AttestationStatus")]
         public string AttestationStatus { get; set; } = string.Empty;
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -425,6 +425,7 @@ namespace Azure.Sdk.Tools.Cli.Services
                 LanguageExclusionRequesterNote = workItem.Fields.TryGetValue("Custom.ReleaseExclusionRequestNote", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 LanguageExclusionApproverNote = workItem.Fields.TryGetValue("Custom.ReleaseExclusionApprovalNote", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 APISpecProjectPath = workItem.Fields.TryGetValue("Custom.ApiSpecProjectPath", out value) ? value?.ToString() ?? string.Empty : string.Empty,
+                SpecCommitSHA = workItem.Fields.TryGetValue("Custom.SpecCommitSHA", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 AttestationStatus = workItem.Fields.TryGetValue("Custom.AttestationStatus", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 ReleasePlanType = workItem.Fields.TryGetValue("Custom.ReleasePlanType", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 Owner = workItem.Fields.TryGetValue("Custom.PrimaryPM", out value) ? value?.ToString() ?? string.Empty : string.Empty,

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/ReleasePlanTool.cs
@@ -137,6 +137,13 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
             DefaultValueFactory = _ => false,
         };
 
+        private readonly Option<string> specCommitShaOpt = new("--spec-commit-sha")
+        {
+            Description = "Spec repository commit SHA",
+            Required = false,
+            DefaultValueFactory = _ => string.Empty,
+        };
+
         private readonly Option<string> namespaceApprovalIssueOpt = new("--namespace-approval-issue")
         {
             Description = "Namespace approval issue URL",
@@ -298,6 +305,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 productTreeIdOpt,
                 optionalPullRequestOpt,
                 isTestReleasePlanOpt,
+                specCommitShaOpt,
             },
             new McpCommand(linkNamespaceApprovalIssueCommandName, "Link namespace approval issue to release plan", LinkNamespaceApprovalToolName) { workItemIdOpt, namespaceApprovalIssueOpt, },
             new McpCommand(checkApiReadinessCommandName, "Check if API spec is ready to generate SDK", CheckApiSpecReadyToolName) { typeSpecProjectPathOpt, pullRequestNumberOpt, workItemIdOpt, },
@@ -316,6 +324,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 optionalServiceTreeIdOpt,
                 optionalProductTreeIdOpt,
                 productTypeOpt,
+                specCommitShaOpt,
             },
             new McpCommand(updateReleasePlanTargetCommandName, "Update the SDK release target month on an existing release plan", UpdateReleasePlanTargetToolName) { workItemIdOpt, targetReleaseOpt, },
         ];
@@ -342,6 +351,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     var specPullRequestUrl = commandParser.GetValue(optionalPullRequestOpt);
                     var apiReleaseType = commandParser.GetValue(apiReleaseTypeOpt);
                     var isTestReleasePlan = commandParser.GetValue(isTestReleasePlanOpt);
+                    var specCommitSha = commandParser.GetValue(specCommitShaOpt);
                     return await CreateReleasePlan(
                         null,
                         typeSpecProjectPath,
@@ -351,6 +361,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                         serviceTreeId: serviceTreeId,
                         productTreeId: productTreeId,
                         isTestReleasePlan: isTestReleasePlan,
+                        specCommitSha: specCommitSha,
                         ct: ct
                     );
 
@@ -386,6 +397,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                         serviceTreeId: commandParser.GetValue(optionalServiceTreeIdOpt),
                         productTreeId: commandParser.GetValue(optionalProductTreeIdOpt),
                         productType: commandParser.GetValue(productTypeOpt),
+                        specCommitSha: commandParser.GetValue(specCommitShaOpt),
                         ct: ct
                     );
 
@@ -575,6 +587,19 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
         {
             try
             {
+                return await UpdateReleasePlan(typeSpecProjectPath, specPullRequestUrl, sdkReleaseType, workItemId, serviceTreeId, productTreeId, productType, string.Empty, ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to update release plan");
+                return new ReleasePlanResponse { ResponseError = $"Failed to update release plan: {ex.Message}" };
+            }
+        }
+
+        private async Task<ReleasePlanResponse> UpdateReleasePlan(string typeSpecProjectPath, string specPullRequestUrl, string sdkReleaseType, int workItemId, string serviceTreeId, string productTreeId, ProductType productType, string specCommitSha, CancellationToken ct = default)
+        {
+            try
+            {
                 sdkReleaseType = sdkReleaseType?.ToLower() ?? "";
 
                 var sdkReleaseTypeMappings = new Dictionary<string, string>
@@ -681,6 +706,11 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     { "Custom.SDKtypetobereleased", sdkReleaseType },
                     { "Custom.ApiSpecProjectPath", specProject },
                 };
+
+                if (!string.IsNullOrWhiteSpace(specCommitSha))
+                {
+                    fieldsToUpdate["Custom.SpecCommitSHA"] = specCommitSha;
+                }
 
                 if (!string.IsNullOrEmpty(serviceTreeId))
                 {
@@ -962,6 +992,19 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
         public async Task<ReleasePlanResponse> CreateReleasePlan(IProgress<ProgressNotificationValue>? progress, string typeSpecProjectPath, string targetReleaseMonthYear, string apiReleaseType, string specPullRequestUrl = "", string serviceTreeId = "", string productTreeId = "", bool isTestReleasePlan = false, CancellationToken ct = default)
         {
             try
+            {
+                return await CreateReleasePlan(progress, typeSpecProjectPath, targetReleaseMonthYear, apiReleaseType, specPullRequestUrl, serviceTreeId, productTreeId, isTestReleasePlan, string.Empty, ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to create release plan");
+                return new ReleasePlanResponse { ResponseError = $"Failed to create release plan: {ex.Message}" };
+            }
+        }
+
+        private async Task<ReleasePlanResponse> CreateReleasePlan(IProgress<ProgressNotificationValue>? progress, string typeSpecProjectPath, string targetReleaseMonthYear, string apiReleaseType, string specPullRequestUrl, string serviceTreeId, string productTreeId, bool isTestReleasePlan, string specCommitSha, CancellationToken ct = default)
+        {
+            try
             {         
                 // Validate and map API release type
                 if (!ApiReleaseTypeExtensions.TryParseFromUserInput(apiReleaseType, out var parsedApiReleaseType))
@@ -1165,7 +1208,8 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                     ProductType = productType,
                     ProductLifecycle = productLifecycle,
                     ApiReleaseType = parsedApiReleaseType,
-                    SpecAPIVersion = apiVersion
+                    SpecAPIVersion = apiVersion,
+                    SpecCommitSHA = specCommitSha ?? string.Empty
                 };
 
                 var reporter = new ProgressReporter(progress, logger, totalSteps: 2, outputHelper);
@@ -2285,4 +2329,3 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
         }
     }
 }
-

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/SpecWorkFlowTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlan/SpecWorkFlowTool.cs
@@ -16,6 +16,7 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
     [Description("This type contains the MCP tool to run SDK generation using pipeline, check SDK generation pipeline status and to get generated SDK pull request details.")]
     [McpServerToolType]
     public class SpecWorkflowTool(IGitHubService githubService,
+        IGitHelper gitHelper,
         IDevOpsService devopsService,
         ITypeSpecHelper typespecHelper,
         ILogger<SpecWorkflowTool> logger,
@@ -345,7 +346,25 @@ namespace Azure.Sdk.Tools.Cli.Tools.ReleasePlan
                 }
 
                 string apiSpecBranchRef = "main";
-                if (pullRequestNumber > 0)
+                var hasValidSpecCommitSha = false;
+                var hasSpecCommitSha = !string.IsNullOrWhiteSpace(releasePlan!.SpecCommitSHA);
+                if (hasSpecCommitSha)
+                {
+                    try
+                    {
+                        hasValidSpecCommitSha = await gitHelper.IsValidCommitAsync(typespecProjectRoot, releasePlan.SpecCommitSHA, ct);
+                    }
+                    catch (InvalidOperationException ex)
+                    {
+                        logger.LogWarning(ex, "Could not validate spec commit SHA {SpecCommitSHA}; using main for SDK generation.", releasePlan.SpecCommitSHA);
+                    }
+                }
+
+                if (hasValidSpecCommitSha)
+                {
+                    apiSpecBranchRef = releasePlan.SpecCommitSHA;
+                }
+                else if (!hasSpecCommitSha && pullRequestNumber > 0)
                 {
                     var pullRequest = await githubService.GetPullRequestAsync(REPO_OWNER, PUBLIC_SPECS_REPO, pullRequestNumber, ct);
                     apiSpecBranchRef = (pullRequest?.Merged ?? false) ? pullRequest.Base.Ref : $"refs/pull/{pullRequestNumber}/merge";


### PR DESCRIPTION
- Add commit SHA as a param in create and update release plan CLI commands
- Pass commit SHA to SDK generation when it's present in the release plan.